### PR TITLE
Secure RNG

### DIFF
--- a/local-modules/api-common/AccessKey.js
+++ b/local-modules/api-common/AccessKey.js
@@ -4,8 +4,8 @@
 
 import sha256 from 'js-sha256';
 
-import { TInt, TString } from 'typecheck';
-import { DataUtil } from 'util-common';
+import { TString } from 'typecheck';
+import { DataUtil, Random } from 'util-common';
 
 /**
  * Information for accessing a network-accessible resource, along with
@@ -33,8 +33,8 @@ export default class AccessKey {
    * @returns {AccessKey} The constructed instance.
    */
   static randomInstance(url) {
-    const id = DataUtil.hexFromBytes(AccessKey._randomByteArray(8));
-    const secret = DataUtil.hexFromBytes(AccessKey._randomByteArray(16));
+    const id = Random.hexByteString(8);
+    const secret = Random.hexByteString(16);
     return new AccessKey(url, id, secret);
   }
 
@@ -132,29 +132,9 @@ export default class AccessKey {
    *   the challenge string and `response` to the expected response.
    */
   randomChallenge() {
-    const bytes = AccessKey._randomByteArray(8);
-
     const id        = this._id;
-    const challenge = DataUtil.hexFromBytes(bytes);
+    const challenge = Random.hexByteString(8);
     const response  = this.challengeResponseFor(challenge);
     return {id, challenge, response};
-  }
-
-  /**
-   * Returns an array of random bytes, of a given length.
-   *
-   * @param {Int} length Desired length.
-   * @returns {Array<Int>} Array of `length` random bytes.
-   */
-  static _randomByteArray(length) {
-    TInt.min(length, 0);
-
-    const result = [];
-
-    for (let i = 0; i < length; i++) {
-      result.push(Math.floor(Math.random() * 256));
-    }
-
-    return result;
   }
 }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -4,7 +4,7 @@
 
 import { Decoder, Encoder, Message } from 'api-common';
 import { SeeAll } from 'see-all';
-import { RandomId } from 'util-common';
+import { Random } from 'util-common';
 
 import MetaHandler from './MetaHandler';
 import TargetMap from './TargetMap';
