### PR TITLE
Implement transform / rebase on both client and server.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex-client",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Browser code for Quillex",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",

--- a/local-modules/delta-util/main.js
+++ b/local-modules/delta-util/main.js
@@ -11,6 +11,11 @@ const EMPTY_DELTA = Object.freeze(new Delta());
  * Quill `Delta` helper utilities.
  */
 export default class DeltaUtil {
+  /** Handy instance of an empty delta. */
+  static get EMPTY_DELTA() {
+    return EMPTY_DELTA;
+  }
+
   /**
    * Returns `true` iff the given delta is empty. This accepts the same set of
    * values as `coerce()`, see which. Anything else is considered to be an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Quill demo application",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex-server",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Server code for Quillex",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",


### PR DESCRIPTION
On the server side, this now handles a request to apply a delta to something
other than the latest version, meaning that the client might now get a
non-empty "correction" delta in response to a submitted change.

On the client side, in addition to the easy cases of "correction" (which were
already handled), this now also allows the client to merge corrections
"underneath" ongoing changes. That is, the user can keep typing while a
change is in mid-flight, and the response coming back from the server will no
longer confuse the client.

Bumped version to 0.1.0, because this seems like a pretty legit milestone.