### PR TITLE
Working in from both ends.

### DIFF
--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -15,7 +15,7 @@ export default class TargetMap {
    */
   constructor(apiClient) {
     /**
-     * The targets being provided, as a map from name to proxy. **Note:** In a
+     * The targets being provided, as a map from ID to proxy. **Note:** In a
      * future incarnation, this map may contain more items and might even grow
      * dynamically.
      */
@@ -25,16 +25,16 @@ export default class TargetMap {
   }
 
   /**
-   * Gets the proxy for the target with the given name.
+   * Gets the proxy for the target with the given ID.
    *
-   * @param {string} name The target name.
+   * @param {string} id The target ID.
    * @returns {object} The corresponding proxy.
    */
-  get(name) {
-    const result = this._targets.get(name);
+  get(id) {
+    const result = this._targets.get(id);
 
     if (!result) {
-      throw new Error(`No such target: ${name}`);
+      throw new Error(`No such target: ${id}`);
     }
 
     return result;

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -14,7 +14,7 @@ export default class Message {
    *
    * @param {Int} id Message ID, used to match requests and responses. Must be
    *   a non-negative integer.
-   * @param {string} target Name of the target object to send to.
+   * @param {string} target ID of the target object to send to.
    * @param {string} action Kind of action to take. Currently, the only valid
    *   value is `call`.
    * @param {string} name Method (or property) name to access.
@@ -24,7 +24,7 @@ export default class Message {
     /** {Int} Message ID. */
     this._id = TInt.min(id, 0);
 
-    /** {string} Name of the target object. */
+    /** {string} ID of the target object. */
     this._target = TString.nonempty(target);
 
     /** {string} Action to take / being taken. */
@@ -77,7 +77,7 @@ export default class Message {
     return this._id;
   }
 
-  /** {string} Name of the target object. */
+  /** {string} ID of the target object. */
   get target() {
     return this._target;
   }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -176,14 +176,14 @@ export default class Connection {
   }
 
   /**
-   * Gets the target associated with the indicated name. This will throw an
-   * error if the named target does not exist.
+   * Gets the target associated with the indicated ID. This will throw an error
+   * if the so-identified target does not exist.
    *
-   * @param {string} name The target name.
+   * @param {string} id The target ID.
    * @returns {object} The so-named target.
    */
-  getTarget(name) {
-    const result = this._targets.get(name);
+  getTarget(id) {
+    const result = this._targets.get(id);
 
     if (result === undefined) {
       throw new Error(`No such target: \`${name}\``);

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -7,7 +7,7 @@ import { SeeAll } from 'see-all';
 import { Random } from 'util-common';
 
 import MetaHandler from './MetaHandler';
-import TargetMap from './TargetMap';
+import Context from './Context';
 
 /** Logger. */
 const log = new SeeAll('api');
@@ -27,11 +27,11 @@ export default class Connection {
    * Constructs an instance. Each instance corresponds to a separate client
    * connection.
    *
-   * @param {TargetMap} targets The targets to provide access to.
+   * @param {Context} targets The targets to provide access to.
    */
   constructor(targets) {
-    /** {TargetMap} The targets to provide access to. */
-    this._targets = TargetMap.check(targets).clone();
+    /** {Context} The targets to provide access to. */
+    this._targets = Context.check(targets).clone();
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -27,15 +27,15 @@ export default class Connection {
    * Constructs an instance. Each instance corresponds to a separate client
    * connection.
    *
-   * @param {Context} targets The targets to provide access to.
+   * @param {Context} context The binding context to provide access to.
    */
-  constructor(targets) {
-    /** {Context} The targets to provide access to. */
-    this._targets = Context.check(targets).clone();
+  constructor(context) {
+    /** {Context} The binding context to provide access to. */
+    this._context = Context.check(context).clone();
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.
-    this._targets.add('meta', new MetaHandler(this));
+    this._context.add('meta', new MetaHandler(this));
 
     /**
      * {string} Short label string used to identify this connection in logs.
@@ -145,7 +145,7 @@ export default class Connection {
    * @returns {Promise} Promise for the result (or error).
    */
   _actOnMessage(msg) {
-    const target = this._targets.get(msg.target);
+    const target = this._context.get(msg.target);
     const action = msg.action;
     const name   = msg.name;
     const args   = msg.args;
@@ -183,7 +183,7 @@ export default class Connection {
    * @returns {object} The so-named target.
    */
   getTarget(id) {
-    const result = this._targets.get(id);
+    const result = this._context.get(id);
 
     if (result === undefined) {
       throw new Error(`No such target: \`${name}\``);

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -56,6 +56,10 @@ export default class Connection {
    * Handles an incoming message, which is expected to be in JSON string form.
    * Returns a promise for the response, which is also in JSON string form.
    *
+   * Notably, messages only succeed when addressed to _uncontrolled_ targets.
+   * In order to act on a controlled target, it first needs to be authorized
+   * via the meta-control system.
+   *
    * **Note:** Subclasses are expected to call this.
    *
    * @param {string} msg Incoming message, in JSON string form.
@@ -152,6 +156,8 @@ export default class Connection {
 
     if (!target) {
       throw new Error(`Unknown target: \`${msg.target}\``);
+    } else if (target.key !== null) {
+      throw new Error(`Unauthorized target: \`${msg.target}\``);
     }
 
     switch (action) {

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -7,12 +7,14 @@ import { TString, TObject } from 'typecheck';
 import Target from './Target';
 
 /**
- * Map of IDs to `Target` instances.
+ * Binding context for an API server or session therein. This is pretty much
+ * just a map from IDs to `Target` instances, along with reasonably
+ * straightforward accessor and update methods.
  *
- * As a convention, `main` is the object providing the main functionality, and
- * `meta` provides meta-information and meta-control.
+ * As a convention, `main` is the ID of the object providing the main
+ * functionality, and `meta` provides meta-information and meta-control.
  */
-export default class TargetMap {
+export default class Context {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *
@@ -20,7 +22,7 @@ export default class TargetMap {
    * @returns {DocumentChange} `value`.
    */
   static check(value) {
-    return TObject.check(value, TargetMap);
+    return TObject.check(value, Context);
   }
 
   /**
@@ -51,8 +53,8 @@ export default class TargetMap {
   }
 
   /**
-   * Adds a new entry to the map. This will throw an error if there is already
-   * another target with the same ID. This is a convenience for calling
+   * Adds a new target to the instance. This will throw an error if there is
+   * already another target with the same ID. This is a convenience for calling
    * `map.addTarget(new Target(id, obj))`.
    *
    * @param {string} id Target ID.
@@ -85,10 +87,10 @@ export default class TargetMap {
    * Clones this instance. The resulting clone has a separate underlying map.
    * That is, adding targets to the clone does not affect its progenitor.
    *
-   * @returns {TargetMap} The newly-cloned instance.
+   * @returns {Context} The newly-cloned instance.
    */
   clone() {
-    const result = new TargetMap();
+    const result = new Context();
 
     for (const t of this._map.values()) {
       result.addTarget(t);

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -39,7 +39,7 @@ export default class MetaHandler {
 
   /**
    * Gets the schema(ta) for the given objects, by ID. This returns an object
-   * that maps each given name to its corresponding schema.
+   * that maps each given ID to its corresponding schema.
    *
    * @param {...string} ids IDs of the object to inquire about.
    * @returns {object} An object mapping each of the `names` to its corresponding

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -38,18 +38,18 @@ export default class MetaHandler {
   }
 
   /**
-   * Gets the schema(ta) for the given objects, by name. This returns an object
+   * Gets the schema(ta) for the given objects, by ID. This returns an object
    * that maps each given name to its corresponding schema.
    *
-   * @param {...string} names Names of the object to inquire about.
+   * @param {...string} ids IDs of the object to inquire about.
    * @returns {object} An object mapping each of the `names` to its corresponding
    *   schema.
    */
-  schemaFor(...names) {
+  schemaFor(...ids) {
     const result = {};
 
-    for (const name of names) {
-      result[name] = this._connection.getTarget(name).schema.propertiesObject;
+    for (const id of ids) {
+      result[id] = this._connection.getTarget(id).schema.propertiesObject;
     }
 
     return result;

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -17,7 +17,7 @@ export default class PostConnection extends Connection {
    *
    * @param {object} req The HTTP request.
    * @param {object} res The HTTP response handler.
-   * @param {TargetMap} targets The targets to provide access to.
+   * @param {Context} targets The targets to provide access to.
    */
   constructor(req, res, targets) {
     super(targets);

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -17,10 +17,10 @@ export default class PostConnection extends Connection {
    *
    * @param {object} req The HTTP request.
    * @param {object} res The HTTP response handler.
-   * @param {Context} targets The targets to provide access to.
+   * @param {Context} context The binding context to provide access to.
    */
-  constructor(req, res, targets) {
-    super(targets);
+  constructor(req, res, context) {
+    super(context);
 
     /** {object} The HTTP request. */
     this._req = req;

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -2,23 +2,39 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { AccessKey } from 'api-common';
 import { TArray, TObject, TString } from 'typecheck';
 
 import Schema from './Schema';
 
 /**
- * Wrapper for an object which is callable through the API.
+ * Wrapper for an object which is callable through the API. A target can be
+ * either "controlled" by a key (that is, have access restricted by a key) or be
+ * "uncontrolled" (that is, be generally available without additional permission
+ * checks).
  */
 export default class Target {
   /**
    * Constructs an instance which wraps the given object.
    *
-   * @param {string} name Name of the target. Used for error messages.
+   * @param {string|AccessKey} nameOrKey Either the name of the target (if
+   *   uncontrolled) _or_ the key which controls access to the target. In the
+   *   former case, the target's `id` is taken to be the given name. In the
+   *   latter case, the target's `id` is considered to be the same as the key's
+   *   `id`.
    * @param {object} target Object from which to derive the schema.
    */
-  constructor(name, target) {
-    /** {string} The target name. */
-    this._name = TString.check(name);
+  constructor(nameOrKey, target) {
+    /**
+     * {AccessKey|null} The access key, or `null` if this is an uncontrolled
+     * target.
+     */
+    this._key = (nameOrKey instanceof AccessKey) ? nameOrKey : null;
+
+    /** {string} The target ID. */
+    this._name = (this._key === null)
+      ? TString.check(nameOrKey)
+      : this._key.id;
 
     /** {object} The target object. */
     this._target = TObject.check(target);
@@ -27,6 +43,14 @@ export default class Target {
     this._schema = new Schema(target);
 
     Object.freeze(this);
+  }
+
+  /**
+   * {AccessKey|null} The access control key or `null` if this is an
+   * uncontrolled target.
+   */
+  get key() {
+    return this._key;
   }
 
   /** {string} The target name. */

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -32,7 +32,7 @@ export default class Target {
     this._key = (nameOrKey instanceof AccessKey) ? nameOrKey : null;
 
     /** {string} The target ID. */
-    this._name = (this._key === null)
+    this._id = (this._key === null)
       ? TString.check(nameOrKey)
       : this._key.id;
 
@@ -53,9 +53,9 @@ export default class Target {
     return this._key;
   }
 
-  /** {string} The target name. */
-  get name() {
-    return this._name;
+  /** {string} The target ID. */
+  get id() {
+    return this._id;
   }
 
   /** {object} The underlying target object. */

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -22,9 +22,10 @@ export default class Target {
    *   former case, the target's `id` is taken to be the given name. In the
    *   latter case, the target's `id` is considered to be the same as the key's
    *   `id`.
-   * @param {object} target Object from which to derive the schema.
+   * @param {object} target Object to provide access to.
+   * @param {Schema|null} schema `target`'s schema, if already known.
    */
-  constructor(nameOrKey, target) {
+  constructor(nameOrKey, target, schema = null) {
     /**
      * {AccessKey|null} The access key, or `null` if this is an uncontrolled
      * target.
@@ -40,7 +41,7 @@ export default class Target {
     this._target = TObject.check(target);
 
     /** {Schema} Schema for the target. */
-    this._schema = new Schema(target);
+    this._schema = schema || new Schema(target);
 
     Object.freeze(this);
   }
@@ -66,6 +67,16 @@ export default class Target {
   /** {Schema} The target's schema. */
   get schema() {
     return this._schema;
+  }
+
+  /**
+   * Returns an instance just like this one, except without the `key`. This
+   * method is used during resource authorization.
+   *
+   * @returns {Target} An "uncontrolled" version of this instance.
+   */
+  withoutKey() {
+    return new Target(this._id, this._target, this._schema);
   }
 
   /**

--- a/local-modules/api-server/TargetMap.js
+++ b/local-modules/api-server/TargetMap.js
@@ -35,7 +35,7 @@ export default class TargetMap {
 
   /**
    * Adds an already-constructed `Target` to the map. This will throw an error
-   * if there is already another target with the same name.
+   * if there is already another target with the same ID.
    *
    * @param {Target} target Target to add.
    */

--- a/local-modules/api-server/TargetMap.js
+++ b/local-modules/api-server/TargetMap.js
@@ -7,7 +7,7 @@ import { TString, TObject } from 'typecheck';
 import Target from './Target';
 
 /**
- * Map of names to `Target` instances.
+ * Map of IDs to `Target` instances.
  *
  * As a convention, `main` is the object providing the main functionality, and
  * `meta` provides meta-information and meta-control.
@@ -41,41 +41,41 @@ export default class TargetMap {
    */
   addTarget(target) {
     TObject.check(target, Target);
-    const name = target.name;
+    const id = target.id;
 
-    if (this._map.get(name) !== undefined) {
-      throw new Error(`Duplicate target: \`${name}\``);
+    if (this._map.get(id) !== undefined) {
+      throw new Error(`Duplicate target: \`${id}\``);
     }
 
-    this._map.set(name, target);
+    this._map.set(id, target);
   }
 
   /**
    * Adds a new entry to the map. This will throw an error if there is already
-   * another target with the same name. This is a convenience for calling
-   * `map.addTarget(new Target(name, obj))`.
+   * another target with the same ID. This is a convenience for calling
+   * `map.addTarget(new Target(id, obj))`.
    *
-   * @param {string} name Target name.
+   * @param {string} id Target ID.
    * @param {object} obj Object to ultimately call on.
    */
-  add(name, obj) {
-    TString.nonempty(name);
+  add(id, obj) {
+    TString.nonempty(id);
     TObject.check(obj);
-    this.addTarget(new Target(name, obj));
+    this.addTarget(new Target(id, obj));
   }
 
   /**
-   * Gets the target associated with the indicated name. This will throw an
-   * error if the named target does not exist.
+   * Gets the target associated with the indicated ID. This will throw an
+   * error if the so-identified target does not exist.
    *
-   * @param {string} name The target name.
-   * @returns {object} The so-named target.
+   * @param {string} id The target ID.
+   * @returns {object} The so-identified target.
    */
-  get(name) {
-    const result = this._map.get(name);
+  get(id) {
+    const result = this._map.get(id);
 
     if (result === undefined) {
-      throw new Error(`No such target: \`${name}\``);
+      throw new Error(`No such target: \`${id}\``);
     }
 
     return result;

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -15,7 +15,7 @@ export default class WsConnection extends Connection {
    * constructed instance to the websocket (as an event listener).
    *
    * @param {WebSocket} ws A websocket instance corresponding to the connection.
-   * @param {TargetMap} targets The targets to provide access to.
+   * @param {Context} targets The targets to provide access to.
    */
   constructor(ws, targets) {
     super(targets);

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -15,10 +15,10 @@ export default class WsConnection extends Connection {
    * constructed instance to the websocket (as an event listener).
    *
    * @param {WebSocket} ws A websocket instance corresponding to the connection.
-   * @param {Context} targets The targets to provide access to.
+   * @param {Context} context The binding context to provide access to.
    */
-  constructor(ws, targets) {
-    super(targets);
+  constructor(ws, context) {
+    super(context);
 
     /** {WebSocket} The Websocket for the client connection. */
     this._ws = ws;

--- a/local-modules/api-server/main.js
+++ b/local-modules/api-server/main.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import Context from './Context';
 import PostConnection from './PostConnection';
 import Target from './Target';
-import TargetMap from './TargetMap';
 import WsConnection from './WsConnection';
 
-export { PostConnection, Target, TargetMap, WsConnection };
+export { Context, PostConnection, Target, WsConnection };

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -40,9 +40,9 @@ export default class Application {
     this._doc = new DocServer('some-id');
 
     /** {Context} All of the objects we provide access to via the API. */
-    const targets = this._targets = new Context();
-    targets.add('auth', new Authorizer());
-    targets.add('main', this._doc);
+    const context = this._context = new Context();
+    context.add('auth', new Authorizer());
+    context.add('main', this._doc);
 
     /** The underlying webserver run by this instance. */
     this._app = express();
@@ -101,9 +101,9 @@ export default class Application {
     // Use the `api-server` module to handle POST and websocket requests at
     // `/api`.
     app.post('/api',
-      (req, res) => { new PostConnection(req, res, this._targets); });
+      (req, res) => { new PostConnection(req, res, this._context); });
     app.ws('/api',
-      (ws, req_unused) => { new WsConnection(ws, this._targets); });
+      (ws, req_unused) => { new WsConnection(ws, this._context); });
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -7,7 +7,7 @@ import express_ws from 'express-ws';
 import fs from 'fs';
 import path from 'path';
 
-import { PostConnection, TargetMap, WsConnection } from 'api-server';
+import { Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
 import { DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
@@ -39,8 +39,8 @@ export default class Application {
      */
     this._doc = new DocServer('some-id');
 
-    /** {TargetMap} All of the objects we provide access to via the API. */
-    const targets = this._targets = new TargetMap();
+    /** {Context} All of the objects we provide access to via the API. */
+    const targets = this._targets = new Context();
     targets.add('auth', new Authorizer());
     targets.add('main', this._doc);
 

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -9,7 +9,7 @@ import path from 'path';
 
 import { Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
-import { DocControl } from 'doc-server';
+import { DocControl, DocForAuthor } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
@@ -34,10 +34,10 @@ export default class Application {
    */
   constructor(devMode) {
     /**
-     * {DocControl} The one document we manage. **TODO:** Needs to be more than
-     * one!
+     * {DocForAuthor} The one document we manage. **TODO:** Needs to be more
+     * than one!
      */
-    this._doc = new DocControl('some-id');
+    this._doc = new DocForAuthor(new DocControl('some-id'), 'some-author');
 
     /** {Context} All of the objects we provide access to via the API. */
     const context = this._context = new Context();

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -9,7 +9,7 @@ import path from 'path';
 
 import { Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
-import { DocServer } from 'doc-server';
+import { DocControl } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
@@ -34,10 +34,10 @@ export default class Application {
    */
   constructor(devMode) {
     /**
-     * {DocServer} The one document we manage. **TODO:** Needs to be more than
+     * {DocControl} The one document we manage. **TODO:** Needs to be more than
      * one!
      */
-    this._doc = new DocServer('some-id');
+    this._doc = new DocControl('some-id');
 
     /** {Context} All of the objects we provide access to via the API. */
     const context = this._context = new Context();

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { AccessKey } from 'api-common';
-import { DocServer } from 'doc-server';
+import { DocControl } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { TString } from 'typecheck';
@@ -21,7 +21,7 @@ export default class Authorizer {
    */
   constructor() {
     /**
-     * {Map<string, DocServer>} The set of active documents, as a map from ID
+     * {Map<string, DocControl>} The set of active documents, as a map from ID
      * to document object.
      */
     this._docs = new Map();
@@ -65,7 +65,7 @@ export default class Authorizer {
 
     let doc = this._docs.get(docId);
     if (doc === undefined) {
-      doc = new DocServer(docId);
+      doc = new DocControl(docId);
       this._docs.set(docId, doc);
     }
 

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -23,10 +23,10 @@ export default class DebugTools {
   /**
    * Constructs an instance.
    *
-   * @param {DocServer} doc The `DocServer` object managed by this process.
+   * @param {DocControl} doc The `DocControl` object managed by this process.
    */
   constructor(doc) {
-    /** {DocServer} The document object. */
+    /** {DocControl} The document object. */
     this._doc = doc;
 
     /** {SeeAll} A rolling log for the `/log` endpoint. */

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -196,12 +196,13 @@ export default class DocControl {
    * @param {number} baseVerNum Version number which `delta` is with respect to.
    * @param {object} delta Delta indicating what has changed with respect to
    *   `baseVerNum`.
-   * @param {string|null} [authorId = null] Author of `delta`.
+   * @param {string|null} authorId Author of `delta`, or `null` if the change
+   *   is to be considered authorless.
    * @returns {object} Object that binds `verNum` to the new version number and
    *   `delta` to a delta _with respect to the implied expected result_ which
    *   can be used to get the new document state.
    */
-  applyDelta(baseVerNum, delta, authorId = null) {
+  applyDelta(baseVerNum, delta, authorId) {
     baseVerNum = this._validateVerNum(baseVerNum, false);
     delta = FrozenDelta.coerce(delta);
     authorId = TString.orNull(authorId);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -10,9 +10,11 @@ import { PromCondition } from 'util-common';
 
 
 /**
- * Server-side representation of a persistent document.
+ * Controller for a given document. There is only ever exactly one instance of
+ * this class per document, no matter how many active editors there are on that
+ * document.
  */
-export default class DocServer {
+export default class DocControl {
   /**
    * Constructs an instance.
    *
@@ -27,7 +29,7 @@ export default class DocServer {
      * as access to a single document. Instead, document IDs need to be plumbed
      * through and used to differentiate between multiple documents.
      */
-    this._doc = DocServer._getDocAccessor(docId);
+    this._doc = DocControl._getDocAccessor(docId);
 
     /**
      * Mapping from version numbers to corresponding document snapshots.

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -1,0 +1,92 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+
+import DocControl from './DocControl';
+
+/**
+ * Controller for a given document, which acts on behalf of one specific author.
+ * This passes non-mutating methods through to the underlying `DocControl` while
+ * implicitly adding an author argument to methods that modify the document.
+ */
+export default class DocForAuthor {
+  /**
+   * Constructs an instance.
+   *
+   * @param {DocControl} doc The underlying document controller.
+   * @param {string} authorId The author this instance acts on behalf of.
+   */
+  constructor(doc, authorId) {
+    /** {DocControl} The underlying document controller. */
+    this._doc = DocControl.check(doc);
+
+    /** {string} Author ID. */
+    this._authorId = TString.nonempty(authorId);
+  }
+
+  /**
+   * The version number corresponding to the current (latest) version of the
+   * document.
+   */
+  get currentVerNum() {
+    return this._doc.currentVerNum;
+  }
+
+  /**
+   * The version number corresponding to the very next change that will be
+   * made to the document.
+   */
+  get nextVerNum() {
+    return this._doc.nextVerNum;
+  }
+
+  /**
+   * Returns a particular change to the document. See the equivalent
+   * `DocControl` method for details.
+   *
+   * @param {number} [verNum = this.currentVerNum] The version number of the
+   *   change.
+   * @returns {DocumentChange} An object representing that change.
+   */
+  change(verNum) {
+    return this._doc.change(verNum);
+  }
+
+  /**
+   * Returns a snapshot of the full document contents. See the equivalent
+   * `DocControl` method for details.
+   *
+   * @param {number} [verNum = this.currentVerNum] Which version to get.
+   * @returns {Snapshot} The corresponding snapshot.
+   */
+  snapshot(verNum) {
+    return this._doc.snapshot(verNum);
+  }
+
+  /**
+   * Returns a promise for a snapshot of any version after the given
+   * `baseVerNum`. See the equivalent `DocControl` method for details.
+   *
+   * @param {number} baseVerNum Version number for the document.
+   * @returns {Promise} A promise for a new version.
+   */
+  deltaAfter(baseVerNum) {
+    return this._doc.deltaAfter(baseVerNum);
+  }
+
+  /**
+   * Applies a delta, assigning authorship of the change to the author
+   * represented by this instance. See the equivalent `DocControl` method for
+   * details.
+   *
+   * @param {number} baseVerNum Version number which `delta` is with respect to.
+   * @param {object} delta Delta indicating what has changed with respect to
+   *   `baseVerNum`.
+   * @returns {object} Object indicating the new latest version.
+   */
+  applyDelta(baseVerNum, delta) {
+    return this._doc.applyDelta(baseVerNum, delta, this._authorId);
+  }
+}

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import DocServer from './DocServer';
+import DocControl from './DocControl';
 
-export { DocServer };
+export { DocControl };

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import DocControl from './DocControl';
+import DocForAuthor from './DocForAuthor';
 
-export { DocControl };
+export { DocControl, DocForAuthor };


### PR DESCRIPTION
This PR moves the bar a bit more for both multiple-doc handling and authorship representation. Highlights:

* Rework the "target map" on the server side to be a "context" which is aware that some targets are access-controlled.
* Add a `DocForAuthor` class which becomes the thing that clients directly talk to via the API.

In both cases, there is still a good amount of stuff which is stubbed out / not yet hooked up. More to come soon!