### PR TITLE
Mostly about error recovery.

### DIFF
--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -39,6 +39,8 @@
   elem.rel = 'stylesheet';
   document.head.appendChild(elem);
 
+  // Add the main JavaScript bundle to the page. Once loaded, this continues
+  // the boot process. You can find its main entrypoint in `client/js/main.js`.
   elem = document.createElement('script');
   elem.src = baseUrl + '/static/bundle.js';
   document.head.appendChild(elem);

--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -32,16 +32,9 @@
     ? window.location.origin
     : url.match(/^https?:\/\/[^\/]+/)[0];
 
-  var elem;
-
-  elem = document.createElement('link');
-  elem.href = baseUrl + '/static/quill/quill.bubble.css';
-  elem.rel = 'stylesheet';
-  document.head.appendChild(elem);
-
   // Add the main JavaScript bundle to the page. Once loaded, this continues
   // the boot process. You can find its main entrypoint in `client/js/main.js`.
-  elem = document.createElement('script');
+  var elem = document.createElement('script');
   elem.src = baseUrl + '/static/bundle.js';
   document.head.appendChild(elem);
 }());

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -101,6 +101,9 @@ window.addEventListener('load', (event_unused) => {
     log.detail('Document client hooked up.');
     log.info('Initialization complete!');
   });
