### PR TITLE
Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ $ ./scripts/clean
 
 * `client` &mdash; Client code and static assets. The main client-side
   application entrypoint is `js/app.js`.
+* `compiler` &mdash; Submodule used to build the server-side code, using Babel
+  in an appropriately-configured manner.
 * `local-modules` &mdash; JavaScript module code (Node modules, essentially)
   which can be used on both the client and server sides.
 * `server` &mdash; Server code. The main entrypoint is `main.js`.

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,14 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "object-inspect": "^1.2.1",
-    "quill": "^1.1.7"
+    "quill": "^1.1.7",
+
+    "delta-util": "local",
+    "json-util": "local",
+    "prom-delay": "local",
+    "see-all": "local",
+    "see-all-browser": "local",
+    "typecheck": "local",
+    "websocket-codes": "local"
   }
 }

--- a/compiler/bayou-compile
+++ b/compiler/bayou-compile
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Copyright 2016 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+require('./main.js');

--- a/compiler/main.js
+++ b/compiler/main.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Copyright 2016 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+//
+// This is a wrapper for the Babel compiler, which calls it in a preconfigured
+// way. This is used instead of calling on the `babel-cli` bin specifically
+// because the CLI tool can't be told to find source files and plugin files in
+// different directories. (That is, it conflates the code for itself with the
+// code to be processed.)
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var babel = require('babel-core');
+
+/**
+ * Compiles a single file.
+ */
+function compileFile(inputFile, outputFile) {
+  let inputStat = null;
+  let outputStat = null;
+
+  try {
+    inputStat = fs.statSync(inputFile);
+    outputStat = fs.statSync(outputFile);
+    if (inputStat.mtime > outputStat.mtime) {
+      console.log('Unchanged', inputFile);
+    }
+  } catch (e) {
+    if (inputStat === null) {
+      console.log('File not found:', inputFile);
+      process.exit(1);
+    }
+    // Trouble statting the output file. It probably doesn't exist, which is
+    // a-okay. Just fall through to the compiler.
+  }
+
+  let output = babel.transformFileSync(inputFile,
+    {
+      filename: inputFile,
+      sourceMaps: 'inline',
+
+      // We have to resolve the presets "manually."
+      presets: ['es2015', 'es2016', 'es2017'].map(function (name) {
+        return require.resolve(`babel-preset-${name}`);
+      })
+    });
+
+  fs.writeFileSync(outputFile, output.code);
+  console.log('Compiled', inputFile);
+}
+
+/**
+ * Compiles a directory.
+ */
+function compileDir(inputDir, outputDir) {
+  let files = fs.readdirSync(inputDir);
+  for (let i = 0; i < files.length; i++) {
+    let f = files[i];
+    let inputFile = path.resolve(inputDir, f);
+    let outputFile = path.resolve(outputDir, f);
+    let stat = fs.statSync(inputFile);
+    if (stat.isDirectory(f)) {
+      if (f !== 'node_modules') {
+        compileDir(inputFile, outputFile);
+      }
+    } else {
+      if (f.match(/\.js$/)) {
+        compileFile(inputFile, outputFile);
+      }
+    }
+  }
+}
+
+let input = process.argv[2];
+let output = process.argv[3];
+
+let stat = fs.statSync(input);
+if (stat.isDirectory()) {
+  compileDir(input, output);
+} else {
+  compileFile(input, output);
+}

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bayou-compiler",
+  "version": "0.2.1",
+  "description": "Compiler (transpiler) code for Bayou",
+  "license": "Apache-2.0",
+  "author": "Dan Bornstein <danfuzz@milk.com>",
+  "contributors": [
+    "SEE AUTHORS.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/danfuzz/bayou.git"
+  },
+
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "babel-core": "^6.21.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es2016": "^6.11.3",
+    "babel-preset-es2017": "^6.14.0"
+  }
+}

--- a/local-modules/delta-util/package.json
+++ b/local-modules/delta-util/package.json
@@ -1,3 +1,9 @@
 {
-  "main": "main.js"
+  "name": "delta-util",
+  "version": "0.0.1",
+  "main": "main.js",
+
+  "dependencies": {
+    "quill-delta": "^3.4.3"
+  }
 }

