### PR TITLE
Handle some errors.

### DIFF
--- a/client/js/ApiError.js
+++ b/client/js/ApiError.js
@@ -1,0 +1,93 @@
+// Copyright 2016 the Quillex Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Error class for reporting errors coming from `ApiClient`. Differentiates
+ * between connection/transport errors and application logic errors.
+ *
+ * **Note:** This is _not_ a subclass of `Error` because all that would provide
+ * is a stack trace, and in fact the stack trace isn't useful by the time you
+ * have an instance of this class (because you will have gotten it from a
+ * promise via `then()` or similar).
+ */
+export default class ApiError {
+  /** Constant indicating an application logic error. */
+  static get APP() { return 'app'; }
+
+  /** Constant indicating a connection / transport error. */
+  static get CONN() { return 'conn'; }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param layer Which layer is the source of the problem. One of `CONN`
+   *   (connection / transport) or `APP` (application, that is, the code on the
+   *   far side of the connection).
+   * @param code Short error code, meant to be human-readable and
+   *   machine-friendly. Must consist only of lowercase alphanumerics and the
+   *   underscore, and be at least 5 and at most 40 characters total.
+   * @param desc (optional; default 'API Error') Longer-form human-readable
+   *   error description.
+   */
+  constructor(layer, code, desc = 'API Error') {
+    if ((layer !== ApiError.APP) && (layer !== ApiError.CONN)) {
+      throw new Error('Invalid value for `layer`.');
+    }
+
+    if (!/[a-z0-9_]{5,40}/.test(code)) {
+      throw new Error('Invalid value for `code`.');
+    }
+
+    /** The error layer. */
+    this._layer = layer;
+
+    /** The short error code. */
+    this._code = code;
+
+    /** The long-form error description. */
+    this._desc = desc;
+  }
+
+  /**
+   * Convenient wrapper for `new ApiError(ApiError.APP, ...)`.
+   */
+  static appError(...args) {
+    return new ApiError(ApiError.APP, ...args);
+  }
+
+  /**
+   * Convenient wrapper for `new ApiError(ApiError.CONN, ...)`.
+   */
+  static connError(...args) {
+    return new ApiError(ApiError.CONN, ...args);
+  }
+
+  /**
+   * Gets the unified string form of this instance.
+   */
+  toString() {
+    return `[${this._layer} ${this._code}] ${this._desc}`;
+  }
+
+  /**
+   * The error layer. One of `ApiError.APP` or `ApiError.CONN`.
+   */
+  get layer() {
+    return this._layer;
+  }
+
+  /**
+   * The short human-readable and machine-friendly error code.
+   */
+  get code() {
+    return this._code;
+  }
+
+  /**
+   * The long-form human-readable description.
+   */
+  get desc() {
+    return this._desc;
+  }
+};

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Browser code for Quillex",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",

--- a/local-modules/see-all/LogBrowser.js
+++ b/local-modules/see-all/LogBrowser.js
@@ -21,7 +21,27 @@ export default class LogBrowser {
    * @param message Message to log.
    */
   log(level, tag, ...message) {
-    const prefix = `[${tag} ${level}]`;
-    console.log(prefix, ...message);
+    const prefix = `%c[${tag} ${level}]`;
+    const style  = 'color: #bbb; font-weight: bold';
+
+    // The browser's `console` methods _mostly_ do the right thing with regard
+    // to providing distinguishing markings and stack traces when appropriate.
+    // We just disagree about `debug`, so in that case we include the message
+    // and a trace in a "group."
+
+    let logMethod;
+    switch (level) {
+      case 'debug': { logMethod = console.group; break; }
+      case 'error': { logMethod = console.error; break; }
+      case 'warn':  { logMethod = console.warn;  break; }
+      default:      { logMethod = console.log;   break; }
+    }
+
+    logMethod.call(console, prefix, style, ...message);
+
+    if (level === 'debug') {
+      console.trace('stack trace');
+      console.groupEnd();
+    }
   }
 }

