### PR TITLE
Expand hierarchy of access keys.

### DIFF
--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -27,19 +27,25 @@ export default class BaseKey {
    * Constructs an instance with the indicated parts.
    *
    * @param {string} url URL at which the resource may be accessed. This is
-   *   expected to be an API endpoint.
+   *   expected to be an API endpoint. Alternatively, if this instance will only
+   *   ever be used in a context where the URL is implied or superfluous, this
+   *   can be passed as `*` (a literal asterisk).
    * @param {string} id Key / resource identifier. This must be a string of 16
    *   hex digits (lower case).
    */
   constructor(url, id) {
-    /** {string} URL at which the resource may be accessed. */
-    this._url = TString.urlAbsolute(url);
+    if (url !== '*') {
+      TString.urlAbsolute(url);
+    }
+
+    /** {string} URL at which the resource may be accessed, or `*`. */
+    this._url = url;
 
     /** {string} Key / resource identifier. */
     this._id = TString.hexBytes(id, 8, 8);
   }
 
-  /** {string} URL at which the resource may be accessed. */
+  /** {string} URL at which the resource may be accessed, or `*`. */
   get url() {
     return this._url;
   }

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -1,0 +1,60 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+
+/**
+ * Base class for access keys. An access key consists of information for
+ * accessing a network-accessible resource, along with functionality for
+ * performing authentication. In general, a given instance of this class
+ * represents access to a particular resource, but that same resource might also
+ * be available via different instances of the class too, and even using
+ * different IDs. (That is, it can be a many-to-one relationship.)
+ *
+ * Instances of this (base) class hold two pieces of information:
+ *
+ * * A URL at which the resource is available.
+ * * The ID of the resource.
+ *
+ * In addition, subclasses can include additional information.
+ *
+ * **Note:** The resource ID is _not_ meant to require secrecy in order for
+ * the system to be secure. That is, IDs are not required to be unguessable.
+ */
+export default class BaseKey {
+  /**
+   * Constructs an instance with the indicated parts.
+   *
+   * @param {string} url URL at which the resource may be accessed. This is
+   *   expected to be an API endpoint.
+   * @param {string} id Key / resource identifier. This must be a string of 16
+   *   hex digits (lower case).
+   */
+  constructor(url, id) {
+    /** {string} URL at which the resource may be accessed. */
+    this._url = TString.urlAbsolute(url);
+
+    /** {string} Key / resource identifier. */
+    this._id = TString.hexBytes(id, 8, 8);
+  }
+
+  /** {string} URL at which the resource may be accessed. */
+  get url() {
+    return this._url;
+  }
+
+  /** {string} Key / resource identifier. */
+  get id() {
+    return this._id;
+  }
+
+  /**
+   * Gets the redacted form of this instance.
+   *
+   * @returns {string} The redacted form.
+   */
+  toString() {
+    return `{${this.constructor.API_NAME} ${this._url} ${this._id}}`;
+  }
+}

--- a/local-modules/api-common/BearerToken.js
+++ b/local-modules/api-common/BearerToken.js
@@ -1,0 +1,85 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Hooks } from 'hooks-server';
+import { TObject } from 'typecheck';
+
+import BaseKey from './BaseKey';
+
+/**
+ * Bearer token, which is a kind of key which conflates ID and secret.
+ * Conflation notwithstanding, some part of a bearer token is always considered
+ * to be its "ID." the `hooks-server` value `Hooks.bearerTokenValidator` can
+ * be used to control ID derivation (and general validation) of bearer token
+ * strings.
+ */
+export default class BearerToken extends BaseKey {
+  /**
+   * Checks that a value is an instance of this class. Throws an error if not.
+   *
+   * @param {*} value Value to check.
+   * @returns {BearerToken} `value`.
+   */
+  static check(value) {
+    return TObject.check(value, BearerToken);
+  }
+
+  /**
+   * Coerces the given value into an instance of this class, if possible. If
+   * given an instance of this class, returns that instance. If given a string,
+   * attempts to construct an instance from that string; this will fail if the
+   * string isn't in an acceptable form.
+   *
+   * @param {*} value Value to coerce.
+   * @returns {BearerToken} `value` or its coercion to a `BearerToken`.
+   */
+  static coerce(value) {
+    return (value instanceof BearerToken) ? value : new BearerToken(value);
+  }
+
+  /**
+   * Constructs an instance with the indicated parts.
+   *
+   * @param {string} secretToken Complete token. This must be a string of at
+   *   least 32 characters.
+   */
+  constructor(secretToken) {
+    if (!Hooks.isBearerToken(secretToken)) {
+      // We don't include any real detail in the error message, as that might
+      // inadvertently leak a secret into the logs.
+      throw new Error('Invalid `secretToken` string.');
+    }
+
+    super('*', Hooks.bearerTokenId(secretToken));
+
+    /** {string} Secret token. */
+    this._secretToken = secretToken;
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {string} Full secret token. **Note:** It is important to _never_ reveal
+   * this value across an unencrypted API boundary or to log it.
+   */
+  get secretToken() {
+    return this._secretToken;
+  }
+
+  /**
+   * Compares this instance to another.
+   *
+   * @param {BearerToken|undefined|null} other Instance to compare to.
+   * @returns {boolean} `true` iff the two instances are both of this class and
+   *   contain the same full secret token value.
+   */
+  sameToken(other) {
+    if ((other === null) || (other === undefined)) {
+      return false;
+    }
+
+    BearerToken.check(other);
+    return this._token === other._token;
+  }
+}

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import AccessKey from './AccessKey';
 import Decoder from './Decoder';
 import Encoder from './Encoder';
 import Message from './Message';
 import Registry from './Registry';
+import SplitKey from './SplitKey';
 
 // Register classes with the API.
-Registry.register(AccessKey);
 Registry.register(Message);
+Registry.register(SplitKey);
 
-export { AccessKey, Decoder, Encoder, Message, Registry };
+export { Decoder, Encoder, Message, Registry, SplitKey };

--- a/local-modules/api-common/package.json
+++ b/local-modules/api-common/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "js-sha256": "^0.5.0",
 
+    "hooks-server": "local",
     "typecheck": "local",
     "util-common": "local"
   }

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { AccessKey } from 'api-common';
+import { SplitKey } from 'api-common';
 import { TArray, TObject, TString } from 'typecheck';
 
 import Schema from './Schema';
