### PR TITLE
Handle POSTs.

### DIFF
--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Decoder, Encoder } from 'api-common';
+import { Decoder, Encoder, Message } from 'api-common';
 import { SeeAll } from 'see-all';
 import { RandomId } from 'util-common';
 
@@ -130,7 +130,9 @@ export default class Connection {
       return {error, id};
     }
 
-    return msg;
+    return (msg instanceof Message)
+      ? msg
+      : {id: -1, error: new Error('Did not receive `Message` object.')};
   }
 
   /**

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import contentType from 'content-type';
+
 import Connection from './Connection';
 
 /**
@@ -29,9 +31,47 @@ export default class PostConnection extends Connection {
     /** {Array<Buffer>} The request POST payload, as individual chunks. */
     this._chunks = [];
 
+    const contentTypeError = this._validateContentType();
+    if (contentTypeError) {
+      this._respond400(`Invalid \`Content-Type\`: ${contentTypeError}`);
+      return;
+    }
+
     req.on('data', this._handleData.bind(this));
     req.on('end', this._handleEnd.bind(this));
     req.on('error', this._handleError.bind(this));
+  }
+
+  /**
+   * Validates the `Content-Type` header. Returns `null` if valid or an error
+   * string if invalid.
+   *
+   * @returns {string|null} The error, if any.
+   */
+  _validateContentType() {
+    const headerString = this._req.headers['content-type'];
+    if (!headerString) {
+      return 'Missing header.';
+    }
+
+    try {
+      const parsed = contentType.parse(headerString);
+      const type = parsed.type;
+      const params = parsed.parameters;
+      if (type !== 'application/json') {
+        return 'Must specify media type `application/json`.';
+      } else if (!params.charset) {
+        return 'Missing `charset` specifier.';
+      } else if (params.charset !== 'utf-8') {
+        return 'Must specify `charset` as `utf-8`.';
+      } else if (Object.keys(params).length !== 1) {
+        return 'Superfluous parameters.';
+      }
+    } catch (e) {
+      return 'Invalid syntax.';
+    }
+
+    return null;
   }
 
   /**
@@ -66,11 +106,28 @@ export default class PostConnection extends Connection {
    * @param {object} error The error event.
    */
   _handleError(error) {
+    // Not logged as `.error()` because it's not an application error (at least
+    // not on this side).
+    this._log.info('Error event:', error);
+    this._respond400('Trouble receiving POST payload.');
+  }
+
+  /**
+   * Responds to the request with a 400 ("Bad Request") response, with a JSON
+   * payload that includes the given error message.
+   *
+   * @param {string} error Message to report.
+   */
+  _respond400(error) {
+    const payload = JSON.stringify({id: -1, error});
+
+    // Not logged as `.error()` because it's not an application error (at least
+    // not on this side).
     this._log.info('Error:', error);
 
     this._res
-    .status(400) // "Bad Request" status code.
+    .status(400)
     .type('application/json')
-    .send('{"id": -1, "error": "Trouble receiving POST payload."}\n');
+    .send(payload);
   }
 }

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -26,9 +26,51 @@ export default class PostConnection extends Connection {
     /** {object} The HTTP response. */
     this._res = res;
 
-    res
-      .status(200)
-      .type('application/json')
-      .send('{"id": -1, "error": "TODO"}\n');
+    /** {Array<Buffer>} The request POST payload, as individual chunks. */
+    this._chunks = [];
+
+    req.on('data', this._handleData.bind(this));
+    req.on('end', this._handleEnd.bind(this));
+    req.on('error', this._handleError.bind(this));
+  }
+
+  /**
+   * Handles a `data` event coming from the request input stream.
+   *
+   * @param {Buffer} chunk Incoming data chunk.
+   */
+  _handleData(chunk) {
+    this._log.detail('Chunk:', chunk);
+    this._chunks.push(chunk);
+  }
+
+  /**
+   * Handles an `end` event coming from the request input stream.
+   */
+  _handleEnd() {
+    this._log.info('Close.');
+
+    const msg = Buffer.concat(this._chunks).toString('utf8');
+    this.handleJsonMessage(msg).then(
+      (response) => {
+        this._res
+          .status(200)
+          .type('application/json')
+          .send(response);
+      });
+  }
+
+  /**
+   * Handles an `error` event coming from the underlying connection.
+   *
+   * @param {object} error The error event.
+   */
+  _handleError(error) {
+    this._log.info('Error:', error);
+
+    this._res
+    .status(400) // "Bad Request" status code.
+    .type('application/json')
+    .send('{"id": -1, "error": "Trouble receiving POST payload."}\n');
   }
 }

--- a/local-modules/api-server/package.json
+++ b/local-modules/api-server/package.json
@@ -4,6 +4,8 @@
   "main": "main.js",
 
   "dependencies": {
+      "content-type": "^1.0.2",
+
       "api-common": "local",
       "see-all": "local",
       "util-common": "local"


### PR DESCRIPTION
This PR fills in the blanks left by the previous PR. In particular, as of this PR, the server will now successfully respond to API requests that are sent via HTTP(S) POST. The payload must be a JSON document which encodes a `Message` object (per earlier description), and it _must_ come with a `Content-Type` declared to be media type `application/json` and with charset `utf-8` (both per se). The code will reject the request as invalid if it fails any of the above criteria.