### PR TITLE
Logging II: The Yak Shavening

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -2,11 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import chalk from 'chalk';
 import express from 'express';
 import express_ws from 'express-ws';
 import fs from 'fs';
-import morgan from 'morgan';
 import path from 'path';
 
 import { PostConnection, TargetMap, WsConnection } from 'api-server';
@@ -18,6 +16,7 @@ import { Dirs } from 'server-env';
 
 import Authorizer from './Authorizer';
 import DebugTools from './DebugTools';
+import RequestLogger from './RequestLogger';
 
 /** Logger. */
 const log = new SeeAll('app');
@@ -70,101 +69,12 @@ export default class Application {
    * Sets up logging for webserver requests.
    */
   _addRequestLogging() {
-    const app = this._app;
-
     // Stream to write to, when logging to a file.
-    const logStream = fs.createWriteStream(
+    const accessStream = fs.createWriteStream(
       path.resolve(Dirs.VAR_DIR, 'access.log'),
       {flags: 'a'});
 
-    // These log regular (non-websocket) requests at the time of completion,
-    // including a short colorized form to the console and a longer form to a
-    // file.
-
-    // Returns whether (`true`) or not (`false`) the given request is a
-    // websocket request.
-    function isWebsocketRequest(req) {
-      // Case doesn't matter, hence the regex test instead of just `===`.
-      const upgrade = req.get('upgrade');
-      return (upgrade !== undefined) && upgrade.match(/^websocket$/i);
-    }
-
-    // Opposite of `isWebsocketRequest()`, used for log skipping.
-    function notWebsocketRequest(req) {
-      return !isWebsocketRequest(req);
-    }
-
-    // This is a status-aware logger, roughly based on morgan's built-in `dev`
-    // style. If `res` is passed as `null`, this indicates that the logging is
-    // being done at the start of the request, so (e.g.) things like content
-    // length won't be available.
-    function shortColorLog(req, res) {
-      const status      = (res === null) ? 0 : (res.statusCode || 0);
-      const statusStr   = `${status || '-'}  `.slice(0, 3);
-      const colorFn     = Application._colorForStatus(status);
-      const isWebsocket = isWebsocketRequest(req);
-      const method      = `${isWebsocket ? 'WS' : req.method}   `.slice(0,4);
-
-      console.log('===== a');
-      // `express-ws` appends a pseudo-path `/.websocket` to the end of
-      // websocket requests. We chop that off here.
-      const url = isWebsocket
-        ? req.originalUrl.replace(/\/\.websocket$/, '')
-        : req.originalUrl;
-
-      let contentLength = (res === null) ? undefined : res.get('content-length');
-      if (contentLength === undefined) {
-        contentLength = '-';
-      } else if (contentLength > (1024 * 1024)) {
-        contentLength = `${Math.round(contentLength / 1024 / 1024 * 10) / 10}M`;
-      } else if (contentLength > 1024) {
-        contentLength = `${Math.round(contentLength / 1024 * 10) / 10}K`;
-      } else {
-        contentLength = `${contentLength}B`;
-      }
-
-      if (contentLength.length < 7) {
-        contentLength += ' '.repeat(7 - contentLength.length);
-      }
-
-      console.log('===== z');
-      return `${colorFn(statusStr)} ${contentLength} ${method} ${url}`;
-    }
-
-    app.use(morgan(
-      (tokens_unused, req, res) => { return shortColorLog(req, res); },
-      {
-        stream: log.infoStream
-      }
-    ));
-
-    app.use(morgan(
-      'common',
-      {
-        stream: logStream
-      }
-    ));
-
-    // These log websocket requests, at the time of request start (not at the
-    // time of completion because these are long-lived requests).
-
-    app.use(morgan(
-      (tokens_unused, req, res_unused) => { return shortColorLog(req, null); },
-      {
-        stream:    log.infoStream,
-        immediate: true,
-        skip:      notWebsocketRequest
-      }
-    ));
-
-    app.use(morgan(
-      'common',
-      {
-        stream:    logStream,
-        immediate: true,
-        skip:      notWebsocketRequest
-      }
-    ));
+    RequestLogger.addLoggers(this._app, log.infoStream, accessStream);
   }
 
   /**
@@ -202,20 +112,5 @@ export default class Application {
   _addDevModeRoutes() {
     const app = this._app;
     app.use('/debug', new DebugTools(this._doc).requestHandler);
-  }
-
-  /**
-   * Given an HTTP status, returns the corresponding `chalk` coloring function,
-   * or a no-op function if the status doesn't demand colorization.
-   *
-   * @param {number} status The HTTP status code.
-   * @returns {function} The corresponding coloring function.
-   */
-  static _colorForStatus(status) {
-    if      (status >= 500) { return chalk.red;    }
-    else if (status >= 400) { return chalk.yellow; }
-    else if (status >= 300) { return chalk.cyan;   }
-    else if (status >= 200) { return chalk.green;  }
-    else                    { return ((x) => x);   } // No-op by default.
   }
 }

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -81,73 +81,90 @@ export default class Application {
     // including a short colorized form to the console and a longer form to a
     // file.
 
-    // This is a status-aware logger, roughly based on morgan's built-in `dev`
-    // style.
-    function shortColorLog(tokens_unused, req, res) {
-      const status    = res.statusCode || 0;
-      const statusStr = res.statusCode || '-  ';
-      const colorFn   = Application._colorForStatus(status);
+    // Returns whether (`true`) or not (`false`) the given request is a
+    // websocket request.
+    function isWebsocketRequest(req) {
+      // Case doesn't matter, hence the regex test instead of just `===`.
+      const upgrade = req.get('upgrade');
+      return (upgrade !== undefined) && upgrade.match(/^websocket$/i);
+    }
 
-      let contentLength = res.get('content-length');
+    // Opposite of `isWebsocketRequest()`, used for log skipping.
+    function notWebsocketRequest(req) {
+      return !isWebsocketRequest(req);
+    }
+
+    // This is a status-aware logger, roughly based on morgan's built-in `dev`
+    // style. If `res` is passed as `null`, this indicates that the logging is
+    // being done at the start of the request, so (e.g.) things like content
+    // length won't be available.
+    function shortColorLog(req, res) {
+      const status      = (res === null) ? 0 : (res.statusCode || 0);
+      const statusStr   = `${status || '-'}  `.slice(0, 3);
+      const colorFn     = Application._colorForStatus(status);
+      const isWebsocket = isWebsocketRequest(req);
+      const method      = `${isWebsocket ? 'WS' : req.method}   `.slice(0,4);
+
+      console.log('===== a');
+      // `express-ws` appends a pseudo-path `/.websocket` to the end of
+      // websocket requests. We chop that off here.
+      const url = isWebsocket
+        ? req.originalUrl.replace(/\/\.websocket$/, '')
+        : req.originalUrl;
+
+      let contentLength = (res === null) ? undefined : res.get('content-length');
       if (contentLength === undefined) {
         contentLength = '-';
       } else if (contentLength > (1024 * 1024)) {
-        contentLength = Math.round(contentLength / 1024 / 1024 * 10) / 10;
-        contentLength += 'M';
+        contentLength = `${Math.round(contentLength / 1024 / 1024 * 10) / 10}M`;
       } else if (contentLength > 1024) {
-        contentLength = Math.round(contentLength / 1024 * 10) / 10;
-        contentLength += 'K';
+        contentLength = `${Math.round(contentLength / 1024 * 10) / 10}K`;
       } else {
-        // Coerce it to a string.
-        contentLength = `${contentLength}`;
+        contentLength = `${contentLength}B`;
       }
 
       if (contentLength.length < 7) {
         contentLength += ' '.repeat(7 - contentLength.length);
       }
 
-      return `${colorFn(statusStr)} ${contentLength} ${req.method} ${req.originalUrl}`;
+      console.log('===== z');
+      return `${colorFn(statusStr)} ${contentLength} ${method} ${url}`;
     }
 
-    app.use(morgan(shortColorLog, {
-      stream: log.infoStream
-    }));
+    app.use(morgan(
+      (tokens_unused, req, res) => { return shortColorLog(req, res); },
+      {
+        stream: log.infoStream
+      }
+    ));
 
-    app.use(morgan('common', {
-      stream: logStream
-    }));
+    app.use(morgan(
+      'common',
+      {
+        stream: logStream
+      }
+    ));
 
     // These log websocket requests, at the time of request start (not at the
     // time of completion because these are long-lived requests).
 
-    // Log skip function: Returns `true` for anything other than a websocket
-    // request.
-    function isWebsocketRequest(req, res_unused) {
-      // Case doesn't matter, hence the regex test instead of just `===`.
-      const upgrade = req.get('upgrade');
-      return (upgrade === undefined) || !upgrade.match(/^websocket$/i);
-    }
+    app.use(morgan(
+      (tokens_unused, req, res_unused) => { return shortColorLog(req, null); },
+      {
+        stream:    log.infoStream,
+        immediate: true,
+        skip:      notWebsocketRequest
+      }
+    ));
 
-    // Logger which is meant to match the formatting of `shortColorLog` above.
-    function shortWsLog(tokens_unused, req, res_unused) {
-      // exress-ws appends a pseudo-path `/.websocket` to the end of websocket
-      // requests.
-      const simpleUrl = req.originalUrl.replace(/\/\.websocket$/, '');
-
-      return `-   -       WS ${simpleUrl}`;
-    }
-
-    app.use(morgan(shortWsLog, {
-      stream:    log.infoStream,
-      immediate: true,
-      skip:      isWebsocketRequest
-    }));
-
-    app.use(morgan('common', {
-      stream:    logStream,
-      immediate: true,
-      skip:      isWebsocketRequest
-    }));
+    app.use(morgan(
+      'common',
+      {
+        stream:    logStream,
+        immediate: true,
+        skip:      notWebsocketRequest
+      }
+    ));
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -122,8 +122,10 @@ export default class Application {
 
     // Log skip function: Returns `true` for anything other than a websocket
     // request.
-    function skip(req, res_unused) {
-      return (req.get('upgrade') !== 'websocket');
+    function isWebsocketRequest(req, res_unused) {
+      // Case doesn't matter, hence the regex test instead of just `===`.
+      const upgrade = req.get('upgrade');
+      return (upgrade === undefined) || !upgrade.match(/^websocket$/i);
     }
 
     // Logger which is meant to match the formatting of `shortColorLog` above.
@@ -138,13 +140,13 @@ export default class Application {
     app.use(morgan(shortWsLog, {
       stream:    log.infoStream,
       immediate: true,
-      skip
+      skip:      isWebsocketRequest
     }));
 
     app.use(morgan('common', {
       stream:    logStream,
       immediate: true,
-      skip
+      skip:      isWebsocketRequest
     }));
   }
 

--- a/local-modules/app-setup/RequestLogger.js
+++ b/local-modules/app-setup/RequestLogger.js
@@ -1,0 +1,148 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import chalk from 'chalk';
+import morgan from 'morgan';
+
+/**
+ * HTTP request logging functions. This includes logging to an HTTP `access.log`
+ * type file in a reasonably-usual format as well as logging to a developer
+ * console. The latter is a status-aware logger, roughly based on `morgan`'s
+ * built-in `dev` style, intended to produce concise logs for display on a
+ * developer's console.
+ */
+export default class RequestLogger {
+  /**
+   * Add all the loggers for the given application.
+   *
+   * @param {object} app The `express` application.
+   * @param {object} consoleStream The stream to write console logs to.
+   * @param {object} accessStream The stream to write HTTP access logs to.
+   */
+  static addLoggers(app, consoleStream, accessStream) {
+    // These log regular (non-websocket) requests, at the time of completion.
+
+    app.use(morgan(
+      RequestLogger._makeConsoleLogEnd,
+      {
+        stream: consoleStream
+      }
+    ));
+
+    app.use(morgan(
+      'common',
+      {
+        stream: accessStream
+      }
+    ));
+
+    // These log websocket requests, at the time of request start (not at the
+    // time of completion because these are long-lived requests).
+
+    app.use(morgan(
+      RequestLogger._makeConsoleLogStart,
+      {
+        stream:    consoleStream,
+        immediate: true,
+        skip:      RequestLogger._notWebsocketRequest
+      }
+    ));
+
+    app.use(morgan(
+      'common',
+      {
+        stream:    accessStream,
+        immediate: true,
+        skip:      RequestLogger._notWebsocketRequest
+      }
+    ));
+  }
+
+  static _makeConsoleLogStart(tokens_unused, req, res_unused) {
+    return RequestLogger._makeConsoleLog(req, null);
+  }
+
+  static _makeConsoleLogEnd(tokens_unused, req, res) {
+    return RequestLogger._makeConsoleLog(req, res);
+  }
+
+  /**
+   * Helper for the console logger methods, which does most of the work. If
+   * `res` is passed as `null`, this indicates that the logging is being done at
+   * the start of the request, so (e.g.) things like content length won't be
+   * available.
+   *
+   * @param {object} req Request object.
+   * @param {object|null} res Response object.
+   * @returns {string} String to log.
+   */
+  static _makeConsoleLog(req, res) {
+    const status      = (res === null) ? 0 : (res.statusCode || 0);
+    const statusStr   = `${status || '-'}  `.slice(0, 3);
+    const colorFn     = RequestLogger._colorForStatus(status);
+    const isWebsocket = RequestLogger._isWebsocketRequest(req);
+    const method      = `${isWebsocket ? 'WS' : req.method}   `.slice(0,4);
+
+    // `express-ws` appends a pseudo-path `/.websocket` to the end of
+    // websocket requests. We chop that off here.
+    const url = isWebsocket
+      ? req.originalUrl.replace(/\/\.websocket$/, '')
+      : req.originalUrl;
+
+    let contentLength = (res === null) ? undefined : res.get('content-length');
+    if (contentLength === undefined) {
+      contentLength = '-';
+    } else if (contentLength > (1024 * 1024)) {
+      contentLength = `${Math.round(contentLength / 1024 / 1024 * 10) / 10}M`;
+    } else if (contentLength > 1024) {
+      contentLength = `${Math.round(contentLength / 1024 * 10) / 10}K`;
+    } else {
+      contentLength = `${contentLength}B`;
+    }
+
+    if (contentLength.length < 7) {
+      contentLength += ' '.repeat(7 - contentLength.length);
+    }
+
+    return `${colorFn(statusStr)} ${contentLength} ${method} ${url}`;
+  }
+
+  /**
+   * Given an HTTP status, returns the corresponding `chalk` coloring function,
+   * or a no-op function if the status doesn't demand colorization.
+   *
+   * @param {number} status The HTTP status code.
+   * @returns {function} The corresponding coloring function.
+   */
+  static _colorForStatus(status) {
+    if      (status >= 500) { return chalk.red;    }
+    else if (status >= 400) { return chalk.yellow; }
+    else if (status >= 300) { return chalk.cyan;   }
+    else if (status >= 200) { return chalk.green;  }
+    else                    { return ((x) => x);   } // No-op by default.
+  }
+
+  /**
+   * Returns whether or not the given request is a websocket request.
+   *
+   * @param {object} req Request object.
+   * @returns {boolean} `true` iff the given request is a websocket request.
+   */
+  static _isWebsocketRequest(req) {
+    // Case doesn't matter, hence the regex test instead of just `===`.
+    const upgrade = req.get('upgrade');
+    return (upgrade !== undefined) && upgrade.match(/^websocket$/i);
+  }
+
+  /**
+   * Opposite of `_isWebsocketRequest()`, used for log skipping.
+   *
+   * @param {object} req Request object.
+   * @returns {boolean} `true` iff the given request is _not_ a websocket
+   *   request.
+   */
+  static _notWebsocketRequest(req) {
+    return !RequestLogger._isWebsocketRequest(req);
+  }
+}

--- a/local-modules/app-setup/RequestLogger.js
+++ b/local-modules/app-setup/RequestLogger.js
@@ -76,9 +76,9 @@ export default class RequestLogger {
    * @returns {string} String to log.
    */
   static _makeConsoleLog(req, res) {
-    const isWebsocket = RequestLogger._isWebsocketRequest(req);
+    const isWs = RequestLogger._isWsRequest(req);
 
-    if ((res === null) && !isWebsocket) {
+    if ((res === null) && !isWs) {
       // We skip start-of-request logging for everything but websockets.
       return null;
     }
@@ -86,11 +86,11 @@ export default class RequestLogger {
     const status    = (res === null) ? 0 : (res.statusCode || 0);
     const statusStr = `${status || '-'}  `.slice(0, 3);
     const colorFn   = RequestLogger._colorForStatus(status);
-    const method    = `${isWebsocket ? 'WS' : req.method}   `.slice(0,4);
+    const method    = `${isWs ? 'WS' : req.method}   `.slice(0,4);
 
     // `express-ws` appends a pseudo-path `/.websocket` to the end of
     // websocket requests. We chop that off here.
-    const url = isWebsocket
+    const url = isWs
       ? req.originalUrl.replace(/\/\.websocket$/, '')
       : req.originalUrl;
 
@@ -133,7 +133,7 @@ export default class RequestLogger {
    * @param {object} req Request object.
    * @returns {boolean} `true` iff the given request is a websocket request.
    */
-  static _isWebsocketRequest(req) {
+  static _isWsRequest(req) {
     // Case doesn't matter, hence the regex test instead of just `===`.
     const upgrade = req.get('upgrade');
     return (upgrade !== undefined) && upgrade.match(/^websocket$/i);


### PR DESCRIPTION
This started out as just a little tweak on websocket logging, but ended up being a mini yak-shave wherein I split all the logging stuff out of the main `Application` file.

BTW, I switched from putting `Websocket` in camelCase names to instead using the abbreviation `Ws` _just_ to avoid the inconsistency of some places casing the word as "websocket" and others "WebSocket" (and I mean inconsistency in the world at large, not our codebase). However you case the full word, "ws" is a pretty common shorthand for it, and our codebase always camel cases shorthands as regular words (e.g., `fooXyz` even when "XYZ" would be all-caps in prose). FWIW, our own docs are pretty consistent about calling these things "websockets" (that is, all lower case). YMMV.