### PR TITLE
Change our client code to poke at Quill in a "nicer" way.

### DIFF
--- a/client/js/DeltaUtil.js
+++ b/client/js/DeltaUtil.js
@@ -1,0 +1,70 @@
+// Copyright 2016 the Quillex Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import Delta from 'quill-delta';
+
+/** Empty `Delta` instance. */
+const EMPTY_DELTA = new Delta();
+
+/**
+ * Quill `Delta` helper utilities.
+ */
+export default class DeltaUtil {
+  /**
+   * Returns `true` iff the given delta is empty. This accepts the same set of
+   * values as `coerce()`, see which. Anything else is considered to be an
+   * error.
+   *
+   * @param delta (null-ok) The delta or delta-like value.
+   * @returns `true` if `delta` is empty or `false` if not.
+   */
+  static isEmpty(delta) {
+    if (delta instanceof Delta) {
+      return (delta.ops.length === 0);
+    } else if ((delta === null) || (delta === undefined)) {
+      return true;
+    } else if (Array.isArray(delta)) {
+      return delta.length === 0;
+    } else if ((typeof delta === 'object') && Array.isArray(delta.ops)) {
+      return delta.ops.length === 0;
+    }
+
+    throw new Error('Invalid value.');
+  }
+
+  /**
+   * Coerces the given value to a `Delta`.
+   *
+   * * If `value` is a `Delta`, returns `value`.
+   * * If `value` is an array, constructs a `Delta` with `value` as the list of
+   *   ops.
+   * * If `value` is an object that binds `ops`, constructs a `Delta` with
+   *   `value.ops` as the list of ops.
+   * * If `value` is `null` or `undefined`, returns an empty `Delta`.
+   * * Throws an error for any other value.
+   *
+   * Unlike the `Delta` constructor:
+   *
+   * * This method does not construct a new instance if the given value is in
+   *   fact a `Delta`.
+   * * This method will throw an error instead of silently accepting invalid
+   *   values.
+   *
+   * @param value (null-ok) The value to coerce to a `Delta`.
+   * @returns the corresponding `Delta`.
+   */
+  static coerce(value) {
+    if (value instanceof Delta) {
+      return value;
+    } else if (DeltaUtil.isEmpty(value)) {
+      return EMPTY_DELTA;
+    } else if (Array.isArray(value)) {
+      return new Delta(value);
+    } else if (Array.isArray(value.ops)) {
+      return new Delta(value.ops);
+    }
+
+    throw new Error('Invalid value.');
+  }
+}

