### PR TITLE
Three kinds of clean

### DIFF
--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -107,6 +107,21 @@ export default class Connection extends CommonBase {
   }
 
   /**
+   * Prevents this instance from handling further messages, and enables
+   * garbage collection of dependent resources, e.g. and specifically anything
+   * referenced by the `context`.
+   *
+   * **Note:** This method is used to explicitly manage the lifecycle of a
+   * connection. This is a useful thing to do in that the outer application
+   * server doesn't necessarily make strong guarantees about promptly cleaning
+   * up its connection-related state.
+   */
+  close() {
+    this._log.info('Closed.');
+    this._context = null;
+  }
+
+  /**
    * Handles an incoming message, which is expected to be in JSON string form.
    * Returns a promise for the response, which is also in JSON string form.
    *
@@ -240,6 +255,11 @@ export default class Connection extends CommonBase {
    */
   getTarget(idOrToken) {
     const context = this._context;
+
+    if (context === null) {
+      throw new Error('Closed.');
+    }
+
     let target = context.getUncontrolledOrNull(idOrToken);
 
     if (target !== null) {
@@ -256,6 +276,6 @@ export default class Connection extends CommonBase {
 
     // We _don't_ include the passed argument, as that might end up revealing
     // secret info.
-    throw new Error('Bad target');
+    throw new Error('Bad target.');
   }
 }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -30,6 +30,11 @@ let activeNow = null;
  * incoming message data, but without the actual transport of bytes over a
  * lower-level connection (or the like). This class in turn mostly bottoms out
  * by calling on target objects, which perform the actual application services.
+ *
+ * **Note:** The `context` used for the connection is set up as a separate
+ * instance (effectively cloned) from the one passed into the constructor and
+ * always has an extra binding of `meta` to a meta-control object that is
+ * specific to the connection.
  */
 export default class Connection extends CommonBase {
   /**
@@ -76,7 +81,7 @@ export default class Connection extends CommonBase {
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.
-    this._context.add('meta', new MetaHandler(this));
+    this._context.addEvergreen('meta', new MetaHandler(this));
 
     this._log.info(`Open via <${this._baseUrl}>.`);
   }

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -2,17 +2,20 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { SeeAll } from 'see-all';
 import { TObject, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import Target from './Target';
 
+/** {SeeAll} Logger. */
+const log = new SeeAll('api');
+
 /**
  * {Int} The amount of time in msec a target must be idle and unaccessed before
  * it is considered idle and therefore subject to automated cleanup.
  */
-//const IDLE_TIME_MSEC = 5 * 60 * 1000; // Five minutes.
-const IDLE_TIME_MSEC = 10 * 1000;
+const IDLE_TIME_MSEC = 10 * 60 * 1000; // Ten minutes.
 
 /**
  * Binding context for an API server or session therein. This is pretty much
@@ -85,17 +88,19 @@ export default class Context extends CommonBase {
     const idleLimit = Date.now() - IDLE_TIME_MSEC;
     const map = this._map;
 
-    console.log('====== cleanup', idleLimit);
+    log.info('Cleaning up idle targets...');
 
     // Note: The ECMAScript spec guarantees that it is safe to delete keys from
     // a map while iterating over it. See
     // <https://tc39.github.io/ecma262/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind>.
     for (const [key, value] of map) {
       if (value.wasIdleAsOf(idleLimit)) {
-        console.log('====== boop!', key);
+        log.info(`Removed: ${key}`);
         map.delete(key);
       }
     }
+
+    log.info('Cleaning up idle targets... done!');
   }
 
   /**

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -11,6 +11,7 @@ import Target from './Target';
  * {Int} The amount of time in msec a target must be idle and unaccessed before
  * it is considered idle and therefore subject to automated cleanup.
  */
+//const IDLE_TIME_MSEC = 5 * 60 * 1000; // Five minutes.
 const IDLE_TIME_MSEC = 10 * 1000;
 
 /**

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -8,13 +8,15 @@ import { CommonBase } from 'util-common';
 import Target from './Target';
 
 /**
+ * {Int} The amount of time in msec a target must be idle and unaccessed before
+ * it is considered idle and therefore subject to automated cleanup.
+ */
+const IDLE_TIME_MSEC = 10 * 1000;
+
+/**
  * Binding context for an API server or session therein. This is pretty much
  * just a map from IDs to `Target` instances, along with reasonably
  * straightforward accessor and update methods.
- *
- * When initially set up, a context only has one binding. Specifically,
- * `meta` is bound to an object which provides meta-information and
- * meta-control.
  */
 export default class Context extends CommonBase {
   /**
@@ -47,7 +49,7 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Adds a new target to the instance. This will throw an error if there is
+   * Adds a new target to this instance. This will throw an error if there is
    * already another target with the same ID. This is a convenience for calling
    * `map.addTarget(new Target(id, obj))`.
    *
@@ -57,8 +59,53 @@ export default class Context extends CommonBase {
    * @param {object} obj Object to ultimately call on.
    */
   add(nameOrKey, obj) {
-    TObject.check(obj);
     this.addTarget(new Target(nameOrKey, obj));
+  }
+
+  /**
+   * Adds a new target to this instance, marking it as "evergreen" (immortal /
+   * never idle). Other than evergreen marking, this is identical to
+   * `this.add()`.
+   *
+   * @param {string|BaseKey} nameOrKey Either the name of the target (if
+   *   uncontrolled) _or_ the key which controls access to the target.
+   * @param {object} obj Object to ultimately call on.
+   */
+  addEvergreen(nameOrKey, obj) {
+    const target = new Target(nameOrKey, obj);
+    target.setEvergreen();
+    this.addTarget(target);
+  }
+
+  /**
+   * Cleans up (removes) bindings for targets that have become idle.
+   */
+  idleCleanup() {
+    const idleLimit = Date.now() - IDLE_TIME_MSEC;
+    const map = this._map;
+
+    console.log('====== cleanup', idleLimit);
+
+    // Note: The ECMAScript spec guarantees that it is safe to delete keys from
+    // a map while iterating over it. See
+    // <https://tc39.github.io/ecma262/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind>.
+    for (const [key, value] of map) {
+      if (value.wasIdleAsOf(idleLimit)) {
+        console.log('====== boop!', key);
+        map.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Starts automatically cleaning up idle targets on this instance. This
+   * initiates a periodic task which iterates over all targets, removing ones
+   * that have become idle.
+   */
+  startAutomaticIdleCleanup() {
+    // We run the callback at a fraction of the overall idle timeout so as to
+    // be a bit more prompt with the cleanup.
+    setInterval(() => { this.idleCleanup(); }, IDLE_TIME_MSEC / 10);
   }
 
   /**

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -90,7 +90,7 @@ export default class PostConnection extends Connection {
    * Handles an `end` event coming from the request input stream.
    */
   _handleEnd() {
-    this._log.info('Close.');
+    this._log.info('Received message.');
 
     const msg = Buffer.concat(this._chunks).toString('utf8');
     this.handleJsonMessage(msg).then((response) => {
@@ -98,6 +98,7 @@ export default class PostConnection extends Connection {
         .status(200)
         .type('application/json')
         .send(response);
+      this.close();
     });
   }
 
@@ -111,6 +112,7 @@ export default class PostConnection extends Connection {
     // not on this side).
     this._log.info('Error event:', error);
     this._respond400('Trouble receiving POST payload.');
+    this.close();
   }
 
   /**

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -51,7 +51,9 @@ export default class WsConnection extends Connection {
   _handleClose(code, msg) {
     const codeStr = WebsocketCodes.close(code);
     const msgStr = msg ? `: ${msg}` : '';
+
     this._log.info(`Close: ${codeStr}${msgStr}`);
+    this.close();
   }
 
   /**
@@ -61,5 +63,6 @@ export default class WsConnection extends Connection {
    */
   _handleError(error) {
     this._log.info('Error:', error);
+    this.close();
   }
 }

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -33,7 +33,8 @@ export default class Application {
    */
   constructor(devMode) {
     /** {Context} All of the objects we provide access to via the API. */
-    const context = this._context = new Context();
+    this._context = new Context();
+    this._context.startAutomaticIdleCleanup();
 
     /**
      * {array<BearerToken>} List of `BearerToken`s that are currently bound in
@@ -46,7 +47,7 @@ export default class Application {
      * protected by the root bearer token(s) returned via the related
      * `hooks-server` hooks.
      */
-    this._rootAccess = new RootAccess(context);
+    this._rootAccess = new RootAccess(this._context);
 
     // Bind `rootAccess` into the `context` using the root token(s), and arrange
     // for their update should the token(s) change.
@@ -147,7 +148,7 @@ export default class Application {
         context.deleteId(t.id);
       }
       for (const t of rootTokens) {
-        context.add(t, this._rootAccess);
+        context.addEvergreen(t, this._rootAccess);
         log.info(`Accept root: ${t}`);
       }
       this._rootTokens = rootTokens;

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -9,6 +9,7 @@
     "doc-common": "local",
     "doc-store": "local",
     "hooks-server": "local",
+    "see-all": "local",
     "typecheck": "local",
     "util-common": "local"
   }

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -4,6 +4,8 @@
   "main": "main.js",
 
   "dependencies": {
+    "weak": "^1.0.1",
+
     "doc-common": "local",
     "doc-store": "local",
     "hooks-server": "local",


### PR DESCRIPTION
This PR adds mechanisms in three places that enable dropping / GC'ing of idle resources:

* The binding context objects associated with connections (HTTP or websocket) will get dropped promptly when the connection is closed. (That is, we don't wait for Express to clean itself up.) Notably, these contexts will generally include a document controller, which then becomes eligible for GC.
* Top-level authed targets (specifically in this case, document controllers) that haven't been used within a specified "idle time" limit (currently ten minutes) will get removed from the top-level binding context. This will make the underlying document objects eligible for GC.
* `doc-server` now keeps the mapped document controllers weakly, so that they can be GC'ed when they are no longer externally accessed. The weak reference scheme means that we are still guaranteed that, when active, we'll only have one instance of a controller per document (which is an essential guarantee to make).