@@ -37,8 +37,11 @@ export default class Connection {
     // to this instance/connection.
     this._targets.add('meta', new MetaHandler(this));
 
-    /** {RandomId} Short ID string used to identify this connection in logs. */
-    this._connectionId = RandomId.make('conn');
+    /**
+     * {string} Short label string used to identify this connection in logs.
+     * _Probably_ but not _guaranteed_ to be unique.
+     */
+    this._connectionId = Random.shortLabel('conn');
 
     /** {Int} Count of messages received. Used for liveness logging. */
     this._messageCount = 0;

--- a/local-modules/util-common/Random.js
+++ b/local-modules/util-common/Random.js
@@ -4,6 +4,10 @@
 
 import secureRandom from 'secure-random';
 
+import { TInt } from 'typecheck';
+
+import DataUtil from './DataUtil';
+
 /**
  * Character set used for ID strings. This is intended to be the set of 32 most
  * visually and audibly unambiguous alphanumerics.
@@ -22,6 +26,28 @@ export default class Random {
    */
   static byte() {
     return secureRandom(1)[0];
+  }
+
+  /**
+   * Returns an array of random bytes, of a given length.
+   *
+   * @param {Int} length Desired length.
+   * @returns {Array<Int>} Array of `length` random bytes.
+   */
+  static byteArray(length) {
+    return secureRandom(TInt.min(length, 0));
+  }
+
+  /**
+   * Returns a string of random hex digits (lower case), of a given length of
+   * _bytes_. That is, the string length will be twice the given `length`.
+   *
+   * @param {Int} length Desired length of bytes.
+   * @returns {string} String of `length * 2` random hexadecimal characters.
+   */
+  static hexByteString(length) {
+    const bytes = Random.byteArray(length);
+    return DataUtil.hexFromBytes(bytes);
   }
 
   /**

--- a/local-modules/util-common/Random.js
+++ b/local-modules/util-common/Random.js
@@ -14,23 +14,7 @@ const ID_CHARS = 'abcdefghjkmnpqrstvwxyz0123456789';
  * Constructor of random ID strings. These are _not_ meant to be _guaranteed_
  * unique, just _typically_ unique for the specific purpose of logging.
  */
-export default class RandomId {
-  /**
-   * Constructs a random ID string with the indicated tag prefix.
-   *
-   * @param {string} prefix The prefix.
-   * @returns {string} The constructed random ID string.
-   */
-  static make(prefix) {
-    let result = `${prefix}-`;
-
-    for (let i = 0; i < 8; i++) {
-      result += ID_CHARS[Math.floor(RandomId.byte() % ID_CHARS.length)];
-    }
-
-    return result;
-  }
-
+export default class Random {
   /**
    * Gets a random byte value (range `0` to `255` inclusive).
    *
@@ -38,5 +22,22 @@ export default class RandomId {
    */
   static byte() {
     return secureRandom(1)[0];
+  }
+
+  /**
+   * Constructs a short label string with the indicated tag prefix. These are
+   * _typically_ but not _guaranteed_ to be unique.
+   *
+   * @param {string} prefix The prefix.
+   * @returns {string} The constructed random ID string.
+   */
+  static shortLabel(prefix) {
+    let result = `${prefix}-`;
+
+    for (let i = 0; i < 8; i++) {
+      result += ID_CHARS[Math.floor(Random.byte() % ID_CHARS.length)];
+    }
+
+    return result;
   }
 }

--- a/local-modules/util-common/Random.js
+++ b/local-modules/util-common/Random.js
@@ -15,8 +15,12 @@ import DataUtil from './DataUtil';
 const ID_CHARS = 'abcdefghjkmnpqrstvwxyz0123456789';
 
 /**
- * Constructor of random ID strings. These are _not_ meant to be _guaranteed_
- * unique, just _typically_ unique for the specific purpose of logging.
+ * Random number utilities. All values are generated using a cryptographically
+ * secure random number generator.
+ *
+ * **Note:** This class uses the `secure-random` module as its interface to the
+ * platform's RNG. That module works both in client and server environments,
+ * using appropriate underlying facilities in each.
  */
 export default class Random {
   /**
@@ -52,7 +56,8 @@ export default class Random {
 
   /**
    * Constructs a short label string with the indicated tag prefix. These are
-   * _typically_ but not _guaranteed_ to be unique.
+   * _typically_ but not _guaranteed_ to be unique and are intended to aid in
+   * disambiguating logs (and not for anything deeper).
    *
    * @param {string} prefix The prefix.
    * @returns {string} The constructed random ID string.

--- a/local-modules/util-common/RandomId.js
+++ b/local-modules/util-common/RandomId.js
@@ -2,11 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import secureRandom from 'secure-random';
+
 /**
- * Character set used for ID strings. This is the set of visually (and mostly
- * audibly) unambiguous alphanumerics.
+ * Character set used for ID strings. This is intended to be the set of 32 most
+ * visually and audibly unambiguous alphanumerics.
  */
-const ID_CHARS = 'abcdefghjkmnpqrstvwxyz23456789';
+const ID_CHARS = 'abcdefghjkmnpqrstvwxyz0123456789';
 
 /**
  * Constructor of random ID strings. These are _not_ meant to be _guaranteed_
@@ -23,9 +25,18 @@ export default class RandomId {
     let result = `${prefix}-`;
 
     for (let i = 0; i < 8; i++) {
-      result += ID_CHARS[Math.floor(Math.random() * ID_CHARS.length)];
+      result += ID_CHARS[Math.floor(RandomId.byte() % ID_CHARS.length)];
     }
 
     return result;
+  }
+
+  /**
+   * Gets a random byte value (range `0` to `255` inclusive).
+   *
+   * @returns {Int} The byte.
+   */
+  static byte() {
+    return secureRandom(1)[0];
   }
 }

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -9,7 +9,7 @@ import JsonUtil from './JsonUtil';
 import PromCondition from './PromCondition';
 import PromDelay from './PromDelay';
 import PropertyIter from './PropertyIter';
-import RandomId from './RandomId';
+import Random from './Random';
 import WebsocketCodes from './WebsocketCodes';
 
 export {
@@ -19,6 +19,6 @@ export {
   PromCondition,
   PromDelay,
   PropertyIter,
-  RandomId,
+  Random,
   WebsocketCodes
 };

--- a/local-modules/util-common/package.json
+++ b/local-modules/util-common/package.json
@@ -4,6 +4,8 @@
   "main": "main.js",
 
   "dependencies": {
-    "typecheck": "local"
+    "typecheck": "local",
+
+    "secure-random": "^1.1.1"
   }
 }


### PR DESCRIPTION
This PR switches us from using `Math.random()` to instead use the `secure-random` module. That module is environment-aware and uses either the browser's or Node's secure random facility, as available.