--- a/local-modules/json-util/package.json
+++ b/local-modules/json-util/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "json-util",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/local-modules/prom-condition/package.json
+++ b/local-modules/prom-condition/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "prom-condition",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/local-modules/prom-delay/package.json
+++ b/local-modules/prom-delay/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "prom-delay",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/local-modules/random-id/package.json
+++ b/local-modules/random-id/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "random-id",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/local-modules/see-all-browser/package.json
+++ b/local-modules/see-all-browser/package.json
@@ -1,3 +1,9 @@
 {
-  "main": "main.js"
+  "name": "see-all-browser",
+  "version": "0.0.1",
+  "main": "main.js",
+
+  "dependencies": {
+    "see-all": "local"
+  }
 }

--- a/local-modules/see-all-recent/package.json
+++ b/local-modules/see-all-recent/package.json
@@ -1,3 +1,12 @@
 {
-  "main": "main.js"
+  "name": "see-all-recent",
+  "version": "0.0.1",
+  "main": "main.js",
+
+  "dependencies": {
+    "ansi-html": "^0.0.7",
+    "chalk": "^1.1.1",
+
+    "see-all": "local"
+  }
 }

--- a/local-modules/see-all-server/package.json
+++ b/local-modules/see-all-server/package.json
@@ -1,3 +1,11 @@
 {
-  "main": "main.js"
+  "name": "see-all-server",
+  "version": "0.0.1",
+  "main": "main.js",
+
+  "dependencies": {
+    "chalk": "^1.1.1",
+
+    "see-all": "local"
+  }
 }

--- a/local-modules/see-all/package.json
+++ b/local-modules/see-all/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "see-all",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/local-modules/typecheck/package.json
+++ b/local-modules/typecheck/package.json
@@ -1,3 +1,11 @@
 {
-  "main": "main.js"
+  "name": "typecheck",
+  "version": "0.0.1",
+  "main": "main.js",
+
+  "dependencies": {
+    "object-inspect": "^1.2.1",
+
+    "delta-util": "local"
+  }
 }

--- a/local-modules/websocket-codes/package.json
+++ b/local-modules/websocket-codes/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "websocket-codes",
+  "version": "0.0.1",
   "main": "main.js"
 }

--- a/scripts/build
+++ b/scripts/build
@@ -150,18 +150,41 @@ function add-directory-mapping {
     ) > "${dirInfoFile}"
 }
 
+# Adds new directory mappings to the build info file for each subdirectory of
+# a source directory. This includes handling of overlays if they exist.
+function add-subdirectory-mapping {
+    local fromDir="$1"
+
+    local names=($(
+        cd "${baseDir}/${fromDir}"
+        find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-
+    ))
+
+    local n
+    for n in "${names[@]}"; do
+        add-directory-mapping "${fromDir}/${n}" "${fromDir}/${n}"
+    done
+}
+
 # Sets up the directory mappings from the source into the `out` directory.
 function set-up-dir-mapping {
+    # This is the sub-module that's holds the compiler (transpiler) used for
+    # processing `server` files.
+    add-directory-mapping 'compiler' 'compiler'
+
     # The `server` files ultimately go through an additional build step (hence
     # the change in directory name), though some of the files are used as-is.
     add-directory-mapping 'server' 'server-src'
-    add-directory-mapping 'local-modules' 'server-src/local-modules'
 
     # The `client` files are used as-is by the server (because it serves the
     # static assets directly and also knows how to (re)build the JavaScript
     # bundle).
     add-directory-mapping 'client' 'client'
-    add-directory-mapping 'local-modules' 'client/local-modules'
+
+    # The `local-modules` get pulled into both `client` and `server` (as
+    # required by dependencies). We make a mapping per subdirectory because it
+    # is the subdirectories (and not the whole) that get pulled in.
+    add-subdirectory-mapping 'local-modules'
 }
 
 # Copies the server and client source directories into `out`, including the
@@ -211,6 +234,30 @@ function copy-sources {
     done
 }
 
