### PR TITLE
Timestamp fun

### DIFF
--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -34,7 +34,7 @@ export default class DocumentChange {
    * @param {number} verNum The version number of the document produced by this
    *   change. If this instance represents the first change to a document, then
    *   this value will be `0`.
-   * @param {number} timestamp The time of the change, as msec since the Unix
+   * @param {Timestamp} timestamp The time of the change, as msec since the Unix
    *   Epoch.
    * @param {Delta|array|object} delta The document change per se, compared to
    *   the immediately-previous version. Must be a value which can be coerced
@@ -74,7 +74,7 @@ export default class DocumentChange {
    * Constructs an instance from API arguments.
    *
    * @param {number} verNum Same as with the regular constructor.
-   * @param {number} timestamp Same as with the regular constructor.
+   * @param {Timestamp} timestamp Same as with the regular constructor.
    * @param {Delta|array|object} delta Same as with the regular constructor.
    * @param {string|null} authorId Same as with the regular constructor.
    * @returns {DocumentChange} The constructed instance.

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -2,51 +2,137 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TypeError } from 'typecheck';
+import { TInt, TObject } from 'typecheck';
 
 /**
- * Minimum acceptable timestamp value.
+ * Minimum (inclusive) acceptable timestamp `secs` value.
  *
  * ```
  * $ date -u -r 1010000000
  * Wed Jan  2 19:33:20 UTC 2002
  * ```
  */
-const MIN_TIME_MSEC = 1010000000 * 1000;
+const MIN_SECS = 1010000000;
 
 /**
- * Maximum acceptable timestamp value.
+ * Maximum (exclusive) acceptable timestamp `secs` value.
  *
  * ```
  * $ date -u -r 2530000000
  * Fri Mar  4 09:46:40 UTC 2050
  * ```
  */
-const MAX_TIME_MSEC = 2530000000 * 1000;
+const MAX_SECS = 2530000000;
+
+/** Number of microseconds in a second. */
+const USECS_PER_SEC = 1000000;
 
 /**
- * Type representation of timestamps. The values themselves are always
- * just non-negative integers. This is just where the type checker code lives.
+ * Microsecond-granularity timestamp. Timestamps are represented with two
+ * components, a standard Unix-ish count of seconds since the "Unix Epoch" and
+ * a whole number of microseconds.
  *
- * More specifically, a timestamp is an integer count of milliseconds since the
- * Unix Epoch, with a minimum value defined to be around the start of 2002 and a
- * maximum value defined to be around the start of 2050.
+ * In addition, in order to help prevent bugs, the seconds component is
+ * restricted to fall within a range of dates with a minimum around the start
+ * of the year 2002 and a maximum around the start of the year 2050.
  */
 export default class Timestamp {
   /**
-   * Checks a value of type `Timestamp`. These are integer counts of milliseconds
-   * since the Unix Epoch, with a minimum value set to be around the start of
-   * 2008.
+   * Checks that a value is an instance of this class. Throws an error if not.
    *
    * @param {*} value Value to check.
-   * @returns {number} `value`.
+   * @returns {Snapshot} `value`.
    */
   static check(value) {
-    try {
-      return TInt.rangeInc(value, MIN_TIME_MSEC, MAX_TIME_MSEC);
-    } catch (e) {
-      // More appropriate error.
-      return TypeError.badValue(value, 'Timestamp');
-    }
+    return TObject.check(value, Timestamp);
+  }
+
+  /**
+   * Constructs an instance from a millisecond-granularity time value, such as
+   * might have been returned from `Date.now()`.
+   *
+   * @param {Int} msec Milliseconds since the Unix Epoch.
+   * @returns {Timestamp} An appropriately-constructed instance of this class.
+   */
+  static fromMsec(msec) {
+    TInt.check(msec);
+    const secs = Math.floor(msec / 1000);
+    const usecs = (msec - (secs * 1000)) * 1000;
+    return new Timestamp(secs, usecs);
+  }
+
+  /**
+   * Constructs an instance from the return value of `Date.now()`.
+   *
+   * @returns {Timestamp} An appropriately-constructed instance of this class.
+   */
+  static now() {
+    return Timestamp.fromMsec(Date.now());
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} secs Seconds since the Unix Epoch. Must be in the "reasonable"
+   *   range as described in the class header.
+   * @param {Int} usecs Additional microseconds. Must be a whole number less
+   *   than 1000000.
+   */
+  constructor(secs, usecs) {
+    /** Seconds since the Unix epoch. */
+    this._secs = TInt.range(secs, MIN_SECS, MAX_SECS);
+
+    /** Additional microseconds. */
+    this._usecs = TInt.range(usecs, 0, USECS_PER_SEC);
+
+    Object.freeze(this);
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'Timestamp';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._secs, this._usecs];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {Int} secs Same as regular constructor.
+   * @param {Int} usecs Same as regular constructor.
+   * @returns {Timestamp} The constructed instance.
+   */
+  static fromApi(secs, usecs) {
+    return new Timestamp(secs, usecs);
+  }
+
+  /** The number of seconds since the Unix Epoch. */
+  get secs() {
+    return this._secs;
+  }
+
+  /** The additional microseconds. */
+  get usecs() {
+    return this._usecs;
+  }
+
+  /**
+   * Returns a string form for this instance. This is always of the form
+   * `<secs>.<usecs>` where `<usecs>` is always six digits long.
+   *
+   * @returns {string} The string form.
+   */
+  toString() {
+    // A little cheeky, but this left-pads the usecs with zeroes.
+    const usecs = ('' + (this._usecs + USECS_PER_SEC)).slice(1);
+
+    return `${this._secs}.${usecs}`;
   }
 }

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -41,7 +41,7 @@ export default class Timestamp {
    * Checks that a value is an instance of this class. Throws an error if not.
    *
    * @param {*} value Value to check.
-   * @returns {Snapshot} `value`.
+   * @returns {Timestamp} `value`.
    */
   static check(value) {
     return TObject.check(value, Timestamp);

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -14,6 +14,7 @@ import VersionNumber from './VersionNumber';
 ApiCommon.registerClass(DocumentChange);
 ApiCommon.registerClass(FrozenDelta);
 ApiCommon.registerClass(Snapshot);
+ApiCommon.registerClass(Timestamp);
 
 export {
   DocumentChange,

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { DocumentChange, FrozenDelta, Snapshot, VersionNumber }
+import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
 import { DEFAULT_DOCUMENT, Hooks } from 'hooks-server';
 import { TInt } from 'typecheck';
@@ -88,7 +88,7 @@ export default class DocServer {
       // up a first version here and change `verNum` to `0`, which will
       // propagate through the rest of the code and end up making everything all
       // work out.
-      const firstChange = new DocumentChange(0, Date.now(),
+      const firstChange = new DocumentChange(0, Timestamp.now(),
         [{insert: '(Recreated document due to format version skew.)\n'}],
         null);
       this._doc.changeAppend(firstChange);
@@ -305,7 +305,7 @@ export default class DocServer {
     }
 
     const author = null; // TODO: Assign an author.
-    const change = new DocumentChange(this.nextVerNum, Date.now(), delta, author);
+    const change = new DocumentChange(this.nextVerNum, Timestamp.now(), delta, author);
     this._doc.changeAppend(change);
     this._changeCondition.value = true;
   }
@@ -342,7 +342,7 @@ export default class DocServer {
     if (!result.exists()) {
       // Initialize the document with static content (for now).
       const firstChange =
-        new DocumentChange(0, Date.now(), DEFAULT_DOCUMENT, null);
+        new DocumentChange(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
       result.changeAppend(firstChange);
     }
 

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -157,14 +157,14 @@ export default class LocalDoc extends BaseDoc {
       try {
         contents = ApiCommon.valueFromJson(encoded);
         TObject.withExactKeys(contents, ['version', 'changes']);
+        if (contents.version !== this._formatVersion) {
+          this._log.warn('Ignoring data with a mismatched format version. ' +
+              `Got ${contents.version}, expected ${this._formatVersion}`);
+          contents = null;
+        }
       } catch (e) {
-        this._log.warn('Ignoring malformed data (bad JSON or unversioned).');
+        this._log.warn('Ignoring malformed data (bad JSON or unversioned).', e);
         contents = null;
-      }
-
-      if (contents.version !== this._formatVersion) {
-        this._log.warn('Ignoring data with a mismatched format version. ' +
-            `Got ${contents.version}, expected ${this._formatVersion}`);
       }
 
       if (contents === null) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.8.2
+version = 0.9.0


### PR DESCRIPTION
This PR reimagines `Timestamp` as an actual value-bearing class, as opposed to just a validator of integers. A `Timestamp` now consists of a seconds and microseconds component, not entirely unlike a standard Slack[*] TS value (though the "microseconds" in the latter aren't really, ¯\\\_(ツ)\_/¯ ).

So, `DocumentChange`s now come with actual `Timestamp`s in their `timestamp` instance variables, which in fact get coded as such across the API and to/from disk.

[*] This project is currently being run by a Slack employee, in case you hadn't noticed.