### PR TITLE
`quill-prom` and lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,28 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true
+  },
+  "ecmaFeatures": {
+    "modules": true,
+    "spread": true,
+    "restParams": true
+  },
+  "rules" : {
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "all",
+        "varsIgnorePattern": "[uU]nused",
+        "argsIgnorePattern": "[uU]nused"
+      }
+    ],
+    "no-undef": 2
+  },
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/client/js/QuillMaker.js
+++ b/client/js/QuillMaker.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import QuillProm from './QuillProm';
+import QuillProm from 'quill-prom';
 
 /** Configuration for the toolbar. */
 const TOOLBAR_OPTIONS = [

--- a/client/package.json
+++ b/client/package.json
@@ -17,11 +17,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "quill": "^1.1.7",
-
     "api-client": "local",
-    "delta-util": "local",
     "doc-client": "local",
+    "quill-prom": "local",
     "see-all-browser": "local"
   }
 }

--- a/local-modules/api-client/ApiError.js
+++ b/local-modules/api-client/ApiError.js
@@ -15,7 +15,7 @@ export default class ApiError {
   /** Constant indicating an application logic error. */
   static get APP() { return 'app'; }
 
-  /** Constant indicating a connection / transport error. */
+  /** Constant indicating a connection / transport error. */
   static get CONN() { return 'conn'; }
 
   /**
@@ -90,4 +90,4 @@ export default class ApiError {
   get desc() {
     return this._desc;
   }
-};
+}

--- a/local-modules/api-client/main.js
+++ b/local-modules/api-client/main.js
@@ -155,7 +155,7 @@ export default class ApiClient {
   /**
    * Common code to handle both `error` and `close` events.
    */
-  _handleTermination(event, error) {
+  _handleTermination(event_unused, error) {
     // Reject the promises of any currently-pending calls.
     for (let id in this._callbacks) {
       this._callbacks[id].reject(error);
@@ -203,7 +203,7 @@ export default class ApiClient {
    * any pending calls (calls that were made while the socket was still in the
    * process of opening).
    */
-  _handleOpen(event) {
+  _handleOpen(event_unused) {
     for (let payload of this._pendingCalls) {
       this._ws.send(payload);
     }
@@ -329,4 +329,4 @@ export default class ApiClient {
   applyDelta(baseVerNum, delta) {
     return this._send('applyDelta', {baseVerNum: baseVerNum, delta: delta});
   }
-};
+}

--- a/local-modules/api-server/main.js
+++ b/local-modules/api-server/main.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import util from 'util';
-
 import JsonUtil from 'json-util';
 import RandomId from 'random-id';
 import SeeAll from 'see-all';
@@ -121,21 +119,21 @@ export default class ApiServer {
   /**
    * API error: Bad value for `method` in call payload (not a string).
    */
-  error_bad_method(args) {
+  error_bad_method(args_unused) {
     throw new Error('bad_method');
   }
 
   /**
    * API error: Missing `method` in call payload.
    */
-  error_missing_method(args) {
+  error_missing_method(args_unused) {
     throw new Error('missing_method');
   }
 
   /**
    * API error: Unknown (undefined) method.
    */
-  error_unknown_method(args) {
+  error_unknown_method(args_unused) {
     throw new Error('unknown_method');
   }
 
@@ -143,7 +141,7 @@ export default class ApiServer {
    * API method `ping`: No-op method that merely verifies (implicitly) that the
    * connection is working. Always returns `true`.
    */
-  method_ping(args) {
+  method_ping(args_unused) {
     return true;
   }
 
@@ -152,7 +150,7 @@ export default class ApiServer {
    * assigned to this connection. This is only meant to be used for logging.
    * For example, it is _not_ guaranteed to be unique.
    */
-  method_connectionId(args) {
+  method_connectionId(args_unused) {
     return this._connectionId;
   }
 
@@ -161,7 +159,7 @@ export default class ApiServer {
    * contents. Result is an object that maps `data` to the snapshot data and
    * `verNum` to the version number.
    */
-  method_snapshot(args) {
+  method_snapshot(args_unused) {
     return this._doc.snapshot();
   }
 

--- a/local-modules/doc-client/main.js
+++ b/local-modules/doc-client/main.js
@@ -274,7 +274,6 @@ export default class DocClient {
       // defined, use the error handler method.
 
       const eventName = event.name;
-      const handlerName = `_handle_${this._state}_${eventName}`;
       const method = this[`_handle_${this._state}_${eventName}`]
         || this[`_handle_default_${eventName}`]
         || this._handle_error;
@@ -317,7 +316,7 @@ export default class DocClient {
    * reason.
    */
   _handle_default_apiError(event) {
-    const method = event.method;
+    const method_unused = event.method;
     const reason = event.reason;
 
     if (reason.layer === ApiClient.ApiError.CONN) {
@@ -331,7 +330,7 @@ export default class DocClient {
     // Wait an appropriate amount of time and then try starting again. The
     // start event will be received in the `errorWait` state, and as such will
     // be handled differently than a clean start from scratch.
-    PromDelay.resolve(RESTART_DELAY_MSEC).then((res) => {
+    PromDelay.resolve(RESTART_DELAY_MSEC).then((res_unused) => {
       this.start();
     });
 
@@ -364,7 +363,7 @@ export default class DocClient {
    *
    * This is the kickoff event.
    */
-  _handle_detached_start(event) {
+  _handle_detached_start(event_unused) {
     // TODO: This should probably arrange for a timeout.
     this._api.snapshot().then(
       (value) => {
@@ -414,7 +413,7 @@ export default class DocClient {
    * or due to a delay timeout. This will make requests both to the server and
    * to the local Quill instance.
    */
-  _handle_idle_wantChanges(event) {
+  _handle_idle_wantChanges(event_unused) {
     // We grab the current version of the doc, so we can refer back to it when
     // a response comes. That is, `_doc` might have changed out from
     // under us between when this event is handled and when the promises used
@@ -432,7 +431,7 @@ export default class DocClient {
       // **Note:** As of this writing, Quill will never reject (report an error
       // on) a document change promise.
       this._currentChange.next.then(
-        (value) => {
+        (value_unused) => {
           this._pendingLocalDocumentChange = false;
           this._event(Events.gotLocalDelta(baseDoc));
         }
@@ -464,7 +463,7 @@ export default class DocClient {
    * because the client is in the middle of doing something else. When it's done
    * with whatever it may be, it will send a new `wantChanges` event.
    */
-  _handle_default_wantChanges(event) {
+  _handle_default_wantChanges(event_unused) {
     // Nothing to do. Stay in the same state.
     return {state: 'same'};
   }
@@ -491,7 +490,7 @@ export default class DocClient {
     // a `PromDelay` for two reasons: (1) We want to pace requests at least a
     // bit. (2) We want to avoid any potential memory leaks due to promise
     // causality chaining.
-    PromDelay.resolve(PULL_DELAY_MSEC).then((res) => {
+    PromDelay.resolve(PULL_DELAY_MSEC).then((res_unused) => {
       this._event(Events.wantChanges());
     });
 
@@ -504,7 +503,7 @@ export default class DocClient {
    * such, it is safe to ignore, because after the local change is integrated,
    * the system will fire off a new `deltaAfter()` request.
    */
-  _handle_default_gotDeltaAfter(event) {
+  _handle_default_gotDeltaAfter(event_unused) {
     return {state: 'same'};
   }
 
@@ -535,7 +534,7 @@ export default class DocClient {
     }
 
     // After the appropriate delay, send a `wantApplyDelta` event.
-    PromDelay.resolve(PUSH_DELAY_MSEC).then((res) => {
+    PromDelay.resolve(PUSH_DELAY_MSEC).then((res_unused) => {
       this._event(Events.wantApplyDelta(baseDoc));
     });
 
@@ -548,7 +547,7 @@ export default class DocClient {
    * chain of local changes. As such, it is safe to ignore, because whatever
    * the change was, it will get handled by that pre-existing process.
    */
-  _handle_default_gotLocalDelta(event) {
+  _handle_default_gotLocalDelta(event_unused) {
     return {state: 'same'};
   }
 

--- a/local-modules/json-util/main.js
+++ b/local-modules/json-util/main.js
@@ -10,7 +10,7 @@ export default class JsonUtil {
    * Like `JSON.parse()`, except the result is always deep-frozen.
    */
   static parseFrozen(text) {
-    return JSON.parse(text, (key, value) => {
+    return JSON.parse(text, (key_unused, value) => {
       return (typeof value === 'object')
         ? Object.freeze(value)
         : value

--- a/local-modules/prom-condition/main.js
+++ b/local-modules/prom-condition/main.js
@@ -105,7 +105,7 @@ export default class PromCondition {
     if (!this._became[idx]) {
       // There's not yet a promise. That is, there aren't yet any other waiters.
       // Make it, and hook up the corresponding trigger.
-      this._became[idx] = new Promise((res, rej) => {
+      this._became[idx] = new Promise((res, rej_unused) => {
         this._trigger[idx] = res;
       });
     }

--- a/local-modules/prom-delay/main.js
+++ b/local-modules/prom-delay/main.js
@@ -21,7 +21,7 @@ export default class PromDelay {
    * @return a promise
    */
   static resolve(delayMsec, value = true) {
-    return new Promise((res, rej) => {
+    return new Promise((res, rej_unused) => {
       setTimeout(() => { res(value); }, delayMsec);
     });
   }
@@ -37,7 +37,7 @@ export default class PromDelay {
    * @return a promise
    */
   static reject(delayMsec, reason) {
-    return new Promise((res, rej) => {
+    return new Promise((res_unused, rej) => {
       setTimeout(() => { rej(reason); }, delayMsec);
     });
   }

--- a/local-modules/quill-prom/DeltaEvent.js
+++ b/local-modules/quill-prom/DeltaEvent.js
@@ -1,0 +1,57 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Event wrapper for a Quill Delta, including reference to the document source,
+ * the old contents, and the chain of subsequent events.
+ */
+export default class DeltaEvent {
+  /**
+   * Constructs an instance.
+   *
+   * @param accessKey Key which protects ability to resolve the next event.
+   * @param delta The change, per se.
+   * @param oldContents The document contents just prior to the change.
+   * @param source The `Quill` instance that emitted this event.
+   */
+  constructor(accessKey, delta, oldContents, source) {
+    this.delta = Object.freeze(delta);
+    this.oldContents = Object.freeze(oldContents);
+    this.source = Object.freeze(source);
+
+    // **Note:** `accessKey` is _not_ exposed as a property. Doing so would
+    // cause the security problem that its existence is meant to prevent. That
+    // is, this arrangement means that we know client code won't be able to
+    // mess with the promise chain.
+
+    // The resolver function for the `next` promise. Used in `_gotChange()`
+    // below.
+    let resolveNext;
+
+    // The resolved value for `next`. Used in `_gotChange` and `nextNow` below.
+    let nextNow = null;
+
+    this.next = Object.freeze(
+      new Promise((res, rej_unused) => { resolveNext = res; }));
+
+    // This method is defined inside the constructor so that we can use the
+    // lexical context for (what amount to) private instance variables.
+    this._gotChange = Object.freeze((key, ...args) => {
+      if (key !== accessKey) {
+        // See note toward the top of this function.
+        throw new Error('Invalid access.');
+      }
+
+      nextNow = new DeltaEvent(key, ...args);
+      resolveNext(nextNow);
+      return nextNow;
+    });
+
+    // Likewise, this is how we can provide a read-only yet changeable `nextNow`
+    // on a frozen object.
+    Object.defineProperty(this, 'nextNow', { get: () => { return nextNow; }});
+
+    Object.freeze(this);
+  }
+}

--- a/local-modules/quill-prom/package.json
+++ b/local-modules/quill-prom/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "quill-prom",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "quill": "^1.1.7",
+
+    "delta-util": "local"
+  }
+}

--- a/local-modules/see-all-browser/main.js
+++ b/local-modules/see-all-browser/main.js
@@ -30,7 +30,7 @@ export default class SeeAllBrowser {
    * @param level Severity level.
    * @param message Message to log.
    */
-  log(nowMsec, level, tag, ...message) {
+  log(nowMsec_unused, level, tag, ...message) {
     const prefix = `%c[${tag} ${level}]`;
     const style  = 'color: #bbb; font-weight: bold';
 
@@ -60,9 +60,7 @@ export default class SeeAllBrowser {
    *
    * @param nowMsec The time.
    */
-  time(nowMsec, utcString, localString) {
-    const date = new Date(nowMsec);
-
+  time(nowMsec_unused, utcString, localString) {
     console.log(`%c[time] %c${utcString} %c/ %c${localString}`,
       'color: #bbb; font-weight: bold',
       'color: #66a; font-weight: bold',

--- a/local-modules/see-all-recent/main.js
+++ b/local-modules/see-all-recent/main.js
@@ -15,14 +15,6 @@ import SeeAll from 'see-all';
  */
 export default class SeeAllRecent {
   /**
-   * Registers an instance of this class as a logger with the main `see-all`
-   * module.
-   */
-  static init() {
-    SeeAll.add(new SeeAllServer());
-  }
-
-  /**
    * Constructs an instance. This will cause the instance to be registered with
    * the main `see-all` module.
    *

--- a/local-modules/see-all-server/main.js
+++ b/local-modules/see-all-server/main.js
@@ -39,7 +39,7 @@ export default class SeeAllServer {
    * @param level Severity level.
    * @param message Message to log.
    */
-  log(nowMsec, level, tag, ...message) {
+  log(nowMsec_unused, level, tag, ...message) {
     const prefix = SeeAllServer._makePrefix(tag, level);
 
     // Make a unified string of the entire message.
@@ -91,7 +91,6 @@ export default class SeeAllServer {
       0);
 
     if (maxLineWidth > (consoleWidth - prefix.length)) {
-      const indent = '  ';
       console.log(prefix.text);
       for (let l of lines) {
         let indent = '  ';
@@ -119,7 +118,7 @@ export default class SeeAllServer {
    *
    * @param nowMsec The time.
    */
-  time(nowMsec, utcString, localString) {
+  time(nowMsec_unused, utcString, localString) {
     utcString = chalk.blue.bold(utcString);
     localString  = chalk.blue.dim.bold(localString);
     const prefix = SeeAllServer._makePrefix('time');

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -37,14 +37,14 @@ export default class LogStream {
 
     if (callback) {
       // Use `then()` to make the callback happen in its own tick/turn.
-      Promise.resolve(true).then((value) => { callback(); });
+      Promise.resolve(true).then((value_unused) => { callback(); });
     }
   }
 
   /**
    * Implementation of standard `stream.Writable` method.
    */
-  end(chunk, encoding, callback) {
+  end(chunk, encoding, callback_unused) {
     // We don't pass the `callback` because this stream never actually gets
     // ended (which is when the `callback` would be called).
     this.write(chunk, encoding);

--- a/local-modules/see-all/main.js
+++ b/local-modules/see-all/main.js
@@ -38,12 +38,6 @@ const LEVELS = {
 const theLoggers = [];
 
 /**
- * The most recent timestamp that was logged as such. Used to figure out when to
- * emit `logger.time()` calls.
- */
-let lastTimeLog = 0;
-
-/**
  * The timestamp of the most recently logged line.
  */
 let lastNow = 0;
@@ -273,10 +267,8 @@ export default class SeeAll {
     const now = Date.now();
 
     if (now >= (lastNow + LULL_MSEC)) {
-      // There was a lull between the last log and this one. Note the end of
-      // the last spate of logging as well as the start of this spate.
+      // There was a lull between the last log and this one.
       SeeAll._callTime(now);
-      lastTimeLog = now;
     } else {
       // Figure out where to "punctuate" longer spates of logging, such that the
       // timestamps come out even multiples of the maximum gap.
@@ -284,7 +276,6 @@ export default class SeeAll {
 
       if (now >= nextGapMarker) {
         SeeAll._callTime(nextGapMarker);
-        lastTimeLog = nextGapMarker;
       }
     }
 

--- a/server/DebugTools.js
+++ b/server/DebugTools.js
@@ -30,7 +30,7 @@ const LOG_LENGTH_MSEC = 1000 * 60 * 60; // One hour.
    /**
     * Gets the log.
     */
-   _log(req, res) {
+   _log(req_unused, res) {
       let result;
 
       try {

--- a/server/DevMode.js
+++ b/server/DevMode.js
@@ -296,7 +296,7 @@ export default class DevMode {
     const serverReady =
       this._startWatching(this._serverMappings, this._handleServerChange);
 
-    Promise.all([clientReady, serverReady]).then((values) => {
+    Promise.all([clientReady, serverReady]).then((values_unused) => {
       log.info('Now monitoring for changes.');
     });
   }
@@ -331,7 +331,7 @@ export default class DevMode {
     // the system was just starting up.
 
     let resolveReady;
-    const ready = new Promise((res, rej) => { resolveReady = res; });
+    const ready = new Promise((res, rej_unused) => { resolveReady = res; });
     const minTime = Date.now() - (10 * 1000); // Ten seconds in the past.
 
     watcher.on('ready', () => {


### PR DESCRIPTION
Two main items here:

* Split out `quill-prom` into its own module, and rework its innards just a bit.
* Add a lint config file (thanks to @meantime) and use it to drive a bunch of code fixes (mostly unused variables).