### PR TITLE
Clean up the box building stuff.

### DIFF
--- a/scripts/box-install
+++ b/scripts/box-install
@@ -133,24 +133,27 @@ tar -x -z -f "${boxFile}" -C "${tmpDir}" || exit 1
 mv "${tmpDir}/.npmbox.cache" "${tmpDir}/box" || exit 1
 
 # Make the `npm install` call in the requested directory. What we do here is
-# similar to (but not quite exactly) what `npmunbox` does. In particular, we ask
-# `npm` to install a local package using the contents of the `.npmbox` as its
-# cache (and avoiding calling out to the net for anything). `npmunbox`, on the
-# other hand, doesn't let you "root" your install on a local package in this
-# manner.
+# effectively identical to what `npmunbox --install` does.
 #
-# TODO: Make a PR for the `npmbox` project which adds this behavior as an
-# option.
-
-# The `HTTPS_PROXY` definition prevents network connections from being made
-# when there's trouble. (That is, it causes a proper fast failure.)
-export HTTPS_PROXY=http://blort.blort/blort
+# TODO: Consider using `npmunbox` directly, since it supports this behavior
+# using the `--install` option (which was added sometime after this script was
+# created).
 
 # `--cache` points at the box. `--cache-min` tells it to consider the cache to
 # be non-stale (900... seconds is about 2800 years). The `--fetch-` arguments
-# keep it from trying in vain to hit the network if something goes wrong.
+# keep it from trying in vain to hit the network if something goes wrong. The
+# `*proxy` definitions prevent `npm` from actually attempting a real network
+# connection if it decides that there's something missing from a box. (That is,
+# it causes a proper fast failure.)
+#
+# **Note:** Port 37 is associated with the traditional "time" protocol. (a) It
+# is commonly disabled. (b) If enabled, it will not respond like an HTTP(S)
+# proxy. (c) If enabled, it also won't actually do anything dire if we send
+# garbage data to it.
 npm \
     --cache="${tmpDir}/box" --cache-min=90000000000 \
     --fetch-retries=0 --fetch-retry-factor=0 \
     --fetch-retry-mintimeout=1 --fetch-retry-maxtimeout=2 \
+    --proxy=http://127.0.0.1:37/network-is-disabled \
+    --https-proxy=http://127.0.0.1:37/network-is-disabled \
     install

--- a/scripts/build-boxes
+++ b/scripts/build-boxes
@@ -84,7 +84,7 @@ fi
 
 # The version of `npmbox` to use. (This can also be changed to a URL or git
 # repo, e.g. `userid/npmbox#tag`, for testing or as otherwise needed.)
-NPMBOX_VERSION='^4.1.0'
+NPMBOX_VERSION='^4.2.0'
 
 # Trivial `package.json` contents for the above.
 NPMBOX_PJ="$(
@@ -126,47 +126,6 @@ function set-up-out {
     outDir="$(cd ${outDir}; /bin/pwd -P)"
 }
 
-# Helper for `build-source` which does one of the directories (as named). This
-# does the following:
-#
-# * Merge the original source and overlay (if any).
-# * Remove any file that isn't required for calculating dependencies. As of
-#   this writing, the only file that matters is `package.json`.
-# * Rewrite the package name to have the suffix `-dependencies`. **Note:** It
-#   is necessary to do a package rename because otherwise `npm` can get
-#   confused during the unbox operation by a package that includes "itself" as
-#   a dependency.
-function build-source-for {
-    local dir="$1"
-    local targetDir="${outDir}/work/${dir}"
-
-    mkdir -p "${targetDir}"
-
-    # Copy original source.
-    rsync --archive --delete "${baseDir}/${dir}/" "${targetDir}"
-
-    # Combine in the overlay source (if any).
-    if [[ ${overlayDir} != '' ]]; then
-        rsync --archive "${overlayDir}/${dir}/" "${targetDir}"
-    fi
-
-    cd "${targetDir}"
-    # Remove files we don't care about.
-
-    find . -type f '!' -name 'package.json' -exec rm '{}' ';'
-
-    # Rename the package.
-    jq '.name+="-dependencies"' package.json > package.json.new
-    mv package.json.new package.json
-}
-
-# Builds the source to be used for boxing, for both client and server
-# directories.
-function build-source {
-    build-source-for client
-    build-source-for server
-}
-
 # Gets and installs `npmbox`.
 function get-npmbox {
     local dir="${outDir}/work/npmbox"
@@ -182,13 +141,39 @@ function get-npmbox {
     npm install
 }
 
+# Helper for `make-box` which "builds" the source for one of the directories (as
+# named). This does the following:
+#
+# * Merge the original source and overlay (if any).
+# * Remove any file that isn't required for calculating dependencies. As of
+#   this writing, the only file that matters is `package.json`.
+function build-source-for {
+    local dir="$1"
+    local targetDir="${outDir}/work/${dir}"
+
+    mkdir -p "${targetDir}"
+
+    # Copy original source.
+    rsync --archive --delete "${baseDir}/${dir}/" "${targetDir}"
+
+    # Combine in the overlay source (if any).
+    if [[ ${overlayDir} != '' ]]; then
+        rsync --archive "${overlayDir}/${dir}/" "${targetDir}"
+    fi
+
+    # Remove files we don't care about.
+    cd "${targetDir}"
+    find . -type f '!' -name 'package.json' -exec rm '{}' ';'
+}
+
 # Creates a box for the given directory's dependencies.
 function make-box {
     local dir="$1"
 
-    cd "${outDir}"
+    build-source-for "${dir}"
 
-    ./work/npmbox/node_modules/.bin/npmbox -t out "file:./work/${dir}" \
+    cd "${outDir}"
+    ./work/npmbox/node_modules/.bin/npmbox -t out "./work/${dir}/package.json" \
         || return 1
 
     # Only overwrite the pre-existing file if the boxing was successful.
@@ -207,7 +192,6 @@ function rm-source {
 
 (
     set-up-out \
-        && build-source \
         && get-npmbox \
         && make-box client \
         && make-box server \


### PR DESCRIPTION
This includes pointing us at `npmbox` v4.2.0, which I produced myself
with the blessing (and oversight) of the original author of the
package. There is a bit more we can do to take advantage of that
version, as noted in the comments; but for now I'm happy enough to
leave this as-is.