+  docClient.when_unrecoverableError().then(() => {
+    log.error('Unrecoverable error! Giving up!');
+  });
 
   log.detail('Async operations now in progress...');
 });

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -80,6 +80,12 @@ window.addEventListener('load', (event_unused) => {
     return;
   }
 
+  // Do our basic page setup. Specifically, we add the CSS we need to the page.
+  const elem = document.createElement('link');
+  elem.href = `${baseUrl}/static/quill/quill.bubble.css`;
+  elem.rel = 'stylesheet';
+  document.head.appendChild(elem);
+
   // Give the overlay a chance to do any initialization.
   Hooks.run(window, baseUrl);
   log.detail('Ran `run()` hook.');

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -34,42 +34,42 @@ export default class ApiClient {
     this._url = ApiClient._getWebsocketUrl(url);
 
     /**
-     * Connection ID conveyed to us by the server. Set / reset in
+     * {string|null} Connection ID conveyed to us by the server. Set / reset in
      * `_resetConnection()`.
      */
     this._connectionId = null;
 
-    /** Logger which prefixes everything with the connection ID. */
+    /** {SeeAll} Logger which prefixes everything with the connection ID. */
     this._log = log.withDynamicPrefix(() => [`[${this._connectionId}]`]);
 
     /**
-     * Actual websocket instance. Set by `open()`. Reset in
+     * {WebSocket} Actual websocket instance. Set by `open()`. Reset in
      * `_resetConnection()`.
      */
     this._ws = null;
 
     /**
-     * Next message ID to use when sending a message. Initialized and reset in
-     * `_resetConnection()`.
+     * {Int} Next message ID to use when sending a message. Initialized and
+     * reset in `_resetConnection()`.
      */
     this._nextId = 0;
 
     /**
-     * Map from message IDs to response callbacks. Each callback is an object
-     * that maps `resolve` and `reject` to functions that obey the usual
-     * promise contract for functions of those names. Initialized and reset in
-     * `_resetConnection()`.
+     * {object<Int,{resolve, reject}>} Map from message IDs to response
+     * callbacks. Each callback is an object that maps `resolve` and `reject` to
+     * functions that obey the usual promise contract for functions of those
+     * names. Initialized and reset in `_resetConnection()`.
      */
     this._callbacks = null;
 
     /**
-     * List of pending payloads (to be sent to the far side of the connection).
-     * Only used when connection is in the middle of being established.
-     * Initialized and reset in `_resetConnection()`.
+     * {array<string>} List of pending payloads (to be sent to the far side of
+     * the connection). Only used when connection is in the middle of being
+     * established. Initialized and reset in `_resetConnection()`.
      */
     this._pendingPayloads = null;
 
-    /** Map of names to target proxies. */
+    /** {TargetMap} Map of names to target proxies. */
     this._targets = new TargetMap(this);
 
     // Initialize the active connection fields (described above).

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -102,24 +102,27 @@ export default class DocClient extends StateMachine {
     this._doc = null;
 
     /**
-     * Current (most recent) local change to the document made by Quill that
-     * this instance is aware of. That is, `_currentChange.next` (once it
-     * resolves) is the first change that this instance has not yet processed.
-     * This variable is initialized by getting `Quill.currentChange` and is
-     * generally updated by retrieving `.nextNow` from the value (or its
-     * replacement, etc.).
+     * {DeltaEvent|object} Current (most recent) local change to the document
+     * made by Quill that this instance is aware of. That is,
+     * `_currentChange.next` (once it resolves) is the first change that this
+     * instance has not yet processed. This variable is initialized by getting
+     * `_quill.currentChange` and is generally updated by waiting on `.next` or
+     * retrieving `.nextNow` from the value. In a couple cases, though, instead
+     * of being a `DeltaEvent` per se, it is a "manually" constructed object
+     * with the general shape of a `DeltaEvent`; these are used very transiently
+     * to handle multi-way change merging.
      */
     this._currentChange = null;
 
     /**
-     * Is there currently a pending (as-yet unfulfilled) `deltaAfter()` request
-     * to the server?
+     * {boolean} Is there currently a pending (as-yet unfulfilled) `deltaAfter()`
+     * request to the server?
      */
     this._pendingDeltaAfter = false;
 
     /**
-     * Is there currently a pending (as-yet unfulfilled) request for a new
-     * local change via the Quill document change promise chain?
+     * {boolean} Is there currently a pending (as-yet unfulfilled) request for a
+     * new local change via the Quill document change promise chain?
      */
     this._pendingLocalDocumentChange = false;
 
@@ -303,7 +306,21 @@ export default class DocClient extends StateMachine {
     // This space intentionally left blank (except for logging): We might get
     // "zombie" events from a connection that's shuffling towards doom. But even
     // if so, we will already have set up a timer to reset the connection.
-    log.info('While error-waiting:', name, args);
+    log.info('While in state `errorWait`:', name, args);
+  }
+
+  /**
+   * In state `unrecoverableError`, handles all events. Specifically, this does
+   * nothing, and no further events can be expected. Client code of this class
+   * can use the transition into this state to perform higher-level error
+   * recovery.
+   *
+   *
+   * @param {string} name The event name.
+   * @param {...*} args The event arguments.
+   */
+  _handle_unrecoverableError_any(name, ...args) {
+    log.info('While in state `unrecoverableError`:', name, args);
   }
 
   /**

--- a/local-modules/quill-util/DeltaEvent.js
+++ b/local-modules/quill-util/DeltaEvent.js
@@ -6,7 +6,22 @@ import { FrozenDelta } from 'doc-common';
 
 /**
  * Event wrapper for a Quill Delta, including reference to the document source,
- * the old contents, and the chain of subsequent events.
+ * the old contents, and the chain of subsequent events. It defines the
+ * following properties:
+ *
+ * * `delta` -- Same as with `text-change` events.
+ * * `oldContents` -- Same as with `text-change` events.
+ * * `source`  -- Same as with `text-change` events.
+ * * `next` -- A promise for the very next change (in order). You can use this
+ *   to iterate over changes as they continue to happen.
+ * * `nextNow` -- The next change after this one as a regular object (not a
+ *   promise), but only if it is already available. You can use this to
+ *   synchronously iterate up to the current (latest) change, and know if in
+ *   fact the change you are looking at is the current one (because `nextNow`
+ *   will be `null` until the next change actually happens).
+ *
+ * Instances of this class are always frozen (read-only) to help protect clients
+ * from each other (or from inadvertently messing with themselves).
  */
 export default class DeltaEvent {
   /**

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -35,8 +35,8 @@ export default class QuillProm extends Quill {
     const accessKey = Object.freeze(['quill-prom-key']);
 
     /**
-     * The most recent resolved event. It is initialized as defined by the
-     * documentation for `currentChange`.
+     * {DeltaEvent} The most recent resolved event. It is initialized as defined
+     * by the documentation for `currentChange`.
      */
     this._currentChange = new DeltaEvent(
       accessKey, FrozenDelta.EMPTY, FrozenDelta.EMPTY, API);
@@ -62,26 +62,11 @@ export default class QuillProm extends Quill {
   }
 
   /**
-   * The current (latest / most recent) document change that has been made to
-   * this instance. It is always a regular value (not a promise), in particular
-   * an object with bindings as follows:
+   * {DeltaEvent} The current (latest / most recent) document change that has
+   * been made to this instance. It is always a regular value (not a promise).
    *
-   * * `delta` -- Same as with `text-change` events.
-   * * `oldContents` -- Same as with `text-change` events.
-   * * `source`  -- Same as with `text-change` events.
-   * * `next` -- A promise for the very next change (in order). You can use this
-   *   to iterate over changes as they continue to happen.
-   * * `nextNow` -- The next change after this one as a regular object (not a
-   *   promise), but only if it is already available. You can use this to
-   *   synchronously iterate up to the current (latest) change, and know if in
-   *   fact the change you are looking at is the current one (because `nextNow`
-   *   will be `null` until the next change actually happens).
-   *
-   * The value is always read-only to help protect clients from each other (or
-   * from inadvertently messing with themselves).
-   *
-   * If accessed before any changes have ever been made to this instance,
-   * `delta` and `oldContents` are both empty deltas.
+   * **Note:** If accessed before any changes have ever been made to this
+   * instance, `delta` and `oldContents` are both empty deltas.
    */
   get currentChange() {
     return this._currentChange;


### PR DESCRIPTION
This PR adds a bit of smarts to `DocClient` so that it can decide when it's gotten into an unrecoverable error state (from its perspective). When this happens, it transitions into a special state. And that transition becomes a signal to the higher layer of the system, which ultimately will be able to do _something_ to further the recovery effort. For now, though, when that happens it just complains to the log and then goes silent.

**Bonus:**
* Cleaned up / fixed / tweaked a bunch of docs.
* Made the `DocClient` logs get prefixed with the document's ID (as known on the client).
* Moved the CSS setup to a more sensical location.