### PR TITLE
Full auth flow and multi-doc support.

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -336,7 +336,9 @@ export default class ApiClient {
 
   /**
    * Gets a proxy for the target with the given ID or which is controlled by the
-   * given key (or which was so controlled prior to authorizing it away).
+   * given key (or which was so controlled prior to authorizing it away). The
+   * target must already have been authorized for this method to work (otherwise
+   * it is an error); use `authorizeTarget()` to perform authorization.
    *
    * @param {string|BaseKey} idOrKey ID or key for the target.
    * @returns {Proxy} Proxy which locally represents the so-identified
@@ -347,7 +349,7 @@ export default class ApiClient {
       ? idOrKey.id
       : TString.check(idOrKey);
 
-    return this._targets.getOrCreate(id);
+    return this._targets.get(id);
   }
 
   /**

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -389,13 +389,6 @@ export default class ApiClient {
   }
 
   /**
-   * {Proxy} The main object upon which API calls can be made.
-   */
-  get main() {
-    return this._targets.get('main');
-  }
-
-  /**
    * {Proxy} The object upon which meta-API calls can be made.
    */
   get meta() {

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -356,23 +356,18 @@ export default class ApiClient {
    * target (that is, `this.getTarget(key)`) can be accessed without further
    * authorization.
    *
+   * If `key.id` is already mapped by this instance, the corresponding target
+   * is returned directly without further authorization. (That is, this method
+   * is idempotent.)
+   *
    * @param {BaseKey} key Key to authorize with.
    * @returns {Promise<Proxy>} Promise which resolves to the proxy that
    *   represents the foreign target which is controlled by `key`, once
    *   authorization is complete.
    */
   authorizeTarget(key) {
-    const id = key.id;
-
-    return this.meta.makeChallenge(id).then((challenge) => {
-      this._log.info(`Got challenge: ${id} ${challenge}`);
-      const response = key.challengeResponseFor(challenge);
-      return this.meta.authWithChallengeResponse(challenge, response);
-    }).then(() => {
-      // Successful auth.
-      this._log.info(`Authed: ${id}`);
-      return this.getTarget(id);
-    });
+    // Just pass through to the target map.
+    return this._targets.authorizeTarget(key);
   }
 
   /**
@@ -382,6 +377,13 @@ export default class ApiClient {
    */
   get connectionId() {
     return this._connectionId;
+  }
+
+  /**
+   * {SeeAll} The client-specific logger.
+   */
+  get log() {
+    return this._log;
   }
 
   /**

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -140,7 +140,6 @@ export default class TargetMap {
     this._pendingAuths = new Map();
 
     // Set up the standard initial map contents.
-    this._addTarget('main');
     this._addTarget('meta');
   }
 

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
+import { BaseClass } from 'util-common';
 
 /**
  * Base class for access keys. An access key consists of information for
@@ -22,7 +23,7 @@ import { TObject, TString } from 'typecheck';
  * **Note:** The resource ID is _not_ meant to require secrecy in order for
  * the system to be secure. That is, IDs are not required to be unguessable.
  */
-export default class BaseKey {
+export default class BaseKey extends BaseClass {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *
@@ -45,6 +46,8 @@ export default class BaseKey {
    *   least 8 characters.
    */
   constructor(url, id) {
+    super();
+
     if (url !== '*') {
       TString.urlAbsolute(url);
     }
@@ -142,16 +145,5 @@ export default class BaseKey {
   toString() {
     const name = this.constructor.API_NAME || this.constructor.name;
     return `{${name} ${this._url} ${this._impl_printableId()}}`;
-  }
-
-  /**
-   * Helper function which always throws. Using this both documents the intent
-   * in code and keeps the linter from complaining about the documentation
-   * (`@param`, `@returns`, etc.).
-   *
-   * @param {...*} args_unused Anything you want, to keep the linter happy.
-   */
-  _mustOverride(...args_unused) {
-    throw new Error('Must override.');
   }
 }

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -11,8 +11,9 @@ import Target from './Target';
  * just a map from IDs to `Target` instances, along with reasonably
  * straightforward accessor and update methods.
  *
- * As a convention, `main` is the ID of the object providing the main
- * functionality, and `meta` provides meta-information and meta-control.
+ * When initially set up, a context only has one binding. Specifically,
+ * `meta` is bound to an object which provides meta-information and
+ * meta-control.
  */
 export default class Context {
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -53,14 +53,6 @@ export default class Application {
     // for their update should the token(s) change.
     this._bindRoot();
 
-    /**
-     * {DocForAuthor} The one document we manage. **TODO:** Needs to be more
-     * than one!
-     */
-    this._doc = new DocForAuthor(
-      DocServer.THE_INSTANCE.getDoc('some-id'), 'some-author');
-    context.add('main', this._doc);
-
     /** The underlying webserver run by this instance. */
     this._app = express();
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -322,8 +322,7 @@ export default class DocClient extends StateMachine {
     // TODO: This whole flow should probably be protected by a timeout.
     this._api.authorizeTarget(this._docKey).then((docProxy) => {
       this._docProxy = docProxy;
-      // TODO: Use the docProxy.
-      return this._api.main.snapshot().then((value) => {
+      return docProxy.snapshot().then((value) => {
         this.q_gotSnapshot(value);
       }).catch((error) => {
         this.q_apiError('snapshot', error);
@@ -411,7 +410,7 @@ export default class DocClient extends StateMachine {
     if (!this._pendingDeltaAfter) {
       this._pendingDeltaAfter = true;
 
-      this._api.main.deltaAfter(baseDoc.verNum).then((value) => {
+      this._docProxy.deltaAfter(baseDoc.verNum).then((value) => {
         this._pendingDeltaAfter = false;
         this.q_gotDeltaAfter(baseDoc, value.verNum, value.delta);
       }).catch((error) => {
@@ -560,7 +559,7 @@ export default class DocClient extends StateMachine {
     const expectedContents = this._doc.contents.compose(delta);
 
     // Send the delta, and handle the response.
-    this._api.main.applyDelta(this._doc.verNum, delta).then((value) => {
+    this._docProxy.applyDelta(this._doc.verNum, delta).then((value) => {
       this.q_gotApplyDelta(expectedContents, value.verNum, value.delta);
     }).catch((error) => {
       this.q_apiError('applyDelta', error);

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -4,6 +4,7 @@
 
 import { DocumentChange, VersionNumber } from 'doc-common';
 import { TBoolean, TObject, TString } from 'typecheck';
+import { BaseClass } from 'util-common';
 
 /**
  * Base class representing access to a particular document. Subclasses must
@@ -14,7 +15,7 @@ import { TBoolean, TObject, TString } from 'typecheck';
  * of changes, with each change having a version number that _must_ form a
  * zero-based integer sequence. Changes are random-access.
  */
-export default class BaseDoc {
+export default class BaseDoc extends BaseClass {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *
@@ -31,6 +32,8 @@ export default class BaseDoc {
    * @param {string} docId The ID of the document this instance represents.
    */
   constructor(docId) {
+    super();
+
     /** The ID of the document that this instance represents. */
     this._id = TString.nonempty(docId);
   }
@@ -175,16 +178,5 @@ export default class BaseDoc {
    */
   _impl_changeAppend(change) {
     this._mustOverride(change);
-  }
-
-  /**
-   * Helper function which always throws. Using this both documents the intent
-   * in code and keeps the linter from complaining about the documentation
-   * (`@param`, `@returns`, etc.).
-   *
-   * @param {...*} args_unused Anything you want, to keep the linter happy.
-   */
-  _mustOverride(...args_unused) {
-    throw new Error('Must override.');
   }
 }

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
+import { BaseClass } from 'util-common';
 
 import BaseDoc from './BaseDoc';
 
@@ -11,7 +12,7 @@ import BaseDoc from './BaseDoc';
  * methods defined by this class, as indicated in the documentation. Methods to
  * override are all named with the prefix `_impl_`.
  */
-export default class BaseDocStore {
+export default class BaseDocStore extends BaseClass {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *
@@ -61,16 +62,5 @@ export default class BaseDocStore {
    */
   _impl_getDocument(docId) {
     return this._mustOverride(docId);
-  }
-
-  /**
-   * Helper function which always throws. Using this both documents the intent
-   * in code and keeps the linter from complaining about the documentation
-   * (`@param`, `@returns`, etc.).
-   *
-   * @param {...*} args_unused Anything you want, to keep the linter happy.
-   */
-  _mustOverride(...args_unused) {
-    throw new Error('Must override.');
   }
 }

--- a/local-modules/doc-store/package.json
+++ b/local-modules/doc-store/package.json
@@ -5,6 +5,7 @@
 
   "dependencies": {
     "doc-common": "local",
-    "typecheck": "local"
+    "typecheck": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/util-common/BaseClass.js
+++ b/local-modules/util-common/BaseClass.js
@@ -1,0 +1,21 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Base class which provides a couple conveniences beyond what baseline
+ * JavaScript has.
+ */
+export default class BaseClass {
+  /**
+   * Helper function which always throws an error with the message `Must
+   * override.`. Using this both documents the intent in code and keeps the
+   * linter from complaining about the documentation (`@param`, `@returns`,
+   * etc.).
+   *
+   * @param {...*} args_unused Anything you want, to keep the linter happy.
+   */
+  _mustOverride(...args_unused) {
+    throw new Error('Must override.');
+  }
+}

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -4,6 +4,7 @@
 
 import { ObjectUtil } from 'util-base';
 
+import BaseClass from './BaseClass';
 import DataUtil from './DataUtil';
 import DeferredLoader from './DeferredLoader';
 import JsonUtil from './JsonUtil';
@@ -14,6 +15,7 @@ import Random from './Random';
 import WebsocketCodes from './WebsocketCodes';
 
 export {
+  BaseClass,
   DataUtil,
   DeferredLoader,
   JsonUtil,

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.10.0
+version = 0.11.0


### PR DESCRIPTION
This PR finishes up the work of getting three-party auth hooked up such that, when performed, the client-side editor gets connected to the document on the back end which it was in fact authorized for.

**Bonus:**

* Straightened out a few other bits in the `api-client` code (definition of `ApiError`, straightforwardness of the `_send()` code).
* Factored out the abstract class helper `_mustOverride()` into a new utility `BaseClass`.