### PR TITLE
Add debugging endpoints.

### DIFF
--- a/server/ClientBundle.js
+++ b/server/ClientBundle.js
@@ -2,10 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-/*
- * Wrapper around Webpack.
- */
-
 import fs from 'fs';
 import memory_fs from 'memory-fs';
 import path from 'path';
@@ -240,8 +236,7 @@ const watchOptions = {
 
   /**
    * The request handler function, suitable for use with Express. Usable as-is
-   * (without `.bind()`). The act of getting this also guarantees that dev mode
-   * has been set up and started.
+   * (without `.bind()`).
    */
   get requestHandler() {
     this.startWatching();

--- a/server/DebugTools.js
+++ b/server/DebugTools.js
@@ -1,0 +1,82 @@
+// Copyright 2016 the Quillex Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import express from 'express';
+
+/**
+ * Introspection to help with debugging. Includes a request handler for hookup
+ * to Express.
+ */
+ export default class DebugTools {
+   /**
+    * Constructs an instance.
+    *
+    * @param doc The `Document` object managed by this process.
+    */
+   constructor(doc) {
+     /** The `Document` object. */
+     this._doc = doc;
+   }
+
+   /**
+    * Gets a particular change to the document.
+    *
+    * * `/change/NNN` -- Gets the change that produced version NNN of the
+    *   document.
+    */
+   _change(req, res) {
+     const match = req.url.match(/\/([0-9]+)$/);
+     const version = Number.parseInt(match[1]);
+     let result;
+
+     try {
+       const change = this._doc.change(version);
+       result = JSON.stringify(change, null, 2);
+     } catch (e) {
+       result = `Error:\n\n${e.stack}`;
+     }
+
+     res
+       .status(200)
+       .type('text/plain')
+       .send(result)
+       .end();
+   }
+
+  /**
+   * Gets a snapshot of the current document.
+   *
+   * * `/snapshot` -- Gets the latest version.
+   * * `/snapshot/NNN` -- Gets version NNN.
+   */
+  _snapshot(req, res) {
+    const match = req.url.match(/\/([0-9]+)$/);
+    const version = match ? [Number.parseInt(match[1])] : [];
+    let result;
+
+    try {
+      const snapshot = this._doc.snapshot(...version);
+      result = JSON.stringify(snapshot, null, 2);
+    } catch (e) {
+      result = `Error:\n\n${e.stack}`;
+    }
+
+    res
+      .status(200)
+      .type('text/plain')
+      .send(result)
+      .end();
+  }
+
+  /**
+   * The request handler function, suitable for use with Express. Usable as-is
+   * (without `.bind()`).
+   */
+  get requestHandler() {
+    const router = new express.Router();
+    router.get(/^\/change\/[0-9]+$/,      this._change.bind(this));
+    router.get(/^\/snapshot(\/[0-9]*)?$/, this._snapshot.bind(this));
+    return router;
+  }
+}

--- a/server/Document.js
+++ b/server/Document.js
@@ -65,6 +65,21 @@ export default class Document {
   }
 
   /**
+   * Returns a particular change to the document. The document consists of a
+   * sequence of changes, each modifying version N of the document to produce
+   * version N+1.
+   *
+   * @param version The version number of the change. The result is the change
+   *   which produced that version. E.g., `0` is a request for the first change
+   *   (the change from the empty document).
+   * @returns An object representing that change.
+   */
+  change(version) {
+    version = this._versionNumber(version);
+    return this._changes[version];
+  }
+
+  /**
    * Returns a snapshot of the full document contents.
    *
    * @param version (optional) Indicates which version to get; defaults to the

--- a/server/main.js
+++ b/server/main.js
@@ -21,6 +21,7 @@ import LogServer from 'see-all/LogServer';
 
 import ApiServer from './ApiServer';
 import ClientBundle from './ClientBundle';
+import DebugTools from './DebugTools';
 import DevMode from './DevMode';
 import Document from './Document';
 
@@ -34,8 +35,11 @@ const PORT = 8080;
 /** Base dir of the product. */
 const baseDir = path.resolve(__dirname, '..');
 
-// Are we in dev mode? If so, we aim to live-sync the original source.
-if (process.argv[2] === '--dev') {
+/** Dev mode? */
+const DEV_MODE = (process.argv[2] === '--dev');
+
+if (DEV_MODE) {
+  // We're in dev mode. This starts the system that live-syncs the client source.
   new DevMode().start();
 }
 
@@ -115,4 +119,9 @@ function addRoutes() {
 
   // Attach the API server.
   app.ws('/api', (ws, req) => { new ApiServer(ws, theDoc); });
+
+  if (DEV_MODE) {
+    // Add a handler for the debug tools.
+    app.use('/debug', new DebugTools(theDoc).requestHandler);
+  }
 }


### PR DESCRIPTION
The main thing here is adding some endpoints at `/debug/*` to give
some visibility into the document model.

* `/debug/snapshot` — Latest document snapshot.
* `/debug/snapshot/NNN` — Snapshot of version NNN of the document.
* `/debug/change/NNN` — Change NNN to the document.

Bonus changes are mostly just cleanup.