### PR TITLE
Keep Quill from flailing while CSS is loading.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -107,7 +107,7 @@ export default class TopControl {
       }
 
       // Give the overlay a chance to do any initialization.
-      const hookDone = Promise.resolve(Hooks.run(this._window, baseUrl));
+      const hookDone = Hooks.run(this._window, baseUrl);
       log.detail('Ran `run()` hook.');
 
       // Make the editor instance, after style addition and hook action are

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -9,6 +9,7 @@ import { Hooks } from 'hooks-client';
 import { QuillMaker } from 'quill-util';
 import { SeeAll } from 'see-all';
 import { TFunction, TString } from 'typecheck';
+import { DomUtil } from 'util-client';
 
 /** {SeeAll} Logger for this module. */
 const log = new SeeAll('top');
@@ -89,14 +90,13 @@ export default class TopControl {
     this._window.addEventListener('load', (event_unused) => {
       log.detail('Initial page load complete.');
 
+      const document = this._window.document;
       const baseUrl = this._apiClient.baseUrl;
 
       // Do our basic page setup. Specifically, we add the CSS we need to the
       // page.
-      const elem = document.createElement('link');
-      elem.href = `${baseUrl}/static/quill/quill.bubble.css`;
-      elem.rel = 'stylesheet';
-      document.head.appendChild(elem);
+      const styleDone = DomUtil.addStylesheet(
+        document, `${baseUrl}/static/quill/quill.bubble.css`);
 
       // Validate `_node`.
       if (document.querySelector(this._node) === null) {
@@ -107,16 +107,18 @@ export default class TopControl {
       }
 
       // Give the overlay a chance to do any initialization.
-      Hooks.run(this._window, baseUrl);
+      const hookDone = Promise.resolve(Hooks.run(this._window, baseUrl));
       log.detail('Ran `run()` hook.');
 
-      // Make the editor instance.
-      this._quill = QuillMaker.make(this._node);
-      log.detail('Made editor instance.');
+      // Make the editor instance, after style addition and hook action are
+      // complete.
+      Promise.all([styleDone, hookDone]).then((res_unused) => {
+        this._quill = QuillMaker.make(this._node);
+        log.detail('Made editor instance.');
 
-      // Hook the API up to the editor instance.
-      this._makeDocClient(this._apiClient);
-
+        // Hook the API up to the editor instance.
+        this._makeDocClient(this._apiClient);
+      });
       log.detail('Async operations now in progress...');
     });
   }

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "doc-client": "local",
     "hooks-client": "local",
     "quill-util": "local",
-    "see-all-browser": "local"
+    "see-all-browser": "local",
+    "util-client": "local"
   }
 }

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -16,6 +16,8 @@ export default class Hooks {
    * @param {object} window_unused Window which contains the application being
    *   set up.
    * @param {string} baseUrl_unused Base URL that points to the server to use.
+   * @returns {Promise|undefined} A promise whose resolution indicates the end
+   *   of hook activity, or `undefined` if there is nothing to wait for.
    */
   static run(window_unused, baseUrl_unused) {
     // This space intentionally left blank.

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -20,7 +20,8 @@ export default class Hooks {
    *   of hook activity, or `undefined` if there is nothing to wait for.
    */
   static run(window_unused, baseUrl_unused) {
-    // This space intentionally left blank.
+    // This space intentionally left (nearly) blank.
+    return undefined;
   }
 
   /**

--- a/local-modules/util-client/DomUtil.js
+++ b/local-modules/util-client/DomUtil.js
@@ -1,0 +1,44 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { PromDelay } from 'util-common';
+
+/**
+ * DOM helper utilities.
+ */
+export default class DomUtil {
+  /**
+   * Adds a stylesheet to the given document by URL, returning a promise that
+   * resolves when it is fully loaded.
+   *
+   * @param {Document} document Document to add to.
+   * @param {string} url URL of the stylesheet.
+   * @returns {Promise<true>} Promise that resolves when the stylesheet has
+   *   been loaded.
+   */
+  static addStylesheet(document, url) {
+    const elem = document.createElement('link');
+    elem.href = url;
+    elem.rel = 'stylesheet';
+    document.head.appendChild(elem);
+
+    return new Promise((res, rej_unused) => {
+      function check() {
+        for (const s of document.styleSheets) {
+          if ((s.href === url) && s.rules && (s.rules.length !== 0)) {
+            // The stylesheet appears to be loaded.
+            res(true);
+            return;
+          }
+        }
+
+        // Not yet loaded. Wait a moment and try again. TODO: Consider rejecting
+        // the promise after a (longer) timeout.
+        PromDelay.resolve(100).then(check);
+      }
+
+      PromDelay.resolve(10).then(check);
+    });
+  }
+}

--- a/local-modules/util-client/main.js
+++ b/local-modules/util-client/main.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import DomUtil from './DomUtil';
+
+export { DomUtil };

--- a/local-modules/util-client/package.json
+++ b/local-modules/util-client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "util-client",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "util-common": "local"
+  }
+}


### PR DESCRIPTION
This PR keeps Quill from getting initialized until after its CSS is all in place. This prevents some ugly screen flickering.