### PR TITLE
Messages

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Decoder, Encoder } from 'api-common';
+import { Decoder, Encoder, Message } from 'api-common';
 import { SeeAll } from 'see-all';
 import { WebsocketCodes } from 'util-common';
 
@@ -148,7 +148,7 @@ export default class ApiClient {
     }
 
     const id = this._nextId;
-    const payloadObj = {id, target, action, name, args};
+    const payloadObj = new Message(id, target, action, name, args);
     const payload = Encoder.encodeJson(payloadObj);
     this._log.detail('Sending raw payload:', payload);
 

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -1,0 +1,97 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray, TInt, TString } from 'typecheck';
+
+/**
+ * The main "envelope" of a message being sent from client to server to requrest
+ * action.
+ */
+export default class Message {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} id Message ID, used to match requests and responses. Must be
+   *   a non-negative integer.
+   * @param {string} target Name of the target object to send to.
+   * @param {string} action Kind of action to take. Currently, the only valid
+   *   value is `call`.
+   * @param {string} name Method (or property) name to access.
+   * @param {Array<*>} args Arguments to include with the message.
+   */
+  constructor(id, target, action, name, args) {
+    /** {Int} Message ID. */
+    this._id = TInt.min(id, 0);
+
+    /** {string} Name of the target object. */
+    this._target = TString.nonempty(target);
+
+    /** {string} Action to take / being taken. */
+    this._action = TString.nonempty(action);
+
+    /** {string} Method / property name to access. */
+    this._name = TString.nonempty(name);
+
+    /** {Array<*>} Arguments of the message. */
+    this._args = TArray.check(args);
+
+    // Validate `action`.
+    if (action !== 'call') {
+      throw new Error(`Invalid value for \`action\`: \`${action}\``);
+    }
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'Message';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._id, this._target, this._action, this._name, this._args];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {Int} id Same as with the regular constructor.
+   * @param {string} target Same as with the regular constructor.
+   * @param {string} action Same as with the regular constructor.
+   * @param {string} name Same as with the regular constructor.
+   * @param {Array<*>} args Same as with the regular constructor.
+   * @returns {Message} The constructed instance.
+   */
+  static fromApi(id, target, action, name, args) {
+    return new Message(id, target, action, name, args);
+  }
+
+  /** {Int} Message ID. */
+  get id() {
+    return this._id;
+  }
+
+  /** {string} Name of the target object. */
+  get target() {
+    return this._target;
+  }
+
+  /** {string} Action to take / being taken. */
+  get action() {
+    return this._action;
+  }
+
+  /** {string} Method / property name to access. */
+  get name() {
+    return this._name;
+  }
+
+  /** {Array<*>} Arguments of the message. */
+  get args() {
+    return this._args;
+  }
+}

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -5,6 +5,10 @@
 import AccessKey from './AccessKey';
 import Decoder from './Decoder';
 import Encoder from './Encoder';
+import Message from './Message';
 import Registry from './Registry';
 
-export { AccessKey, Decoder, Encoder, Registry };
+// Register classes with the API.
+Registry.register(Message);
+
+export { AccessKey, Decoder, Encoder, Message, Registry };

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.9.1
+version = 0.10.0


### PR DESCRIPTION
This PR changes the top-level coded form of an API message from being a plain object (simple key-value mapping) into being a proper class instance, of a class named `Message`.

Before:

```
{"id": 0, target: "main", "action": "call", "name": "deltaAfter", "args", [12]}
```

After:

```
["Message", 0, "main", "call", "deltaAfter", ["array", 12]]
```
