### PR TITLE
Hook the `Authorizer` up.

### DIFF
--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString, TObject } from 'typecheck';
+import { TObject } from 'typecheck';
 
 import Target from './Target';
 
@@ -57,13 +57,14 @@ export default class Context {
    * already another target with the same ID. This is a convenience for calling
    * `map.addTarget(new Target(id, obj))`.
    *
-   * @param {string} id Target ID.
+   * @param {string} nameOrKey Either the name of the target (if
+   *   uncontrolled) _or_ the key which controls access to the target. See the
+   *   docs for `Target.add()` for more details.
    * @param {object} obj Object to ultimately call on.
    */
-  add(id, obj) {
-    TString.nonempty(id);
+  add(nameOrKey, obj) {
     TObject.check(obj);
-    this.addTarget(new Target(id, obj));
+    this.addTarget(new Target(nameOrKey, obj));
   }
 
   /**
@@ -74,13 +75,36 @@ export default class Context {
    * @returns {object} The so-identified target.
    */
   get(id) {
-    const result = this._map.get(id);
+    const result = this.getOrNull(id);
 
-    if (result === undefined) {
+    if (!result) {
       throw new Error(`No such target: \`${id}\``);
     }
 
     return result;
+  }
+
+  /**
+   * Gets the target associated with the indicated ID, or `null` if the
+   * so-identified target does not exits.
+   *
+   * @param {string} id The target ID.
+   * @returns {object|null} The so-identified target.
+   */
+  getOrNull(id) {
+    const result = this._map.get(id);
+    return (result !== undefined) ? result : null;
+  }
+
+  /**
+   * Returns an indication of whether or not this instance has a binding for
+   * the given ID.
+   *
+   * @param {string} id The target ID.
+   * @returns {boolean} `true` iff `id` is bound.
+   */
+  hasId(id) {
+    return this.getOrNull(id) !== null;
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -9,7 +9,7 @@ import path from 'path';
 
 import { Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
-import { DocControl, DocForAuthor } from 'doc-server';
+import { DocForAuthor, DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
@@ -37,7 +37,8 @@ export default class Application {
      * {DocForAuthor} The one document we manage. **TODO:** Needs to be more
      * than one!
      */
-    this._doc = new DocForAuthor(new DocControl('some-id'), 'some-author');
+    this._doc = new DocForAuthor(
+      DocServer.THE_INSTANCE.getDoc('some-id'), 'some-author');
 
     /** {Context} All of the objects we provide access to via the API. */
     const context = this._context = new Context();

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -42,7 +42,7 @@ export default class Application {
 
     /** {Context} All of the objects we provide access to via the API. */
     const context = this._context = new Context();
-    context.add('auth', new Authorizer());
+    context.add('auth', new Authorizer(context));
     context.add('main', this._doc);
 
     /** The underlying webserver run by this instance. */

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -21,12 +21,6 @@ export default class Authorizer {
    */
   constructor() {
     /**
-     * {Map<string, DocControl>} The set of active documents, as a map from ID
-     * to document object.
-     */
-    this._docs = new Map();
-
-    /**
      * {Map<string, {key, doc}>} The set of active access keys and associated
      * info, as a map from key ID to access info. `doc` is a `DocForAuthor`
      * instance.
@@ -64,12 +58,7 @@ export default class Authorizer {
       throw new Error('Not authorized.');
     }
 
-    let docControl = this._docs.get(docId);
-    if (docControl === undefined) {
-      docControl = DocServer.THE_INSTANCE.getDoc(docId);
-      this._docs.set(docId, docControl);
-    }
-
+    const docControl = DocServer.THE_INSTANCE.getDoc(docId);
     const doc = new DocForAuthor(docControl, authorId);
 
     let key = null;

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { AccessKey } from 'api-common';
-import { DocControl, DocForAuthor } from 'doc-server';
+import { DocForAuthor, DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { TString } from 'typecheck';
@@ -66,7 +66,7 @@ export default class Authorizer {
 
     let docControl = this._docs.get(docId);
     if (docControl === undefined) {
-      docControl = new DocControl(docId);
+      docControl = DocServer.THE_INSTANCE.getDoc(docId);
       this._docs.set(docId, docControl);
     }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -34,9 +34,6 @@ export default class DocControl {
     /** {BaseDoc} Storage access for the document. */
     this._doc = BaseDoc.check(docStorage);
 
-    /** {string} Document ID. */
-    this._docId = docStorage.id;
-
     /**
      * Mapping from version numbers to corresponding document snapshots.
      * Sparse.

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -4,7 +4,7 @@
 
 import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
-import { DEFAULT_DOCUMENT, Hooks } from 'hooks-server';
+import { BaseDoc } from 'doc-store';
 import { TInt, TObject, TString } from 'typecheck';
 import { PromCondition } from 'util-common';
 
@@ -28,18 +28,14 @@ export default class DocControl {
   /**
    * Constructs an instance.
    *
-   * @param {string} docId The document ID.
+   * @param {BaseDoc} docStorage The underlying document storage.
    */
-  constructor(docId) {
-    /** {string} Document ID. */
-    this._docId = TString.nonempty(docId);
+  constructor(docStorage) {
+    /** {BaseDoc} Storage access for the document. */
+    this._doc = BaseDoc.check(docStorage);
 
-    /**
-     * Storage access for the document. TODO: Right now this just bottoms out
-     * as access to a single document. Instead, document IDs need to be plumbed
-     * through and used to differentiate between multiple documents.
-     */
-    this._doc = DocControl._getDocAccessor(docId);
+    /** {string} Document ID. */
+    this._docId = docStorage.id;
 
     /**
      * Mapping from version numbers to corresponding document snapshots.
@@ -349,25 +345,5 @@ export default class DocControl {
     } else {
       return VersionNumber.check(verNum, current);
     }
-  }
-
-  /**
-   * Gets the document storage access object for the document with the given ID.
-   * If the document doesn't exist, it gets initialized.
-   *
-   * @param {string} docId The document ID.
-   * @returns {BaseDoc} The corresponding document accessor.
-   */
-  static _getDocAccessor(docId) {
-    const result = Hooks.docStore.getDocument(docId);
-
-    if (!result.exists()) {
-      // Initialize the document with static content (for now).
-      const firstChange =
-        new DocumentChange(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
-      result.changeAppend(firstChange);
-    }
-
-    return result;
   }
 }

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -1,0 +1,75 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { DocumentChange, Timestamp } from 'doc-common';
+import { DEFAULT_DOCUMENT, Hooks } from 'hooks-server';
+import { TString } from 'typecheck';
+
+import DocControl from './DocControl';
+
+/**
+ * {DocServer|null} The unique instance of this class. Initialized in the
+ * `THE_INSTANCE` getter below.
+ */
+let THE_INSTANCE = null;
+
+/**
+ * Interface between this module and the storage layer. This class is
+ * responsible for instantiating and tracking `DocControl` instances, such that
+ * only one instance is created per actual document.
+ */
+export default class DocServer {
+  /** {DocServer} The unique instance of this class. */
+  static get THE_INSTANCE() {
+    if (THE_INSTANCE === null) {
+      THE_INSTANCE = new DocServer();
+    }
+
+    return THE_INSTANCE;
+  }
+
+  /**
+   * Constructs an instance. This is not meant to be used publicly.
+   */
+  constructor() {
+    if (THE_INSTANCE !== null) {
+      throw new Error('Attempt to construct a second instance.');
+    }
+
+    /**
+     * {Map<string,DocControl>} Map from document IDs to their corresponding
+     * document controllers.
+     */
+    this._controls = new Map();
+  }
+
+  /**
+   * Gets the document controller for the document with the given ID. If the
+   * document doesn't exist, it gets initialized.
+   *
+   * @param {string} docId The document ID.
+   * @returns {DocControl} The corresponding document accessor.
+   */
+  getDoc(docId) {
+    TString.nonempty(docId);
+
+    const already = this._controls.get(docId);
+    if (already) {
+      return already;
+    }
+
+    const docStorage = Hooks.docStore.getDocument(docId);
+
+    if (!docStorage.exists()) {
+      // Initialize the document with static content (for now).
+      const firstChange =
+        new DocumentChange(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
+      docStorage.changeAppend(firstChange);
+    }
+
+    const result = new DocControl(docStorage);
+    this._controls.set(docId, result);
+    return result;
+  }
+}

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -4,5 +4,6 @@
 
 import DocControl from './DocControl';
 import DocForAuthor from './DocForAuthor';
+import DocServer from './DocServer';
 
-export { DocControl, DocForAuthor };
+export { DocControl, DocForAuthor, DocServer };

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -5,6 +5,7 @@
 
   "dependencies": {
     "doc-common": "local",
+    "doc-store": "local",
     "hooks-server": "local",
     "typecheck": "local",
     "util-common": "local"


### PR DESCRIPTION
This PR nearly closes the loop on getting three-party intro working, by pushing most of what `Authorizer` does into the `doc-server` module (on one end) and the `api-server` module (on the other end). The big bit of remaining work is enabling clients to actually perform `AccessKey`-based auth on the auth-controlled resources that end up in the server `Context`.