### PR TITLE
Rework `DebugTools`.

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -3,9 +3,14 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import express from 'express';
+import util from 'util';
 
 import { Encoder } from 'api-common';
+import { SeeAll } from 'see-all';
 import { SeeAllRecent } from 'see-all-server';
+
+/** Logger for this module. */
+const log = new SeeAll('app-debug');
 
 /** How long a log to maintain, in msec. */
 const LOG_LENGTH_MSEC = 1000 * 60 * 60; // One hour.
@@ -106,14 +111,64 @@ export default class DebugTools {
   }
 
   /**
+   * Validates a version number as a request parameter.
+   *
+   * @param {object} req_unused Express request.
+   * @param {object} res_unused Express response.
+   * @param {Function} next Next handler to call.
+   * @param {string} value Request parameter value.
+   * @param {string} name_unused Request parameter name.
+   */
+  _check_verNum(req_unused, res_unused, next, value, name_unused) {
+    if (!value.match(/^[0-9]+$/)) {
+      const error = new Error();
+      error.debugMsg = 'Bad value for `verNum`.';
+      throw error;
+    }
+
+    next();
+  }
+
+  /**
    * The request handler function, suitable for use with Express. Usable as-is
    * (without `.bind()`).
    */
   get requestHandler() {
     const router = new express.Router();
-    router.get(/^\/change\/[0-9]+$/,      this._change.bind(this));
-    router.get('/log',                    this._log.bind(this));
-    router.get(/^\/snapshot(\/[0-9]*)?$/, this._snapshot.bind(this));
+
+    router.get('/change/:verNum',   this._change.bind(this));
+    router.get('/log',              this._log.bind(this));
+    router.get('/snapshot',         this._snapshot.bind(this));
+    router.get('/snapshot/:verNum', this._snapshot.bind(this));
+
+    router.param('verNum', this._check_verNum.bind(this));
+
+    // Error handler. Express "knows" this is an error handler _explicitly_
+    // because it is defined to take four arguments. (Yeah, kinda precarious.)
+    router.use((err, req_unused, res, next_unused) => {
+      let text = 'Error while handling debug URL:\n\n';
+
+      if (err.debugMsg) {
+        // We added our own message. Use that instead of just dumping a
+        // stack trace.
+        text += `    ${err.debugMsg}\n`;
+      } else {
+        // If there was no error message, then this isn't just (something like)
+        // a user input error, so report the whole stack trace back.
+        //
+        // **Note:** It is reasonably safe to spew a stack trace back over the
+        // connection because we should only be running code in this file at all
+        // if the product is running in a dev (not production) configuration.
+        log.error(err);
+        text += util.inspect(err);
+      }
+
+      res
+        .status(500)
+        .type('text/plain')
+        .send(text);
+    });
+
     return router;
   }
 }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -26,10 +26,10 @@ export default class DebugTools {
    * @param {DocServer} doc The `DocServer` object managed by this process.
    */
   constructor(doc) {
-    /** The `Document` object. */
+    /** {DocServer} The document object. */
     this._doc = doc;
 
-    /** A rolling log for the `/log` endpoint. */
+    /** {SeeAll} A rolling log for the `/log` endpoint. */
     this._logger = new SeeAllRecent(LOG_LENGTH_MSEC);
   }
 
@@ -40,15 +40,9 @@ export default class DebugTools {
    * @param {object} res HTTP response handler.
    */
   _log(req_unused, res) {
-    let result;
-
-    try {
-      // TODO: Format it nicely.
-      const contents = this._logger.htmlContents;
-      result = `<html><body>${contents}</body></html>`;
-    } catch (e) {
-      result = `Error:\n\n${e.stack}`;
-    }
+    // TODO: Format it nicely.
+    const contents = this._logger.htmlContents;
+    const result = `<html><body>${contents}</body></html>`;
 
     res
       .status(200)

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -34,12 +34,31 @@ export default class DebugTools {
   }
 
   /**
+   * The request handler function, suitable for use with Express. Usable as-is
+   * (without `.bind()`).
+   */
+  get requestHandler() {
+    const router = new express.Router();
+
+    router.param('verNum', this._check_verNum.bind(this));
+
+    router.get('/change/:verNum',   this._handle_change.bind(this));
+    router.get('/log',              this._handle_log.bind(this));
+    router.get('/snapshot',         this._handle_snapshotLatest.bind(this));
+    router.get('/snapshot/:verNum', this._handle_snapshot.bind(this));
+
+    router.use(this._error.bind(this));
+
+    return router;
+  }
+
+  /**
    * Gets the log.
    *
    * @param {object} req_unused HTTP request.
    * @param {object} res HTTP response handler.
    */
-  _log(req_unused, res) {
+  _handle_log(req_unused, res) {
     // TODO: Format it nicely.
     const contents = this._logger.htmlContents;
     const result = `<html><body>${contents}</body></html>`;
@@ -56,7 +75,7 @@ export default class DebugTools {
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
    */
-  _change(req, res) {
+  _handle_change(req, res) {
     const verNum = Number.parseInt(req.params.verNum);
     const change = this._doc.change(verNum);
     const result = Encoder.encodeJson(change, 2);
@@ -73,7 +92,7 @@ export default class DebugTools {
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
    */
-  _snapshot(req, res) {
+  _handle_snapshot(req, res) {
     const verNum = Number.parseInt(req.params.verNum);
     const snapshot = this._doc.snapshot(verNum);
     const result = Encoder.encodeJson(snapshot, true);
@@ -90,7 +109,7 @@ export default class DebugTools {
    * @param {object} req_unused HTTP request.
    * @param {object} res HTTP response handler.
    */
-  _snapshot_latest(req_unused, res) {
+  _handle_snapshotLatest(req_unused, res) {
     const snapshot = this._doc.snapshot();
     const result = Encoder.encodeJson(snapshot, true);
 
@@ -152,24 +171,5 @@ export default class DebugTools {
       .status(500)
       .type('text/plain')
       .send(text);
-  }
-
-  /**
-   * The request handler function, suitable for use with Express. Usable as-is
-   * (without `.bind()`).
-   */
-  get requestHandler() {
-    const router = new express.Router();
-
-    router.param('verNum', this._check_verNum.bind(this));
-
-    router.get('/change/:verNum',   this._change.bind(this));
-    router.get('/log',              this._log.bind(this));
-    router.get('/snapshot',         this._snapshot_latest.bind(this));
-    router.get('/snapshot/:verNum', this._snapshot.bind(this));
-
-    router.use(this._error.bind(this));
-
-    return router;
   }
 }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -105,7 +105,8 @@ export default class DebugTools {
   }
 
   /**
-   * Validates a version number as a request parameter.
+   * Validates a version number as a request parameter. If valid, replaces the
+   * parameter in the request object with the parsed form.
    *
    * @param {object} req HTTP request.
    * @param {object} res_unused HTTP response.

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -68,14 +68,8 @@ export default class DebugTools {
   _change(req, res) {
     const match = req.url.match(/\/([0-9]+)$/);
     const verNum = Number.parseInt(match[1]);
-    let result;
-
-    try {
-      const change = this._doc.change(verNum);
-      result = Encoder.encodeJson(change, 2);
-    } catch (e) {
-      result = `Error:\n\n${e.stack}`;
-    }
+    const change = this._doc.change(verNum);
+    const result = Encoder.encodeJson(change, 2);
 
     res
       .status(200)
@@ -95,14 +89,8 @@ export default class DebugTools {
   _snapshot(req, res) {
     const match = req.url.match(/\/([0-9]+)$/);
     const verNum = match ? [Number.parseInt(match[1])] : [];
-    let result;
-
-    try {
-      const snapshot = this._doc.snapshot(...verNum);
-      result = Encoder.encodeJson(snapshot, true);
-    } catch (e) {
-      result = `Error:\n\n${e.stack}`;
-    }
+    const snapshot = this._doc.snapshot(...verNum);
+    const result = Encoder.encodeJson(snapshot, true);
 
     res
       .status(200)

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -53,6 +53,29 @@ export default class DebugTools {
   }
 
   /**
+   * Validates a version number as a request parameter. If valid, replaces the
+   * parameter in the request object with the parsed form.
+   *
+   * @param {object} req HTTP request.
+   * @param {object} res_unused HTTP response.
+   * @param {Function} next Next handler to call.
+   * @param {string} value Request parameter value.
+   * @param {string} name_unused Request parameter name.
+   */
+  _check_verNum(req, res_unused, next, value, name_unused) {
+    if (!value.match(/^[0-9]+$/)) {
+      const error = new Error();
+      error.debugMsg = 'Bad value for `verNum`.';
+      throw error;
+    }
+
+    // Replace the string parameter with the actual parsed value.
+    req.params.verNum = Number.parseInt(value);
+
+    next();
+  }
+
+  /**
    * Gets the log.
    *
    * @param {object} req_unused HTTP request.
@@ -102,29 +125,6 @@ export default class DebugTools {
     const result = Encoder.encodeJson(snapshot, true);
 
     this._textResponse(res, result);
-  }
-
-  /**
-   * Validates a version number as a request parameter. If valid, replaces the
-   * parameter in the request object with the parsed form.
-   *
-   * @param {object} req HTTP request.
-   * @param {object} res_unused HTTP response.
-   * @param {Function} next Next handler to call.
-   * @param {string} value Request parameter value.
-   * @param {string} name_unused Request parameter name.
-   */
-  _check_verNum(req, res_unused, next, value, name_unused) {
-    if (!value.match(/^[0-9]+$/)) {
-      const error = new Error();
-      error.debugMsg = 'Bad value for `verNum`.';
-      throw error;
-    }
-
-    // Replace the string parameter with the actual parsed value.
-    req.params.verNum = Number.parseInt(value);
-
-    next();
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -60,13 +60,9 @@ export default class DebugTools {
    */
   _handle_log(req_unused, res) {
     // TODO: Format it nicely.
-    const contents = this._logger.htmlContents;
-    const result = `<html><body>${contents}</body></html>`;
+    const result = this._logger.htmlContents;
 
-    res
-      .status(200)
-      .type('text/html')
-      .send(result);
+    this._htmlResponse(res, result);
   }
 
   /**
@@ -80,10 +76,7 @@ export default class DebugTools {
     const change = this._doc.change(verNum);
     const result = Encoder.encodeJson(change, 2);
 
-    res
-      .status(200)
-      .type('text/plain')
-      .send(result);
+    this._textResponse(res, result);
   }
 
   /**
@@ -97,10 +90,7 @@ export default class DebugTools {
     const snapshot = this._doc.snapshot(verNum);
     const result = Encoder.encodeJson(snapshot, true);
 
-    res
-      .status(200)
-      .type('text/plain')
-      .send(result);
+    this._textResponse(res, result);
   }
 
   /**
@@ -113,10 +103,7 @@ export default class DebugTools {
     const snapshot = this._doc.snapshot();
     const result = Encoder.encodeJson(snapshot, true);
 
-    res
-      .status(200)
-      .type('text/plain')
-      .send(result);
+    this._textResponse(res, result);
   }
 
   /**
@@ -171,5 +158,34 @@ export default class DebugTools {
       .status(500)
       .type('text/plain')
       .send(text);
+  }
+
+  /**
+   * Responds with a `text/plain` result.
+   *
+   * @param {object} res HTTP response.
+   * @param {string} text Text to respond with.
+   */
+  _textResponse(res, text) {
+    res
+      .status(200)
+      .type('text/plain')
+      .send(text);
+  }
+
+  /**
+   * Responds with a `text/html` result. The given string is used as the
+   * HTML body.
+   *
+   * @param {object} res HTTP response.
+   * @param {string} body HTML body text.
+   */
+  _htmlResponse(res, body) {
+    const html = `<!doctype html>\n<html><body>\n${body}\n</body></html>\n`;
+
+    res
+      .status(200)
+      .type('text/html')
+      .send(html);
   }
 }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -72,9 +72,8 @@ export default class DebugTools {
    * @param {object} res HTTP response handler.
    */
   _handle_change(req, res) {
-    const verNum = Number.parseInt(req.params.verNum);
-    const change = this._doc.change(verNum);
-    const result = Encoder.encodeJson(change, 2);
+    const change = this._doc.change(req.params.verNum);
+    const result = Encoder.encodeJson(change, true);
 
     this._textResponse(res, result);
   }
@@ -86,8 +85,7 @@ export default class DebugTools {
    * @param {object} res HTTP response handler.
    */
   _handle_snapshot(req, res) {
-    const verNum = Number.parseInt(req.params.verNum);
-    const snapshot = this._doc.snapshot(verNum);
+    const snapshot = this._doc.snapshot(req.params.verNum);
     const result = Encoder.encodeJson(snapshot, true);
 
     this._textResponse(res, result);
@@ -109,18 +107,21 @@ export default class DebugTools {
   /**
    * Validates a version number as a request parameter.
    *
-   * @param {object} req_unused HTTP request.
+   * @param {object} req HTTP request.
    * @param {object} res_unused HTTP response.
    * @param {Function} next Next handler to call.
    * @param {string} value Request parameter value.
    * @param {string} name_unused Request parameter name.
    */
-  _check_verNum(req_unused, res_unused, next, value, name_unused) {
+  _check_verNum(req, res_unused, next, value, name_unused) {
     if (!value.match(/^[0-9]+$/)) {
       const error = new Error();
       error.debugMsg = 'Bad value for `verNum`.';
       throw error;
     }
+
+    // Replace the string parameter with the actual parsed value.
+    req.params.verNum = Number.parseInt(value);
 
     next();
   }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -122,6 +122,9 @@ export default class DebugTools {
   /**
    * Error handler.
    *
+   * **Note:** Express "knows" this is an error handler _explicitly_ because it
+   * is defined to take four arguments. (Yeah, kinda precarious.)
+   *
    * @param {Error} error Error that got thrown during request handling.
    * @param {object} req_unused HTTP request.
    * @param {object} res HTTP response.
@@ -158,18 +161,14 @@ export default class DebugTools {
   get requestHandler() {
     const router = new express.Router();
 
+    router.param('verNum', this._check_verNum.bind(this));
+
     router.get('/change/:verNum',   this._change.bind(this));
     router.get('/log',              this._log.bind(this));
     router.get('/snapshot',         this._snapshot_latest.bind(this));
     router.get('/snapshot/:verNum', this._snapshot.bind(this));
 
-    router.param('verNum', this._check_verNum.bind(this));
-
-    // Error handler. Express "knows" this is an error handler _explicitly_
-    // because it is defined to take four arguments. (Yeah, kinda precarious.)
-    router.use((err, req_unused, res, next_unused) => {
-      this._error(err, req_unused, res, next_unused);
-    });
+    router.use(this._error.bind(this));
 
     return router;
   }

--- a/local-modules/see-all-server/SeeAllServer.js
+++ b/local-modules/see-all-server/SeeAllServer.js
@@ -47,8 +47,13 @@ export default class SeeAllServer {
     // Make a unified string of the entire message.
     let text = '';
     let atLineStart = true;
+    let gotError = false;
     for (let m of message) {
       if (typeof m === 'object') {
+        if (m instanceof Error) {
+          gotError = true; // Used after the `for` loop, below.
+        }
+
         // Convert the object to a string. If it's a single line, just add it
         // to the text inline. If it's multiple lines, make sure it all ends up
         // on its own lines.
@@ -66,11 +71,11 @@ export default class SeeAllServer {
       }
     }
 
-    if ((level !== 'detail') && (level !== 'info')) {
-      // It's at a level that warrants a stack trace. Append it. We drop the
-      // first couple lines, because those are (a) the exception header which is
-      // info-free in this case, and (b) lines corresponding to the logging
-      // code itself.
+    if (!gotError && (level !== 'detail') && (level !== 'info')) {
+      // It's at a level that warrants a stack trace, and none of the arguments
+      // is an `Error`. So, append one. We drop the first couple lines, because
+      // those are (a) the `Error` header, which is info-free in this case; and
+      // (b) lines corresponding to the logging code itself.
       let trace = util.inspect(new Error());
       trace = trace.replace(/^[\s\S]*\n    at SeeAll[^\n]+\n/, '');
       trace = trace.replace(/^    at /mg, '  at '); // Partially outdent.


### PR DESCRIPTION
This PR massively cleans up `DebugTools` in preparation for further expansion.

Bonus: Better spew when you `log.error()` or `log.debug()` and pass an exception as a message argument.