### PR TITLE
Batting cleanup

### DIFF
--- a/local-modules/api-common/package.json
+++ b/local-modules/api-common/package.json
@@ -1,5 +1,10 @@
 {
   "name": "api-common",
   "version": "1.0.0",
-  "main": "main.js"
+  "main": "main.js",
+
+  "dependencies": {
+    "typecheck": "local",
+    "util-common": "local"
+  }
 }

--- a/local-modules/api-server/ApiServer.js
+++ b/local-modules/api-server/ApiServer.js
@@ -49,8 +49,8 @@ export default class ApiServer {
      * accessing it. (Whee!)
      */
     this._targets = new Map();
-    this._targets.set('main', new Target('main', target));
-    this._targets.set('meta', new Target('meta', new MetaHandler(this)));
+    this._addTarget(new Target('main', target));
+    this._addTarget(new Target('meta', new MetaHandler(this)));
 
     /** Count of messages received. Used for liveness logging. */
     this._messageCount = 0;
@@ -63,6 +63,15 @@ export default class ApiServer {
     ws.on('error', this._handleError.bind(this));
 
     this._log.info('Open.');
+  }
+
+  /**
+   * Adds a target to the set thereof.
+   *
+   * @param {Target} target Target to add.
+   */
+  _addTarget(target) {
+    this._targets.set(target.name, target);
   }
 
   /**

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
+import { TArray, TObject, TString } from 'typecheck';
 
 import Schema from './Schema';
 
@@ -13,9 +13,13 @@ export default class Target {
   /**
    * Constructs an instance which wraps the given object.
    *
+   * @param {string} name Name of the target. Used for error messages.
    * @param {object} target Object from which to derive the schema.
    */
-  constructor(target) {
+  constructor(name, target) {
+    /** {string} The target name. */
+    this._name = TString.check(name);
+
     /** {object} The target object. */
     this._target = TObject.check(target);
 
@@ -23,6 +27,11 @@ export default class Target {
     this._schema = new Schema(target);
 
     Object.freeze(this);
+  }
+
+  /** {string} The target name. */
+  get name() {
+    return this._name;
   }
 
   /** {object} The underlying target object. */
@@ -33,5 +42,42 @@ export default class Target {
   /** {Schema} The target's schema. */
   get schema() {
     return this._schema;
+  }
+
+  /**
+   * Queues up an instance method call on the target object, for execution in a
+   * later turn. Returns a promise for the result. This will throw an error
+   * promptly (that is, _not_ return a promise) if the arguments passed to this
+   * method are invalid _including_ if `name` doesn't correspond to an instance
+   * method of the target.
+   *
+   * @param {string} name The method name.
+   * @param {Array} args Arguments to the method.
+   * @returns {Promise} A promise for the result.
+   */
+  call(name, args) {
+    TString.nonempty(name);
+    TArray.check(args);
+
+    const schema = this._schema;
+
+    if (schema.getDescriptor(name) !== 'method') {
+      // Not in the schema, or not a method.
+      throw new Error(`No such method: \`${this._name}.${name}\``);
+    }
+
+    // Listed in the schema as a method. So it exists, is public, is in
+    // fact bound to a function, etc.
+
+    const target = this._target;
+    const impl = target[name];
+
+    return new Promise((res, rej) => {
+      try {
+        res(impl.apply(target, args));
+      } catch (e) {
+        rej(e);
+      }
+    });
   }
 }

--- a/local-modules/util-common/DataUtil.js
+++ b/local-modules/util-common/DataUtil.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import ObjectUtil from './ObjectUtil';
+
 /**
  * "Data value" helper utilities. A "data value" is defined as any JavaScript
  * value or object which has no behavior. This includes anything that can be
@@ -50,8 +52,15 @@ export default class DataUtil {
         let newObj = value;
         let any = false; // Becomes `true` the first time a change is made.
 
-        for (const k in value) {
-          const oldValue = value[k];
+        for (const k of Object.getOwnPropertyNames(value)) {
+          const prop = Object.getOwnPropertyDescriptor(value, k);
+          const oldValue = prop.value;
+          if (   (oldValue === undefined)
+              && !ObjectUtil.hasOwnProperty(prop, 'value')) {
+            // **Note:** The `undefined` check just prevents us from having to
+            // call `hasOwnProperty()` in the usual case.
+            throw new Error(`Cannot deep-freeze object with synthetic property: ${value}`);
+          }
           const newValue = DataUtil.deepFreeze(oldValue);
           if (oldValue !== newValue) {
             if (!any) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.9.0
+version = 0.9.1


### PR DESCRIPTION
This PR finishes up stuff I'd started with the last PR.

* Rearranged the code in `api-server` to be more sensical. This included pulling some bits from `ApiServer` into `Target` as well as restructuring the big ole mess that was `ApiServer._handleMessage()`.
* Better error detection of object content edge cases in `ObjectUtil` and `api-common.Encoder`.