--- a/client/js/QuillMaker.js
+++ b/client/js/QuillMaker.js
@@ -32,7 +32,8 @@ export default class QuillMaker {
   /**
    * Makes an instance of `Quill`.
    *
-   * @param id DOM id of the element to attach to
+   * @param id DOM id of the element to attach to.
+   * @returns instance of `Quill`.
    */
   static make(id) {
     return new Quill(id, {

--- a/server/ApiServer.js
+++ b/server/ApiServer.js
@@ -115,13 +115,6 @@ export default class ApiServer {
   }
 
   /**
-   * API method `test`: Returns the same arguments as it was passed.
-   */
-  method_test(args) {
-    return args;
-  }
-
-  /**
    * API method `snapshot`: Returns an instantaneous snapshot of the document
    * contents. Result is an object that maps `data` to the snapshot data and
    * `version` to the version number.

--- a/server/Condition.js
+++ b/server/Condition.js
@@ -15,7 +15,7 @@ export default class Condition {
   /**
    * Constructs an instance.
    *
-   * @param value Initial value; defaults to `false`
+   * @param value Initial value; defaults to `false`.
    */
   constructor(initialValue) {
     initialValue = Condition._ensureBoolean(initialValue, false);
@@ -121,6 +121,7 @@ export default class Condition {
    * @param defaultValue Optional default value. If passed, indicates that
    *   `undefined` should be treated as that value. If not passed, `undefined`
    *   is an error.
+   * @returns `value` or `defaultValue`
    */
   static _ensureBoolean(value, defaultValue) {
     if ((value === undefined) && (defaultValue !== undefined)) {

--- a/server/Document.js
+++ b/server/Document.js
@@ -54,10 +54,12 @@ export default class Document {
   }
 
   /**
-   * Returns a snapshot of the full document contents. Optional `version`
-   * indicates which version to get; defaults to the current version. Result is
-   * an object that maps `data` to the document data and `version` to the
-   * version number.
+   * Returns a snapshot of the full document contents.
+   *
+   * @param version (optional) Indicates which version to get; defaults to the
+   *   current version.
+   * @returns An object that maps `data` to the document data and `version` to
+   *   the version number.
    */
   snapshot(version) {
     version = this._versionNumber(version, true);
@@ -106,11 +108,14 @@ export default class Document {
 
   /**
    * Returns a promise for a snapshot of any version after the given
-   * `baseVersion`, and relative to that version. Result is an object
-   * consisting of a new version number, and a delta which can be applied
-   * to version `baseVersion` to get the new document. If called when
-   * `baseVersion` is the current version, this will not fulfill the result
-   * promise until at least one change has been made.
+   * `baseVersion`, and relative to that version. If called when `baseVersion`
+   * is the current version, this will not resolve the result promise until at
+   * least one change has been made.
+   *
+   * @param baseVersion Version number for the document.
+   * @returns A promise which ultimately resolves to an object that maps
+   *   `version` to the new version and `delta` to a change with respect to
+   *   `baseVersion`.
    */
   deltaAfter(baseVersion) {
     baseVersion = this._versionNumber(baseVersion, false);
@@ -143,9 +148,18 @@ export default class Document {
 
   /**
    * Takes a base version number and delta therefrom, and applies the delta,
-   * including merging of any intermediate versions. Result is an object
-   * consisting of a new version number, and a delta which can be applied to
-   * version `baseVersion` to get the new document.
+   * including merging of any intermediate versions. The return value consists
+   * of a new version number, and a delta to be used to get the new document
+   * state. The delta is with respect to the client's "expected result," that
+   * is to say, what the client would get if the delta were applied with no
+   * intervening changes.
+   *
+   * @param baseVersion Version number which `delta` is with respect to.
+   * @param delta Delta indicating what has changed with respect to
+   *   `baseVersion`.
+   * @returns Object that binds `version` to the new version number and `delta`
+   *   to a delta _with respect to the implied expected result_ which can be
+   *   used to get the new document state.
    */
   applyDelta(baseVersion, delta) {
     baseVersion = this._versionNumber(baseVersion, false);
@@ -170,6 +184,8 @@ export default class Document {
    * `true` to release any waiters.
    *
    * **Note:** If the delta is a no-op, then this method does nothing.
+   *
+   * @param delta The delta to append.
    */
   _appendDelta(delta) {
     if (delta.length === 0) {
@@ -181,12 +197,12 @@ export default class Document {
   }
 
   /**
-   * Checks a version number for sanity. Throws an error when insane. Returns
-   * the version number.
+   * Checks a version number for sanity. Throws an error when insane.
    *
    * @param version the (alleged) version number to check
    * @param wantLatest if `true` indicates that `undefined` should be treated as
    * a request for the latest version. If `false`, `undefined` is an error.
+   * @returns the version number
    */
   _versionNumber(version, wantLatest) {
     if (wantLatest && (version === undefined)) {


### PR DESCRIPTION
In particular, when updating the document content, we use incremental deltas
whenever possible, which makes Quill more willing and able to maintain
cursor / selection state when integrating changes from the server.

Bonus changes:
- Split out `DeltaUtil` into its own file and expanded it a little.
- Removed the `test()` API call, as it no longer served a useful purpose.
- Cleaned up and clarified a bunch of comments.
- Fixed the API client code to consistently report errors via promises
  instead of synchronously, because I am an un-fan of ZA̡͊͠͝LGΌ.
