### PR TITLE
Hook up root tokens to the main app context.

### DIFF
--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -27,14 +27,33 @@ export default class BearerToken extends BaseKey {
   /**
    * Coerces the given value into an instance of this class, if possible. If
    * given an instance of this class, returns that instance. If given a string,
-   * attempts to construct an instance from that string; this will fail if the
-   * string isn't in an acceptable form.
+   * attempts to construct an instance from that string. This will throw an
+   * error if the string isn't in an acceptable form.
    *
    * @param {*} value Value to coerce.
    * @returns {BearerToken} `value` or its coercion to a `BearerToken`.
    */
   static coerce(value) {
     return (value instanceof BearerToken) ? value : new BearerToken(value);
+  }
+
+  /**
+   * Coerces the given value into an instance of this class, if possible. If
+   * given an instance of this class, returns that instance. If given a string,
+   * attempts to construct an instance from that string. This will return `null`
+   * if the string isn't in an acceptable form.
+   *
+   * @param {*} value Value to coerce.
+   * @returns {BearerToken|null} `value` or its coercion to a `BearerToken`, or
+   *   `null` if `value` can't be coerced.
+   */
+  static coerceOrNull(value) {
+    try {
+      return BearerToken.coerce(value);
+    } catch (e) {
+      // Convert error to a `null` return.
+      return null;
+    }
   }
 
   /**

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -93,4 +93,27 @@ export default class BearerToken extends BaseKey {
     BearerToken.check(other);
     return this._secretToken === other._secretToken;
   }
+
+  /**
+   * Compares two arrays of `BearerToken`s for equality.
+   *
+   * @param {array<BearerToken>} array1 One array.
+   * @param {array<BearerToken>} array2 The other array.
+   * @returns {boolean} `true` iff the two arrays contain the same elements in
+   *   the same order.
+   */
+  static sameArrays(array1, array2) {
+    if (array1.length !== array2.length) {
+      return false;
+    }
+
+    for (let i = 0; i < array1.length; i++) {
+      const token1 = BearerToken.check(array1[i]);
+      if (!token1.sameToken(array2[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -86,6 +86,21 @@ export default class Connection {
     this._log.info(`Open via <${this._baseUrl}>.`);
   }
 
+  /** {string} The base URL. */
+  get baseUrl() {
+    return this._baseUrl;
+  }
+
+  /** {string} The connection ID. */
+  get connectionId() {
+    return this._connectionId;
+  }
+
+  /** {Context} The resource-binding context. */
+  get context() {
+    return this._context;
+  }
+
   /**
    * Handles an incoming message, which is expected to be in JSON string form.
    * Returns a promise for the response, which is also in JSON string form.
@@ -208,20 +223,5 @@ export default class Connection {
         throw new Error(`Bad action: \`${action}\``);
       }
     }
-  }
-
-  /** {string} The base URL. */
-  get baseUrl() {
-    return this._baseUrl;
-  }
-
-  /** {string} The connection ID. */
-  get connectionId() {
-    return this._connectionId;
-  }
-
-  /** {Context} The resource-binding context. */
-  get context() {
-    return this._context;
   }
 }

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -72,7 +72,7 @@ export default class Context {
    * error if the so-identified target does not exist.
    *
    * @param {string} id The target ID.
-   * @returns {object} The so-identified target.
+   * @returns {Target} The so-identified target.
    */
   get(id) {
     const result = this.getOrNull(id);
@@ -89,7 +89,7 @@ export default class Context {
    * so-identified target does not exist.
    *
    * @param {string} id The target ID.
-   * @returns {object|null} The so-identified target.
+   * @returns {Target|null} The so-identified target, or `null` if unbound.
    */
   getOrNull(id) {
     TString.check(id);
@@ -103,7 +103,7 @@ export default class Context {
    * so-identified target does not exist.
    *
    * @param {string} id The target ID.
-   * @returns {object} The so-identified target.
+   * @returns {Target} The so-identified target.
    */
   getUncontrolled(id) {
     const result = this.get(id);

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -116,6 +116,19 @@ export default class Context {
   }
 
   /**
+   * Gets the target associated with the indicated ID, but only if it is
+   * uncontrolled (that is, no auth required).
+   *
+   * @param {string} id The target ID.
+   * @returns {Target|null} The so-identified target if it is in fact bound and
+   *   uncontrolled, or `null` if it is either unbound or access-controlled.
+   */
+  getUncontrolledOrNull(id) {
+    const result = this.getOrNull(id);
+    return ((result !== null) && (result.key === null)) ? result : null;
+  }
+
+  /**
    * Returns an indication of whether or not this instance has a binding for
    * the given ID.
    *

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -14,9 +14,9 @@ import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { Dirs } from 'server-env';
 
-import Authorizer from './Authorizer';
 import DebugTools from './DebugTools';
 import RequestLogger from './RequestLogger';
+import RootAccess from './RootAccess';
 
 /** Logger. */
 const log = new SeeAll('app');
@@ -33,16 +33,23 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
+    /** {Context} All of the objects we provide access to via the API. */
+    const context = this._context = new Context();
+
+    /**
+     * {RootAccess} The "root access" object. This is the object which is
+     * protected by the root bearer token(s) returned via the related
+     * `hooks-server` hooks.
+     */
+    const rootAccess = this._rootAccess = new RootAccess(context);
+    context.add('auth', rootAccess.legacyAuth);
+
     /**
      * {DocForAuthor} The one document we manage. **TODO:** Needs to be more
      * than one!
      */
     this._doc = new DocForAuthor(
       DocServer.THE_INSTANCE.getDoc('some-id'), 'some-author');
-
-    /** {Context} All of the objects we provide access to via the API. */
-    const context = this._context = new Context();
-    context.add('auth', new Authorizer(context));
     context.add('main', this._doc);
 
     /** The underlying webserver run by this instance. */

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -10,13 +10,13 @@ import { SeeAll } from 'see-all';
 import { TString } from 'typecheck';
 
 /** Logger. */
-const log = new SeeAll('app-auth');
+const log = new SeeAll('root-access');
 
 /**
- * Handler for authorization. This is what answers `auth` requests that come in
- * via the API.
+ * "Root access" object. This is the object which is protected by the root
+ * bearer token(s) returned via the related `hooks-server` hooks.
  */
-export default class Authorizer {
+export default class RootAccess {
   /**
    * Constructs an instance.
    *
@@ -33,10 +33,6 @@ export default class Authorizer {
    * one author. If the document doesn't exist, this will cause it to be
    * created.
    *
-   * @param {BearerToken|string} rootCredential Credential (either a
-   *   `BearerToken` or a string that can be coerced to same) which provides
-   *   "root" access to this server. This method will throw an error if this
-   *   value does not correspond to a credential known to the server.
    * @param {string} authorId ID which corresponds to the author of changes that
    *   are made using the resulting authorization.
    * @param {string} docId ID of the document which the resulting authorization
@@ -44,14 +40,9 @@ export default class Authorizer {
    * @returns {SplitKey} Split token (ID + secret) which provides the requested
    *   access.
    */
-  makeAccessKey(rootCredential, authorId, docId) {
-    rootCredential = BearerToken.coerce(rootCredential);
+  makeAccessKey(authorId, docId) {
     TString.nonempty(authorId);
     TString.nonempty(docId);
-
-    if (!Hooks.bearerTokens.grantsRoot(rootCredential)) {
-      throw new Error('Not authorized.');
-    }
 
     const docControl = DocServer.THE_INSTANCE.getDoc(docId);
     const doc = new DocForAuthor(docControl, authorId);
@@ -76,5 +67,43 @@ export default class Authorizer {
     log.info(`  key id: ${key.id}`); // The ID is safe to log.
 
     return key;
+  }
+
+  /**
+   * An object which should be bound to the `auth` API endpoint. This is the
+   * old way to do root access. (Yeah, not actually _that_ old.)
+   *
+   * TODO: Remove this and `_legacyMakeAccessKey()` once `auth` is no longer
+   * used (that is, when we consistently use a bearer token in the API message
+   * `target` position to perform root auth).
+   *
+   * @returns {object} Object suitable for binding to `auth`.
+   */
+  get legacyAuth() {
+    return { makeAccessKey: this._legacyMakeAccessKey.bind(this) };
+  }
+
+  /**
+   * Old version of `makeAccessKey()` which takes an explicit token argument.
+   *
+   * @param {BearerToken|string} rootCredential Credential (either a
+   *   `BearerToken` or a string that can be coerced to same) which provides
+   *   "root" access to this server. This method will throw an error if this
+   *   value does not correspond to a credential known to the server.
+   * @param {string} authorId ID which corresponds to the author of changes that
+   *   are made using the resulting authorization.
+   * @param {string} docId ID of the document which the resulting authorization
+   *   allows access to.
+   * @returns {SplitKey} Split token (ID + secret) which provides the requested
+   *   access.
+   */
+  _legacyMakeAccessKey(rootCredential, authorId, docId) {
+    rootCredential = BearerToken.coerce(rootCredential);
+
+    if (!Hooks.bearerTokens.grantsRoot(rootCredential)) {
+      throw new Error('Not authorized.');
+    }
+
+    return this.makeAccessKey(authorId, docId);
   }
 }

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -5,7 +5,6 @@
 import { SplitKey } from 'api-common';
 import { BearerToken, Connection, Context } from 'api-server';
 import { DocForAuthor, DocServer } from 'doc-server';
-import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
 import { TString } from 'typecheck';
 
@@ -99,9 +98,12 @@ export default class RootAccess {
    */
   _legacyMakeAccessKey(rootCredential, authorId, docId) {
     rootCredential = BearerToken.coerce(rootCredential);
+    const target = this._context.getOrNull(rootCredential.id);
 
-    if (!Hooks.bearerTokens.grantsRoot(rootCredential)) {
+    if (target === null) {
       throw new Error('Not authorized.');
+    } if (target.target !== this) {
+      throw new Error('Not authorized (wrong target).');
     }
 
     return this.makeAccessKey(authorId, docId);

--- a/local-modules/hooks-server/BearerTokens.js
+++ b/local-modules/hooks-server/BearerTokens.js
@@ -2,6 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { BearerToken } from 'api-server';
+import { PromDelay } from 'util-common';
+
 /**
  * {BearerTokens|null} The unique instance of this class. Initialized in the
  * `THE_INSTANCE` getter below.
@@ -52,6 +55,17 @@ export default class BearerTokens {
   }
 
   /**
+   * {array<BearerToken>} Array of bearer tokens which grant root access to the
+   * system.
+   *
+   * The (obviously insecure) default is that a token consisting of 32 zeroes
+   * grants access.
+   */
+  get rootTokens() {
+    return Object.freeze([new BearerToken('0'.repeat(32))]);
+  }
+
+  /**
    * Returns the portion of `tokenString` which should be considered its "ID"
    * for the purposes of lookup, logging, etc.
    *
@@ -63,5 +77,22 @@ export default class BearerTokens {
    */
   tokenId(tokenString) {
     return tokenString.slice(0, 16);
+  }
+
+  /**
+   * Returns a promise which becomes resolved (to `true`) the next time that
+   * the list of `rootTokens` changes, or (on the margin) could conceivably have
+   * changed.
+   *
+   * The default implementation is for the promise to become resolved every
+   * ten minutes even though by default the root tokens never get updated, just
+   * so that the update logic gets excercised in the default configuration.
+   *
+   * @returns {Promise<true>} Promise that resolves when the root tokens should
+   *   be checked for update.
+   */
+  whenRootTokensChange() {
+    const CHANGE_FREQUENCY_MSEC = 10 * 60 * 60 * 1000;
+    return PromDelay.resolve(CHANGE_FREQUENCY_MSEC);
   }
 }

--- a/local-modules/hooks-server/BearerTokens.js
+++ b/local-modules/hooks-server/BearerTokens.js
@@ -27,19 +27,6 @@ export default class BearerTokens {
   }
 
   /**
-   * Returns `true` iff `token` (a `BearerToken` per se) grants root access to
-   * the system. The (obviously insecure) default is to treat a bearer token of
-   * 32 zeroes as granting access.
-   *
-   * @param {BearerToken} token Token to check.
-   * @returns {boolean} `true` iff `token` grants root access.
-   */
-  grantsRoot(token) {
-    // TODO: We should probably provide a less trivial default.
-    return token.secretToken === '0'.repeat(32);
-  }
-
-  /**
    * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
    * token (whether or not it actually grants any access). This will only ever
    * get called on strings (per se) of at least 32 characters, so it is safe to

--- a/local-modules/hooks-server/package.json
+++ b/local-modules/hooks-server/package.json
@@ -4,6 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
+    "api-server": "local",
     "doc-store-local": "local",
     "util-common": "local"
   }

--- a/local-modules/util-common/PromCondition.js
+++ b/local-modules/util-common/PromCondition.js
@@ -19,11 +19,9 @@ export default class PromCondition {
    *
    * @param {boolean} [initialValue = false] Initial value.
    */
-  constructor(initialValue) {
-    initialValue = TBoolean.check(initialValue, false);
-
+  constructor(initialValue = false) {
     /** Current value. */
-    this._value = initialValue;
+    this._value = TBoolean.check(initialValue);
 
     /**
      * Promises which get resolved when `_value` is `false` (index `0`) or

--- a/local-modules/util-common/PromCondition.js
+++ b/local-modules/util-common/PromCondition.js
@@ -71,6 +71,16 @@ export default class PromCondition {
   }
 
   /**
+   * Instantaneously switches the condition to `true` and then immediately
+   * back to `false`. This will cause all promises to resolve, no matter which
+   * state they were waiting for.
+   */
+  onOff() {
+    this.value = true;
+    this.value = false;
+  }
+
+  /**
    * Returns a promise which becomes resolved to `true` when the value of this
    * instance becomes `true`. If the value is already `true` then the return
    * value is an already-resolved promise.


### PR DESCRIPTION
This PR represents a markèd improvement to how the API is put together, changing root tokens from being a weird sidecar on the `auth` methods to instead being first-class targets. TLDR, before and after for the form of a key auth message:

Before:
```
["Message", 0, "auth", "call", "makeAccessKey", ["array", "root-token-99999", "author-id", "doc-id"]]
```

After:
```
["Message", 0, "root-token-99999", "call", "makeAccessKey", ["array", "author-id", "doc-id"]]
```

Actual console session (using the standard dummy token):
```
$ curl --silent --header 'Content-Type: application/json; charset=utf-8' \
    --data-raw '["Message", 0, "00000000000000000000000000000000", "call", "makeAccessKey", ["array", "author-id", "doc-id"]]' \
    http://localhost:8080/api \
    | jq .
{
  "id": 0,
  "result": [
    "SplitKey",
    "http://localhost:8080/api",
    "b0122abbe8f1bf8a",
    "878edebdb6c1b9b081181dab0022fdc4"
  ]
}
```
