### PR TITLE
Improve server-side logging.

### DIFF
--- a/client/js/DocumentPlumbing.js
+++ b/client/js/DocumentPlumbing.js
@@ -364,13 +364,6 @@ export default class DocumentPlumbing {
    * This is the kickoff event.
    */
   _handle_detached_start(event) {
-    // Just for logging, note the connection ID used by the server.
-    this._api.connectionId().then(
-      (value) => {
-        log.info(`Connection ID: ${value}`);
-      }
-    )
-
     // TODO: This should probably arrange for a timeout.
     this._api.snapshot().then(
       (value) => {

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -9,9 +9,15 @@
  * there to be a DOM node tagged with id `editor`.
  */
 
+import LogBrowser from 'see-all/LogBrowser';
+import SeeAll from 'see-all';
+
 import ApiClient from './ApiClient';
 import DocumentPlumbing from './DocumentPlumbing';
 import QuillMaker from './QuillMaker';
+
+// Init logging.
+SeeAll.init(LogBrowser);
 
 // Make the instance.
 const quill = QuillMaker.make('#editor');

--- a/local-modules/see-all/LogServer.js
+++ b/local-modules/see-all/LogServer.js
@@ -4,6 +4,14 @@
 
 import util from 'util';
 
+import chalk from 'chalk';
+
+/**
+ * Number of columns to reserve for log line prefixes. Prefixes under this
+ * length get padded.
+ */
+const PREFIX_COLS = 24;
+
 /**
  * The code that actually does logging in the context of a server. This gets
  * loaded by `main.js` when running in a browser.
@@ -23,7 +31,17 @@ export default class LogServer {
    * @param message Message to log.
    */
   log(level, tag, ...message) {
-    const prefix = `[${tag} ${level}] `;
+    let prefix = `[${tag} ${level}] `;
+    if (prefix.length < PREFIX_COLS) {
+      prefix += ' '.repeat(PREFIX_COLS - prefix.length);
+    }
+
+    // Color the prefix according to level.
+    switch (level) {
+      case 'error': { prefix = chalk.red.bold(prefix);    break; }
+      case 'warn':  { prefix = chalk.yellow.bold(prefix); break; }
+      default:      { prefix = chalk.dim.bold(prefix);    break; }
+    }
 
     // Make a unified string of the entire message.
     let text = '';

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -1,0 +1,52 @@
+// Copyright 2016 the Quillex Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Adaptor which provides a writable stream on top of a logger at a particular
+ * severity level.
+ *
+ * **Note:** This implements just the basic functionality, _not_ including any
+ * events or flow control.
+ */
+export default class LogStream {
+  /**
+   * Constructs an instance.
+   *
+   * @param logger Underlying logger to use.
+   * @param level Severity level to log at.
+   */
+  constructor(logger, level) {
+    /** Underlying logger to use. */
+    this._logger = logger;
+
+    /** Severity level. */
+    this._level = level;
+  }
+
+  /**
+   * Implementation of standard `stream.Writable` method.
+   */
+  write(chunk, encoding, callback) {
+    if (typeof chunk !== 'string') {
+      // Assume it's a buffer, which it's supposed to be if it's not a string.
+      chunk = chunk.toString(encoding);
+    }
+
+    this._logger.log(this._level, chunk);
+
+    if (callback) {
+      // Use `then()` to make the callback happen in its own tick/turn.
+      Promise.resolve(true).then((value) => { callback(); });
+    }
+  }
+
+  /**
+   * Implementation of standard `stream.Writable` method.
+   */
+  end(chunk, encoding, callback) {
+    // We don't pass the `callback` because this stream never actually gets
+    // ended (which is when the `callback` would be called).
+    this.write(chunk, encoding);
+  }
+}

--- a/server/main.js
+++ b/server/main.js
@@ -17,6 +17,7 @@ import path from 'path';
 import process from 'process';
 
 import SeeAll from 'see-all';
+import LogServer from 'see-all/LogServer';
 
 import ApiServer from './ApiServer';
 import ClientBundle from './ClientBundle';
@@ -25,6 +26,7 @@ import Document from './Document';
 
 /** Logger. */
 const log = new SeeAll('main');
+SeeAll.init(LogServer);
 
 /** What port to listen for connections on. */
 const PORT = 8080;
@@ -44,12 +46,12 @@ const app = express();
 express_ws(app);
 
 // An abbreviated and colorized log to the console.
-app.use(morgan('dev'));
+app.use(morgan('dev', { stream: log.infoStream }));
 
 // A fairly complete log written to a file.
 const logStream =
-  fs.createWriteStream(path.resolve(baseDir, 'access.log'), {flags: 'a'});
-app.use(morgan('common', {stream: logStream}));
+  fs.createWriteStream(path.resolve(baseDir, 'access.log'), { flags: 'a' });
+app.use(morgan('common', { stream: logStream }));
 
 // Map Quill files into `/static/quill`. This is used for CSS files but not for
 // the JS code; the JS code is included in the overall JS bundle file.

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2016": "^6.11.3",
     "babel-preset-es2017": "^6.14.0",
+    "chalk": "^1.1.1",
     "express": "^4.14.0",
     "express-ws": "^2.0.0",
     "fs-extra": "^0.30.0",


### PR DESCRIPTION
* Use the logging facility for the HTTP logs (instead of having them
  write directly to the console).
* Color the log line prefixes according to severity.
* Make `ApiClient` aware of its connection ID.
* Align logged content vertically, that is, space out the prefix from
  the content consistently.