### PR TITLE
Make the API a bit realer, and start sending deltas to the server.

### DIFF
--- a/client/js/ApiClient.js
+++ b/client/js/ApiClient.js
@@ -2,11 +2,18 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-/*
+/**
  * Connection with the server, via a websocket.
  */
-
 export default class ApiClient {
+  /**
+   * Constructs an instance. `url` should represent the origin as an `http` or
+   * `https` URL. This instance will connect to a websocket at the same domain
+   * at the path `/api`. Once this constructor returns, it is safe to call any
+   * API methods on the instance; if the socket isn't yet ready for traffic,
+   * the calls will get enqueued and then replayed in order once the socket
+   * becomes ready.
+   */
   constructor(url) {
     url = new URL(url);
 
@@ -21,25 +28,145 @@ export default class ApiClient {
     url.search = '';
     url.hash = '';
 
+    /** URL for the websocket server. */
     this.url = url.href;
+
+    /** Actual websocket instance. Set by `open()`. */
+    this.ws = null;
+
+    /** Next message ID to use when sending a message. */
+    this.nextId = 0;
+
+    /** Map from message IDs to response callbacks. */
+    this.callbacks = {};
+
+    /**
+     * List of pending calls. Only used when connection is in the middle of
+     * being established.
+     */
+    this.pendingCalls = [];
   }
 
-  test() {
-    var url = this.url;
-    var ws = new WebSocket(url);
-    var pendingCount = 3;
-    ws.onopen = function (event) {
-      ws.send('{"method": "test", "args": [1]}');
-      ws.send('{"method": "test", "args": [2]}');
-      ws.send('{"method": "test", "args": [3]}');
-    };
-    ws.onmessage = function (event) {
-      console.log('API received');
-      console.log(event.data);
-      pendingCount--;
-      if (pendingCount === 0) {
-        ws.close();
+  /**
+   * Sends the given call to the server. Arranges for `callback` to be called
+   * when a response comes back.
+   */
+  _send(method, args, callback) {
+    var id = this.nextId;
+    var payload = JSON.stringify({ method: method, args: args, id: id });
+    this.callbacks[id] = callback;
+    this.nextId++;
+
+    switch (this.ws.readyState) {
+      case WebSocket.CONNECTING: {
+        // Not yet open. Need to queue it up.
+        this.pendingCalls.push(payload);
+        break;
       }
-    };
+      case WebSocket.OPEN: {
+        this.ws.send(payload);
+        break;
+      }
+      default: {
+        throw new Error('Websocket is closed or closing.');
+      }
+    }
+  }
+
+  /**
+   * Handles the `open` event coming from a websocket. In this case, it sends
+   * any pending calls (calls that were made while the socket was still in the
+   * process of opening).
+   */
+  _handleOpen(event) {
+    for (let payload of this.pendingCalls) {
+      this.ws.send(payload);
+    }
+    this.pendingCalls = [];
+  }
+
+  /**
+   * Handles a `message` event coming from a websocket. In this case, messages
+   * are expected to be the responses from previous calls, encoded as JSON. The
+   * `id` of the response is used to look up the callback function in
+   * `this.callbacks`. That callback is then called in a separate tick.
+   */
+  _handleMessage(event) {
+    var payload = JSON.parse(event.data);
+    var id = payload.id;
+    var result = payload.result;
+    var error = payload.error;
+
+    if (typeof id !== 'number') {
+      if (!id) {
+        throw new Error('Missing ID on API response.');
+      } else {
+        throw new Error(`Strange ID type \`${typeof id}\` on API response.`);
+      }
+    }
+
+    if (result === undefined) {
+      result = null;
+    }
+
+    if (error === undefined) {
+      error = null;
+    }
+
+    var callback = this.callbacks[id];
+    if (!callback) {
+      throw new Error(`Orphan call for ID ${id}.`);
+    } else {
+      // Use `setTimeout()` so that the callback runs in its own tick.
+      setTimeout(callback, 0, payload.result, payload.error);
+      delete this.callbacks[id];
+    }
+  }
+
+  /**
+   * Opens the websocket. Once open, any pending calls will get sent to the
+   * server side.
+   */
+  open() {
+    if (this.ws !== null) {
+      throw new Error('Already open');
+    }
+
+    var url = this.url;
+    this.ws = new WebSocket(url);
+    this.ws.onmessage = this._handleMessage.bind(this);
+    this.ws.onopen    = this._handleOpen.bind(this);
+  }
+
+  /**
+   * API call `update`. Sends a document delta to the server.
+   */
+  update(delta) {
+    var call = { method: 'update', delta: delta };
+    this._send('update', { delta: delta }, (result, error) => {
+      if (!error) {
+        console.log('Update good.');
+      } else {
+        console.log('Update error:');
+        console.log(error);
+      }
+    });
+  }
+
+  /**
+   * API call `test`. Sends a test message to the server. The server is
+   * expected to respond with the same value. If `wantClose` is passed as
+   * `true`, the client side will close the socket after the response is
+   * received.
+   */
+  test(value, wantClose) {
+    this._send('test', { value: value }, (result, error) => {
+      console.log('Test received');
+      console.log(result);
+      console.log(error);
+      if (wantClose) {
+        this.ws.close();
+      }
+    });
   }
 };

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -9,6 +9,11 @@
  */
 
 import Quill from 'quill';
+import ApiClient from './ApiClient';
+
+// Initialize the API connection.
+var api = new ApiClient(document.URL);
+api.open();
 
 const toolbarOptions = [
   ['bold', 'italic', 'underline', 'strike', 'code'],// toggled buttons
@@ -36,13 +41,16 @@ var quill = new Quill('#editor', {
   }
 });
 
+// Get Quill to report deltas to the server.
+quill.on('text-change', (delta, oldDelta, source) => {
+  if (source !== 'user') {
+    return;
+  }
+  api.update(delta);
+});
+
 // Demonstrates that Webpack conversion and bundling is working as expected.
 import TypescriptDemo from './TypescriptDemo';
 import EcmaDemo from './EcmaDemo';
 console.log('ES2017: ' + EcmaDemo.square(20));
 console.log('TypeScript: ' + TypescriptDemo.triple(5));
-
-// Demo of API access.
-import ApiClient from './ApiClient';
-var api = new ApiClient(document.URL);
-api.test();

--- a/server/ApiServer.js
+++ b/server/ApiServer.js
@@ -1,0 +1,113 @@
+// Copyright 2016 the Quillex Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import util from 'util';
+
+import log from './log';
+
+export default class ApiServer {
+  /**
+   * Constructs an instance. Each instance corresponds to a separate client
+   * connection. `ws` is a websocket instance corresponding to that connection.
+   * As a side effect, the contructor attaches the constructed instance to the
+   * websocket.
+   */
+  constructor(ws) {
+    this.ws = ws;
+    ws.on('message', this._handleMessage.bind(this));
+    ws.on('close', this._handleClose.bind(this));
+    ws.on('error', this._handleError.bind(this));
+  }
+
+  /**
+   * Handles a `message` event coming from the underlying websocket.
+   */
+  _handleMessage(msg) {
+    log('Websocket message:');
+    msg = JSON.parse(msg);
+    log(msg);
+
+    var method = msg.method;
+    var impl;
+    if (method === undefined) {
+      impl = this.error_missing_method;
+    } else if (typeof method !== 'string') {
+      impl = this.error_bad_method;
+    } else {
+      impl = this[`method_${method}`];
+      if (!impl) {
+        impl = this.error_unknown_method;
+      }
+    }
+
+    var response = { ok: false, id: msg.id };
+    try {
+      let result = impl.call(this, msg.args);
+      if (result !== undefined) {
+        response.result = result;
+      }
+      response.ok = true;
+    } catch (e) {
+      response.error = e.message;
+    }
+
+    log('Websocket response:');
+    log(response);
+    this.ws.send(JSON.stringify(response));
+  }
+
+  /**
+   * Handles a `close` event coming from the underlying websocket.
+   */
+  _handleClose(code, msg) {
+    log('Websocket close:');
+    log(code);
+    log(msg);
+  }
+
+  /**
+   * Handles an `error` event coming from the underlying websocket.
+   */
+  _handleError(err) {
+    log('Websocket error:');
+    log(err);
+  }
+
+  /**
+   * API error: Bad value for `method` in call payload (not a string).
+   */
+  error_bad_method(args) {
+    throw new Error('bad_method');
+  }
+
+  /**
+   * API error: Missing `method` in call payload.
+   */
+  error_missing_method(args) {
+    throw new Error('missing_method');
+  }
+
+  /**
+   * API error: Unknown (undefined) method.
+   */
+  error_unknown_method(args) {
+    throw new Error('unknown_method');
+  }
+
+  /**
+   * API method `test`: Responds back with the same arguments as it was passed.
+   */
+  method_test(args) {
+    return args;
+  }
+
+  /**
+   * API method `update`: Accepts a document update from the client.
+   */
+  method_update(args) {
+    // TODO: Something real.
+    log('Delta');
+    log(util.inspect(args.delta));
+  }
+}

--- a/server/main.js
+++ b/server/main.js
@@ -16,6 +16,7 @@ import morgan from 'morgan';
 import path from 'path';
 import process from 'process';
 
+import ApiServer from './ApiServer';
 import ClientBundle from './ClientBundle';
 import DevMode from './DevMode';
 import log from './log';
@@ -53,26 +54,8 @@ app.get('/static/bundle.js', ClientBundle.requestHandler);
 // top-level `index.html` and `favicon`, as well as stuff under `static/`.
 app.use('/', express.static(path.resolve(baseDir, 'client/assets')));
 
-// Demo of Websocket API service.
-app.ws('/api', function (ws, req) {
-  log('Websocket connected.')
-  ws.on('message', function (msg) {
-    log('Websocket message:');
-    msg = JSON.parse(msg);
-    log(msg);
-    msg.ok = true;
-    ws.send(JSON.stringify(msg));
-  });
-  ws.on('close', function (code, msg) {
-    log('Websocket close:');
-    log(code);
-    log(msg);
-  });
-  ws.on('error', function (err) {
-    log('Websocket error:');
-    log(err);
-  });
-})
+// Attach the API server.
+app.ws('/api', (ws, req) => { new ApiServer(ws); });
 
 app.listen(PORT, function () {
   log(`Quillex listening on port ${PORT}.`);


### PR DESCRIPTION
- Define an API envelope format that includes message IDs, and use it to
  associate calls and responses.
- Actually dispatch to different method implementations on the server side
  (though kinda trivially).
- Split out `open()` as a separate client method, instead of bundling it into
  the `test()` API call.
- Handle the case where the client tries to make API calls before the socket
  is open.
- Handle (mostly throw errors) various other edge cases.
- Hook up Quill on the client side to start sending deltas to an `update()`
  API method (which does nothing but log them for now).
