### PR TITLE
Base class again

### DIFF
--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -25,16 +25,6 @@ import { CommonBase } from 'util-common';
  */
 export default class BaseKey extends CommonBase {
   /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {BearerToken} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, BaseKey);
-  }
-
-  /**
    * Constructs an instance with the indicated parts. Subclasses should override
    * methods as described in the documentation.
    *

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
-import { BaseClass } from 'util-common';
+import { CommonBase } from 'util-common';
 
 /**
  * Base class for access keys. An access key consists of information for
@@ -23,7 +23,7 @@ import { BaseClass } from 'util-common';
  * **Note:** The resource ID is _not_ meant to require secrecy in order for
  * the system to be secure. That is, IDs are not required to be unguessable.
  */
-export default class BaseKey extends BaseClass {
+export default class BaseKey extends CommonBase {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 /**

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -15,35 +15,15 @@ import { TString } from 'typecheck';
  */
 export default class BearerToken extends BaseKey {
   /**
-   * Coerces the given value into an instance of this class, if possible. If
-   * given an instance of this class, returns that instance. If given a string,
-   * attempts to construct an instance from that string. This will throw an
-   * error if the string isn't in an acceptable form.
+   * Main coercion implementation, per the superclass documentation. In this
+   * case, `value` must be a string that follows the proper syntax for bearer
+   * tokens. If not, this will throw an error.
    *
    * @param {*} value Value to coerce.
-   * @returns {BearerToken} `value` or its coercion to a `BearerToken`.
+   * @returns {BearerToken} `value` as coerced to a `BearerToken`.
    */
-  static coerce(value) {
-    return (value instanceof BearerToken) ? value : new BearerToken(value);
-  }
-
-  /**
-   * Coerces the given value into an instance of this class, if possible. If
-   * given an instance of this class, returns that instance. If given a string,
-   * attempts to construct an instance from that string. This will return `null`
-   * if the string isn't in an acceptable form.
-   *
-   * @param {*} value Value to coerce.
-   * @returns {BearerToken|null} `value` or its coercion to a `BearerToken`, or
-   *   `null` if `value` can't be coerced.
-   */
-  static coerceOrNull(value) {
-    try {
-      return BearerToken.coerce(value);
-    } catch (e) {
-      // Convert error to a `null` return.
-      return null;
-    }
+  static _impl_coerce(value) {
+    return new BearerToken(value);
   }
 
   /**

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -4,7 +4,7 @@
 
 import { BaseKey } from 'api-common';
 import { Hooks } from 'hooks-server';
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
 
 /**
  * Bearer token, which is a kind of key which conflates ID and secret.

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -15,16 +15,6 @@ import { TObject, TString } from 'typecheck';
  */
 export default class BearerToken extends BaseKey {
   /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {BearerToken} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, BearerToken);
-  }
-
-  /**
    * Coerces the given value into an instance of this class, if possible. If
    * given an instance of this class, returns that instance. If given a string,
    * attempts to construct an instance from that string. This will throw an
@@ -109,7 +99,13 @@ export default class BearerToken extends BaseKey {
       return false;
     }
 
+    // It's an error if `other` is not a key, but it's merely a `false` return
+    // if `other` isn't an instance of this class.
     BaseKey.check(other);
+    if (!(other instanceof BearerToken)) {
+      return false;
+    }
+
     return this._secretToken === other._secretToken;
   }
 

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -4,8 +4,8 @@
 
 import { Decoder, Encoder, Message } from 'api-common';
 import { SeeAll } from 'see-all';
-import { TString, TObject } from 'typecheck';
-import { Random } from 'util-common';
+import { TString } from 'typecheck';
+import { CommonBase, Random } from 'util-common';
 
 import BearerToken from './BearerToken';
 import MetaHandler from './MetaHandler';
@@ -31,7 +31,7 @@ let activeNow = null;
  * lower-level connection (or the like). This class in turn mostly bottoms out
  * by calling on target objects, which perform the actual application services.
  */
-export default class Connection {
+export default class Connection extends CommonBase {
   /**
    * {Connection|null} The instance of this class that is currently active, or
    * `null` if no connection is active _within this turn of execution_. This is
@@ -45,16 +45,6 @@ export default class Connection {
   }
 
   /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {Connection} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, Connection);
-  }
-
-  /**
    * Constructs an instance. Each instance corresponds to a separate client
    * connection.
    *
@@ -64,6 +54,8 @@ export default class Connection {
    * @param {string} baseUrl The public-facing base URL for this connection.
    */
   constructor(context, baseUrl) {
+    super();
+
     /** {Context} The binding context to provide access to. */
     this._context = Context.check(context).clone();
 

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 import Target from './Target';
 
@@ -15,21 +16,13 @@ import Target from './Target';
  * `meta` is bound to an object which provides meta-information and
  * meta-control.
  */
-export default class Context {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {DocumentChange} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, Context);
-  }
-
+export default class Context extends CommonBase {
   /**
    * Constructs an instance which is initially empty.
    */
   constructor() {
+    super();
+
     /** {Map<string,Target>} The underlying map. */
     this._map = new Map();
 

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -3,7 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { FrozenDelta } from 'doc-common';
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 import Timestamp from './Timestamp';
 import VersionNumber from './VersionNumber';
@@ -17,17 +18,7 @@ import VersionNumber from './VersionNumber';
  * if a mutable delta is passed to the constructor of this class, it is coerced
  * into immutable form.
  */
-export default class DocumentChange {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {DocumentChange} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, DocumentChange);
-  }
-
+export default class DocumentChange extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -43,6 +34,8 @@ export default class DocumentChange {
    *   author of the change. Allowed to be `null` if the change is authorless.
    */
   constructor(verNum, timestamp, delta, authorId) {
+    super();
+
     /** The produced version number. */
     this._verNum = VersionNumber.check(verNum);
 

--- a/local-modules/doc-common/Snapshot.js
+++ b/local-modules/doc-common/Snapshot.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 import FrozenDelta from './FrozenDelta';
 import VersionNumber from './VersionNumber';
@@ -11,17 +11,7 @@ import VersionNumber from './VersionNumber';
 /**
  * Snapshot of a document, with other associated information.
  */
-export default class Snapshot {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {Snapshot} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, Snapshot);
-  }
-
+export default class Snapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -30,6 +20,8 @@ export default class Snapshot {
    *   anything that can be coerced into a `FrozenDelta`.
    */
   constructor(verNum, contents) {
+    super();
+
     /** Version number. */
     this._verNum = VersionNumber.check(verNum);
 

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -2,7 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TObject } from 'typecheck';
+import { TInt } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 /**
  * Minimum (inclusive) acceptable timestamp `secs` value.
@@ -36,17 +37,7 @@ const USECS_PER_SEC = 1000000;
  * restricted to fall within a range of dates with a minimum around the start
  * of the year 2002 and a maximum around the start of the year 2050.
  */
-export default class Timestamp {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {Timestamp} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, Timestamp);
-  }
-
+export default class Timestamp extends CommonBase {
   /**
    * Constructs an instance from a millisecond-granularity time value, such as
    * might have been returned from `Date.now()`.
@@ -79,6 +70,8 @@ export default class Timestamp {
    *   than 1000000.
    */
   constructor(secs, usecs) {
+    super();
+
     /** Seconds since the Unix epoch. */
     this._secs = TInt.range(secs, MIN_SECS, MAX_SECS);
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -5,8 +5,8 @@
 import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
 import { BaseDoc } from 'doc-store';
-import { TInt, TObject, TString } from 'typecheck';
-import { PromCondition } from 'util-common';
+import { TInt, TString } from 'typecheck';
+import { CommonBase, PromCondition } from 'util-common';
 
 
 /**
@@ -14,23 +14,15 @@ import { PromCondition } from 'util-common';
  * this class per document, no matter how many active editors there are on that
  * document.
  */
-export default class DocControl {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {DocControl} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, DocControl);
-  }
-
+export default class DocControl extends CommonBase {
   /**
    * Constructs an instance.
    *
    * @param {BaseDoc} docStorage The underlying document storage.
    */
   constructor(docStorage) {
+    super();
+
     /** {BaseDoc} Storage access for the document. */
     this._doc = BaseDoc.check(docStorage);
 

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -4,7 +4,7 @@
 
 import { DocumentChange, VersionNumber } from 'doc-common';
 import { TBoolean, TObject, TString } from 'typecheck';
-import { BaseClass } from 'util-common';
+import { CommonBase } from 'util-common';
 
 /**
  * Base class representing access to a particular document. Subclasses must
@@ -15,7 +15,7 @@ import { BaseClass } from 'util-common';
  * of changes, with each change having a version number that _must_ form a
  * zero-based integer sequence. Changes are random-access.
  */
-export default class BaseDoc extends BaseClass {
+export default class BaseDoc extends CommonBase {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { DocumentChange, VersionNumber } from 'doc-common';
-import { TBoolean, TObject, TString } from 'typecheck';
+import { TBoolean, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 /**
@@ -16,16 +16,6 @@ import { CommonBase } from 'util-common';
  * zero-based integer sequence. Changes are random-access.
  */
 export default class BaseDoc extends CommonBase {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {BaseDoc} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, BaseDoc);
-  }
-
   /**
    * Constructs an instance.
    *

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import BaseDoc from './BaseDoc';
@@ -13,16 +13,6 @@ import BaseDoc from './BaseDoc';
  * override are all named with the prefix `_impl_`.
  */
 export default class BaseDocStore extends CommonBase {
-  /**
-   * Checks that a value is an instance of this class. Throws an error if not.
-   *
-   * @param {*} value Value to check.
-   * @returns {BaseDocStore} `value`.
-   */
-  static check(value) {
-    return TObject.check(value, BaseDocStore);
-  }
-
   /**
    * Checks a document ID for validity. Returns regularly (with no value) if
    * all is well, or throws an error if the ID is invalid. Only ever called on

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
-import { BaseClass } from 'util-common';
+import { CommonBase } from 'util-common';
 
 import BaseDoc from './BaseDoc';
 
@@ -12,7 +12,7 @@ import BaseDoc from './BaseDoc';
  * methods defined by this class, as indicated in the documentation. Methods to
  * override are all named with the prefix `_impl_`.
  */
-export default class BaseDocStore extends BaseClass {
+export default class BaseDocStore extends CommonBase {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -2,11 +2,28 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TObject } from 'typecheck';
+
 /**
  * Base class which provides a couple conveniences beyond what baseline
  * JavaScript has.
  */
 export default class CommonBase {
+  /**
+   * Checks that a value is an instance of this class. Throws an error if not.
+   * This works for any subclass of this class, e.g., if `Foo` is a subclass of
+   * `CommonBase`, then `Foo.check(value)` is a check that `value` is an
+   * instance of `Foo` (and not just and instance of `CommonBase`).
+   *
+   * @param {*} value Value to check.
+   * @returns {BearerToken} `value`.
+   */
+  static check(value) {
+    // **Note:** In the context of static methods, `this` refers to the class
+    // that was called upon.
+    return TObject.check(value, this);
+  }
+
   /**
    * Helper function which always throws an error with the message `Must
    * override.`. Using this both documents the intent in code and keeps the

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -10,6 +10,25 @@ import { TObject } from 'typecheck';
  */
 export default class CommonBase {
   /**
+   * Adds the instance and static methods defined on this class to another
+   * class, that is, treat this class as a "mixin" and apply it to the given
+   * class.
+   *
+   * @param {class} clazz Class to mix into.
+   */
+  static mixInto(clazz) {
+    clazz.check         = this.check;
+    clazz.coerce        = this.coerce;
+    clazz.coerceOrNull  = this.coerceOrNull;
+    clazz._mustOverride = this.mustOverride;
+
+    const thisProto  = this.prototype;
+    const clazzProto = clazz.prototype;
+
+    clazzProto._mustOverride = thisProto._mustOverride;
+  }
+
+  /**
    * Checks that a value is an instance of this class. Throws an error if not.
    *
    * This method works for any subclass of this class, e.g., if `Foo` is a
@@ -47,10 +66,10 @@ export default class CommonBase {
     // that was called upon.
 
     if (value instanceof this) {
-      return this;
+      return value;
     } else {
       const result = this._impl_coerce(value);
-      if (!(value instanceof this)) {
+      if (!(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
         throw new Error('Invalid `_impl_coerce()` implementation.');
@@ -95,7 +114,7 @@ export default class CommonBase {
     // that was called upon.
 
     if (value instanceof this) {
-      return this;
+      return value;
     } else {
       const result = this._impl_coerceOrNull(value);
       if (!(result instanceof this)) {

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -11,9 +11,10 @@ import { TObject } from 'typecheck';
 export default class CommonBase {
   /**
    * Checks that a value is an instance of this class. Throws an error if not.
-   * This works for any subclass of this class, e.g., if `Foo` is a subclass of
-   * `CommonBase`, then `Foo.check(value)` is a check that `value` is an
-   * instance of `Foo` (and not just and instance of `CommonBase`).
+   *
+   * This method works for any subclass of this class, e.g., if `Foo` is a
+   * subclass of `CommonBase`, then `Foo.check(value)` is a check that `value`
+   * is an instance of `Foo` (and not just and instance of `CommonBase`).
    *
    * @param {*} value Value to check.
    * @returns {BearerToken} `value`.
@@ -25,6 +26,106 @@ export default class CommonBase {
   }
 
   /**
+   * Coerces the given value into an instance of this class, if possible. If
+   * given an instance of this class, returns that instance. If given any other
+   * argument, calls `_impl_coerce()` on that value, which is responsible for
+   * the main act of coercion. If coercion isn't possible, this throws an error.
+   *
+   * This method works for any subclass of this class, e.g., if `Foo` is a
+   * subclass of `CommonBase`, then `Foo.coerce(value)` is a coercion of `value`
+   * to class `Foo`.
+   *
+   * By default, `_impl_coerce()` always throws an error. Subclasses can
+   * override this to provide more useful behavior.
+   *
+   * @param {*} value Value to coerce.
+   * @returns {object|null} `value` or its coercion to the class that this was
+   *   called on, or `null` if `value` can't be coerced.
+   */
+  static coerce(value) {
+    // **Note:** In the context of static methods, `this` refers to the class
+    // that was called upon.
+
+    if (value instanceof this) {
+      return this;
+    } else {
+      const result = this._impl_coerce(value);
+      if (!(value instanceof this)) {
+        // There is a bug in the subclass, as it should never return any other
+        // kind of value.
+        throw new Error('Invalid `_impl_coerce()` implementation.');
+      }
+      return result;
+    }
+  }
+
+  /**
+   * Subclass-specifc implementation of `coerce()`. Subclasses can override this
+   * as needed.
+   *
+   * @param {*} value Value to coerce. This is guaranteed _not_ to be an
+   *   instance of this class.
+   * @returns {object|null} `value` or its coercion to the class that this was
+   *   called on, or `null` if `value` can't be coerced.
+   */
+  static _impl_coerce(value) {
+    return this._mustOverride(value);
+  }
+
+  /**
+   * Coerces the given value into an instance of this class, if possible. If
+   * given an instance of this class, returns that instance. If given any other
+   * argument, calls `_impl_coerceOrNull()` on that value, which is responsible
+   * for the main act of coercion.
+   *
+   * This method works for any subclass of this class, e.g., if `Foo` is a
+   * subclass of `CommonBase`, then `Foo.coerceOrNull(value)` is a coercion of
+   * `value` to class `Foo`.
+   *
+   * By default, `_impl_coerceOrNull()` calls through to `_impl_coerce()` and
+   * converts any thrown exceptions to a `null` return. Subclasses can override
+   * this to provide more nuanced behavior.
+   *
+   * @param {*} value Value to coerce.
+   * @returns {object|null} `value` or its coercion to the class that this was
+   *   called on, or `null` if `value` can't be coerced.
+   */
+  static coerceOrNull(value) {
+    // **Note:** In the context of static methods, `this` refers to the class
+    // that was called upon.
+
+    if (value instanceof this) {
+      return this;
+    } else {
+      const result = this._impl_coerceOrNull(value);
+      if (!(result instanceof this)) {
+        // There is a bug in the subclass, as it should never return any other
+        // kind of value.
+        throw new Error('Invalid `_impl_coerceOrNull()` implementation.');
+      }
+      return result;
+    }
+  }
+
+  /**
+   * Subclass-specific implementation of `coerceOrNull()`. Subclasses can
+   * override this as needed.
+   *
+   * @param {*} value Value to coerce. This is guaranteed _not_ to be an
+   *   instance of this class.
+   * @returns {object|null} `value` or its coercion to the class that this was
+   *   called on, or `null` if `value` can't be coerced.
+   */
+  static _impl_coerceOrNull(value) {
+    try {
+      return this._impl_coerce(value);
+    } catch (error_unused) {
+      // Swallow the error and return `null`, per the docs.
+      return null;
+    }
+  }
+
+  /**
    * Helper function which always throws an error with the message `Must
    * override.`. Using this both documents the intent in code and keeps the
    * linter from complaining about the documentation (`@param`, `@returns`,
@@ -33,6 +134,18 @@ export default class CommonBase {
    * @param {...*} args_unused Anything you want, to keep the linter happy.
    */
   _mustOverride(...args_unused) {
+    CommonBase._mustOverride();
+  }
+
+  /**
+   * Helper function which always throws an error with the message `Must
+   * override.`. Using this both documents the intent in code and keeps the
+   * linter from complaining about the documentation (`@param`, `@returns`,
+   * etc.).
+   *
+   * @param {...*} args_unused Anything you want, to keep the linter happy.
+   */
+  static _mustOverride(...args_unused) {
     throw new Error('Must override.');
   }
 }

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -6,7 +6,7 @@
  * Base class which provides a couple conveniences beyond what baseline
  * JavaScript has.
  */
-export default class BaseClass {
+export default class CommonBase {
   /**
    * Helper function which always throws an error with the message `Must
    * override.`. Using this both documents the intent in code and keeps the

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -4,7 +4,7 @@
 
 import { ObjectUtil } from 'util-base';
 
-import BaseClass from './BaseClass';
+import CommonBase from './CommonBase';
 import DataUtil from './DataUtil';
 import DeferredLoader from './DeferredLoader';
 import JsonUtil from './JsonUtil';
@@ -15,7 +15,7 @@ import Random from './Random';
 import WebsocketCodes from './WebsocketCodes';
 
 export {
-  BaseClass,
+  CommonBase,
   DataUtil,
   DeferredLoader,
   JsonUtil,


### PR DESCRIPTION
This PR expands the common base class that was defined in an earlier PR, to add the static methods `check()`, `coerce()`, and `coerceOrNull()` that had been defined in a more ad-hoc fashion throughout the code base.

The one somewhat-tricky bit was getting this stuff into `FrozenDelta`, because it already had a superclass (`Delta`) whose definition we don't control and so could not be made to inherit from our base class. What I did was define a `mixInto()` static method to shuttle the base class methods onto an otherwise-complete class.

Of note, I renamed `BaseClass` to `CommonBase`, because when the word `class` appears as a class name, it is commonly assumed that _instances_ of that class are classes, which was not the case here.