### PR TITLE
Error recovery

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -168,15 +168,15 @@ export default class TopControl {
   _recoverIfPossible() {
     log.error('Editor gave up!');
 
-    const newKeyJson = this._recover();
-    if (typeof newKeyJson !== 'string') {
+    const newKey = this._recover();
+    if (typeof newKey !== 'string') {
       log.info('Nothing more to do. :\'(');
       return;
     }
 
-    //const newKey = Decoder.decodeJson(newKeyJson);
-    log.info('Giving up!');
-
-    // TODO: Something useful.
+    log.info('Attempting recovery with new key...');
+    this._key = SplitKey.check(Decoder.decodeJson(newKey));
+    this._makeApiClient();
+    this._makeDocClient();
   }
 }

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -24,8 +24,6 @@ export default class TopControl {
    * @param {Window} window The browser window in which we are operating.
    */
   constructor(window) {
-    const document = window.document;
-
     /** {Window} The browser window in which we are operating. */
     this._window = window;
 
@@ -69,14 +67,13 @@ export default class TopControl {
    * Start things up.
    */
   start() {
-    // Initialize the API connection. We do this in parallel with the rest of the
-    // page loading, so as to minimize time-to-interactive.
+    // Initialize the API connection. We do this in parallel with the rest of
+    // the page loading, so as to minimize time-to-interactive.
 
     log.detail('Opening API client...');
+
     const apiClient = new ApiClient(this._getUrl());
 
-    // Start opening the connection, to maybe save a bit of time (that is, the
-    // document can finish loading in parallel with the API connection opening up).
     apiClient.open().then(() => {
       log.detail('API client open.');
     });
@@ -109,14 +106,7 @@ export default class TopControl {
       log.detail('Made editor instance.');
 
       // Hook the API up to the editor instance.
-      this._docClient = new DocClient(this._quill, apiClient, this._key);
-      this._docClient.start();
-      this._docClient.when_idle().then(() => {
-        log.detail('Document client hooked up.');
-        log.info('Initialization complete!');
-      });
-      this._docClient.when_unrecoverableError().then(
-        this._recoverIfPossible.bind(this));
+      this._makeDocClient(apiClient);
 
       log.detail('Async operations now in progress...');
     });
@@ -141,6 +131,22 @@ export default class TopControl {
     return (this._key.url !== '*')
       ? this._key.url
       : this._window.document.URL;
+  }
+
+  /**
+   * Constructs and hooks up a `DocClient` instance.
+   *
+   * @param {ApiClient} apiClient API client instance to use.
+   */
+  _makeDocClient(apiClient) {
+    this._docClient = new DocClient(this._quill, apiClient, this._key);
+    this._docClient.start();
+    this._docClient.when_idle().then(() => {
+      log.detail('Document client hooked up.');
+      log.info('Initialization complete!');
+    });
+    this._docClient.when_unrecoverableError().then(
+      this._recoverIfPossible.bind(this));
   }
 
   /**

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -1,0 +1,169 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { ApiClient } from 'api-client';
+import { Decoder, SplitKey } from 'api-common';
+import { DocClient } from 'doc-client';
+import { Hooks } from 'hooks-client';
+import { QuillMaker } from 'quill-util';
+import { SeeAll } from 'see-all';
+import { TFunction, TString } from 'typecheck';
+
+/** {SeeAll} Logger for this module. */
+const log = new SeeAll('top');
+
+/**
+ * Top-level control for an editor. This is responsible for setting up the
+ * browser environment and for keeping things going.
+ */
+export default class TopControl {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Window} window The browser window in which we are operating.
+   */
+  constructor(window) {
+    const document = window.document;
+
+    /** {Window} The browser window in which we are operating. */
+    this._window = window;
+
+    // Pull the incoming parameters from `window.*` globals into instance
+    // variables. Validate that they're present before doing anything further.
+
+    /**
+     * {string} Key that authorizes access and update to a particular document as
+     * a specific author. This is expected to be a `SplitKey` in JSON-encoded form.
+     */
+    this._key = SplitKey.check(Decoder.decodeJson(window.BAYOU_KEY));
+
+    /**
+     * {string} DOM Selector string that indicates which node in the DOM should
+     * become the editor.
+     */
+    this._node = TString.nonempty(window.BAYOU_NODE);
+
+    /**
+     * {function} Function to call when the editor finds itself in an unrecoverable
+     * (to it) situation. If it returns at all, it is expected to return a new key
+     * to use (instead of `BAYOU_KEY`); if it does not return a string that can
+     * be decoded into a `SplitKey`, the system will simply halt.
+     *
+     * If not supplied, this variable defaults to a no-op function.
+    */
+    this._recover =
+      TFunction.check(window.BAYOU_RECOVER || (() => { /* empty */ }));
+
+    // For calculating the `baseUrl`, below (see which).
+    const fullUrl = (this._key.url !== '*') ? this._key.url : document.URL;
+
+    /**
+     * {string} The base URL of our server. We use the info from the key if
+     * available but default to the document URL if not.
+     *
+     * **Note:** We don't just _always_ use the document's URL because it is
+     * possible (and common even) to embed an editor on a page that has a
+     * different origin than the server.
+     *
+     * **Note:** Under normal circumstances, the key we receive comes with a
+     * real URL. However, when using the debugging routes, it's possible that we
+     * end up with the catchall "URL" `*`. If so, that's when we fall back to
+     * using the document's URL.
+     */
+    this._baseUrl = fullUrl.match(/^([a-z]+:\/\/[^\/]+)?/)[0];
+
+    // **Note:** It's always safe to take the `.length`, because we put the main
+    // expression in a `?` group, guaranteeing that the regex will have matched
+    // at least the empty string.
+    if (this._baseUrl.length === 0) {
+      throw new Error(`Could not determine base URL of: ${fullUrl}`);
+    }
+
+    /** {QuillProm|null} Editor instance. Becomes non-null in `start()`. */
+    this._quill = null;
+
+    /**
+     * {DocClient|null} Client instance (API-to-editor hookup). Becomes non-null
+     * in `start()`.
+     */
+    this._docClient = null;
+  }
+
+  /**
+   * Start things up.
+   */
+  start() {
+    // Initialize the API connection. We do this in parallel with the rest of the
+    // page loading, so as to minimize time-to-interactive.
+
+    log.detail('Opening API client...');
+    const apiClient = new ApiClient(this._baseUrl);
+
+    // Start opening the connection, to maybe save a bit of time (that is, the
+    // document can finish loading in parallel with the API connection opening up).
+    apiClient.open().then(() => {
+      log.detail('API client open.');
+    });
+
+    // Arrange for the rest of initialization to happen once the initial page
+    // contents are fully loaded.
+    this._window.addEventListener('load', (event_unused) => {
+      log.detail('Initial page load complete.');
+
+      // Do our basic page setup. Specifically, we add the CSS we need to the page.
+      const elem = document.createElement('link');
+      elem.href = `${this._baseUrl}/static/quill/quill.bubble.css`;
+      elem.rel = 'stylesheet';
+      document.head.appendChild(elem);
+
+      // Validate `_node`.
+      if (document.querySelector(this._node) === null) {
+        // If we land here, no further init can possibly be done, so we just
+        // `throw` out of it.
+        const extra = (this._node[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
+        throw new Error(`No such selector${extra}: \`${this._node}\``);
+      }
+
+      // Give the overlay a chance to do any initialization.
+      Hooks.run(this._window, this._baseUrl);
+      log.detail('Ran `run()` hook.');
+
+      // Make the editor instance.
+      this._quill = QuillMaker.make(this._node);
+      log.detail('Made editor instance.');
+
+      // Hook the API up to the editor instance.
+      this._docClient = new DocClient(this._quill, apiClient, this._key);
+      this._docClient.start();
+      this._docClient.when_idle().then(() => {
+        log.detail('Document client hooked up.');
+        log.info('Initialization complete!');
+      });
+      this._docClient.when_unrecoverableError().then(
+        this._recoverIfPossible.bind(this));
+
+      log.detail('Async operations now in progress...');
+    });
+  }
+
+  /**
+   * This gets called when the editor gives up from getting too many errors. If
+   * the `_recover` function returns something useful, this attempts to restart
+   * the client.
+   */
+  _recoverIfPossible() {
+    log.error('Editor gave up!');
+
+    const newKeyJson = this._recover();
+    if (typeof newKeyJson !== 'string') {
+      log.info('Nothing more to do. :\'(');
+      return;
+    }
+
+    //const newKey = Decoder.decodeJson(newKeyJson);
+    log.info('Giving up!');
+
+    // TODO: Something useful.
+  }
+}

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -55,21 +55,6 @@ export default class TopControl {
     this._recover =
       TFunction.check(window.BAYOU_RECOVER || (() => { /* empty */ }));
 
-    /**
-     * {string} The URL of our server. We use the info from the key if
-     * available but default to the document URL if not.
-     *
-     * **Note:** We don't just _always_ use the document's URL because it is
-     * possible (and common even) to embed an editor on a page that has a
-     * different origin than the server.
-     *
-     * **Note:** Under normal circumstances, the key we receive comes with a
-     * real URL. However, when using the debugging routes, it's possible that we
-     * end up with the catchall "URL" `*`. If so, that's when we fall back to
-     * using the document's URL.
-     */
-    this._url = (this._key.url !== '*') ? this._key.url : document.URL;
-
     /** {QuillProm|null} Editor instance. Becomes non-null in `start()`. */
     this._quill = null;
 
@@ -88,7 +73,7 @@ export default class TopControl {
     // page loading, so as to minimize time-to-interactive.
 
     log.detail('Opening API client...');
-    const apiClient = new ApiClient(this._url);
+    const apiClient = new ApiClient(this._getUrl());
 
     // Start opening the connection, to maybe save a bit of time (that is, the
     // document can finish loading in parallel with the API connection opening up).
@@ -135,6 +120,27 @@ export default class TopControl {
 
       log.detail('Async operations now in progress...');
     });
+  }
+
+  /**
+   * Gets the URL to use when attaching to a server. We use the info from the
+   * `_key` if but default to the document URL if not.
+   *
+   * **Note:** We don't just _always_ use the document's URL because it is
+   * possible (and common even) to embed an editor on a page that has a
+   * different origin than the server.
+   *
+   * **Note:** Under normal circumstances, the key we receive comes with a
+   * real URL. However, when using the debugging routes, it's possible that we
+   * end up with the catchall "URL" `*`. If so, that's when we fall back to
+   * using the document's URL. client.
+   *
+   * @returns {string} The server URL.
+   */
+  _getUrl() {
+    return (this._key.url !== '*')
+      ? this._key.url
+      : this._window.document.URL;
   }
 
   /**

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -55,11 +55,8 @@ export default class TopControl {
     this._recover =
       TFunction.check(window.BAYOU_RECOVER || (() => { /* empty */ }));
 
-    // For calculating the `baseUrl`, below (see which).
-    const fullUrl = (this._key.url !== '*') ? this._key.url : document.URL;
-
     /**
-     * {string} The base URL of our server. We use the info from the key if
+     * {string} The URL of our server. We use the info from the key if
      * available but default to the document URL if not.
      *
      * **Note:** We don't just _always_ use the document's URL because it is
@@ -71,14 +68,7 @@ export default class TopControl {
      * end up with the catchall "URL" `*`. If so, that's when we fall back to
      * using the document's URL.
      */
-    this._baseUrl = fullUrl.match(/^([a-z]+:\/\/[^\/]+)?/)[0];
-
-    // **Note:** It's always safe to take the `.length`, because we put the main
-    // expression in a `?` group, guaranteeing that the regex will have matched
-    // at least the empty string.
-    if (this._baseUrl.length === 0) {
-      throw new Error(`Could not determine base URL of: ${fullUrl}`);
-    }
+    this._url = (this._key.url !== '*') ? this._key.url : document.URL;
 
     /** {QuillProm|null} Editor instance. Becomes non-null in `start()`. */
     this._quill = null;
@@ -98,7 +88,7 @@ export default class TopControl {
     // page loading, so as to minimize time-to-interactive.
 
     log.detail('Opening API client...');
-    const apiClient = new ApiClient(this._baseUrl);
+    const apiClient = new ApiClient(this._url);
 
     // Start opening the connection, to maybe save a bit of time (that is, the
     // document can finish loading in parallel with the API connection opening up).
@@ -113,7 +103,7 @@ export default class TopControl {
 
       // Do our basic page setup. Specifically, we add the CSS we need to the page.
       const elem = document.createElement('link');
-      elem.href = `${this._baseUrl}/static/quill/quill.bubble.css`;
+      elem.href = `${apiClient.baseUrl}/static/quill/quill.bubble.css`;
       elem.rel = 'stylesheet';
       document.head.appendChild(elem);
 
@@ -126,7 +116,7 @@ export default class TopControl {
       }
 
       // Give the overlay a chance to do any initialization.
-      Hooks.run(this._window, this._baseUrl);
+      Hooks.run(this._window, apiClient.baseUrl);
       log.detail('Ran `run()` hook.');
 
       // Make the editor instance.

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -9,101 +9,18 @@
  * there to be a DOM node tagged with id `editor`.
  */
 
-import { ApiClient } from 'api-client';
-import { Decoder } from 'api-common';
-import { DocClient } from 'doc-client';
-import { Hooks } from 'hooks-client';
-import { QuillMaker } from 'quill-util';
 import { SeeAll } from 'see-all';
 import { SeeAllBrowser } from 'see-all-browser';
 
-// Pull the incoming parameters from `window.` globals into locals, to prevent
-// them from getting trampled by other init code. Validate that they're present
-// before doing anything further.
-
-const BAYOU_KEY = window.BAYOU_KEY;
-const BAYOU_NODE = window.BAYOU_NODE;
-
-if (!(BAYOU_KEY && BAYOU_NODE)) {
-  throw new Error('Missing configuration.');
-}
+import TopControl from './TopControl';
 
 // Init logging.
 SeeAllBrowser.init();
 const log = new SeeAll('page-init');
 log.detail('Starting...');
 
-// Figure out the URL of our server. We use the `BAYOU_KEY` global specified by
-// the enclosing HTML. We don't just _always_ use the document's URL because it
-// is possible (and common even) to embed an editor on a page that has a
-// different origin than the server.
-//
-// **Note:** Under normal circumstances, the key we receive comes with a real
-// URL. However, when using the debugging routes, it's possible that we end up
-// with the catchall "URL" `*`. If so, we detect that here and fall back to
-// using the document's URL.
-const docKey = Decoder.decodeJson(BAYOU_KEY);
-const url = (docKey.url !== '*') ? docKey.url : document.URL;
+const control = new TopControl(window);
+log.detail('Made `control`.');
 
-// Cut off after the host name. Putting the main expression in a `?` group
-// guarantees that the regex will match at least the empty string, which makes
-// the subsequent logic a little nicer.
-const baseUrl = url.match(/^([a-z]+:\/\/[^\/]+)?/)[0];
-if (baseUrl.length === 0) {
-  throw new Error(`Could not determine base URL of: ${url}`);
-}
-
-// Initialize the API connection. We do this in parallel with the rest of the
-// page loading, so as to minimize time-to-interactive.
-
-log.detail('Opening API client...');
-const apiClient = new ApiClient(baseUrl);
-
-// Start opening the connection, to maybe save a bit of time (that is, the
-// document can finish loading in parallel with the API connection opening up).
-apiClient.open().then(() => {
-  log.detail('API client open.');
-});
-
-// Arrange for the rest of initialization to happen once the initial page
-// contents are fully loaded.
-window.addEventListener('load', (event_unused) => {
-  log.detail('Initial page load complete.');
-
-  // Figure out what node we're attaching the editor to. We use the `BAYOU_NODE`
-  // global specified by the enclosing HTML.
-  if (document.querySelector(BAYOU_NODE) === null) {
-    // If we land here, no further init can possibly be done, so we just
-    // `return` out of it.
-    const extra = (BAYOU_NODE[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
-    log.error(`No such selector${extra}: \`${BAYOU_NODE}\``);
-    return;
-  }
-
-  // Do our basic page setup. Specifically, we add the CSS we need to the page.
-  const elem = document.createElement('link');
-  elem.href = `${baseUrl}/static/quill/quill.bubble.css`;
-  elem.rel = 'stylesheet';
-  document.head.appendChild(elem);
-
-  // Give the overlay a chance to do any initialization.
-  Hooks.run(window, baseUrl);
-  log.detail('Ran `run()` hook.');
-
-  // Make the editor instance.
-  const quill = QuillMaker.make(BAYOU_NODE);
-  log.detail('Made editor instance.');
-
-  // Hook the API up to the editor instance.
-  const docClient = new DocClient(quill, apiClient, docKey);
-  docClient.start();
-  docClient.when_idle().then(() => {
-    log.detail('Document client hooked up.');
-    log.info('Initialization complete!');
-  });
-  docClient.when_unrecoverableError().then(() => {
-    log.error('Unrecoverable error! Giving up!');
-  });
-
-  log.detail('Async operations now in progress...');
-});
+control.start();
+log.detail('Done with outer init.');

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -160,8 +160,9 @@ export default class DebugTools {
       '<h1>Editor</h1>\n' +
       '<div id="editor"><p>Loading&hellip;</p></div>\n' +
       '<script>\n' +
-      '  BAYOU_KEY  = ' + quotedKey + ';\n' +
-      '  BAYOU_NODE = "#editor";\n' +
+      `  BAYOU_KEY     = ${quotedKey};\n` +
+      '  BAYOU_NODE    = "#editor";\n' +
+      '  BAYOU_RECOVER = () => { window.location.reload(true); };\n' +
       '</script>\n' +
       '<script src="/boot-from-key.js"></script>\n';
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -277,6 +277,9 @@ export default class DocClient extends StateMachine {
    * @param {object} reason Error reason.
    */
   _handle_any_apiError(method, reason) {
+    // Stop the user from trying to do more edits, as they'd get lost.
+    this._quill.disable();
+
     if (reason.layer === ApiError.CONN) {
       // It's connection-related and probably no big deal.
       this._log.info(`${reason.code}, ${reason.desc}`);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.11.0
+version = 0.11.1


### PR DESCRIPTION
The main point of this PR is to flesh out the recovery mechanism that kicks in if/when `DocClient` decides it's getting too many API errors. In production, this will happen because a server died unexpectedly or (say) during an extended network outage on the client side. The code here defers to higher-level logic, which is _not_ provided here for production, as that requires coordination within the higher layer (and said higher layer isn't actually part of this project).

That said, this recovery facility _is_ used in the debugging environment to just reload the editor page after the `DocClient` gives up. This is done because in all likelihood what just happened is that the developer updated the server code, which restarted the server, which effectively invalidated all the active keys. Reloading will cause a new key to be generated / provided, and getting the browser window conveniently back on its feet.

**Bonus:** Major cleanup of the top-level application code (formerly in `main.js`, now mostly in its own class, `TopControl`).