### PR TITLE
First step towards an asynchronous document storage interface.

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -58,15 +58,15 @@ export default class DebugTools {
     this._bindParam('documentId');
     this._bindParam('verNum');
 
-    router.get('/change/:documentId/:verNum',   this._handle_change.bind(this));
-    router.get('/edit/:documentId',             this._handle_edit.bind(this));
-    router.get('/edit/:documentId/:authorId',   this._handle_edit.bind(this));
-    router.get('/key/:documentId',              this._handle_key.bind(this));
-    router.get('/key/:documentId/:authorId',    this._handle_key.bind(this));
-    router.get('/log',                          this._handle_log.bind(this));
-    router.get('/snapshot/:documentId',         this._handle_snapshot.bind(this));
-    router.get('/snapshot/:documentId/:verNum', this._handle_snapshot.bind(this));
-    router.get('/test',                         this._handle_test.bind(this));
+    this._bindHandler('change',   ':documentId/:verNum');
+    this._bindHandler('edit',     ':documentId');
+    this._bindHandler('edit',     ':documentId/:authorId');
+    this._bindHandler('key',      ':documentId');
+    this._bindHandler('key',      ':documentId/:authorId');
+    this._bindHandler('log');
+    this._bindHandler('snapshot', ':documentId');
+    this._bindHandler('snapshot', ':documentId/:verNum');
+    this._bindHandler('test');
 
     router.use(this._error.bind(this));
   }
@@ -89,6 +89,24 @@ export default class DebugTools {
     }
 
     this._router.param(name, checkParam);
