### PR TITLE
Write console logs to a file now too.

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -10,7 +10,7 @@ import { BayouMocha } from 'bayou-mocha';
 import { AuthorId, DocumentId } from 'doc-common';
 import { DocServer } from 'doc-server';
 import { SeeAll } from 'see-all';
-import { SeeAllRecent } from 'see-all-server';
+import { RecentLogger } from 'see-all-server';
 
 /** Logger for this module. */
 const log = new SeeAll('app-debug');
@@ -33,7 +33,7 @@ export default class DebugTools {
     this._rootAccess = rootAccess;
 
     /** {SeeAll} A rolling log for the `/log` endpoint. */
-    this._logger = new SeeAllRecent(LOG_LENGTH_MSEC);
+    this._logger = new RecentLogger(LOG_LENGTH_MSEC);
 
     /** {Router} The router (request handler) for this instance. */
     this._router = new express.Router();

--- a/local-modules/see-all-server/FileLogger.js
+++ b/local-modules/see-all-server/FileLogger.js
@@ -44,7 +44,7 @@ export default class FileLogger {
   }
 
   /**
-   * Logs the indicated time value as "punctuation" on the log.
+   * Logs the indicated time value.
    *
    * @param {number} nowMsec Timestamp to log.
    * @param {string} utcString String representation of the time, as UTC.

--- a/local-modules/see-all-server/FileLogger.js
+++ b/local-modules/see-all-server/FileLogger.js
@@ -1,0 +1,68 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import fs from 'fs';
+import util from 'util';
+
+import { SeeAll } from 'see-all';
+
+/**
+ * Implementation of the `SeeAll` logger protocol which stores logged items to
+ * a file.
+ */
+export default class FileLogger {
+  /**
+   * Constructs an instance. This will cause the instance to be registered with
+   * the main `see-all` module.
+   *
+   * @param {string} path Path of the file to log to.
+   */
+  constructor(path) {
+    /** {string} Path of the file to log to. */
+    this._path = path;
+
+    SeeAll.add(this);
+  }
+
+  /**
+   * Logs a message at the given severity level.
+   *
+   * @param {number} nowMsec Timestamp of the message.
+   * @param {string} level Severity level.
+   * @param {string} tag Name of the component associated with the message.
+   * @param {...string} message Message to log.
+   */
+  log(nowMsec, level, tag, ...message) {
+    // For any items in `message` that aren't strings, use `util.inspect()` to
+    // stringify them.
+    message = message.map((x) => {
+      return (typeof x === 'string') ? x : util.inspect(x);
+    });
+
+    this._writeJson({ nowMsec, level, tag, message });
+  }
+
+  /**
+   * Logs the indicated time value as "punctuation" on the log.
+   *
+   * @param {number} nowMsec Timestamp to log.
+   * @param {string} utcString String representation of the time, as UTC.
+   * @param {string} localString String representation of the time, in the local
+   *   timezone.
+   */
+  time(nowMsec, utcString, localString) {
+    this.log(nowMsec, 'info', 'time', utcString, localString);
+  }
+
+  /**
+   * Appends the JSON-encoded form of a given value to the log, along with a
+   * newline.
+   *
+   * @param {*} value Value to log.
+   */
+  _writeJson(value) {
+    const string = `${JSON.stringify(value)}\n`;
+    fs.appendFileSync(this._path, string);
+  }
+}

--- a/local-modules/see-all-server/RecentLogger.js
+++ b/local-modules/see-all-server/RecentLogger.js
@@ -13,7 +13,7 @@ import { SeeAll } from 'see-all';
  * Implementation of the `SeeAll` logger protocol which collects a rolling
  * compendium of recently logged items.
  */
-export default class SeeAllRecent {
+export default class RecentLogger {
   /**
    * Constructs an instance. This will cause the instance to be registered with
    * the main `see-all` module.
@@ -90,7 +90,7 @@ export default class SeeAllRecent {
     result.push('<table>');
 
     for (const l of this._log) {
-      result.push(SeeAllRecent._htmlLine(l));
+      result.push(RecentLogger._htmlLine(l));
     }
 
     result.push('</table>');

--- a/local-modules/see-all-server/main.js
+++ b/local-modules/see-all-server/main.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import FileLogger from './FileLogger';
-import SeeAllRecent from './SeeAllRecent';
+import RecentLogger from './RecentLogger';
 import SeeAllServer from './SeeAllServer';
 
-export { FileLogger, SeeAllRecent, SeeAllServer };
+export { FileLogger, RecentLogger, SeeAllServer };

--- a/local-modules/see-all-server/tests/test_FileLogger.js
+++ b/local-modules/see-all-server/tests/test_FileLogger.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import FileLogger from './FileLogger';
-import SeeAllRecent from './SeeAllRecent';
-import SeeAllServer from './SeeAllServer';
+import { describe, it } from 'mocha';
 
-export { FileLogger, SeeAllRecent, SeeAllServer };
+describe('see-all-server.FileLogger', () => {
+  it('needs a way to be tested');
+});

--- a/local-modules/see-all-server/tests/test_RecentLogger.js
+++ b/local-modules/see-all-server/tests/test_RecentLogger.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 
-import { SeeAllRecent } from 'see-all-server';
+import { RecentLogger } from 'see-all-server';
 
 let log = null;
 const LOG_LEVEL = 'debug';
@@ -14,7 +14,7 @@ const LOG_PREFIX = 'this is log line ';
 const NUM_LINES = 4;
 
 beforeEach(() => {
-  log = new SeeAllRecent(30 * 1000);
+  log = new RecentLogger(30 * 1000);
 
   const now = new Date();
 
@@ -23,7 +23,7 @@ beforeEach(() => {
   }
 });
 
-describe('see-all-server.SeeAllRecent', () => {
+describe('see-all-server.RecentLogger', () => {
   describe('#time(nowMsec, utcString, localString', () => {
     it('needs a way to be tested');
   });

--- a/server/main.js
+++ b/server/main.js
@@ -22,8 +22,8 @@ import { ClientBundle } from 'client-bundle';
 import { DevMode } from 'dev-mode';
 import { Hooks } from 'hooks-server';
 import { SeeAll } from 'see-all';
-import { SeeAllServer } from 'see-all-server';
-import { ProductInfo, ServerEnv } from 'server-env';
+import { FileLogger, SeeAllServer } from 'see-all-server';
+import { Dirs, ProductInfo, ServerEnv } from 'server-env';
 
 
 /** Logger for this file. */
@@ -131,6 +131,7 @@ function clientBundle() {
 
 // Initialize logging.
 SeeAllServer.init();
+new FileLogger(path.resolve(Dirs.VAR_DIR, 'general.log'));
 
 if (clientBundleMode) {
   clientBundle();


### PR DESCRIPTION
They're stored as a series of JSON-encoded lines, which should make them reasonably straightforward to use both directly (`grep` etc.) and for ingestion into a log-processing-pipeline type thinger, should that come to pass.