### PR TITLE
WIP on back-end auth and multiple docs

### DIFF
--- a/local-modules/api-common/AccessKey.js
+++ b/local-modules/api-common/AccessKey.js
@@ -46,6 +46,31 @@ export default class AccessKey {
     Object.freeze(this);
   }
 
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'AccessKey';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._id, this._secret];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {string} id Same as with the regular constructor.
+   * @param {string} secret Same as with the regular constructor.
+   * @returns {AccessKey} The constructed instance.
+   */
+  static fromApi(id, secret) {
+    return new AccessKey(id, secret);
+  }
+
   /** {string} Key / resource identifier. */
   get id() {
     return this._id;

--- a/local-modules/api-common/AccessKey.js
+++ b/local-modules/api-common/AccessKey.js
@@ -4,18 +4,30 @@
 
 import sha256 from 'js-sha256';
 
-import { TString } from 'typecheck';
+import { TInt, TString } from 'typecheck';
 import { DataUtil } from 'util-common';
 
 /**
- * A key consisting of two parts, an ID (which is safe to share across the wire)
- * and a shared secret (which is not). Instances of this class are used to
- * effect authentication over API connections. In general a given instance of
- * this class represents access to a particular resource, but that same resource
- * might also be available via different instances of the class too. (That is,
- * it can be a many-to-one relationship.)
+ * A key consisting of two parts, an ID (which is safe to share across the wire
+ * without encryption) and a shared secret (which is not safe for unencrypted
+ * transport and should even be treated gingerly when encrypted). Instances of
+ * this class are used to effect authentication over API connections. In
+ * general, a given instance of this class represents access to a particular
+ * resource, but that same resource might also be available via different
+ * instances of the class too. (That is, it can be a many-to-one relationship.)
  */
 export default class AccessKey {
+  /**
+   * Constructs an instance with random parts.
+   *
+   * @returns {AccessKey} The constructed instance.
+   */
+  static randomInstance() {
+    const id = DataUtil.hexFromBytes(AccessKey._randomByteArray(8));
+    const secret = DataUtil.hexFromBytes(AccessKey._randomByteArray(16));
+    return new AccessKey(id, secret);
+  }
+
   /**
    * Constructs an instance with the indicated parts.
    *
@@ -41,7 +53,7 @@ export default class AccessKey {
 
   /**
    * {string} Shared secret. **Note:** It is important to _never_ reveal this
-   * value across an API boundary or to log it.
+   * value across an unencrypted API boundary or to log it.
    */
   get secret() {
     return this._secret;
@@ -71,15 +83,30 @@ export default class AccessKey {
    *   the challenge string and `response` to the expected response.
    */
   randomChallenge() {
-    const bytes = [];
-    for (let i = 0; i < 8; i++) {
-      bytes.push(Math.floor(Math.random() * 256));
-    }
+    const bytes = AccessKey._randomByteArray(8);
 
     const id        = this._id;
     const challenge = DataUtil.hexFromBytes(bytes);
     const response  = this.challengeResponseFor(challenge);
 
     return {id, challenge, response};
+  }
+
+  /**
+   * Returns an array of random bytes, of a given length.
+   *
+   * @param {Int} length Desired length.
+   * @returns {Array<Int>} Array of `length` random bytes.
+   */
+  static _randomByteArray(length) {
+    TInt.min(length, 0);
+
+    const result = [];
+
+    for (let i = 0; i < length; i++) {
+      result.push(Math.floor(Math.random() * 256));
+    }
+
+    return result;
   }
 }

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -9,6 +9,7 @@ import Message from './Message';
 import Registry from './Registry';
 
 // Register classes with the API.
+Registry.register(AccessKey);
 Registry.register(Message);
 
 export { AccessKey, Decoder, Encoder, Message, Registry };

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -7,7 +7,6 @@ import { SeeAll } from 'see-all';
 import { RandomId } from 'util-common';
 
 import MetaHandler from './MetaHandler';
-import Target from './Target';
 import TargetMap from './TargetMap';
 
 /** Logger. */
@@ -36,7 +35,7 @@ export default class Connection {
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.
-    this._targets.add(new Target('meta', new MetaHandler(this)));
+    this._targets.add('meta', new MetaHandler(this));
 
     /** {RandomId} Short ID string used to identify this connection in logs. */
     this._connectionId = RandomId.make('conn');

--- a/local-modules/api-server/TargetMap.js
+++ b/local-modules/api-server/TargetMap.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
+import { TString, TObject } from 'typecheck';
 
 import Target from './Target';
 
@@ -24,18 +24,6 @@ export default class TargetMap {
   }
 
   /**
-   * Constructs an instance which initially has a single target bound to `main`.
-   *
-   * @param {object} target The target.
-   * @returns {TargetMap} An appropriately-constructed instance.
-   */
-  static singleTarget(target) {
-    const result = new TargetMap();
-    result.add(new Target('main', target));
-    return result;
-  }
-
-  /**
    * Constructs an instance which is initially empty.
    */
   constructor() {
@@ -46,12 +34,13 @@ export default class TargetMap {
   }
 
   /**
-   * Adds a new entry to the map. This will throw an error if there is already
-   * another target with the same name.
+   * Adds an already-constructed `Target` to the map. This will throw an error
+   * if there is already another target with the same name.
    *
    * @param {Target} target Target to add.
    */
-  add(target) {
+  addTarget(target) {
+    TObject.check(target, Target);
     const name = target.name;
 
     if (this._map.get(name) !== undefined) {
@@ -59,6 +48,20 @@ export default class TargetMap {
     }
 
     this._map.set(name, target);
+  }
+
+  /**
+   * Adds a new entry to the map. This will throw an error if there is already
+   * another target with the same name. This is a convenience for calling
+   * `map.addTarget(new Target(name, obj))`.
+   *
+   * @param {string} name Target name.
+   * @param {object} obj Object to ultimately call on.
+   */
+  add(name, obj) {
+    TString.nonempty(name);
+    TObject.check(obj);
+    this.addTarget(new Target(name, obj));
   }
 
   /**
@@ -88,7 +91,7 @@ export default class TargetMap {
     const result = new TargetMap();
 
     for (const t of this._map.values()) {
-      result.add(t);
+      result.addTarget(t);
     }
 
     return result;

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -15,10 +15,11 @@ import { DocServer } from 'doc-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
 
+import Authorizer from './Authorizer';
 import DebugTools from './DebugTools';
 
 /** Logger. */
-const log = new SeeAll('app');
+const log = new SeeAll('app', true);
 
 /** What port to listen for connections on. */
 const PORT = 8080;
@@ -41,12 +42,10 @@ export default class Application {
      */
     this._doc = new DocServer('some-id');
 
-    /**
-     * {TargetMap} All of the objects we provide access to via the API.
-     *
-     * **TODO:** This will eventually grow beyond a single target.
-     */
-    this._targets = TargetMap.singleTarget(this._doc);
+    /** {TargetMap} All of the objects we provide access to via the API. */
+    const targets = this._targets = new TargetMap();
+    targets.add('auth', new Authorizer());
+    targets.add('main', this._doc);
 
     /** The underlying webserver run by this instance. */
     this._app = express();

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -19,7 +19,7 @@ import Authorizer from './Authorizer';
 import DebugTools from './DebugTools';
 
 /** Logger. */
-const log = new SeeAll('app', true);
+const log = new SeeAll('app');
 
 /** What port to listen for connections on. */
 const PORT = 8080;

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -39,7 +39,7 @@ export default class Application {
      * {DocServer} The one document we manage. **TODO:** Needs to be more than
      * one!
      */
-    this._doc = new DocServer();
+    this._doc = new DocServer('some-id');
 
     /**
      * {TargetMap} All of the objects we provide access to via the API.

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -11,6 +11,7 @@ import path from 'path';
 
 import { PostConnection, TargetMap, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
+import { DocServer } from 'doc-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
 
@@ -30,20 +31,22 @@ export default class Application {
   /**
    * Constructs an instance.
    *
-   * @param {DocServer} doc The document managed by the instance.
    * @param {boolean} devMode Whether or not to run in dev mode. If `true`, this
    *   activates `/debug/*` endpoints.
    */
-  constructor(doc, devMode) {
-    /** {DocServer} The document. */
-    this._doc = doc;
+  constructor(devMode) {
+    /**
+     * {DocServer} The one document we manage. **TODO:** Needs to be more than
+     * one!
+     */
+    this._doc = new DocServer();
 
     /**
      * {TargetMap} All of the objects we provide access to via the API.
      *
      * **TODO:** This will eventually grow beyond a single target.
      */
-    this._targets = TargetMap.singleTarget(doc);
+    this._targets = TargetMap.singleTarget(this._doc);
 
     /** The underlying webserver run by this instance. */
     this._app = express();

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -1,0 +1,85 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { AccessKey } from 'api-common';
+import { DocServer } from 'doc-server';
+import { Hooks } from 'hooks-server';
+import { SeeAll } from 'see-all';
+import { TObject, TString } from 'typecheck';
+
+/** Logger. */
+const log = new SeeAll('app-auth');
+
+/**
+ * Handler for authorization. This is what answers `auth` requests that come in
+ * via the API.
+ */
+export default class Authorizer {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    /**
+     * {Map<string, DocServer>} The set of active documents, as a map from ID
+     * to document object.
+     */
+    this._docs = new Map();
+
+    /**
+     * {Map<string, {key, authorID, doc}>} The set of active access keys and
+     * associated info, as a map from key ID to access info.
+     *
+     * **TODO:** Values of the map should have better structure.
+     */
+    this._accessors = new Map();
+  }
+
+  /**
+   * Makes an access key which specifically allows access to one document by
+   * one author. If the document doesn't exist, this will cause it to be
+   * created.
+   *
+   * @param {object} rootCredential Credential (commonly but not necessarily a
+   *   bearer token) which provides "root" access to this server. This method
+   *   will throw an error if this value does not correspond to a credential
+   *   known to the server.
+   * @param {string} authorId ID which corresponds to the author of changes that
+   *   are made using the resulting authorization.
+   * @param {string} docId ID of the document which the resulting authorization
+   *   allows access to.
+   * @returns {AccessKey} Split token (ID + secret) which provides the requested
+   *   access.
+   */
+  makeAccessKey(rootCredential, authorId, docId) {
+    TObject.check(rootCredential);
+    TString.nonempty(authorId);
+    TString.nonempty(docId);
+
+    if (!Hooks.rootValidator.checkCredential(rootCredential)) {
+      throw new Error('Not authorized.');
+    }
+
+    log.info(`Authorized access for \`${authorId}\` to \`${docId}\`.`);
+
+    let doc = this._docs.get(docId);
+    if (doc === undefined) {
+      doc = new DocServer(docId);
+      this._docs.set(docId, doc);
+    }
+
+    let key = null;
+    for (;;) {
+      key = AccessKey.makeRandomKey();
+      if (this._accessors.get(key.id) === undefined) {
+        break;
+      }
+
+      // We managed to get an ID collision. Unlikely, but it can happen. So,
+      // just iterate and try again.
+    }
+
+    this._accessors.set(key.id, {key, doc, authorId});
+    return key;
+  }
+}

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -6,7 +6,7 @@ import { AccessKey } from 'api-common';
 import { DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
 
 /** Logger. */
 const log = new SeeAll('app-auth');
@@ -40,7 +40,7 @@ export default class Authorizer {
    * one author. If the document doesn't exist, this will cause it to be
    * created.
    *
-   * @param {object} rootCredential Credential (commonly but not necessarily a
+   * @param {*} rootCredential Credential (commonly but not necessarily a
    *   bearer token) which provides "root" access to this server. This method
    *   will throw an error if this value does not correspond to a credential
    *   known to the server.
@@ -52,7 +52,6 @@ export default class Authorizer {
    *   access.
    */
   makeAccessKey(rootCredential, authorId, docId) {
-    TObject.check(rootCredential);
     TString.nonempty(authorId);
     TString.nonempty(docId);
 
@@ -70,7 +69,7 @@ export default class Authorizer {
 
     let key = null;
     for (;;) {
-      key = AccessKey.makeRandomKey();
+      key = AccessKey.randomInstance();
       if (this._accessors.get(key.id) === undefined) {
         break;
       }

--- a/local-modules/app-setup/package.json
+++ b/local-modules/app-setup/package.json
@@ -12,6 +12,7 @@
     "api-common": "local",
     "api-server": "local",
     "client-bundle": "local",
+    "doc-server": "local",
     "see-all": "local",
     "see-all-server": "local",
     "server-env": "local"

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -5,7 +5,7 @@
 import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
 import { DEFAULT_DOCUMENT, Hooks } from 'hooks-server';
-import { TInt } from 'typecheck';
+import { TInt, TString } from 'typecheck';
 import { PromCondition } from 'util-common';
 
 
@@ -15,14 +15,20 @@ import { PromCondition } from 'util-common';
 export default class DocServer {
   /**
    * Constructs an instance.
+   *
+   * @param {string} [docId = 'some-doc-id'] The document ID. TODO: It shouldn't
+   *   have a default value.
    */
-  constructor() {
+  constructor(docId = 'some-id') {
+    /** {string} Document ID. */
+    this._docId = TString.nonempty(docId);
+
     /**
      * Storage access for the document. TODO: Right now this just bottoms out
      * as access to a single document. Instead, document IDs need to be plumbed
      * through and used to differentiate between multiple documents.
      */
-    this._doc = DocServer._getDocAccessor('some-id');
+    this._doc = DocServer._getDocAccessor(docId);
 
     /**
      * Mapping from version numbers to corresponding document snapshots.

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -16,10 +16,9 @@ export default class DocServer {
   /**
    * Constructs an instance.
    *
-   * @param {string} [docId = 'some-doc-id'] The document ID. TODO: It shouldn't
-   *   have a default value.
+   * @param {string} [docId] The document ID.
    */
-  constructor(docId = 'some-id') {
+  constructor(docId) {
     /** {string} Document ID. */
     this._docId = TString.nonempty(docId);
 

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -27,4 +27,16 @@ export default class Hooks {
   static get docStore() {
     return LocalDocStore.THE_INSTANCE;
   }
+
+  /**
+   * The object which validates root credentials. These are credentials which
+   * provide "root" access to the server.
+   */
+  static get rootValidator() {
+    // By default, we provide a no-op implementation. TODO: Should probably
+    // provide a non-no-op default.
+    return {
+      checkCredential: ((cred_unused) => { return true; })
+    };
+  }
 }

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -46,13 +46,13 @@ export default class TString {
       TString.check(value, /^([0-9a-f]{2})*$/);
     } catch (e) {
       // More on-point error.
-      return TypeError.badValue(value, 'String', 'not hex bytes');
+      return TypeError.badValue(value, 'String', 'even number of hex digits');
     }
 
     if (value.length < (minBytes * 2)) {
-      return TypeError.badValue(value, 'String', `byteCount < ${minBytes}`);
+      return TypeError.badValue(value, 'String', `byteCount >= ${minBytes}`);
     } else if ((maxBytes !== null) && (value.length > (maxBytes * 2))) {
-      return TypeError.badValue(value, 'String', `byteCount > ${maxBytes}`);
+      return TypeError.badValue(value, 'String', `byteCount <= ${maxBytes}`);
     }
 
     return value;

--- a/local-modules/util-common/DataUtil.js
+++ b/local-modules/util-common/DataUtil.js
@@ -108,6 +108,12 @@ export default class DataUtil {
    */
   static hexFromBytes(bytes) {
     TArray.check(bytes, TInt.check); // TODO: Should validate range too.
-    return bytes.map((v) => v.toString(16)).join('');
+
+    function byteString(byte) {
+      const result = byte.toString(16);
+      return (byte < 16) ? `0${result}` : result;
+    }
+
+    return bytes.map(byteString).join('');
   }
 }

--- a/server/main.js
+++ b/server/main.js
@@ -20,7 +20,6 @@ import minimist from 'minimist';
 import { Application } from 'app-setup';
 import { ClientBundle } from 'client-bundle';
 import { DevMode } from 'dev-mode';
-import { DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { SeeAllServer } from 'see-all-server';
@@ -111,11 +110,8 @@ function run() {
 
   Hooks.run();
 
-  /** The single document managed by this instance. */
-  const theDoc = new DocServer();
-
   /** The main app server. */
-  const theApp = new Application(theDoc, devMode);
+  const theApp = new Application(devMode);
 
   // Start the app!
   theApp.start();

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,6 @@
     "app-setup": "local",
     "client-bundle": "local",
     "dev-mode": "local",
-    "doc-server": "local",
     "hooks-server": "local",
     "see-all": "local",
     "see-all-server": "local",


### PR DESCRIPTION
This PR represents a decent chunk of the work required to get the server to allow back-end authorization and manage multiple documents.

Specifically, there is now an `auth` API target which responds to the message `makeAccessKey(token, authorId, docId)` by providing a new `AccessKey` instance for accessing the given doc as the given author. It does _not_ yet check the token for validity, so you can pass anything there and it will work. In addition, while this does in fact mint a new access key which does get registered in the system, there is nothing you can actually do with that key, yet. So, still a lot of `TODO`s.

In addition, I fixed a bunch of problems I noticed will getting the former to work, including a couple really embarrassing bugs. (So it goes.)

TLDR for making an auth call:

```
$ curl --silent \
    --header 'Content-Type: application/json; charset=utf-8' \
    --data-raw '["Message", 0, "auth", "call", "makeAccessKey", ["array", "fakey-token", "author-id", "doc-id"]]' \
    http://localhost:8080/api \
  | jq .
{
  "id": 0,
  "result": [
    "AccessKey",
    "d81d4e02e88d33f8",
    "4e03730e9e5f1985d8b07c1eab5bc7ea"
  ]
}
```