### PR TITLE
Perform auth!

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -42,8 +42,8 @@ log.detail('Starting...');
 // URL. However, when using the debugging routes, it's possible that we end up
 // with the catchall "URL" `*`. If so, we detect that here and fall back to
 // using the document's URL.
-const key = Decoder.decodeJson(BAYOU_KEY);
-const url = (key.url !== '*') ? key.url : document.URL;
+const documentKey = Decoder.decodeJson(BAYOU_KEY);
+const url = (documentKey.url !== '*') ? documentKey.url : document.URL;
 
 // Cut off after the host name. Putting the main expression in a `?` group
 // guarantees that the regex will match at least the empty string, which makes
@@ -68,7 +68,7 @@ apiClient.open().then(() => {
 
 // Ask for a challenge on the key we have. When we get it, provide the challenge
 // response so as to strip auth off of the so-guarded document.
-apiClient.meta.makeChallenge(key.id).then((challenge) => {
+apiClient.meta.makeChallenge(documentKey.id).then((challenge) => {
   // TODO: Respond.
   log.info('Got challenge:', challenge);
 });
@@ -97,7 +97,7 @@ window.addEventListener('load', (event_unused) => {
   log.detail('Made editor instance.');
 
   // Hook the API up to the editor instance.
-  const docClient = new DocClient(quill, apiClient);
+  const docClient = new DocClient(quill, apiClient, documentKey);
   docClient.start();
   docClient.when_idle().then(() => {
     log.detail('Document client hooked up.');

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -58,8 +58,19 @@ if (baseUrl.length === 0) {
 
 log.detail('Opening API client...');
 const apiClient = new ApiClient(baseUrl);
+
+// Start opening the connection. Even though the connection won't become open
+// synchronously, the API client code allows us to start sending messages over
+// it immediately. (They'll just get queued up.)
 apiClient.open().then(() => {
   log.detail('API client open.');
+});
+
+// Ask for a challenge on the key we have. When we get it, provide the challenge
+// response so as to strip auth off of the so-guarded document.
+apiClient.meta.makeChallenge(key.id).then((challenge) => {
+  // TODO: Respond.
+  log.info('Got challenge:', challenge);
 });
 
 // Arrange for the rest of initialization to happen once the initial page

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -312,6 +312,7 @@ export default class ApiClient {
 
     if (this._ws !== null) {
       // Already open(ing). Just return an appropriately-behaved promise.
+      this._log.detail('open() called while already opening.');
       return this.meta.ping();
     }
 
@@ -321,6 +322,8 @@ export default class ApiClient {
     this._ws.onerror   = this._handleError.bind(this);
     this._ws.onmessage = this._handleMessage.bind(this);
     this._ws.onopen    = this._handleOpen.bind(this);
+
+    this._log.detail('Opening connection...');
 
     return this.meta.connectionId().then((value) => {
       this._connectionId = value;

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -2,8 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Decoder, Encoder, Message } from 'api-common';
+import { BaseKey, Decoder, Encoder, Message } from 'api-common';
 import { SeeAll } from 'see-all';
+import { TString } from 'typecheck';
 import { WebsocketCodes } from 'util-common';
 
 import ApiError from './ApiError';
@@ -330,6 +331,22 @@ export default class ApiClient {
       this._log.info('Open.');
       return true;
     });
+  }
+
+  /**
+   * Gets a proxy for the target with the given ID or which is controlled by the
+   * given key (or which was so controlled prior to authorizing it away).
+   *
+   * @param {string|BaseKey} idOrKey ID or key for the target.
+   * @returns {Proxy} Proxy which locally represents the so-identified
+   *   server-side target.
+   */
+  getTarget(idOrKey) {
+    const id = (idOrKey instanceof BaseKey)
+      ? idOrKey.id
+      : TString.check(idOrKey);
+
+    return this._targets.createOrGet(id);
   }
 
   /**

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -300,14 +300,19 @@ export default class ApiClient {
 
   /**
    * Opens the websocket. Once open, any pending calls will get sent to the
-   * server side.
+   * server side. If the socket is already open (or in the process of opening),
+   * this does not re-open (that is, the existing open is allowed to continue).
    *
    * @returns {Promise} A promise for the result of opening. This will resolve
    * as a `true` success or fail with an `ApiError`.
    */
   open() {
+    // If `_ws` is `null` that means that the connection is not already open or
+    // in the process of opening.
+
     if (this._ws !== null) {
-      return Promise.reject(this._connError('client_bug', 'Already open.'));
+      // Already open(ing). Just return an appropriately-behaved promise.
+      return this.meta.ping();
     }
 
     const url = this._url;

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from 'typecheck';
+
 import TargetHandler from './TargetHandler';
 
 /**
@@ -14,21 +16,46 @@ export default class TargetMap {
    * @param {ApiClient} apiClient The client to forward calls to.
    */
   constructor(apiClient) {
+    /** {ApiClient} The client to forward calls to. */
+    this._apiClient = apiClient;
+
     /**
-     * The targets being provided, as a map from ID to proxy. **Note:** In a
-     * future incarnation, this map may contain more items and might even grow
-     * dynamically.
+     * {Map<string, TargetHandler>} The targets being provided, as a map from ID
+     * to proxy.
      */
     this._targets = new Map();
-    this._targets.set('main', TargetHandler.makeProxy(apiClient, 'main'));
-    this._targets.set('meta', TargetHandler.makeProxy(apiClient, 'meta'));
+
+    // Set up the standard initial map contents.
+    this.createOrGet('main');
+    this.createOrGet('meta');
+  }
+
+  /**
+   * Gets the proxy for the target with the given ID. If this ID isn't actually
+   * known to this instance, it creates it first, adding it to the map.
+   *
+   * @param {string} id The target ID.
+   * @returns {Proxy} The corresponding proxy.
+   */
+  createOrGet(id) {
+    TString.check(id);
+
+    const already = this._targets.get(id);
+
+    if (already) {
+      return already;
+    }
+
+    const result = TargetHandler.makeProxy(this._apiClient, id);
+    this._targets.set(id, result);
+    return result;
   }
 
   /**
    * Gets the proxy for the target with the given ID.
    *
    * @param {string} id The target ID.
-   * @returns {object} The corresponding proxy.
+   * @returns {Proxy} The corresponding proxy.
    */
   get(id) {
     const result = this._targets.get(id);

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -21,13 +21,11 @@ export default class TargetMap {
 
     /**
      * {Map<string, TargetHandler>} The targets being provided, as a map from ID
-     * to proxy.
+     * to proxy. Initialized in `reset()`.
      */
-    this._targets = new Map();
+    this._targets = null;
 
-    // Set up the standard initial map contents.
-    this.createOrGet('main');
-    this.createOrGet('meta');
+    this.reset();
   }
 
   /**
@@ -65,5 +63,17 @@ export default class TargetMap {
     }
 
     return result;
+  }
+
+  /**
+   * Resets the targets of this instance. This is used during instance init
+   * as well as when a connection gets reset.
+   */
+  reset() {
+    this._targets = new Map();
+
+    // Set up the standard initial map contents.
+    this.createOrGet('main');
+    this.createOrGet('meta');
   }
 }

--- a/local-modules/api-client/package.json
+++ b/local-modules/api-client/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "api-common": "local",
     "see-all": "local",
+    "typecheck": "local",
     "util-common": "local"
   }
 }

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -74,11 +74,13 @@ export default class BaseKey {
    * @param {string} challenge The challenge. This must be a string which was
    *   previously returned as the `challenge` binding from a call to
    *   `makeChallenge()` (either in this process or any other).
-   * @returns {string} The challenge response.
+   * @returns {string} The challenge response. It is guaranteed to be at least
+   *   16 characters long.
    */
   challengeResponseFor(challenge) {
     TString.minLen(challenge, 16);
-    return this._impl_challengeResponseFor(challenge);
+    const response = this._impl_challengeResponseFor(challenge);
+    return TString.minLen(response, 16);
   }
 
   /**

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -67,6 +67,61 @@ export default class BaseKey {
   }
 
   /**
+   * Gets a challenge response. This is used as a tactic for two sides of a
+   * connection to authenticate each other without ever having to provide a
+   * shared secret directly over a connection.
+   *
+   * @param {string} challenge The challenge. This must be a string which was
+   *   previously returned as the `challenge` binding from a call to
+   *   `makeChallenge()` (either in this process or any other).
+   * @returns {string} The challenge response.
+   */
+  challengeResponseFor(challenge) {
+    TString.minLen(challenge, 16);
+    return this._impl_challengeResponseFor(challenge);
+  }
+
+  /**
+   * Main implementation of `challengeResponseFor()`. By default this throws
+   * an error ("not implemented"). Subclasses wishing to support challenges
+   * must override this to do something else.
+   *
+   * @param {string} challenge The challenge. It is guaranteed to be a string of
+   *   at least 16 characters.
+   * @returns {string} The challenge response.
+   */
+  _impl_challengeResponseFor(challenge) {
+    return this._mustOverride(challenge);
+  }
+
+  /**
+   * Creates a random challenge, to be used for authenticating a peer, and
+   * provides both it and the expected response.
+   *
+   * @returns {object} An object which maps `challenge` to a random challenge
+   *   string and `response` to the expected response.
+   */
+  makeChallengePair() {
+    const challenge = this._impl_randomChallengeString();
+    const response  = this.challengeResponseFor(challenge);
+
+    TString.minLen(challenge, 16);
+    return { challenge, response };
+  }
+
+  /**
+   * Creates and returns a random challenge string. The returned string must be
+   * at least 16 characters long but may be longer. By default this throws an
+   * error ("not implemented"). Subclasses wishing to support challenges must
+   * override this to do something else.
+   *
+   * @returns {string} A random challenge string.
+   */
+  _impl_randomChallengeString() {
+    return this._mustOverride();
+  }
+
+  /**
    * Gets the printable form of the ID. This defaults to the same as `.id`,
    * but subclasses can override this if they want to produce something
    * different.

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -84,15 +84,13 @@ export default class SplitKey extends BaseKey {
   }
 
   /**
-   * Gets a challenge response. This is used as a tactic for two sides of a
-   * connection to authenticate each other without ever having to provide a
-   * shared secret directly over a connection.
+   * Main implementation of `challengeResponseFor()`, as defined by the
+   * superclass.
    *
-   * @param {string} challenge Challenge. This must be a string of 16 hex digits
-   *   (lower case).
+   * @param {string} challenge The challenge.
    * @returns {string} The challenge response.
    */
-  challengeResponseFor(challenge) {
+  _impl_challengeResponseFor(challenge) {
     TString.hexBytes(challenge, 8, 8);
 
     const hash = sha256.create();
@@ -104,15 +102,13 @@ export default class SplitKey extends BaseKey {
   }
 
   /**
-   * Creates a random challenge, to be used for authenticating a peer.
+   * Creates and returns a random challenge string, as defined by the
+   * superclass. In this case, the result is always an eight byte long hex
+   * string (lower case).
    *
-   * @returns {object} An object which maps `id` to the key ID, `challenge` to
-   *   the challenge string and `response` to the expected response.
+   * @returns {string} A random challenge string.
    */
-  randomChallenge() {
-    const id        = this._id;
-    const challenge = Random.hexByteString(8);
-    const response  = this.challengeResponseFor(challenge);
-    return { id, challenge, response };
+  _impl_randomChallengeString() {
+    return Random.hexByteString(8);
   }
 }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -11,7 +11,7 @@ import BearerToken from './BearerToken';
 import MetaHandler from './MetaHandler';
 import Context from './Context';
 
-/** Logger. */
+/** {SeeAll} Logger. */
 const log = new SeeAll('api');
 
 /**
@@ -58,7 +58,9 @@ export default class Connection {
    * Constructs an instance. Each instance corresponds to a separate client
    * connection.
    *
-   * @param {Context} context The binding context to provide access to.
+   * @param {Context} context The binding context to provide access to. This
+   *   value gets cloned, so that changes to the `this.context` do not affect
+   *   the originally passed value.
    * @param {string} baseUrl The public-facing base URL for this connection.
    */
   constructor(context, baseUrl) {
@@ -67,10 +69,6 @@ export default class Connection {
 
     /** {string} The public-facing base URL for this connection. */
     this._baseUrl = TString.nonempty(baseUrl);
-
-    // We add a `meta` binding to the initial set of targets, which is specific
-    // to this instance/connection.
-    this._context.add('meta', new MetaHandler(this));
 
     /**
      * {string} Short label string used to identify this connection in logs.
@@ -83,6 +81,10 @@ export default class Connection {
 
     /** {SeeAll} Logger which includes the connection ID as a prefix. */
     this._log = log.withPrefix(`[${this._connectionId}]`);
+
+    // We add a `meta` binding to the initial set of targets, which is specific
+    // to this instance/connection.
+    this._context.add('meta', new MetaHandler(this));
 
     this._log.info(`Open via <${this._baseUrl}>.`);
   }
@@ -100,6 +102,11 @@ export default class Connection {
   /** {Context} The resource-binding context. */
   get context() {
     return this._context;
+  }
+
+  /** {SeeAll} Connection-specific logger. */
+  get log() {
+    return this._log;
   }
 
   /**

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -169,6 +169,19 @@ export default class Context {
   }
 
   /**
+   * Removes the key that controls the target with the given ID. It is an error
+   * to try to operate on a nonexistent or uncontrolled target. This replaces
+   * the `target` with a newly-constructed one that has no auth control; it
+   * does _not_ modify the original `target` object (which is immutable).
+   *
+   * @param {string} id The ID of the target whose key is to be removed.
+   */
+  removeKey(id) {
+    const target = this.getControlled(id);
+    this._map.set(id, target.withoutKey());
+  }
+
+  /**
    * Clones this instance. The resulting clone has a separate underlying map.
    * That is, adding targets to the clone does not affect its progenitor.
    *

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -176,7 +176,7 @@ export default class Context {
    *
    * @param {string} id The ID of the target whose key is to be removed.
    */
-  removeKey(id) {
+  removeControl(id) {
     const target = this.getControlled(id);
     this._map.set(id, target.withoutKey());
   }

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -85,6 +85,24 @@ export default class Context {
   }
 
   /**
+   * Gets the target associated with the indicated ID, but only if it is
+   * controlled (that is, it requires auth). This will throw an error if the
+   * so-identified target does not exist.
+   *
+   * @param {string} id The target ID.
+   * @returns {Target} The so-identified target.
+   */
+  getControlled(id) {
+    const result = this.get(id);
+
+    if (result.key === null) {
+      throw new Error(`Not a controlled target: \`${id}\``);
+    }
+
+    return result;
+  }
+
+  /**
    * Gets the target associated with the indicated ID, or `null` if the
    * so-identified target does not exist.
    *

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -2,6 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from 'typecheck';
+import { PromDelay } from 'util-common';
+
+/** {Int} How long an unanswered challenge remains active for, in msec. */
+const CHALLENGE_TIMEOUT_MSEC = 5 * 60 * 1000; // Five minutes.
+
 /**
  * Class to handle meta-requests.
  */
@@ -12,14 +18,65 @@ export default class MetaHandler {
    * @param {Connection} connection The connection.
    */
   constructor(connection) {
-    /** The connection. */
+    /** {Connection} The connection. */
     this._connection = connection;
+
+    /** {SeeAll} The connection-specific logger. */
+    this._log = connection.log;
+
+    /**
+     * {Map<challenge, {id, response}>} Map from challenge string to associated
+     * ID and response.
+     */
+    this._activeChallenges = new Map();
+  }
+
+  /**
+   * Called to respond to a successful challenge (which was presumably made via
+   * `makeChallenge()`. If `challenge` and `response` correspond to an active
+   * challenge-response pair, then this method will remove the key that controls
+   * the associated target, in the current session. (Other sessions will not be
+   * affected, including sessions created later.) It is only ever valid to
+   * respond to any given challenge once.
+   *
+   * This method will throw an error if the arguments don't refer to an active
+   * challenge (because it never existed, because it was already used, or
+   * because it expired).
+   *
+   * @param {string} challenge The challenge string.
+   * @param {string} response The challenge response.
+   */
+  authWithChallengeResponse(challenge, response) {
+    TString.check(challenge);
+    TString.check(response);
+
+    const challengeInfo = this._activeChallenges.get(challenge);
+
+    if (!challengeInfo || (response !== challengeInfo.response)) {
+      // **Note:** We don't differentiate reasons for rejection (beyond type
+      // checking, above), as that could reveal security-sensitive info.
+      throw new Error('Invalid challenge pair.');
+    }
+
+    const id = challengeInfo.id;
+
+    // Remove the challenge from the active set, so that a given challenge can
+    // only be used once.
+    this._activeChallenges.delete(challenge);
+
+    // The main action: Replace the target for `id` with an equivalent one
+    // except without auth control.
+    this._connection.context.removeControl(id);
+
+    this._log.info(`Authed challenge: ${id} ${challenge}`);
   }
 
   /**
    * Generates and returns a challenge for the key that controls the target with
    * the given ID. It is an error to request a challenge for a nonexistent or
-   * uncontrolled target.
+   * uncontrolled target. Once returned, challenges are considered active only
+   * for a limited amount of time (approximately five minutes), after which
+   * they are expired.
    *
    * @param {string} id Target whose key is to be challenged.
    * @returns {string} A challenge string that can subsequently be answered so
@@ -28,11 +85,37 @@ export default class MetaHandler {
    */
   makeChallenge(id) {
     const target = this._connection.context.getControlled(id);
-    const challengePair = target.key.makeChallengePair();
 
-    // TODO: Remember the challenge, so we can validate it when the response
-    // comes in.
-    return challengePair.challenge;
+    let challengePair;
+    for (;;) {
+      challengePair = target.key.makeChallengePair();
+      if (!this._activeChallenges.get(challenge)) {
+        break;
+      }
+
+      // We managed to get a duplicate challenge. This is highly unusual, but
+      // it _can_ happen. So, just iterate and try again.
+    }
+
+    const { challenge, response } = challengePair;
+
+    // Store the challenge, and arrange for its expiry.
+
+    this._activeChallenges.set(challenge, { id, response });
+    PromDelay.resolve(CHALLENGE_TIMEOUT_MSEC).then(() => {
+      if (this._activeChallenges.delete(challenge)) {
+        // `delete` returns `true` to indicate that the value was found. In this
+        // case, it means that it expired.
+        this._log.info(`Challenge expired: ${id} ${challenge}`);
+      }
+    });
+
+    // **Note:** It's probably okay to log the expected response, but may be
+    // worth thinking a bit more about. (Attention: Security professionals!)
+    this._log.info(`New challenge: ${id} ${challenge}`);
+    this._log.info(`  => ${response}`);
+
+    return challenge;
   }
 
   /**

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -17,6 +17,25 @@ export default class MetaHandler {
   }
 
   /**
+   * Generates and returns a challenge for the key that controls the target with
+   * the given ID. It is an error to request a challenge for a nonexistent or
+   * uncontrolled target.
+   *
+   * @param {string} id Target whose key is to be challenged.
+   * @returns {string} A challenge string that can subsequently be answered so
+   *   as to remove key control for the target, in the context of the current
+   *   session.
+   */
+  makeChallenge(id) {
+    const target = this._connection.context.getControlled(id);
+    const challengePair = target.key.makeChallengePair();
+
+    // TODO: Remember the challenge, so we can validate it when the response
+    // comes in.
+    return challengePair.challenge;
+  }
+
+  /**
    * API meta-method `connectionId`: Returns the connection ID that is assigned
    * to this connection. This is only meant to be used for logging. For example,
    * it is _not_ guaranteed to be unique.

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -85,7 +85,9 @@ export default class Target {
    *
    * @param {string} name The method name.
    * @param {Array} args Arguments to the method.
-   * @returns {Promise} A promise for the result.
+   * @returns {*} The result of calling. Because `undefined` isn't used across
+   *   the API, this method returns `null` if the original method returned
+   *   `undefined`.
    */
   call(name, args) {
     TString.nonempty(name);
@@ -103,6 +105,8 @@ export default class Target {
 
     const target = this._target;
     const impl = target[name];
-    return impl.apply(target, args);
+    const result = impl.apply(target, args);
+
+    return (result === undefined) ? null : result;
   }
 }

--- a/local-modules/api-server/package.json
+++ b/local-modules/api-server/package.json
@@ -9,6 +9,7 @@
       "api-common": "local",
       "hooks-server": "local",
       "see-all": "local",
+      "typecheck": "local",
       "util-common": "local"
   }
 }

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -310,6 +310,7 @@ export default class DocClient extends StateMachine {
     this._api.open();
 
     // Perform a challenge-response to authorize access to the document.
+    // TODO: This should be moved into the `ApiClient` code.
     this._api.meta.makeChallenge(this._docId).then((challenge) => {
       log.info(`Got challenge: ${challenge}`);
       const response = this._docKey.challengeResponseFor(challenge);

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -73,15 +73,20 @@ export default class DocClient extends StateMachine {
    *
    * @param {Quill} quill Quill editor instance.
    * @param {ApiClient} api API Client instance.
+   * @param {BaseKey} documentKey Key that identifies and controls access to the
+   *   document on the server.
    */
-  constructor(quill, api) {
+  constructor(quill, api, documentKey) {
     super('detached', log);
 
-    /** Editor object. */
+    /** {Quill} Editor object. */
     this._quill = quill;
 
-    /** API interface. */
+    /** {ApiClient} API interface. */
     this._api = api;
+
+    /** {BaseKey} Key that identifies and controls access to the document. */
+    this._documentKey = documentKey;
 
     /**
      * {Snapshot|null} Current version of the document as received from the
@@ -270,9 +275,6 @@ export default class DocClient extends StateMachine {
     this._pendingDeltaAfter = false;
     this._pendingLocalDocumentChange = false;
 
-    // Reopen the connection to the server.
-    this._api.open();
-
     // After this, it's just like starting from the `detached` state.
     this.s_detached();
     this.q_start();
@@ -284,6 +286,9 @@ export default class DocClient extends StateMachine {
    * This is the kickoff event.
    */
   _handle_detached_start() {
+    // Open (or reopen) the connection to the server.
+    this._api.open();
+
     // TODO: This should probably arrange for a timeout.
     this._api.main.snapshot().then(
       (value) => {

--- a/local-modules/doc-client/StateMachine.js
+++ b/local-modules/doc-client/StateMachine.js
@@ -109,6 +109,11 @@ export default class StateMachine {
     this._serviceEventQueue(); // Set up the queue servicer; it self-perpetuates.
   }
 
+  /** {string} The current state. */
+  get state() {
+    return this._state;
+  }
+
   /**
    * Adds to this instance one method per event name, named `q_<name>`, each of
    * which takes any number of arguments and enqueues an event with the
@@ -126,6 +131,10 @@ export default class StateMachine {
 
         if ((validArgs !== undefined) && !Array.isArray(validArgs)) {
           throw new Error(`Invalid validator result (non-array) for \`${name}\`.`);
+        }
+
+        if (this._eventQueue === null) {
+          throw new Error('Cannot queue events on aborted instance.');
         }
 
         this._log.detail('Enqueued:', name, args);


### PR DESCRIPTION
The main thrust of this PR is to push authorization all the way through, such that the document client code actually does get authorized for the document represented by the key it gets passed in the top-level JS init code. ***Whee!*** That said, the authed document still isn't used in the client. But _that_ said, there's not that much left to do to enable it.

**Bonus:** Improved a lot of error reporting and edge case handling, because I tripped over all of that stuff while trying to get the main part of this PR working.