### PR TITLE
More recovery stuff

### DIFF
--- a/client/assets/boot-for-debug.js
+++ b/client/assets/boot-for-debug.js
@@ -17,8 +17,6 @@
  * If that's successful, we report it back up through the layers.
  */
 function BAYOU_RECOVER(key) {
-  //window.location.reload(true);
-
   var docId = DEBUG_DOCUMENT_ID;
   var authorId = DEBUG_AUTHOR_ID;
   var url = `${new URL(key.url).origin}/debug/key/${docId}/${authorId}`;

--- a/client/assets/boot-for-debug.js
+++ b/client/assets/boot-for-debug.js
@@ -16,8 +16,38 @@
  * this case, we rely on the `/key/*` debugging endpoints to generate a new key.
  * If that's successful, we report it back up through the layers.
  */
-function BAYOU_RECOVER() {
-  window.location.reload(true);
+function BAYOU_RECOVER(key) {
+  //window.location.reload(true);
+
+  var docId = DEBUG_DOCUMENT_ID;
+  var authorId = DEBUG_AUTHOR_ID;
+  var url = `${new URL(key.url).origin}/debug/key/${docId}/${authorId}`;
+
+  return new Promise((res, rej_unused) => {
+    var req = new XMLHttpRequest();
+    req.open('GET', url);
+    req.send();
+    req.addEventListener('abort', reloadPage);
+    req.addEventListener('error', reloadPage);
+    req.addEventListener('load', gotKey);
+
+    // If there's any trouble, we just ask the window to reload. This will
+    // almost certainly work but is definitely a last-resort hail-mary kind of
+    // thing.
+    function reloadPage() {
+      window.location.reload(true);
+    }
+
+    // On successful request completion, check to see if we actually got good
+    // data. If so, report it back. If not, fall back to `reloadPage()`.
+    function gotKey() {
+      if (req.status === 200) {
+        res(req.response);
+      } else {
+        reloadPage();
+      }
+    }
+  })
 }
 
 // We wrap everything else in an immediately-executed function so as to avoid

--- a/client/assets/boot-for-debug.js
+++ b/client/assets/boot-for-debug.js
@@ -1,0 +1,30 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// This file is included by the `/edit/*` debugging endpoints. What it does is
+// arrange to get called if/when the editor decides it needs to recover (e.g.
+// and most likely because the developer restarted their local server). Beyond
+// that, it _also_ kicks off loading of the regular bootstrap code.
+
+// Disable Eslint, because this file is delivered as-is and has to be fairly
+// conservative.
+/* eslint-disable */
+
+/**
+ * This global function is what ultimately gets called to attempt recovery. In
+ * this case, we rely on the `/key/*` debugging endpoints to generate a new key.
+ * If that's successful, we report it back up through the layers.
+ */
+function BAYOU_RECOVER() {
+  window.location.reload(true);
+}
+
+// We wrap everything else in an immediately-executed function so as to avoid
+// polluting the global namespace.
+(function () {
+  // Add the standard bootstrap code to the page.
+  var elem = document.createElement('script');
+  elem.src = '/boot-from-key.js';
+  document.head.appendChild(elem);
+}());

--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -12,6 +12,8 @@
 //   be embedded.
 // * `BAYOU_RECOVER` (optional) -- Function to use when attempting to recover
 //   from connection trouble.
+//
+// See `TopControl` for more details about these parameters.
 
 // Disable Eslint, because this file is delivered as-is and has to be fairly
 // conservative.

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -60,7 +60,7 @@ export default class SplitKey extends BaseKey {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this._url, this._id, this._secret];
+    return [this.url, this.id, this._secret];
   }
 
   /**
@@ -81,6 +81,17 @@ export default class SplitKey extends BaseKey {
    */
   get secret() {
     return this._secret;
+  }
+
+  /**
+   * Returns a clone of this instance, except with the given URL instead of
+   * whatever this instance came with.
+   *
+   * @param {string} url Replacement URL.
+   * @returns {SplitKey} New instance, as described.
+   */
+  withUrl(url) {
+    return new SplitKey(url, this.id, this._secret);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -157,16 +157,16 @@ export default class DebugTools {
     const quotedKey = JSON.stringify(key);
 
     // TODO: Probably want to use a real template.
-    const head = '<title>Editor</title>\n';
-    const body =
-      '<h1>Editor</h1>\n' +
-      '<div id="editor"><p>Loading&hellip;</p></div>\n' +
+    const head =
+      '<title>Editor</title>\n' +
       '<script>\n' +
       `  BAYOU_KEY     = ${quotedKey};\n` +
       '  BAYOU_NODE    = "#editor";\n' +
-      '  BAYOU_RECOVER = () => { window.location.reload(true); };\n' +
       '</script>\n' +
-      '<script src="/boot-from-key.js"></script>\n';
+      '<script src="/boot-for-debug.js"></script>\n';
+    const body =
+      '<h1>Editor</h1>\n' +
+      '<div id="editor"><p>Loading&hellip;</p></div>\n';
 
     this._htmlResponse(res, head, body);
   }


### PR DESCRIPTION
The main thrust of this PR is to make it so that an in-browser editor can recover from a server reboot without reloading the browser page. This is done for the debugging endpoint only, but more importantly this fleshes out the underlying mechanism such that we can do the same for the production deployment, when the time comes.
