### PR TITLE
More auth / multi-doc prep.

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -89,6 +89,10 @@ window.addEventListener('load', (event_unused) => {
   log.detail('Hooking up document client...');
   const docClient = new DocClient(quill, apiClient);
   docClient.start();
+  docClient.when_idle().then(() => {
+    log.detail('Document client hooked up.');
+    log.info('Initialization complete!');
+  });
 
-  log.detail('Done(ish). Async operations now in progress...');
+  log.detail('Async operations now in progress...');
 });

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -14,6 +14,7 @@ import { Decoder } from 'api-common';
 import { DocClient } from 'doc-client';
 import { Hooks } from 'hooks-client';
 import { QuillMaker } from 'quill-util';
+import { SeeAll } from 'see-all';
 import { SeeAllBrowser } from 'see-all-browser';
 
 // Pull the incoming parameters from `window.` globals into locals, to prevent
@@ -29,6 +30,7 @@ if (!(BAYOU_KEY && BAYOU_NODE)) {
 
 // Init logging.
 SeeAllBrowser.init();
+const log = new SeeAll('page-init');
 
 // Figure out the URL of our server. We use the `BAYOU_KEY` global specified by
 // the enclosing HTML. We don't just _always_ use the document's URL because it
@@ -50,26 +52,44 @@ if (baseUrl.length === 0) {
   throw new Error(`Could not determine base URL of: ${url}`);
 }
 
-// Give the overlay a chance to do any initialization.
-Hooks.run(window, baseUrl);
+// Arrange for the rest of initialization to happen once the initial page
+// contents are fully loaded.
+window.addEventListener('load', (event_unused) => {
+  log.info('Initial page load complete.');
 
-// Figure out what node we're attaching the editor to. We use the `BAYOU_NODE`
-// global specified by the enclosing HTML.
-if (document.querySelector(BAYOU_NODE) === null) {
-  const extra = (BAYOU_NODE[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
-  throw new Error(`No such selector${extra}: \`${BAYOU_NODE}\``);
-}
+  // Figure out what node we're attaching the editor to. We use the `BAYOU_NODE`
+  // global specified by the enclosing HTML.
+  if (document.querySelector(BAYOU_NODE) === null) {
+    // If we land here, no further init can possibly be done, so we just
+    // `return` out of it.
+    const extra = (BAYOU_NODE[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
+    log.error(`No such selector${extra}: \`${BAYOU_NODE}\``);
+    return;
+  }
 
-// Make the editor instance.
-const quill = QuillMaker.make(BAYOU_NODE);
+  // Give the overlay a chance to do any initialization.
+  log.detail('Running `run()` hook...');
+  Hooks.run(window, baseUrl);
 
-// Initialize the API connection, and hook it up to the Quill instance. Similar
-// to the node identification (immediately above), we use the URL inside the
-// `BAYOU_KEY`, if that's passed, falling back on the document URL for the
-// soon-to-be legacy case. TODO: Should probably insist on `BAYOU_KEY` being
-// defined.
+  // Make the editor instance.
+  log.detail('Making editor instance...');
+  const quill = QuillMaker.make(BAYOU_NODE);
 
-const apiClient = new ApiClient(baseUrl);
-apiClient.open();
-const docClient = new DocClient(quill, apiClient);
-docClient.start();
+  // Initialize the API connection, and hook it up to the Quill instance. Similar
+  // to the node identification (immediately above), we use the URL inside the
+  // `BAYOU_KEY`, if that's passed, falling back on the document URL for the
+  // soon-to-be legacy case. TODO: Should probably insist on `BAYOU_KEY` being
+  // defined.
+
+  log.detail('Opening API client...');
+  const apiClient = new ApiClient(baseUrl);
+  apiClient.open().then(() => {
+    log.detail('API client open.');
+  });
+
+  log.detail('Hooking up document client...');
+  const docClient = new DocClient(quill, apiClient);
+  docClient.start();
+
+  log.detail('Done(ish). Async operations now in progress...');
+});

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -16,20 +16,19 @@ import { Hooks } from 'hooks-client';
 import { QuillMaker } from 'quill-util';
 import { SeeAllBrowser } from 'see-all-browser';
 
-// Init logging.
-SeeAllBrowser.init();
+// Pull the incoming parameters from `window.` globals into locals, to prevent
+// them from getting trampled by other init code. Validate that they're present
+// before doing anything further.
 
-if (!(window.BAYOU_KEY && window.BAYOU_NODE)) {
+const BAYOU_KEY = window.BAYOU_KEY;
+const BAYOU_NODE = window.BAYOU_NODE;
+
+if (!(BAYOU_KEY && BAYOU_NODE)) {
   throw new Error('Missing configuration.');
 }
 
-// Figure out what node we're attaching the editor to. We use the `BAYOU_NODE`
-// global specified by the enclosing HTML
-const editorNode = window.BAYOU_NODE;
-if (document.querySelector(editorNode) === null) {
-  const extra = (editorNode[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
-  throw new Error(`No such selector${extra}: \`${editorNode}\``);
-}
+// Init logging.
+SeeAllBrowser.init();
 
 // Figure out the URL of our server. We use the `BAYOU_KEY` global specified by
 // the enclosing HTML. We don't just _always_ use the document's URL because it
@@ -40,7 +39,7 @@ if (document.querySelector(editorNode) === null) {
 // URL. However, when using the debugging routes, it's possible that we end up
 // with the catchall "URL" `*`. If so, we detect that here and fall back to
 // using the document's URL.
-const key = Decoder.decodeJson(window.BAYOU_KEY);
+const key = Decoder.decodeJson(BAYOU_KEY);
 const url = (key.url !== '*') ? key.url : document.URL;
 
 // Cut off after the host name. Putting the main expression in a `?` group
@@ -54,8 +53,15 @@ if (baseUrl.length === 0) {
 // Give the overlay a chance to do any initialization.
 Hooks.run(window, baseUrl);
 
+// Figure out what node we're attaching the editor to. We use the `BAYOU_NODE`
+// global specified by the enclosing HTML.
+if (document.querySelector(BAYOU_NODE) === null) {
+  const extra = (BAYOU_NODE[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
+  throw new Error(`No such selector${extra}: \`${BAYOU_NODE}\``);
+}
+
 // Make the editor instance.
-const quill = QuillMaker.make(editorNode);
+const quill = QuillMaker.make(BAYOU_NODE);
 
 // Initialize the API connection, and hook it up to the Quill instance. Similar
 // to the node identification (immediately above), we use the URL inside the

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -86,7 +86,6 @@ window.addEventListener('load', (event_unused) => {
   log.detail('Made editor instance.');
 
   // Hook the API up to the editor instance.
-  log.detail('Hooking up document client...');
   const docClient = new DocClient(quill, apiClient);
   docClient.start();
   docClient.when_idle().then(() => {


### PR DESCRIPTION
This PR makes the init code structure more suitable for having it do a real auth interaction, which ultimately will result in (a) proper auth being done, and (b) hooking up the correct document.

As a bit of a bonus, it is no longer necessary to put the `<script>` tag for the boot JS code after the definition of the editor `<div>`.