+# Fixes the `package.json` files so that local modules are referred to by
+# explicit path.
+function fix-packages {
+    local files=(
+        "${outDir}/client/package.json"
+        "${outDir}/server-src/package.json"
+        $(find "${outDir}/local-modules" -name package.json)
+    )
+
+    local f unfixed
+    for f in "${files[@]}"; do
+        unfixed="$(dirname "${f}")/package-unfixed.json"
+        if [[ -r "${unfixed}" ]]; then
+            continue
+        fi
+
+        # This one hasn't yet been fixed with regard to local dependencies.
+        # Fix it!
+        cp "${f}" "${unfixed}"
+        "${progDir}/fix-dependencies" --out="${f}" "${unfixed}" \
+            || return 1
+    done
+}
+
 # Does an `npm install` in the given directory, or the equivalent by using
 # boxed dependencies. After installation, applies local patches to installed
 # modules.
@@ -249,43 +296,33 @@ function build-server {
     local fromDir="${outDir}/server-src"
     local toDir="${outDir}/server"
 
-    # We get Babel by virtue of its modules being listed as dependencies in the
-    # server `package.json`, so the first thing we need to do is copy over that
-    # file and get `npm` to fluff it out. See above about `rsync` rationale.
-    mkdir -p "${toDir}"
-    rsync --archive "${fromDir}/package.json" "${toDir}"
-    do-install server || return 1
-
-    # Find the `babel` script (provided by the `babel-cli` package). It can
-    # appear at the top level _or_ in a sub-module, the latter which can be the
-    # case when installing from boxed dependencies (even though the npm
-    # documentation implies that it shouldn't happen).
-    local babel="$(find "${toDir}/node_modules" -path '*/.bin/babel')"
-    if [[ ${babel} == '' ]]; then
-        echo 'Could not find babel-cli script.' 1>&2
+    # Find the `babel` script (provided by the `compiler` submodule).
+    local compile="$(find "${outDir}/compiler" -name 'bayou-compile')"
+    if [[ ${compile} == '' ]]; then
+        echo 'Could not find compiler script.' 1>&2
         return 1
     fi
 
-    # Run Babel on all of the local source files, storing them next to the
-    # imported and patched modules. We symlink the output `node_modules` back to
-    # the source directory, because Babel wants to find presets (and related
-    # dependencies) relative to the source.
-    if [[ ! -e "${fromDir}/node_modules" ]]; then
-        ln -s "${toDir}/node_modules" "${fromDir}"
-    fi
-    "${babel}" --no-babelrc --copy-files \
-        --ignore 'node_modules' \
-        --presets 'es2015,es2016,es2017' --source-maps true \
-        --out-dir "${toDir}" "${fromDir}" \
-        || return 1
+    # Do the initial npm(ish) installation.
+    do-install server-src || return 1
 
-    # Symlink all the local modules back into `node_modules`, so that the
-    # Node module resolver will find them.
-    local m modPath
-    for m in $(local-module-names); do
-        modPath="${toDir}/node_modules/${m}"
-        if [[ ! -e "${modPath}" ]]; then
-            ln -s "../local-modules/${m}" "${modPath}"
+    # Copy everything over to the final `server` directory. See above about
+    # why we use `rsync`.
+    rsync --archive --delete "${fromDir}/" "${toDir}"
+
+    # Run Babel on all of the local source files, storing them next to the
+    # imported and patched modules.
+
+    # Process the main `server` directory.
+    "${compile}" "${fromDir}" "${toDir}" || return 1
+
+    # Process each of the local modules that are used by `server`.
+    local name
+    for name in $(local-module-names); do
+        if [[ -d "${fromDir}/node_modules/${name}" ]]; then
+            "${compile}" "${fromDir}/node_modules/${name}" \
+                "${toDir}/node_modules/${name}" \
+                || return 1
         fi
     done
 }