+  }
+
+  /**
+   * Binds a GET handler to the router for this instance.
+   *
+   * @param {string} name The name of the handler. This is also the first
+   *   component of the bound path.
+   * @param {string|null} [paramPath = null] The parameter path to accept, or
+   *   `null` if there are no parameters. These become the remainder of the
+   *   bound path.
+   */
+  _bindHandler(name, paramPath) {
+    const fullPath = (paramPath === null)
+      ? `/${name}`
+      : `/${name}/${paramPath}`;
+    const handlerMethod = this[`_handle_${name}`].bind(this);
+
+    this._router.get(fullPath, handlerMethod);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -193,34 +193,37 @@ export default class DebugTools {
    *
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
+   * @returns {Promise} Promise whose rejection indicates an error to be
+   *   reported back to the user.
    */
   _handle_edit(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
-    const key        = this._makeEncodedKey(documentId, authorId);
 
-    // These are already strings (JSON-encoded even, in the case of `key`), but
-    // we still have to JSON-encode _those_ strings, so as to make them proper
-    // JS source within the <script> block below.
-    const quotedKey        = JSON.stringify(key);
-    const quotedDocumentId = JSON.stringify(documentId);
-    const quotedAuthorId   = JSON.stringify(authorId);
+    return this._makeEncodedKey(documentId, authorId).then((key) => {
+      // These are already strings (JSON-encoded even, in the case of `key`),
+      // but we still have to JSON-encode _those_ strings, so as to make them
+      // proper JS source within the <script> block below.
+      const quotedKey        = JSON.stringify(key);
+      const quotedDocumentId = JSON.stringify(documentId);
+      const quotedAuthorId   = JSON.stringify(authorId);
 
-    // TODO: Probably want to use a real template.
-    const head =
-      '<title>Editor</title>\n' +
-      '<script>\n' +
-      `  BAYOU_KEY         = ${quotedKey};\n` +
-      '  BAYOU_NODE        = "#editor";\n' +
-      `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
-      `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
-      '</script>\n' +
-      '<script src="/boot-for-debug.js"></script>\n';
-    const body =
-      '<h1>Editor</h1>\n' +
-      '<div id="editor"><p>Loading&hellip;</p></div>\n';
+      // TODO: Probably want to use a real template.
+      const head =
+        '<title>Editor</title>\n' +
+        '<script>\n' +
+        `  BAYOU_KEY         = ${quotedKey};\n` +
+        '  BAYOU_NODE        = "#editor";\n' +
+        `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
+        `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
+        '</script>\n' +
+        '<script src="/boot-for-debug.js"></script>\n';
+      const body =
+        '<h1>Editor</h1>\n' +
+        '<div id="editor"><p>Loading&hellip;</p></div>\n';
 
-    this._htmlResponse(res, head, body);
+      this._htmlResponse(res, head, body);
+    });
   }
 
   /**
@@ -229,13 +232,16 @@ export default class DebugTools {
    *
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
+   * @returns {Promise} Promise whose rejection indicates an error to be
+   *   reported back to the user.
    */
   _handle_key(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
-    const key        = this._makeEncodedKey(documentId, authorId);
 
-    this._jsonResponse(res, key);
+    return this._makeEncodedKey(documentId, authorId).then((key) => {
+      this._jsonResponse(res, key);
+    });
   }
 
   /**
@@ -353,16 +359,17 @@ export default class DebugTools {
   }
 
   /**
-   * Makes and returns a new authorization key for the given document / author
-   * combo.
+   * Makes and returns a promise for a new authorization key for the given
+   * document / author combo.
    *
    * @param {string} documentId The document ID.
    * @param {string} authorId The author ID.
-   * @returns {string} A new `SplitKey` encoded as JSON.
+   * @returns {Promise<string>} Promise for a new `SplitKey` encoded as JSON.
    */
   _makeEncodedKey(documentId, authorId) {
-    return Encoder.encodeJson(
-      this._rootAccess.makeAccessKey(authorId, documentId));
+    return this._rootAccess.makeAccessKey(authorId, documentId).then((key) => {
+      return Encoder.encodeJson(key);
+    });
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -100,13 +100,23 @@ export default class DebugTools {
    *   `null` if there are no parameters. These become the remainder of the
    *   bound path.
    */
-  _bindHandler(name, paramPath) {
+  _bindHandler(name, paramPath = null) {
     const fullPath = (paramPath === null)
       ? `/${name}`
       : `/${name}/${paramPath}`;
     const handlerMethod = this[`_handle_${name}`].bind(this);
 
-    this._router.get(fullPath, handlerMethod);
+    function handleRequest(req, res, next) {
+      try {
+        Promise.resolve(handlerMethod(req, res)).catch((error) => {
+          next(error);
+        });
+      } catch (error) {
+        next(error);
+      }
+    }
+
+    this._router.get(fullPath, handleRequest);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -34,6 +34,10 @@ export default class DebugTools {
 
     /** {SeeAll} A rolling log for the `/log` endpoint. */
     this._logger = new SeeAllRecent(LOG_LENGTH_MSEC);
+
+    /** {Router} The router (request handler) for this instance. */
+    this._router = new express.Router();
+    this._addRoutes();
   }
 
   /**
@@ -41,11 +45,18 @@ export default class DebugTools {
    * (without `.bind()`).
    */
   get requestHandler() {
-    const router = new express.Router();
+    return this._router;
+  }
 
-    this._bindParam(router, 'authorId');
-    this._bindParam(router, 'documentId');
-    this._bindParam(router, 'verNum');
+  /**
+   * Adds all the routes needed for this instance.
+   */
+  _addRoutes() {
+    const router = this._router;
+
+    this._bindParam('authorId');
+    this._bindParam('documentId');
+    this._bindParam('verNum');
 
     router.get('/change/:documentId/:verNum',   this._handle_change.bind(this));
     router.get('/edit/:documentId',             this._handle_edit.bind(this));
@@ -58,11 +69,14 @@ export default class DebugTools {
     router.get('/test',                         this._handle_test.bind(this));
 
     router.use(this._error.bind(this));
-
-    return router;
   }
 
-  _bindParam(router, name) {
+  /**
+   * Binds a parameter checker to the router for this instance.
+   *
+   * @param {string} name The name of the parameter.
+   */
+  _bindParam(name) {
     const checkerMethod = this[`_check_${name}`].bind(this);
 
     function checkParam(req, res, next, value, name_unused) {
@@ -74,7 +88,7 @@ export default class DebugTools {
       }
     }
 
-    router.param(name, checkParam);
+    this._router.param(name, checkParam);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -79,9 +79,9 @@ export default class DebugTools {
   _bindParam(name) {
     const checkerMethod = this[`_check_${name}`].bind(this);
 
-    function checkParam(req, res, next, value, name_unused) {
+    function checkParam(req, res_unused, next, value, name_unused) {
       try {
-        checkerMethod(req, res, value);
+        checkerMethod(req, value);
         next();
       } catch (error) {
         next(error);
@@ -123,10 +123,9 @@ export default class DebugTools {
    * Validates an author ID as a request parameter.
    *
    * @param {object} req_unused HTTP request.
-   * @param {object} res_unused HTTP response.
    * @param {string} value Request parameter value.
    */
-  _check_authorId(req_unused, res_unused, value) {
+  _check_authorId(req_unused, value) {
     try {
       AuthorId.check(value);
     } catch (error) {
@@ -140,10 +139,9 @@ export default class DebugTools {
    * Validates a document ID as a request parameter.
    *
    * @param {object} req_unused HTTP request.
-   * @param {object} res_unused HTTP response.
    * @param {string} value Request parameter value.
    */
-  _check_documentId(req_unused, res_unused, value) {
+  _check_documentId(req_unused, value) {
     try {
       DocumentId.check(value);
     } catch (error) {
@@ -158,10 +156,9 @@ export default class DebugTools {
    * parameter in the request object with the parsed form.
    *
    * @param {object} req HTTP request.
-   * @param {object} res_unused HTTP response.
    * @param {string} value Request parameter value.
    */
-  _check_verNum(req, res_unused, value) {
+  _check_verNum(req, value) {
     if (!value.match(/^[0-9]+$/)) {
       const error = new Error();
       error.debugMsg = 'Bad value for `verNum`.';

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -328,10 +328,7 @@ export default class DebugTools {
    */
   _getExistingDoc(req) {
     const documentId = req.params.documentId;
-
-    // TODO: Remove the `Promise.resolve(...)` cladding once `DocServer`
-    // actually starts behaving asynchronously.
-    const docPromise = Promise.resolve(DocServer.theOne.getDocOrNull(documentId));
+    const docPromise = DocServer.theOne.getDocOrNull(documentId);
 
     return docPromise.then((doc) => {
       if (doc === null) {

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -36,8 +36,8 @@ export default class RootAccess {
    *   are made using the resulting authorization.
    * @param {string} docId ID of the document which the resulting authorization
    *   allows access to.
-   * @returns {SplitKey} Split token (ID + secret) which provides the requested
-   *   access.
+   * @returns {Promise<SplitKey>} Promise for a split token (ID + secret) which
+   *   provides the requested access.
    */
   makeAccessKey(authorId, docId) {
     TString.nonempty(authorId);

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -43,34 +43,35 @@ export default class RootAccess {
     TString.nonempty(authorId);
     TString.nonempty(docId);
 
-    const docControl = DocServer.theOne.getDoc(docId);
-    const doc = new DocForAuthor(docControl, authorId);
+    return DocServer.theOne.getDoc(docId).then((docControl) => {
+      const doc = new DocForAuthor(docControl, authorId);
 
-    // Under normal circumstances, this method is called in the context of an
-    // active API connection, but it can also be called when debugging, and in
-    // that case we just fall back on the catchall `*` for the associated URL.
-    const url = Connection.activeNow
-      ? `${Connection.activeNow.baseUrl}/api`
-      : '*';
+      // Under normal circumstances, this method is called in the context of an
+      // active API connection, but it can also be called when debugging, and in
+      // that case we just fall back on the catchall `*` for the associated URL.
+      const url = Connection.activeNow
+        ? `${Connection.activeNow.baseUrl}/api`
+        : '*';
 
-    let key = null;
-    for (;;) {
-      key = SplitKey.randomInstance(url);
-      if (!this._context.hasId(key.id)) {
-        break;
+      let key = null;
+      for (;;) {
+        key = SplitKey.randomInstance(url);
+        if (!this._context.hasId(key.id)) {
+          break;
+        }
+
+        // We managed to get an ID collision. Unlikely, but it can happen. So,
+        // just iterate and try again.
       }
 
-      // We managed to get an ID collision. Unlikely, but it can happen. So,
-      // just iterate and try again.
-    }
+      this._context.add(key, doc);
 
-    this._context.add(key, doc);
+      log.info(`Newly-authorized access.`);
+      log.info(`  author: ${authorId}`);
+      log.info(`  doc:    ${docId}`);
+      log.info(`  key id: ${key.id}`); // The ID is safe to log.
 
-    log.info(`Newly-authorized access.`);
-    log.info(`  author: ${authorId}`);
-    log.info(`  doc:    ${docId}`);
-    log.info(`  key id: ${key.id}`); // The ID is safe to log.
-
-    return key;
+      return key;
+    });
   }
 }

--- a/local-modules/app-setup/package.json
+++ b/local-modules/app-setup/package.json
@@ -11,6 +11,7 @@
 
     "api-common": "local",
     "api-server": "local",
+    "bayou-mocha": "local",
     "client-bundle": "local",
     "doc-common": "local",
     "doc-server": "local",

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -36,7 +36,9 @@ export default class DocServer extends Singleton {
    * @returns {DocControl} The corresponding document accessor.
    */
   getDoc(docId) {
-    return this._getDoc(docId, true);
+    // TODO: Remove the `Promise.resolve()` cladding once `_getDoc()` actually
+    // has asynchronous behavior.
+    return Promise.resolve(this._getDoc(docId, true));
   }
 
   /**

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -44,11 +44,13 @@ export default class DocServer extends Singleton {
    * document doesn't exist, this returns `null`.
    *
    * @param {string} docId The document ID.
-   * @returns {DocControl|null} The corresponding document accessor, or `null`
-   *   if there is no such document.
+   * @returns {Promise<DocControl|null>} Promise for the corresponding document
+   *   accessor, or `null` if there is no such document.
    */
   getDocOrNull(docId) {
-    return this._getDoc(docId, false);
+    // TODO: Remove the `Promise.resolve()` cladding once `_getDoc()` actually
+    // has asynchronous behavior.
+    return Promise.resolve(this._getDoc(docId, false));
   }
 
   /**


### PR DESCRIPTION
The main point of this PR is to introduce asynchrony in the `doc-server` interface. For now, it's just _nominal_ asynchrony in that no real behavior has changed other than that it returns promises from `getDoc*()` instead of direct instances. But this alone is enough to shake out a handful of places that needed to be updated, mostly (but not entirely) in the `DebugTools` code.

I took the opportunity to refactor `DebugTools` a bit, so that in the end the changes that needed to be made there were simpler and less boilerplatey.

In the near term, the mix of promise-based and sequential code will add a bit of confusion, alas. Over time, I'm hoping that as promises work their way more thoroughly through the system, we'll see at least a modicum of improvement on that front, as there will be fewer impedance-mismatch boundaries.