--- a/local-modules/see-all/main.js
+++ b/local-modules/see-all/main.js
@@ -19,7 +19,7 @@ const THE_LOGGER = new LOGGER_CLASS();
  */
 const LEVELS = {
   'debug':  true,
-  'err':    true,
+  'error':  true,
   'warn':   true,
   'info':   true,
   'detail': true
@@ -27,7 +27,7 @@ const LEVELS = {
 
 /**
  * Logger which associates a tag (typically a subsystem or module name) and a
- * severity level (`info`, `err`, etc.) with all activity. Stack traces are
+ * severity level (`info`, `error`, etc.) with all activity. Stack traces are
  * included for any message logged at a level that indicates any sort of
  * problem.
  *
@@ -48,7 +48,7 @@ export default class SeeAll {
    * innocuous errory thing that normally happens from time to time, such as,
    * for example, a network connection that dropped unexpectedly.
    */
-  static get ERR() { return 'err'; }
+  static get ERROR() { return 'error'; }
 
   /**
    * Severity level indicating a warning. Trouble, but not dire. Logs at this
@@ -120,16 +120,16 @@ export default class SeeAll {
    * @param ...message Message to log. See `log()` for details.
    */
   debug(...message) {
-    this.log(SeeAll.INFO, ...message);
+    this.log(SeeAll.DEBUG, ...message);
   }
 
   /**
-   * Logs a message at the `ERR` level.
+   * Logs a message at the `ERROR` level.
    *
    * @param ...message Message to log. See `log()` for details.
    */
-  err(...message) {
-    this.log(SeeAll.ERR, ...message);
+  error(...message) {
+    this.log(SeeAll.ERROR, ...message);
   }
 
   /**
@@ -160,7 +160,7 @@ export default class SeeAll {
   }
 
   /**
-   * "What a terrible failure!" Logs a message at the `ERR` level, indicating
+   * "What a terrible failure!" Logs a message at the `ERROR` level, indicating
    * a violation of an explicit or implied assertion. That is, this represents
    * a "shouldn't happen" condition that in fact was detected to have happened.
    * After so logging, this throws an exception, which is meant to cause the
@@ -169,7 +169,7 @@ export default class SeeAll {
    * @param ...message Message to log. See `log()` for details.
    */
   wtf(...message) {
-    err('Shouldn\'t happen:', ...message);
+    this.error('Shouldn\'t happen:', ...message);
     throw new Error('shouldnt_happen');
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Quill demo application",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",

--- a/server/ApiServer.js
+++ b/server/ApiServer.js
@@ -105,8 +105,8 @@ export default class ApiServer {
   /**
    * Handles an `error` event coming from the underlying websocket.
    */
-  _handleError(err) {
-    log.info(`${this._connectionId} error:`, err);
+  _handleError(error) {
+    log.info(`${this._connectionId} error:`, error);
   }
 
   /**
@@ -128,6 +128,14 @@ export default class ApiServer {
    */
   error_unknown_method(args) {
     throw new Error('unknown_method');
+  }
+
+  /**
+   * API method `ping`: No-op method that merely verifies (implicitly) that the
+   * connection is working. Always returns `true`.
+   */
+  method_ping(args) {
+    return true;
   }
 
   /**

--- a/server/ClientBundle.js
+++ b/server/ClientBundle.js
@@ -164,7 +164,7 @@ const watchOptions = {
     * Handles the results of running a compile. This gets called as a callback
     * from Webpack.
     */
-   _handleCompilation(err, stats) {
+   _handleCompilation(error, stats) {
      const warnings = stats.compilation.warnings;
      const errors = stats.compilation.errors;
 
@@ -176,11 +176,11 @@ const watchOptions = {
        }
      }
 
-     if (err || (errors && (errors.length !== 0))) {
-       log.err('Trouble compiling JS bundle.')
+     if (error || (errors && (errors.length !== 0))) {
+       log.error('Trouble compiling JS bundle.')
        for (let i = 0; i < errors.length; i++) {
          const e = errors[i];
-         log.err(e.message);
+         log.error(e.message);
        }
        return;
      }

--- a/server/DevMode.js
+++ b/server/DevMode.js
@@ -110,7 +110,7 @@ export default class DevMode {
     }
 
     if (basePath === null) {
-      log.err(`[dev-mode] Weird path: ${fromPath}`);
+      log.error(`[dev-mode] Weird path: ${fromPath}`);
       return;
     }
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quillex-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Server code for Quillex",
   "license": "Apache-2.0",
   "author": "Dan Bornstein <danfuzz@milk.com>",


### PR DESCRIPTION
The main point here is to get `DocumentPlumbing` to start to behave
somewhat sensibly in the face of a network trouble. That meant getting
`ApiClient` to provide more meaningful errors, such that the plumbing
can determine a bit better what's going on. There is still _way_ more
to do before we can count on the system to truly recover from network
interruptions, to be clear.

Bonus: Better browser logging stuff.