@@ -17,7 +17,7 @@ export default class Target {
   /**
    * Constructs an instance which wraps the given object.
    *
-   * @param {string|AccessKey} nameOrKey Either the name of the target (if
+   * @param {string|SplitKey} nameOrKey Either the name of the target (if
    *   uncontrolled) _or_ the key which controls access to the target. In the
    *   former case, the target's `id` is taken to be the given name. In the
    *   latter case, the target's `id` is considered to be the same as the key's
@@ -27,10 +27,10 @@ export default class Target {
    */
   constructor(nameOrKey, target, schema = null) {
     /**
-     * {AccessKey|null} The access key, or `null` if this is an uncontrolled
+     * {SplitKey|null} The access key, or `null` if this is an uncontrolled
      * target.
      */
-    this._key = (nameOrKey instanceof AccessKey) ? nameOrKey : null;
+    this._key = (nameOrKey instanceof SplitKey) ? nameOrKey : null;
 
     /** {string} The target ID. */
     this._id = (this._key === null)
@@ -47,7 +47,7 @@ export default class Target {
   }
 
   /**
-   * {AccessKey|null} The access control key or `null` if this is an
+   * {SplitKey|null} The access control key or `null` if this is an
    * uncontrolled target.
    */
   get key() {

--- a/local-modules/app-setup/Authorizer.js
+++ b/local-modules/app-setup/Authorizer.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { AccessKey } from 'api-common';
+import { SplitKey } from 'api-common';
 import { Connection, Context } from 'api-server';
 import { DocForAuthor, DocServer } from 'doc-server';
 import { Hooks } from 'hooks-server';
@@ -41,7 +41,7 @@ export default class Authorizer {
    *   are made using the resulting authorization.
    * @param {string} docId ID of the document which the resulting authorization
    *   allows access to.
-   * @returns {AccessKey} Split token (ID + secret) which provides the requested
+   * @returns {SplitKey} Split token (ID + secret) which provides the requested
    *   access.
    */
   makeAccessKey(rootCredential, authorId, docId) {
@@ -62,7 +62,7 @@ export default class Authorizer {
 
     let key = null;
     for (;;) {
-      key = AccessKey.randomInstance(`${baseUrl}/api`);
+      key = SplitKey.randomInstance(`${baseUrl}/api`);
       if (!this._context.hasId(key.id)) {
         break;
       }

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -39,6 +39,30 @@ export default class Hooks {
   }
 
   /**
+   * {object} The object which validates bearer tokens. See
+   * `api-client.BearerToken` for details. This object must implement two
+   * methods:
+   *
+   * * `isToken(token)` -- Returns `true` if the `token` is _syntactically_
+   *   valid (whether or not it actually grants any access).
+   * * `tokenId(token)` -- Returns the portion of `token` which should be
+   *   considered its "ID" for the purposes of lookup, logging, etc.
+   */
+  static get bearerTokenValidator() {
+    // By default, bearer tokens merely have to be at least 32 characters long,
+    // with the first 16 being treated as the ID.
+
+    return {
+      isToken: ((token) => {
+        return ((typeof token) === 'string') && (token.length >= 32);
+      }),
+      tokenId: ((token) => {
+        return token.slice(0, 16);
+      })
+    };
+  }
+
+  /**
    * The object which provides access to document storage. This is an instance
    * of a subclass of `BaseDocStore`, as defined by the `doc-store` module.
    */


### PR DESCRIPTION
This is still WIP, with the ultimate aim of retiring `rootValidator` as it currently stands.