### PR TITLE
Improve bearer token stuff.

### DIFF
--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -24,14 +24,15 @@ import { TString } from 'typecheck';
  */
 export default class BaseKey {
   /**
-   * Constructs an instance with the indicated parts.
+   * Constructs an instance with the indicated parts. Subclasses should override
+   * methods as described in the documentation.
    *
    * @param {string} url URL at which the resource may be accessed. This is
    *   expected to be an API endpoint. Alternatively, if this instance will only
    *   ever be used in a context where the URL is implied or superfluous, this
    *   can be passed as `*` (a literal asterisk).
-   * @param {string} id Key / resource identifier. This must be a string of 16
-   *   hex digits (lower case).
+   * @param {string} id Key / resource identifier. This must be a string of at
+   *   least 8 characters.
    */
   constructor(url, id) {
     if (url !== '*') {
@@ -42,7 +43,7 @@ export default class BaseKey {
     this._url = url;
 
     /** {string} Key / resource identifier. */
-    this._id = TString.hexBytes(id, 8, 8);
+    this._id = TString.minLen(id, 8);
   }
 
   /** {string} URL at which the resource may be accessed, or `*`. */
@@ -56,11 +57,34 @@ export default class BaseKey {
   }
 
   /**
+   * Gets the printable form of the ID. This defaults to the same as `.id`,
+   * but subclasses can override this if they want to produce something
+   * different.
+   *
+   * @returns {string} The printable form of the ID.
+   */
+  _impl_printableId() {
+    return this.id;
+  }
+
+  /**
    * Gets the redacted form of this instance.
    *
    * @returns {string} The redacted form.
    */
   toString() {
-    return `{${this.constructor.API_NAME} ${this._url} ${this._id}}`;
+    const name = this.constructor.API_NAME || this.constructor.name;
+    return `{${name} ${this._url} ${this._impl_printableId()}}`;
+  }
+
+  /**
+   * Helper function which always throws. Using this both documents the intent
+   * in code and keeps the linter from complaining about the documentation
+   * (`@param`, `@returns`, etc.).
+   *
+   * @param {...*} args_unused Anything you want, to keep the linter happy.
+   */
+  _mustOverride(...args_unused) {
+    throw new Error('Must override.');
   }
 }

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -41,7 +41,7 @@ export default class SplitKey extends BaseKey {
    *   digits (lower case).
    */
   constructor(url, id, secret) {
-    super(url, id);
+    super(url, TString.hexBytes(id, 8, 8));
 
     /** {string} Shared secret. */
     this._secret = TString.hexBytes(secret, 16, 16);

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -4,7 +4,7 @@
 
 import { BaseKey } from 'api-common';
 import { Hooks } from 'hooks-server';
-import { TObject } from 'typecheck';
+import { TObject, TString } from 'typecheck';
 
 /**
  * Bearer token, which is a kind of key which conflates ID and secret.
@@ -44,6 +44,8 @@ export default class BearerToken extends BaseKey {
    *   least 32 characters.
    */
   constructor(secretToken) {
+    TString.minLen(secretToken, 32);
+
     if (!Hooks.bearerTokenValidator.isToken(secretToken)) {
       // We don't include any real detail in the error message, as that might
       // inadvertently leak a secret into the logs.

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -44,18 +44,28 @@ export default class BearerToken extends BaseKey {
    *   least 32 characters.
    */
   constructor(secretToken) {
-    if (!Hooks.isBearerToken(secretToken)) {
+    if (!Hooks.bearerTokenValidator.isToken(secretToken)) {
       // We don't include any real detail in the error message, as that might
       // inadvertently leak a secret into the logs.
       throw new Error('Invalid `secretToken` string.');
     }
 
-    super('*', Hooks.bearerTokenId(secretToken));
+    super('*', Hooks.bearerTokenValidator.tokenId(secretToken));
 
     /** {string} Secret token. */
     this._secretToken = secretToken;
 
     Object.freeze(this);
+  }
+
+  /**
+   * Gets the printable form of the ID. This class adds an "ASCII ellipsis" to
+   * the ID, to make it clear that the ID is a redaction of the full token.
+   *
+   * @returns {string} The printable form of the ID.
+   */
+  _impl_printableId() {
+    return `${this.id}...`;
   }
 
   /**

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -54,12 +54,13 @@ export default class Hooks {
    */
   static get bearerTokenValidator() {
     return {
-      isToken: ((token_unused) => {
+      isToken(token_unused) {
         return true;
-      }),
-      tokenId: ((token) => {
+      },
+
+      tokenId(token) {
         return token.slice(0, 16);
-      })
+      }
     };
   }
 
@@ -97,8 +98,13 @@ export default class Hooks {
     // `root`. TODO: Should probably provide a less trivial default.
 
     return {
-      isCredential:    ((cred) => { return (typeof cred) === 'string'; }),
-      checkCredential: ((cred) => { return cred === 'root'; })
+      checkCredential(cred) {
+        return cred === 'root';
+      },
+
+      isCredential(cred) {
+        return (typeof cred) === 'string';
+      }
     };
   }
 }

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -90,30 +90,4 @@ export default class Hooks {
   static get listenPort() {
     return 8080;
   }
-
-  /**
-   * {object} The object which validates root credentials. These are credentials
-   * which provide "root" access to the server. This object must implement two
-   * methods:
-   *
-   * * `checkCredential(cred)` -- Returns `true` if the `cred` is valid and
-   *    grants root access, or `false` if not.
-   * * `isCredential(cred)` -- Returns `true` if the `cred` is _syntactically_
-   *   valid (whether or not it actually grants root access).
-   */
-  static get rootValidator() {
-    // By default, we provide a very simple and obviously insecure default,
-    // which just checks to see if the given credential is the literal string
-    // `root`. TODO: Should probably provide a less trivial default.
-
-    return {
-      checkCredential(cred) {
-        return cred === 'root';
-      },
-
-      isCredential(cred) {
-        return (typeof cred) === 'string';
-      }
-    };
-  }
 }

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -39,11 +39,14 @@ export default class Hooks {
   }
 
   /**
-   * {object} The object which validates bearer tokens. See
-   * `api-client.BearerToken` for details. This object must implement two
+   * {object} The object which validates and authorizes bearer tokens. See
+   * `api-client.BearerToken` for details. This object must implement these
    * methods:
    *
-   * * `isToken(tokenString)` -- Returns `true` if the `tokenString` is
+   * * `grantsRoot(token)` -- Returns `true` iff `token` (a `BearerToken` per
+   *   se) grants root access to the system. The (obviously insecure) default is
+   *   to treat a bearer token of 32 zeroes as granting access.
+   * * `isToken(tokenString)` -- Returns `true` iff the `tokenString` is
    *   _syntactically_ valid as a bearer token (whether or not it actually
    *   grants any access). This will only ever get called on strings (per se) of
    *   at least 32 characters, so it is safe to assume those facts. The default
@@ -55,6 +58,11 @@ export default class Hooks {
    */
   static get bearerTokenValidator() {
     return {
+      grantsRoot(token) {
+        // TODO: We should probably provide a less trivial default.
+        return token.secretToken === '0'.repeat(32);
+      },
+
       isToken(tokenString_unused) {
         return true;
       },

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -44,17 +44,17 @@ export default class Hooks {
    * methods:
    *
    * * `isToken(token)` -- Returns `true` if the `token` is _syntactically_
-   *   valid (whether or not it actually grants any access).
+   *   valid (whether or not it actually grants any access). This will only ever
+   *   get called on strings (per se) of at least 32 characters, so it is safe
+   *   to assume those facts. The default implementation just returns `true`.
    * * `tokenId(token)` -- Returns the portion of `token` which should be
-   *   considered its "ID" for the purposes of lookup, logging, etc.
+   *   considered its "ID" for the purposes of lookup, logging, etc. The default
+   *   implementation just returns the first 16 characters of the token.
    */
   static get bearerTokenValidator() {
-    // By default, bearer tokens merely have to be at least 32 characters long,
-    // with the first 16 being treated as the ID.
-
     return {
-      isToken: ((token) => {
-        return ((typeof token) === 'string') && (token.length >= 32);
+      isToken: ((token_unused) => {
+        return true;
       }),
       tokenId: ((token) => {
         return token.slice(0, 16);

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -47,9 +47,10 @@ export default class Hooks {
    *   valid (whether or not it actually grants any access). This will only ever
    *   get called on strings (per se) of at least 32 characters, so it is safe
    *   to assume those facts. The default implementation just returns `true`.
-   * * `tokenId(token)` -- Returns the portion of `token` which should be
-   *   considered its "ID" for the purposes of lookup, logging, etc. The default
-   *   implementation just returns the first 16 characters of the token.
+   * * `tokenId(token)` -- Returns the portion of (the string) `token` which
+   *   should be considered its "ID" for the purposes of lookup, logging, etc.
+   *   The default implementation just returns the first 16 characters of the
+   *   token.
    */
   static get bearerTokenValidator() {
     return {

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -43,23 +43,24 @@ export default class Hooks {
    * `api-client.BearerToken` for details. This object must implement two
    * methods:
    *
-   * * `isToken(token)` -- Returns `true` if the `token` is _syntactically_
-   *   valid (whether or not it actually grants any access). This will only ever
-   *   get called on strings (per se) of at least 32 characters, so it is safe
-   *   to assume those facts. The default implementation just returns `true`.
-   * * `tokenId(token)` -- Returns the portion of (the string) `token` which
+   * * `isToken(tokenString)` -- Returns `true` if the `tokenString` is
+   *   _syntactically_ valid as a bearer token (whether or not it actually
+   *   grants any access). This will only ever get called on strings (per se) of
+   *   at least 32 characters, so it is safe to assume those facts. The default
+   *   implementation just returns `true`.
+   * * `tokenId(tokenString)` -- Returns the portion of `tokenString` which
    *   should be considered its "ID" for the purposes of lookup, logging, etc.
    *   The default implementation just returns the first 16 characters of the
-   *   token.
+   *   string.
    */
   static get bearerTokenValidator() {
     return {
-      isToken(token_unused) {
+      isToken(tokenString_unused) {
         return true;
       },
 
-      tokenId(token) {
-        return token.slice(0, 16);
+      tokenId(tokenString) {
+        return tokenString.slice(0, 16);
       }
     };
   }


### PR DESCRIPTION
This PR cleans up a couple interconnected bearer token messes:

* Make the `BearerToken` class actually work properly. (It was untested before and had a couple deficiencies and a couple outright bugs.)
* Merge the hook `rootValidator` into the hook `bearerTokenValidator`, which removed what was formerly a bit of redundant functionality.

Bonus: Used moderner syntax in a couple places.
