### PR TITLE
More docs more better

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -131,9 +131,9 @@ export default class Application {
     function shortWsLog(tokens_unused, req, res_unused) {
       // exress-ws appends a pseudo-path `/.websocket` to the end of websocket
       // requests.
-      const url = req.originalUrl.replace(/\/\.websocket$/, '');
+      const simpleUrl = req.originalUrl.replace(/\/\.websocket$/, '');
 
-      return `-   -       WS ${url}`;
+      return `-   -       WS ${simpleUrl}`;
     }
 
     app.use(morgan(shortWsLog, {

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -12,6 +12,7 @@ import path from 'path';
 import { PostConnection, TargetMap, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
 import { DocServer } from 'doc-server';
+import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
 
@@ -20,9 +21,6 @@ import DebugTools from './DebugTools';
 
 /** Logger. */
 const log = new SeeAll('app');
-
-/** What port to listen for connections on. */
-const PORT = 8080;
 
 /**
  * Web server for the application. This serves all HTTP(S) requests, including
@@ -62,8 +60,9 @@ export default class Application {
    * Starts up the server.
    */
   start() {
-    this._app.listen(PORT, () => {
-      log.info(`Now listening on port ${PORT}.`);
+    const port = Hooks.listenPort;
+    this._app.listen(port, () => {
+      log.info(`Now listening on port ${port}.`);
     });
   }
 

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -69,7 +69,7 @@ export default class Authorizer {
 
     let key = null;
     for (;;) {
-      key = AccessKey.randomInstance('https://TODO'); // TODO: Fill this in.
+      key = AccessKey.randomInstance(`${Hooks.baseUrl}/api`);
       if (this._accessors.get(key.id) === undefined) {
         break;
       }

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -69,7 +69,7 @@ export default class Authorizer {
 
     let key = null;
     for (;;) {
-      key = AccessKey.randomInstance();
+      key = AccessKey.randomInstance('https://TODO'); // TODO: Fill this in.
       if (this._accessors.get(key.id) === undefined) {
         break;
       }

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -21,6 +21,14 @@ export default class Hooks {
   }
 
   /**
+   * {string} The base URL for accessing this server. The default value is
+   * is `http://localhost:8080`.
+   */
+  static get baseUrl() {
+    return 'http://localhost:8080';
+  }
+
+  /**
    * The object which provides access to document storage. This is an instance
    * of a subclass of `BaseDocStore`, as defined by the `doc-store` module.
    */

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -37,6 +37,16 @@ export default class Hooks {
   }
 
   /**
+   * {Int} The local port to listen for connections on. The default value is
+   * `8080`. In general, this often but does not necessarily match the value
+   * in `baseUrl`. It won't match in cases where this server runs behind a
+   * reverse proxy, for example.
+   */
+  static get listenPort() {
+    return 8080;
+  }
+
+  /**
    * The object which validates root credentials. These are credentials which
    * provide "root" access to the server.
    */

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import url from 'url';
+
 import TypeError from './TypeError';
 
 /**
@@ -98,6 +100,25 @@ export default class TString {
   static orNull(value) {
     if ((value !== null) && (typeof value !== 'string')) {
       return TypeError.badValue(value, 'String|null');
+    }
+
+    return value;
+  }
+
+  /**
+   * Checks a value which must be a syntactically valid absolute URL.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static urlAbsolute(value) {
+    TString.nonempty(value);
+
+    // `url.parse()` is fairly lenient. TODO: Might want to be less lenient.
+    const parsed = url.parse(value);
+
+    if (!(parsed.protocol && parsed.slashes && parsed.host)) {
+      return TypeError.badValue(value, 'String', 'absolute URL syntax');
     }
 
     return value;


### PR DESCRIPTION
* Added a URL field to `AccessKey`. This affects the encoded form too (see below).
* Pulled out a couple more hooks for better customization.
* A couple other related tweaks.

```
$ curl --silent \
    --header 'Content-Type: application/json; charset=utf-8' \
    --data-raw '["Message", 0, "auth", "call", "makeAccessKey", ["array", "fakey-token", "author-id", "doc-id"]]' \
    http://localhost:8080/api \
  | jq .
{
  "id": 0,
  "result": [
    "AccessKey",
    "http://localhost:8080/api",
    "af58a9b7fdb2b627",
    "1b13cdd9151de308817e707e1628bcbe"
  ]
}
```