### PR TITLE
API targets

### DIFF
--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -30,9 +30,6 @@ export default class TargetHandler {
     /** The name of the target. */
     this._targetName = targetName;
 
-    /** The action to use when sending messages. */
-    this._action = (targetName === 'meta') ? 'meta' : 'call';
-
     /** Cached method call handlers, as a map from name to handler. */
     this._methods = new Map();
 
@@ -47,10 +44,10 @@ export default class TargetHandler {
    * @returns {function} An appropriately-constructed handler.
    */
   _makeMethodHandler(name) {
-    const apiClient = this._apiClient; // Avoid re-(re-)lookup on every call.
-    const action    = this._action;    // Likewise.
+    const apiClient  = this._apiClient;  // Avoid re-(re-)lookup on every call.
+    const targetName = this._targetName; // Likewise.
     return (...args) => {
-      return apiClient._send(action, name, args);
+      return apiClient._send(targetName, 'call', name, args);
     };
   }
 

--- a/local-modules/api-client/main.js
+++ b/local-modules/api-client/main.js
@@ -129,14 +129,15 @@ export default class ApiClient {
   /**
    * Sends the given call to the server.
    *
-   * @param {string} action Name of action to invoke.
+   * @param {string} target Name of the target object.
+   * @param {string} action Action to invoke.
    * @param {string} name Name of method (or meta-method) to call on the server.
    * @param {object} [args = []] JSON-encodable object of arguments.
    * @returns {Promise} Promise for the result (or error) of the call. In the
    *   case of an error, the rejection reason will always be an instance of
    *   `ApiError` (see which for details).
    */
-  _send(action, name, args = []) {
+  _send(target, action, name, args = []) {
     const wsState = this._ws.readyState;
 
     // Handle the cases where socket shutdown is imminent or has already
@@ -152,7 +153,7 @@ export default class ApiClient {
     }
 
     const id = this._nextId;
-    const payloadObj = {id, action, name, args};
+    const payloadObj = {id, target, action, name, args};
     const payload = JSON.stringify(payloadObj);
 
     let callback;

--- a/local-modules/api-client/main.js
+++ b/local-modules/api-client/main.js
@@ -330,14 +330,14 @@ export default class ApiClient {
    * This class automatically sets the ID when connections get made, so that
    * clients don't generally have to make an API call to get this info.
    */
-  get id() {
+  get connectionId() {
     return this._connectionId;
   }
 
   /**
    * The main object upon which API calls can be made.
    */
-  get target() {
+  get main() {
     return this._targets.get('main');
   }
 

--- a/local-modules/doc-client/main.js
+++ b/local-modules/doc-client/main.js
@@ -286,7 +286,7 @@ export default class DocClient extends StateMachine {
    */
   _handle_detached_start() {
     // TODO: This should probably arrange for a timeout.
-    this._api.target.snapshot().then(
+    this._api.main.snapshot().then(
       (value) => {
         const snapshot = new Snapshot(value.verNum, value.contents);
         this.q_gotSnapshot(snapshot);
@@ -368,7 +368,7 @@ export default class DocClient extends StateMachine {
     if (!this._pendingDeltaAfter) {
       this._pendingDeltaAfter = true;
 
-      this._api.target.deltaAfter(baseDoc.verNum).then(
+      this._api.main.deltaAfter(baseDoc.verNum).then(
         (value) => {
           this._pendingDeltaAfter = false;
           this.q_gotDeltaAfter(baseDoc, value.verNum, value.delta);
@@ -519,7 +519,7 @@ export default class DocClient extends StateMachine {
     const expectedContents = this._doc.contents.compose(delta);
 
     // Send the delta, and handle the response.
-    this._api.target.applyDelta(this._doc.verNum, delta).then(
+    this._api.main.applyDelta(this._doc.verNum, delta).then(
       (value) => {
         this.q_gotApplyDelta(expectedContents, value.verNum, value.delta);
       },


### PR DESCRIPTION
This PR finishes up the work of making the `main` and `meta` objects get treated uniformly in the API, and makes it possible end-to-end to begin to expose more objects.