@@ -293,6 +330,11 @@ function build-server {
 # Builds the client code.
 function build-client {
     do-install client || return 1
+}
+
+# Builds the compiler (transpiler) code.
+function build-compiler {
+    do-install compiler || return 1
 }
 
 # "Builds" the `bin` directory.
@@ -336,6 +378,8 @@ fi
 (
     set-up-dir-mapping \
         && copy-sources \
+        && fix-packages \
+        && build-compiler \
         && build-client \
         && build-server \
         && build-bin

--- a/scripts/fix-dependencies
+++ b/scripts/fix-dependencies
@@ -1,0 +1,186 @@
+#!/bin/bash
+#
+# Copyright 2016 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Derives module dependencies for the given `package.json`, by iterating over
+# local dependencies. This outputs a replacement `package.json`.
+
+# Set `progName` to the program name, `progDir` to its directory, and `baseDir`
+# to `progDir`'s directory. Follows symlinks.
+function init-prog {
+    local newp p="$0"
+
+    while newp="$(readlink "$p")"; do
+    [[ ${newp} =~ ^/ ]] && p="${newp}" || p="$(dirname "$p")/${newp}"
+    done
+
+    progName="${p##*/}"
+    progDir="$(cd "$(dirname "$p")"; /bin/pwd -P)"
+    baseDir="$(cd "${progDir}/.."; /bin/pwd -P)"
+}
+init-prog
+
+
+#
+# Argument parsing
+#
+
+# Output file.
+outFile='/dev/stdout'
+
+# Error during argument processing?
+argError=0
+
+# Need help?
+showHelp=0
+
+while (( $# != 0 )); do
+    opt="$1"
+    if [[ ${opt} == '--' ]]; then
+        shift
+        break
+    elif [[    ${opt} == '--help'
+            || ${opt} == '-h' ]]; then
+        showHelp=1
+    elif [[ ${opt} =~ ^--out=(.*) ]]; then
+        outFile="${BASH_REMATCH[1]}"
+    elif [[ ${opt} =~ ^- ]]; then
+        echo "Unknown option: ${opt}" 1>&2
+        argError=1
+        break
+    else
+        break
+    fi
+    shift
+done
+unset opt
+
+if (( $# != 1 )); then
+    argError=1
+else
+    inputFile="$1"
+fi
+
+if (( ${showHelp} || ${argError} )); then
+    echo 'Usage:'
+    echo ''
+    echo "${progName} [--out=<path>] <path/to/package.json>"
+    echo '  Derives local dependencies.'
+    echo '  --out=<file>  Where to store the output.'
+    echo ''
+    echo "${progName} [--help | -h]"
+    echo "  Display this message."
+    exit ${argError}
+fi
+
+
+#
+# Main script
+#
+
+# Find all of the local modules referenced by this package, and all of _their_
+# referenced local modules, etc. This uses a work queue arrangement where we
+# start with the main input as the to-be-processed queue.
+unprocessed=("${inputFile}")
+localDeps=()
+regularDeps=()
+while (( ${#unprocessed[@]} != 0 )); do
+    oneDep="${unprocessed[0]}"
+    unprocessed=("${unprocessed[@]:1}") # Delete first element.
+
+    already=0
+    for f in "${localDeps[@]}"; do
+        if [[ ${f} == ${oneDep} ]]; then
+            already=1
+            break
+        fi
+    done
+
+    if (( ${already} )); then
+        # We already processed this one.
+        continue
+    fi
+
+    localDeps+=("${oneDep}")
+
+    # Fluff it into a full path if just a simple name. This is the case for all
+    # dependencies but the original input file.
+    if [[ !(${oneDep} =~ '/') && ! -r ${oneDep} ]]; then
+        oneDep="${baseDir}/local-modules/${oneDep}/package.json"
+    fi
+
+    if [[ ! -r "${oneDep}" ]]; then
+        echo "Not readable: ${oneDep}" 1>&2
+        exit 1
+    fi
+
+    # Extract local dependencies.
+    unprocessed+=($(
+        jq --raw-output \
+            '(.dependencies // {}) | to_entries | .[] | select(.value == "local") | .key' \
+            "${oneDep}"
+    ))
+
+    # Extract regular dependencies.
+    regularDeps+=($(
+        jq --raw-output \
+            '(.dependencies // {}) | to_entries | .[] | select(.value != "local") | .key + "@" + .value' \
+            "${oneDep}"
+    ))
+done
+
+# Remove the first "local dep" because that's the original input file.
+localDeps=("${localDeps[@]:1}")
+
+# Verify that there aren't two (or more) different versions listed for any
+# single regular dependency. We do this by constructing and evaluating a `jq`
+# program that emits a complaint when there's trouble.
+problem="$(
+    (
+        echo '{}'
+
+        for d in "${regularDeps[@]}"; do
+            [[ ${d} =~ ^(.*)@([^@]*)$ ]]
+            name="${BASH_REMATCH[1]}"
+            spec="${BASH_REMATCH[2]}"
+            nameq='"'"${name}"'"'
+            specq='"'"${spec}"'"'
+
+            echo "| if (.dependencies.${nameq} // ${specq}) == ${specq}"
+            echo "then .dependencies.${nameq} = ${specq}"
+            echo 'else .error = (.error // "") + "Differing versions of " +' "${nameq}" '+ ".\n"'
+            echo "end"
+        done
+
+        echo '| if (.error) then .error else "" end'
+    ) | jq -f /dev/stdin --null-input --raw-output
+)"
+if [[ ${problem} != '' ]]; then
+    echo "${problem}" 1>&2
+    exit 1
+fi
+
+
+# Construct and evaluate a `jq` program to perform all the edits.
+(
+    echo '.'
+
+    for d in "${localDeps[@]}"; do
+        nameq='"'"${d}"'"'
+        specq='"'"../local-modules/${d}"'"'
+
+        echo "| .dependencies.${nameq} = ${specq}"
+    done
+
+    for d in "${regularDeps[@]}"; do
+        [[ ${d} =~ ^(.*)@([^@]*)$ ]]
+        name="${BASH_REMATCH[1]}"
+        spec="${BASH_REMATCH[2]}"
+        nameq='"'"${name}"'"'
+        specq='"'"${spec}"'"'
+
+        echo "| .dependencies.${nameq} = ${specq}"
+    done
+) | jq -f /dev/stdin "${inputFile}" > "${outFile}"

--- a/server/ClientBundle.js
+++ b/server/ClientBundle.js
@@ -62,9 +62,6 @@ const webpackOptions = {
       // Likewise, `parchment`.
       'parchment': path.resolve(clientDir, 'node_modules/parchment/src/parchment.ts'),
     },
-    // We look for `local-modules` (modules whose source lives with this
-    // project) as well as the default `node_modules`.
-    modulesDirectories: ['node_modules', 'local-modules'],
     // All the extensions listed here except `.ts` are in the default list.
     // Webpack doesn't offer a way to simply add to the defaults (alas).
     extensions: ['', '.webpack.js', '.web.js', '.js', '.ts']

--- a/server/package.json
+++ b/server/package.json
@@ -18,8 +18,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "ansi-html": "^0.0.6",
-    "babel-cli": "^6.14.0",
+    "babel-core": "^6.21.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
@@ -31,12 +30,22 @@
     "express-ws": "^2.0.0",
     "fs-extra": "^0.30.0",
     "html-loader": "^0.4.4",
+    "memory-fs": "^0.4.1",
     "morgan": "^1.7.0",
-    "object-inspect": "^1.2.1",
-    "quill-delta": "^3.4.0",
     "source-map-support": "^0.4.2",
     "ts-loader": "^1.3.0",
     "typescript": "^2.1.4",
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2",
+
+    "delta-util": "local",
+    "json-util": "local",
+    "prom-condition": "local",
+    "prom-delay": "local",
+    "random-id": "local",
+    "see-all": "local",
+    "see-all-recent": "local",
+    "see-all-server": "local",
+    "typecheck": "local",
+    "websocket-codes": "local"
   }
 }


### PR DESCRIPTION
The point of this PR is to start treating the `local-modules` more like regular Node modules, including having them list their dependencies, as opposed to lumping all dependencies in the `server` or `client` `package.json`. The reason for doing this is to avoid turning our top-level `package.json` dependencies into an unmaintainable morass (a situation which we'd end up in were we do go much further without this PR). As a side benefit, when running `develop`, the server will now no longer restart itself if all you did was modify a `local-module` that's _only_ used on the client side.

Downsides of this PR, which I hope to mitigate in follow-ups (though with details still TBD):

* There's a new top-level submodule, `compiler`, _just_ for the version of Babel used on the server files. So we now end up with two copies of a bunch of Babel-related modules (one in `compiler` and one in `server`).
* The build process involves multiple invocations of Babel, instead of a single invocation for the whole tree. This is a little slower than before.

