### PR TITLE
Use Chokidar instead of Watchpack.

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2016": "^6.11.3",
     "babel-preset-es2017": "^6.14.0",
     "chalk": "^1.1.1",
+    "chokidar": "^1.6.1",
     "express": "^4.14.0",
     "express-ws": "^2.0.0",
     "fs-extra": "^0.30.0",
@@ -33,7 +34,6 @@
     "source-map-support": "^0.4.2",
     "ts-loader": "^0.9.3",
     "typescript": "^2.0.3",
-    "watchpack": "^1.1.0",
     "webpack": "^1.13.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The main reason is that the former gives you a way to monitor file
removals but the latter does not.

As it turns out, Watchpack uses Chokidar under the covers, so this was
pretty straightforward. I _did_ have to rewrite Watchpack's convenient
"start looking for changes as of time N" where N can be a time in the
past; but that turned out to be reasonably easy.