### PR TITLE
A bunch of test-related stuff.

### DIFF
--- a/local-modules/api-common/tests/test_BaseKey.js
+++ b/local-modules/api-common/tests/test_BaseKey.js
@@ -53,7 +53,7 @@ describe('api-common/BaseKey', () => {
     });
   });
 
-  describe('#toString()', () => {
+  describe('toString()', () => {
     it('returns a redacted (log-safe) representation of the key', () => {
       const s = key.toString();
 
@@ -61,7 +61,7 @@ describe('api-common/BaseKey', () => {
     });
   });
 
-  describe('#makeChallengePair()', () => {
+  describe('makeChallengePair()', () => {
     it('returns a challenge/response pair in an object', () => {
       const pair = key.makeChallengePair();
 

--- a/local-modules/api-common/tests/test_BaseKey.js
+++ b/local-modules/api-common/tests/test_BaseKey.js
@@ -41,7 +41,7 @@ describe('api-common.BaseKey', () => {
     it('should return the URL passed to the constructor', () => {
       const url = key.url;
 
-      assert.equal(url, URL);
+      assert.strictEqual(url, URL);
     });
   });
 
@@ -49,7 +49,7 @@ describe('api-common.BaseKey', () => {
     it('should return the ID passed to the constructor', () => {
       const id = key.id;
 
-      assert.equal(id, ID);
+      assert.strictEqual(id, ID);
     });
   });
 

--- a/local-modules/api-common/tests/test_BaseKey.js
+++ b/local-modules/api-common/tests/test_BaseKey.js
@@ -36,7 +36,7 @@ beforeEach(() => {
   key = new FakeKey(URL, ID);
 });
 
-describe('api-common.BaseKey', () => {
+describe('api-common/BaseKey', () => {
   describe('.url', () => {
     it('should return the URL passed to the constructor', () => {
       const url = key.url;

--- a/local-modules/api-common/tests/test_Decoder.js
+++ b/local-modules/api-common/tests/test_Decoder.js
@@ -17,7 +17,7 @@ before(() => {
   }
 });
 
-describe('api-common.Decoder', () => {
+describe('api-common/Decoder', () => {
   describe('#decode(value)', () => {
     it('should pass non-object values through as-is', () => {
       assert.strictEqual(Decoder.decode(37), 37);

--- a/local-modules/api-common/tests/test_Decoder.js
+++ b/local-modules/api-common/tests/test_Decoder.js
@@ -20,10 +20,10 @@ before(() => {
 describe('api-common.Decoder', () => {
   describe('#decode(value)', () => {
     it('should pass non-object values through as-is', () => {
-      assert.equal(Decoder.decode(37), 37);
-      assert.equal(Decoder.decode(true), true);
-      assert.equal(Decoder.decode(false), false);
-      assert.equal(Decoder.decode('Happy string'), 'Happy string');
+      assert.strictEqual(Decoder.decode(37), 37);
+      assert.strictEqual(Decoder.decode(true), true);
+      assert.strictEqual(Decoder.decode(false), false);
+      assert.strictEqual(Decoder.decode('Happy string'), 'Happy string');
       assert.isNull(Decoder.decode(null));
     });
 

--- a/local-modules/api-common/tests/test_Decoder.js
+++ b/local-modules/api-common/tests/test_Decoder.js
@@ -18,7 +18,7 @@ before(() => {
 });
 
 describe('api-common/Decoder', () => {
-  describe('#decode(value)', () => {
+  describe('decode(value)', () => {
     it('should pass non-object values through as-is', () => {
       assert.strictEqual(Decoder.decode(37), 37);
       assert.strictEqual(Decoder.decode(true), true);

--- a/local-modules/api-common/tests/test_Encoder.js
+++ b/local-modules/api-common/tests/test_Encoder.js
@@ -21,7 +21,7 @@ class NoToApi {
 }
 
 describe('api-common/Encoder', () => {
-  describe('#encode(value)', () => {
+  describe('encode(value)', () => {
     it('should reject function values', () => {
       assert.throws(() => Encoder.encode(function () { true; }));
     });

--- a/local-modules/api-common/tests/test_Encoder.js
+++ b/local-modules/api-common/tests/test_Encoder.js
@@ -35,11 +35,11 @@ describe('api-common.Encoder', () => {
     });
 
     it('should pass through non-object values and null as-is', () => {
-      assert.equal(Encoder.encode(37), 37);
-      assert.equal(Encoder.encode(true), true);
-      assert.equal(Encoder.encode(false), false);
-      assert.equal(Encoder.encode('blort'), 'blort');
-      assert.equal(Encoder.encode(null), null);
+      assert.strictEqual(Encoder.encode(37), 37);
+      assert.strictEqual(Encoder.encode(true), true);
+      assert.strictEqual(Encoder.encode(false), false);
+      assert.strictEqual(Encoder.encode('blort'), 'blort');
+      assert.strictEqual(Encoder.encode(null), null);
     });
 
     it('should pass through simple objects whose values are self-encoding as-is', () => {

--- a/local-modules/api-common/tests/test_Encoder.js
+++ b/local-modules/api-common/tests/test_Encoder.js
@@ -20,7 +20,7 @@ class NoToApi {
   }
 }
 
-describe('api-common.Encoder', () => {
+describe('api-common/Encoder', () => {
   describe('#encode(value)', () => {
     it('should reject function values', () => {
       assert.throws(() => Encoder.encode(function () { true; }));

--- a/local-modules/api-common/tests/test_Message.js
+++ b/local-modules/api-common/tests/test_Message.js
@@ -17,7 +17,7 @@ before(() => {
   }
 });
 
-describe('api-common.Message', () => {
+describe('api-common/Message', () => {
   describe('#constructor(id, target, action, name, args)', () => {
     it('should require integer ids >= 0', () => {
       assert.throws(() => new Message('this better not work!', 'foo', 'call', 'bar', []));

--- a/local-modules/api-common/tests/test_Message.js
+++ b/local-modules/api-common/tests/test_Message.js
@@ -18,7 +18,7 @@ before(() => {
 });
 
 describe('api-common/Message', () => {
-  describe('#constructor(id, target, action, name, args)', () => {
+  describe('constructor(id, target, action, name, args)', () => {
     it('should require integer ids >= 0', () => {
       assert.throws(() => new Message('this better not work!', 'foo', 'call', 'bar', []));
       assert.throws(() => new Message(3.7, 'target', 'call', 'method', []));

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -74,7 +74,7 @@ class NoFromApi {
   }
 }
 
-describe('api-common.Registry', () => {
+describe('api-common/Registry', () => {
   describe('.ARRAY_TAG', () => {
     it("should return 'array'", () => {
       assert.strictEqual(Registry.ARRAY_TAG, 'array');

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -77,7 +77,7 @@ class NoFromApi {
 describe('api-common.Registry', () => {
   describe('.ARRAY_TAG', () => {
     it("should return 'array'", () => {
-      assert.equal(Registry.ARRAY_TAG, 'array');
+      assert.strictEqual(Registry.ARRAY_TAG, 'array');
     });
   });
 

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -81,7 +81,7 @@ describe('api-common/Registry', () => {
     });
   });
 
-  describe('#register(class)', () => {
+  describe('register(class)', () => {
     it('should require classes with an APP_NAME property, fromName() class method, and toApi() instance method', () => {
       assert.throws(() => Registry.register(true));
       assert.throws(() => Registry.register(37));
@@ -98,7 +98,7 @@ describe('api-common/Registry', () => {
     });
   });
 
-  describe('#find(className)', () => {
+  describe('find(className)', () => {
     it('should throw an error if an unregistered class is requested', () => {
       const randomName = Random.hexByteString(32);
       assert.throws(() => Registry.find(randomName));

--- a/local-modules/api-common/tests/test_SplitKey.js
+++ b/local-modules/api-common/tests/test_SplitKey.js
@@ -11,7 +11,7 @@ const FAKE_KEY = '0011223344556677';
 const FAKE_SECRET = '00112233445566778899aabbccddeeff';
 
 describe('api-common/SplitKey', () => {
-  describe('#constructor(url, id, secret)', () => {
+  describe('constructor(url, id, secret)', () => {
     it('should reject non-string urls', () => {
       assert.throws(() => new SplitKey(37, FAKE_KEY, FAKE_SECRET));
     });
@@ -36,7 +36,7 @@ describe('api-common/SplitKey', () => {
     });
   });
 
-  describe('#randomInstance(url)', () => {
+  describe('randomInstance(url)', () => {
     it('should return a frozen instance of SplitKey', () => {
       const key = SplitKey.randomInstance('https://www.example.com');
 

--- a/local-modules/api-common/tests/test_SplitKey.js
+++ b/local-modules/api-common/tests/test_SplitKey.js
@@ -10,7 +10,7 @@ import { SplitKey } from 'api-common';
 const FAKE_KEY = '0011223344556677';
 const FAKE_SECRET = '00112233445566778899aabbccddeeff';
 
-describe('api-common.SplitKey', () => {
+describe('api-common/SplitKey', () => {
   describe('#constructor(url, id, secret)', () => {
     it('should reject non-string urls', () => {
       assert.throws(() => new SplitKey(37, FAKE_KEY, FAKE_SECRET));

--- a/local-modules/api-server/tests/test_BearerToken.js
+++ b/local-modules/api-server/tests/test_BearerToken.js
@@ -9,7 +9,7 @@ import { BearerToken } from 'api-server';
 
 const SECRET_TOKEN = 'Setec Astronomy Setec Astronomy ';
 
-describe('api-server.BearerToken', () => {
+describe('api-server/BearerToken', () => {
   describe('#constructor(secret)', () => {
     it('should reject secrets with length < 32', () => {
       assert.throws(() => new BearerToken('Setec Astronomy'));

--- a/local-modules/api-server/tests/test_BearerToken.js
+++ b/local-modules/api-server/tests/test_BearerToken.js
@@ -27,7 +27,7 @@ describe('api-server.BearerToken', () => {
     it('should return the token provided to the constructor', () => {
       const token = new BearerToken(SECRET_TOKEN);
 
-      assert.equal(token.secretToken, SECRET_TOKEN);
+      assert.strictEqual(token.secretToken, SECRET_TOKEN);
     });
   });
 

--- a/local-modules/api-server/tests/test_BearerToken.js
+++ b/local-modules/api-server/tests/test_BearerToken.js
@@ -10,7 +10,7 @@ import { BearerToken } from 'api-server';
 const SECRET_TOKEN = 'Setec Astronomy Setec Astronomy ';
 
 describe('api-server/BearerToken', () => {
-  describe('#constructor(secret)', () => {
+  describe('constructor(secret)', () => {
     it('should reject secrets with length < 32', () => {
       assert.throws(() => new BearerToken('Setec Astronomy'));
     });
@@ -31,7 +31,7 @@ describe('api-server/BearerToken', () => {
     });
   });
 
-  describe('#sameToken(other)', () => {
+  describe('sameToken(other)', () => {
     it('should return false when passed null', () => {
       const token = new BearerToken(SECRET_TOKEN);
 
@@ -59,7 +59,7 @@ describe('api-server/BearerToken', () => {
     });
   });
 
-  describe('#sameArrays(array1, array2)', () => {
+  describe('sameArrays(array1, array2)', () => {
     it('should reject arrays that are different lengths', () => {
       const token1 = new BearerToken(SECRET_TOKEN);
       const token2 = new BearerToken(SECRET_TOKEN);

--- a/local-modules/bayou-mocha/Mocks.js
+++ b/local-modules/bayou-mocha/Mocks.js
@@ -21,12 +21,13 @@ class FakeApiObject {
 }
 
 /**
- * A collection of methods for creating mock objects needed for Bayou unit testing.
+ * A collection of methods for creating mock objects needed for Bayou unit
+ * testing.
  */
 export default class Mocks {
   static nodeRequest(uri = 'http://www.example.com',
                      method = 'GET',
-                     headers = { host: 'example.com', 'x-forwarded-host': 'example.com' },
+                     headers = { host: 'example.com' },
                      timeout = 10 * 1000,
                      followRedirects = true,
                      maxRedirects = 10) {

--- a/local-modules/doc-common/FrozenDelta.js
+++ b/local-modules/doc-common/FrozenDelta.js
@@ -20,7 +20,7 @@ let emptyDelta = null;
  * `Delta` provides.
  */
 export default class FrozenDelta extends Delta {
-  /** Frozen (immutable) empty `Delta` instance. */
+  /** {FrozenDelta} Empty instance of this class. */
   static get EMPTY() {
     if (emptyDelta === null) {
       emptyDelta = new FrozenDelta([]);
@@ -32,8 +32,11 @@ export default class FrozenDelta extends Delta {
   /**
    * Returns `true` iff the given delta or delta-like value is empty. This
    * accepts the same set of values as `coerce()`, see which. Anything else is
-   * considered to be an error. This is a static method exactly because it
-   * accepts things other than instances of `FrozenDelta` per se.
+   * considered to be an error, except that when not given a `Delta` per se the
+   * array contents (if any) are not inspected for validity.
+   *
+   * **Note:** This is a static method exactly because it accepts things other
+   * than instances of `FrozenDelta` per se.
    *
    * @param {object|array|null|undefined} delta The delta or delta-like value.
    * @returns {boolean} `true` if `delta` is empty or `false` if not.
@@ -103,6 +106,7 @@ export default class FrozenDelta extends Delta {
    *   given value.
    */
   constructor(ops) {
+    // TODO: Should consider validating the contents of `ops`.
     TArray.check(ops);
 
     super(DataUtil.deepFreeze(ops));

--- a/local-modules/doc-common/tests/test_AuthorId.js
+++ b/local-modules/doc-common/tests/test_AuthorId.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { AuthorId } from 'doc-common';
 
 describe('doc-common/AuthorId', () => {
-  describe('#check', () => {
+  describe('check', () => {
     it('should reject null values by default', () => {
       assert.throws(() => AuthorId.check(null));
     });

--- a/local-modules/doc-common/tests/test_DocumentId.js
+++ b/local-modules/doc-common/tests/test_DocumentId.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { DocumentId } from 'doc-common';
 
 describe('doc-common/DocumentId', () => {
-  describe('#check', () => {
+  describe('check', () => {
     it('should reject null values', () => {
       assert.throws(() => DocumentId.check(null));
     });

--- a/local-modules/doc-common/tests/test_FrozenDelta.js
+++ b/local-modules/doc-common/tests/test_FrozenDelta.js
@@ -10,7 +10,7 @@ import util from 'util';
 import { FrozenDelta } from 'doc-common';
 
 describe('doc-common/FrozenDelta', () => {
-  describe('EMPTY', () => {
+  describe('.EMPTY', () => {
     const empty = FrozenDelta.EMPTY;
 
     it('should be an instance of `FrozenDelta`', () => {
@@ -34,7 +34,7 @@ describe('doc-common/FrozenDelta', () => {
     });
   });
 
-  describe('isEmpty', () => {
+  describe('isEmpty()', () => {
     describe('valid empty values', () => {
       const values = [
         new Delta([]),

--- a/local-modules/doc-common/tests/test_FrozenDelta.js
+++ b/local-modules/doc-common/tests/test_FrozenDelta.js
@@ -22,7 +22,7 @@ describe('doc-common/FrozenDelta', () => {
     });
 
     it('should have an empty `ops`', () => {
-      assert.equal(empty.ops.length, 0);
+      assert.strictEqual(empty.ops.length, 0);
     });
 
     it('should have a frozen `ops`', () => {

--- a/local-modules/doc-common/tests/test_FrozenDelta.js
+++ b/local-modules/doc-common/tests/test_FrozenDelta.js
@@ -25,6 +25,10 @@ describe('doc-common/FrozenDelta', () => {
       assert.equal(empty.ops.length, 0);
     });
 
+    it('should have a frozen `ops`', () => {
+      assert.isFrozen(empty.ops);
+    });
+
     it('should be `FrozenDelta.isEmpty()`', () => {
       assert.isTrue(FrozenDelta.isEmpty(empty));
     });
@@ -100,18 +104,34 @@ describe('doc-common/FrozenDelta', () => {
   });
 
   describe('isDocument(doc)', () => {
-    it('should return true if all ops are insert', () => {
-      const insertOps = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
-      const document = FrozenDelta.coerce(insertOps);
+    describe('`true` cases', () => {
+      const values = [
+        [],
+        [{ insert: 'line 1' }],
+        [{ insert: 'line 1' }, { insert: '\n' }],
+        [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }]
+      ];
 
-      assert.isTrue(document.isDocument());
+      for (const v of values) {
+        it(`should return \`true\` for: ${util.inspect(v)}`, () => {
+          assert.isTrue(FrozenDelta.coerce(v).isDocument());
+        });
+      }
     });
 
-    it('should return false if any ops are not insert', () => {
-      const insertOps = [{ retain: 5 }, { insert: '\n' }, { insert: 'line 2' }];
-      const document = FrozenDelta.coerce(insertOps);
+    describe('`false` cases', () => {
+      const values = [
+        [{ retain: 37 }],
+        [{ insert: 'line 1' }, { retain: 9 }],
+        [{ insert: 'line 1' }, { retain: 14 }, { insert: '\n' }],
+        [{ insert: 'line 1' }, { insert: '\n' }, { retain: 23 }, { insert: 'line 2' }]
+      ];
 
-      assert.isFalse(document.isDocument());
+      for (const v of values) {
+        it(`should return \`false\` for: ${util.inspect(v)}`, () => {
+          assert.isFalse(FrozenDelta.coerce(v).isDocument());
+        });
+      }
     });
   });
 });

--- a/local-modules/doc-common/tests/test_FrozenDelta.js
+++ b/local-modules/doc-common/tests/test_FrozenDelta.js
@@ -5,61 +5,101 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import Delta from 'quill-delta';
+import util from 'util';
 
 import { FrozenDelta } from 'doc-common';
 
 describe('doc-common/FrozenDelta', () => {
-  describe('.EMPTY', () => {
-    it('should return an empty, frozen Delta', () => {
-      const empty = FrozenDelta.EMPTY;
+  describe('EMPTY', () => {
+    const empty = FrozenDelta.EMPTY;
 
+    it('should be an instance of `FrozenDelta`', () => {
       assert.instanceOf(empty, FrozenDelta);
+    });
+
+    it('should be a frozen object', () => {
       assert.isFrozen(empty);
-      assert.equal(empty['ops'].length, 0);
+    });
+
+    it('should have an empty `ops`', () => {
+      assert.equal(empty.ops.length, 0);
+    });
+
+    it('should be `FrozenDelta.isEmpty()`', () => {
       assert.isTrue(FrozenDelta.isEmpty(empty));
     });
   });
 
-  describe('#isEmpty', () => {
-    it('should return true for an empty Delta or subclass', () => {
-      const emptyDelta = new Delta();
+  describe('isEmpty', () => {
+    describe('valid empty values', () => {
+      const values = [
+        new Delta([]),
+        new FrozenDelta([]),
+        FrozenDelta.EMPTY,
+        null,
+        undefined,
+        [],
+        { ops: [] }
+      ];
 
-      assert.isTrue(FrozenDelta.isEmpty(emptyDelta));
+      for (const v of values) {
+        it(`should return \`true\` for: ${util.inspect(v)}`, () => {
+          assert.isTrue(FrozenDelta.isEmpty(v));
+        });
+      }
     });
 
-    it('should return true for null and undefined', () => {
-      assert.isTrue(FrozenDelta.isEmpty(null));
-      assert.isTrue(FrozenDelta.isEmpty(undefined));
+    describe('valid non-empty values', () => {
+      const ops1 = [{ insert: 'x' }];
+      const ops2 = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
+
+      // This one is not a valid `ops` array, but per docs, `isEmpty()` doesn't
+      // inspect the contents of `ops` arrays and so using this value should
+      // succeed.
+      const invalidNonEmptyOps = [null, undefined, /blort/, 1, 2, 3];
+
+      const values = [
+        ops1,
+        { ops: ops1 },
+        new Delta(ops1),
+        new FrozenDelta(ops1),
+        ops2,
+        { ops: ops2 },
+        new Delta(ops2),
+        new FrozenDelta(ops2),
+        invalidNonEmptyOps,
+        { ops: invalidNonEmptyOps }
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${util.inspect(v)}`, () => {
+          assert.isFalse(FrozenDelta.isEmpty(v));
+        });
+      }
     });
 
-    it('should return true for empty Delta-like objects', () => {
-      const emptyObject = { ops: [] };
+    describe('non-delta-like values', () => {
+      const values = [
+        37,
+        true,
+        false,
+        '',
+        'this better not work!',
+        {},
+        () => true,
+        /blort/,
+        Symbol.for('foo')
+      ];
 
-      assert.isTrue(FrozenDelta.isEmpty(emptyObject));
-    });
-
-    it('should return true for empty Delta-like objects', () => {
-      const emptyObject = { ops: [] };
-
-      assert.isTrue(FrozenDelta.isEmpty(emptyObject));
-    });
-
-    it('should return true for arrays', () => {
-      assert.isTrue(FrozenDelta.isEmpty([]));
-    });
-
-    it('should throw an Error for any other value', () => {
-      assert.throws(() => FrozenDelta.isEmpty(37));
-      assert.throws(() => FrozenDelta.isEmpty(true));
-      assert.throws(() => FrozenDelta.isEmpty(''));
-      assert.throws(() => FrozenDelta.isEmpty('this better not work!'));
-      assert.throws(() => FrozenDelta.isEmpty({}));
-      assert.throws(() => FrozenDelta.isEmpty({ ops: [1, 2, 3] }));
-      assert.throws(() => FrozenDelta.isEmpty(function foo() { /* */ }));
+      for (const v of values) {
+        it(`should throw for: ${util.inspect(v)}`, () => {
+          assert.throws(() => { FrozenDelta.isEmpty(v); });
+        });
+      }
     });
   });
 
-  describe('#isDocument(doc)', () => {
+  describe('isDocument(doc)', () => {
     it('should return true if all ops are insert', () => {
       const insertOps = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
       const document = FrozenDelta.coerce(insertOps);
@@ -72,19 +112,6 @@ describe('doc-common/FrozenDelta', () => {
       const document = FrozenDelta.coerce(insertOps);
 
       assert.isFalse(document.isDocument());
-    });
-  });
-
-  describe('#isEmpty()', () => {
-    it('should return true if the Delta has no ops', () => {
-      assert.isTrue(FrozenDelta.EMPTY.isEmpty());
-    });
-
-    it('should return false if the Delta has any ops', () => {
-      const insertOps = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
-      const document = FrozenDelta.coerce(insertOps);
-
-      assert.isFalse(document.isEmpty());
     });
   });
 });

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -31,17 +31,17 @@ describe('doc-store-local/LocalDoc', () => {
       const doc = new LocalDoc('0', '0', _documentPath());
       const oldVersion = doc.currentVerNum();
 
-      //  Docs start off with a null version number
+      // Docs start off with a null version number
       assert.isNull(oldVersion);
       _addChangeToDocument(doc);
 
       let newVersion = doc.currentVerNum();
 
-      assert.equal(newVersion, 0);
+      assert.strictEqual(newVersion, 0);
 
       _addChangeToDocument(doc);
       newVersion = doc.currentVerNum();
-      assert.equal(newVersion, 1);
+      assert.strictEqual(newVersion, 1);
     });
 
     // Need a good way to test this with a delay. Documents don't resolve a Promise
@@ -72,7 +72,7 @@ describe('doc-store-local/LocalDoc', () => {
 
       const postCreateVersion = doc.currentVerNum();
 
-      assert.equal(preCreateVersion, postCreateVersion);
+      assert.strictEqual(preCreateVersion, postCreateVersion);
     });
   });
 });

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -26,7 +26,7 @@ describe('doc-store-local/LocalDoc', () => {
     });
   });
 
-  describe('#changeAppend(change)', () => {
+  describe('changeAppend(change)', () => {
     it('should increment the version after a change is applied', () => {
       const doc = new LocalDoc('0', '0', _documentPath());
       const oldVersion = doc.currentVerNum();
@@ -57,7 +57,7 @@ describe('doc-store-local/LocalDoc', () => {
     // });
   });
 
-  describe('#create()', () => {
+  describe('create()', () => {
     it('should erase the document if called on a non-empty document', () => {
       const doc = new LocalDoc('0', '0', _documentPath());
 

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -58,21 +58,14 @@ describe('doc-store-local/LocalDoc', () => {
   });
 
   describe('#create()', () => {
-    it('should not affect the document if called multiple times', () => {
+    it('should erase the document if called on a non-empty document', () => {
       const doc = new LocalDoc('0', '0', _documentPath());
 
       _addChangeToDocument(doc);
-      _addChangeToDocument(doc);
-      _addChangeToDocument(doc);
-      _addChangeToDocument(doc);
-
-      const preCreateVersion = doc.currentVerNum();
+      assert.strictEqual(doc.currentVerNum(), 0); // Baseline assumption.
 
       doc.create();
-
-      const postCreateVersion = doc.currentVerNum();
-
-      assert.strictEqual(preCreateVersion, postCreateVersion);
+      assert.isNull(doc.currentVerNum()); // The real test.
     });
   });
 });

--- a/local-modules/hooks-client/tests/test_Hooks.js
+++ b/local-modules/hooks-client/tests/test_Hooks.js
@@ -6,6 +6,6 @@ import { describe, it } from 'mocha';
 
 // import { Hooks } from 'hooks-client';
 
-describe('hooks-client.Hooks', () => {
+describe('hooks-client/Hooks', () => {
   it('has nothing worth testing yet');
 });

--- a/local-modules/hooks-common/tests/test_Hooks.js
+++ b/local-modules/hooks-common/tests/test_Hooks.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { Hooks } from 'hooks-common';
 
-describe('hooks-common.Hooks', () => {
+describe('hooks-common/Hooks', () => {
   describe('isAuthorId(id)', () => {
     it('should accept 32-character alphanum ASCII strings', () => {
       assert.isTrue(Hooks.isAuthorId('123abc7890ABC456789012'));

--- a/local-modules/hooks-server/tests/test_BearerToken.js
+++ b/local-modules/hooks-server/tests/test_BearerToken.js
@@ -34,7 +34,7 @@ describe('hooks-server.BearerTokens', () => {
       const fakeTokenString = 'abcdefghijklmnopqrstuvwxyz';
       const tokenId = BEARER_TOKEN.tokenId(fakeTokenString);
 
-      assert.equal(tokenId, fakeTokenString.slice(0, 16));
+      assert.strictEqual(tokenId, fakeTokenString.slice(0, 16));
     });
   });
 

--- a/local-modules/hooks-server/tests/test_BearerToken.js
+++ b/local-modules/hooks-server/tests/test_BearerToken.js
@@ -11,7 +11,7 @@ import { BearerTokens } from 'hooks-server';
 const BEARER_TOKEN = BearerTokens.theOne;
 
 describe('hooks-server/BearerTokens', () => {
-  describe('#isToken(tokenString)', () => {
+  describe('isToken(tokenString)', () => {
     it('should accept any value', () => {
       assert.isTrue(BEARER_TOKEN.isToken('abc123'));
     });
@@ -29,7 +29,7 @@ describe('hooks-server/BearerTokens', () => {
     });
   });
 
-  describe('#tokenId(tokenString)', () => {
+  describe('tokenId(tokenString)', () => {
     it('should return the first 16 characters of the string passed to it', () => {
       const fakeTokenString = 'abcdefghijklmnopqrstuvwxyz';
       const tokenId = BEARER_TOKEN.tokenId(fakeTokenString);
@@ -38,7 +38,7 @@ describe('hooks-server/BearerTokens', () => {
     });
   });
 
-  describe('#whenRootTokensChange()', () => {
+  describe('whenRootTokensChange()', () => {
     it('should return a promise', () => {
       const changePromise = BEARER_TOKEN.whenRootTokensChange();
 

--- a/local-modules/hooks-server/tests/test_BearerToken.js
+++ b/local-modules/hooks-server/tests/test_BearerToken.js
@@ -10,7 +10,7 @@ import { BearerTokens } from 'hooks-server';
 
 const BEARER_TOKEN = BearerTokens.theOne;
 
-describe('hooks-server.BearerTokens', () => {
+describe('hooks-server/BearerTokens', () => {
   describe('#isToken(tokenString)', () => {
     it('should accept any value', () => {
       assert.isTrue(BEARER_TOKEN.isToken('abc123'));

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -20,27 +20,20 @@ describe('hooks-server/Hooks', () => {
   });
 
   describe('.bearerTokens', () => {
-    it('should return an array of BearerToken', () => {
-      const tokens = Hooks.bearerTokens;
-
-      assert.instanceOf(tokens, BearerTokens);
+    it('should return an instance of `BearerTokens`', () => {
+      assert.instanceOf(Hooks.bearerTokens, BearerTokens);
     });
   });
 
   describe('.docStore', () => {
     it('should return an instance of BaseDocStore', () => {
-      const store = Hooks.docStore;
-
-      assert.instanceOf(store, BaseDocStore);
+      assert.instanceOf(Hooks.docStore, BaseDocStore);
     });
   });
 
   describe('.listenPort', () => {
-    it('should return the default TCP listen port number', () => {
-      const port = Hooks.listenPort;
-
-      assert.isNumber(port);
-      assert.strictEqual(port, 8080);
+    it('should return the documented value', () => {
+      assert.strictEqual(Hooks.listenPort, 8080);
     });
   });
 });

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -19,7 +19,7 @@ describe('hooks-server/Hooks', () => {
     });
   });
 
-  describe('bearerTokens', () => {
+  describe('.bearerTokens', () => {
     it('should return an array of BearerToken', () => {
       const tokens = Hooks.bearerTokens;
 
@@ -27,7 +27,7 @@ describe('hooks-server/Hooks', () => {
     });
   });
 
-  describe('docStore', () => {
+  describe('.docStore', () => {
     it('should return an instance of BaseDocStore', () => {
       const store = Hooks.docStore;
 
@@ -35,7 +35,7 @@ describe('hooks-server/Hooks', () => {
     });
   });
 
-  describe('listenPort', () => {
+  describe('.listenPort', () => {
     it('should return the default TCP listen port number', () => {
       const port = Hooks.listenPort;
 

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -10,7 +10,7 @@ import { BaseDocStore } from 'doc-store';
 import { BearerTokens, Hooks } from 'hooks-server';
 
 describe('hooks-server/Hooks', () => {
-  describe('#baseUrlFromRequest(request)', () => {
+  describe('baseUrlFromRequest(request)', () => {
     it('should return a new URL referencing just the host with no path, query args, or anchors', () => {
       const request = Mocks.nodeRequest();
       const uri = Hooks.baseUrlFromRequest(request);

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -15,7 +15,7 @@ describe('hooks-server.Hooks', () => {
       const request = Mocks.nodeRequest();
       const uri = Hooks.baseUrlFromRequest(request);
 
-      assert.equal(uri, 'http://example.com');
+      assert.strictEqual(uri, 'http://example.com');
     });
   });
 
@@ -40,7 +40,7 @@ describe('hooks-server.Hooks', () => {
       const port = Hooks.listenPort;
 
       assert.isNumber(port);
-      assert.equal(port, 8080);
+      assert.strictEqual(port, 8080);
     });
   });
 });

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -9,7 +9,7 @@ import { Mocks } from 'bayou-mocha';
 import { BaseDocStore } from 'doc-store';
 import { BearerTokens, Hooks } from 'hooks-server';
 
-describe('hooks-server.Hooks', () => {
+describe('hooks-server/Hooks', () => {
   describe('#baseUrlFromRequest(request)', () => {
     it('should return a new URL referencing just the host with no path, query args, or anchors', () => {
       const request = Mocks.nodeRequest();

--- a/local-modules/hooks-server/tests/test_default-document.js
+++ b/local-modules/hooks-server/tests/test_default-document.js
@@ -15,7 +15,7 @@ describe('hooks-server/default-document', () => {
       for (const command of document) {
         assert.isObject(command);
         assert.property(command, 'insert');
-        assert.isString(command['insert']);
+        assert.isString(command.insert);
       }
     });
   });

--- a/local-modules/hooks-server/tests/test_default-document.js
+++ b/local-modules/hooks-server/tests/test_default-document.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import document from '../default-document';
 
-describe('hooks-server.default-document', () => {
+describe('hooks-server/default-document', () => {
   describe('default document', () => {
     it('should return be an array of Parchment insert objects', () => {
       assert.isArray(document);

--- a/local-modules/proppy/tests/test_Proppy.js
+++ b/local-modules/proppy/tests/test_Proppy.js
@@ -148,9 +148,9 @@ function _testStringParsing(input, expectedObject) {
 
   const keys = Object.keys(expectedObject);
 
-  assert.equal(TObject.withExactKeys(output, keys), output);
+  assert.strictEqual(TObject.withExactKeys(output, keys), output);
 
   for (const key of keys) {
-    assert.equal(output[key], expectedObject[key]);
+    assert.strictEqual(output[key], expectedObject[key]);
   }
 }

--- a/local-modules/proppy/tests/test_Proppy.js
+++ b/local-modules/proppy/tests/test_Proppy.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { Proppy } from 'proppy';
 import { TObject } from 'typecheck';
 
-describe('proppy.Proppy', () => {
+describe('proppy/Proppy', () => {
   describe('#parseStream(value)', () => {
     it('needs testing');
   });

--- a/local-modules/proppy/tests/test_Proppy.js
+++ b/local-modules/proppy/tests/test_Proppy.js
@@ -9,15 +9,15 @@ import { Proppy } from 'proppy';
 import { TObject } from 'typecheck';
 
 describe('proppy/Proppy', () => {
-  describe('#parseStream(value)', () => {
+  describe('parseStream(value)', () => {
     it('needs testing');
   });
 
-  describe('#parseFile(value)', () => {
+  describe('parseFile(value)', () => {
     it('needs testing');
   });
 
-  describe('#parseString(value)', () => {
+  describe('parseString(value)', () => {
     it('should ignore comments and blank lines', () => {
       const input = '# this is comment line one\n' +
                     '# this is comment line two\n' +

--- a/local-modules/see-all-browser/tests/test_BrowserSink.js
+++ b/local-modules/see-all-browser/tests/test_BrowserSink.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all-server.BrowserSink', () => {
+describe('see-all-server/BrowserSink', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/see-all-server/tests/test_FileSink.js
+++ b/local-modules/see-all-server/tests/test_FileSink.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all-server.FileSink', () => {
+describe('see-all-server/FileSink', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -23,7 +23,7 @@ beforeEach(() => {
   }
 });
 
-describe('see-all-server.RecentSink', () => {
+describe('see-all-server/RecentSink', () => {
   describe('#time(nowMsec, utcString, localString', () => {
     it('needs a way to be tested');
   });

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 describe('see-all-server/RecentSink', () => {
-  describe('#time(nowMsec, utcString, localString', () => {
+  describe('time(nowMsec, utcString, localString', () => {
     it('needs a way to be tested');
   });
 

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -35,9 +35,9 @@ describe('see-all-server.RecentSink', () => {
       for (let i = 0; i < NUM_LINES; i++) {
         const line = logContents[i];
 
-        assert.equal(line['level'], LOG_LEVEL);
-        assert.equal(line['tag'], LOG_TAG);
-        assert.equal(line['message'][0], LOG_PREFIX + i);
+        assert.strictEqual(line['level'], LOG_LEVEL);
+        assert.strictEqual(line['tag'], LOG_TAG);
+        assert.strictEqual(line['message'][0], LOG_PREFIX + i);
         assert.isTrue(Number.isSafeInteger(line['nowMsec']));
       }
     });
@@ -50,7 +50,7 @@ describe('see-all-server.RecentSink', () => {
 
       // One line for each log entry, plus one more each for the <table> and </table>
       // This is kind of a weak test but it's better than nothing.
-      assert.equal(lines.length, 1 + NUM_LINES + 1);
+      assert.strictEqual(lines.length, 1 + NUM_LINES + 1);
     });
   });
 });

--- a/local-modules/see-all-server/tests/test_ServerSink.js
+++ b/local-modules/see-all-server/tests/test_ServerSink.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all-server.ServerSink', () => {
+describe('see-all-server/ServerSink', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/see-all/tests/test_BaseLogger.js
+++ b/local-modules/see-all/tests/test_BaseLogger.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all.BaseLogger', () => {
+describe('see-all/BaseLogger', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/see-all/tests/test_LogStream.js
+++ b/local-modules/see-all/tests/test_LogStream.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all.LogStream', () => {
+describe('see-all/LogStream', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/see-all/tests/test_Logger.js
+++ b/local-modules/see-all/tests/test_Logger.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('see-all.Logger', () => {
+describe('see-all/Logger', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/server-env/tests/test_Dirs.js
+++ b/local-modules/server-env/tests/test_Dirs.js
@@ -10,7 +10,7 @@ import path from 'path';
 
 import { Dirs } from 'server-env';
 
-describe('server-env.Dirs', () => {
+describe('server-env/Dirs', () => {
   describe('BASE_DIR', () => {
     it('should return a directory path that exists', () => {
       const baseDir = Dirs.BASE_DIR;

--- a/local-modules/server-env/tests/test_Dirs.js
+++ b/local-modules/server-env/tests/test_Dirs.js
@@ -11,7 +11,7 @@ import path from 'path';
 import { Dirs } from 'server-env';
 
 describe('server-env/Dirs', () => {
-  describe('BASE_DIR', () => {
+  describe('.BASE_DIR', () => {
     it('should return a directory path that exists', () => {
       const baseDir = Dirs.BASE_DIR;
 
@@ -19,7 +19,7 @@ describe('server-env/Dirs', () => {
     });
   });
 
-  describe('CLIENT_DIR', () => {
+  describe('.CLIENT_DIR', () => {
     it('should return a known subdirectory off of BASE_DIR', () => {
       const baseDir = Dirs.BASE_DIR;
       const clientDir = path.join(baseDir, 'client');
@@ -29,7 +29,7 @@ describe('server-env/Dirs', () => {
     });
   });
 
-  describe('CLIENT_CODE_DIR', () => {
+  describe('.CLIENT_CODE_DIR', () => {
     it('should return a known subdirectory off of CLIENT_DIR', () => {
       const clientDir = Dirs.CLIENT_DIR;
       const codeDir = path.join(clientDir, 'js');
@@ -39,7 +39,7 @@ describe('server-env/Dirs', () => {
     });
   });
 
-  describe('SERVER_DIR', () => {
+  describe('.SERVER_DIR', () => {
     it('should return a known subdirectory off of BASE_DIR', () => {
       const baseDir = Dirs.BASE_DIR;
       const serverDir = path.join(baseDir, 'server');
@@ -49,7 +49,7 @@ describe('server-env/Dirs', () => {
     });
   });
 
-  describe('VAR_DIR', () => {
+  describe('.VAR_DIR', () => {
     it('should return a known subdirectory off of BASE_DIR', () => {
       const baseDir = Dirs.BASE_DIR;
       const varDir = path.join(baseDir, 'var');

--- a/local-modules/server-env/tests/test_Dirs.js
+++ b/local-modules/server-env/tests/test_Dirs.js
@@ -24,7 +24,7 @@ describe('server-env.Dirs', () => {
       const baseDir = Dirs.BASE_DIR;
       const clientDir = path.join(baseDir, 'client');
 
-      assert.equal(clientDir, Dirs.CLIENT_DIR);
+      assert.strictEqual(clientDir, Dirs.CLIENT_DIR);
       assert.isTrue(fs.existsSync(clientDir));
     });
   });
@@ -34,7 +34,7 @@ describe('server-env.Dirs', () => {
       const clientDir = Dirs.CLIENT_DIR;
       const codeDir = path.join(clientDir, 'js');
 
-      assert.equal(codeDir, Dirs.CLIENT_CODE_DIR);
+      assert.strictEqual(codeDir, Dirs.CLIENT_CODE_DIR);
       assert.isTrue(fs.existsSync(codeDir));
     });
   });
@@ -44,7 +44,7 @@ describe('server-env.Dirs', () => {
       const baseDir = Dirs.BASE_DIR;
       const serverDir = path.join(baseDir, 'server');
 
-      assert.equal(serverDir, Dirs.SERVER_DIR);
+      assert.strictEqual(serverDir, Dirs.SERVER_DIR);
       assert.isTrue(fs.existsSync(serverDir));
     });
   });
@@ -54,7 +54,7 @@ describe('server-env.Dirs', () => {
       const baseDir = Dirs.BASE_DIR;
       const varDir = path.join(baseDir, 'var');
 
-      assert.equal(varDir, Dirs.VAR_DIR);
+      assert.strictEqual(varDir, Dirs.VAR_DIR);
       assert.isTrue(fs.existsSync(varDir));
     });
   });

--- a/local-modules/server-env/tests/test_PidFile.js
+++ b/local-modules/server-env/tests/test_PidFile.js
@@ -14,7 +14,7 @@ import { Dirs } from 'server-env';
 //import { PidFile } from 'server-env';
 
 describe('server-env/PidFile', () => {
-  describe('#init(basePath)', () => {
+  describe('init(basePath)', () => {
     it('should create a pid.txt file at a known position off of baseDir', () => {
       /*
        * TODO: We have a small problem here in that the test runner is launched by

--- a/local-modules/server-env/tests/test_PidFile.js
+++ b/local-modules/server-env/tests/test_PidFile.js
@@ -13,7 +13,7 @@ import { Dirs } from 'server-env';
 // see comment below for why this is commented out
 //import { PidFile } from 'server-env';
 
-describe('server-env.PidFile', () => {
+describe('server-env/PidFile', () => {
   describe('#init(basePath)', () => {
     it('should create a pid.txt file at a known position off of baseDir', () => {
       /*

--- a/local-modules/server-env/tests/test_ProductInfo.js
+++ b/local-modules/server-env/tests/test_ProductInfo.js
@@ -11,7 +11,7 @@ import { TObject } from 'typecheck';
 // see comment below for why this is commented out
 //import { PidFile } from 'server-env';
 
-describe('server-env.ProductInfo', () => {
+describe('server-env/ProductInfo', () => {
   describe('.INFO', () => {
     it('should return an object full of product info', () => {
       const info = ProductInfo.INFO;

--- a/local-modules/typecheck/tests/test_TArray.js
+++ b/local-modules/typecheck/tests/test_TArray.js
@@ -10,7 +10,7 @@ import { TInt } from 'typecheck';
 import { TString } from 'typecheck';
 
 describe('typecheck/TArray', () => {
-  describe('#check(value)', () => {
+  describe('check(value)', () => {
     it('should return the provided value when passed an array', () => {
       const value = [1, 2, 3];
 
@@ -25,7 +25,7 @@ describe('typecheck/TArray', () => {
     });
   });
 
-  describe('#check(value, elementChecker)', () => {
+  describe('check(value, elementChecker)', () => {
     it('should validate array elements with an element checker', () => {
       const value = [1, 2, 3];
 

--- a/local-modules/typecheck/tests/test_TArray.js
+++ b/local-modules/typecheck/tests/test_TArray.js
@@ -15,7 +15,7 @@ describe('typecheck.TArray', () => {
       const value = [1, 2, 3];
 
       assert.doesNotThrow(() => TArray.check(value));
-      assert.equal(TArray.check(value), value);
+      assert.strictEqual(TArray.check(value), value);
     });
 
     it('should throw an Error when passed anything other than an array', () => {

--- a/local-modules/typecheck/tests/test_TArray.js
+++ b/local-modules/typecheck/tests/test_TArray.js
@@ -9,7 +9,7 @@ import { TArray } from 'typecheck';
 import { TInt } from 'typecheck';
 import { TString } from 'typecheck';
 
-describe('typecheck.TArray', () => {
+describe('typecheck/TArray', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed an array', () => {
       const value = [1, 2, 3];

--- a/local-modules/typecheck/tests/test_TBoolean.js
+++ b/local-modules/typecheck/tests/test_TBoolean.js
@@ -10,8 +10,8 @@ import { TBoolean } from 'typecheck';
 describe('typecheck.TBoolean', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed a boolean', () => {
-      assert.equal(TBoolean.check(true), true);
-      assert.equal(TBoolean.check(false), false);
+      assert.strictEqual(TBoolean.check(true), true);
+      assert.strictEqual(TBoolean.check(false), false);
     });
 
     it('should throw an Error when passed undefined', () => {
@@ -29,11 +29,11 @@ describe('typecheck.TBoolean', () => {
 
   describe('#check(value, defaultValue)', () => {
     it('should return defaultValue if passed undefined', () => {
-      assert.equal(TBoolean.check(undefined, true), true);
+      assert.strictEqual(TBoolean.check(undefined, true), true);
     });
 
     it('should return value if passed anything but undefined', () => {
-      assert.equal(TBoolean.check(false, true), false);
+      assert.strictEqual(TBoolean.check(false, true), false);
     });
   });
 });

--- a/local-modules/typecheck/tests/test_TBoolean.js
+++ b/local-modules/typecheck/tests/test_TBoolean.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { TBoolean } from 'typecheck';
 
-describe('typecheck.TBoolean', () => {
+describe('typecheck/TBoolean', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed a boolean', () => {
       assert.strictEqual(TBoolean.check(true), true);

--- a/local-modules/typecheck/tests/test_TBoolean.js
+++ b/local-modules/typecheck/tests/test_TBoolean.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TBoolean } from 'typecheck';
 
 describe('typecheck/TBoolean', () => {
-  describe('#check(value)', () => {
+  describe('check(value)', () => {
     it('should return the provided value when passed a boolean', () => {
       assert.strictEqual(TBoolean.check(true), true);
       assert.strictEqual(TBoolean.check(false), false);
@@ -27,7 +27,7 @@ describe('typecheck/TBoolean', () => {
 
   });
 
-  describe('#check(value, defaultValue)', () => {
+  describe('check(value, defaultValue)', () => {
     it('should return defaultValue if passed undefined', () => {
       assert.strictEqual(TBoolean.check(undefined, true), true);
     });

--- a/local-modules/typecheck/tests/test_TFunction.js
+++ b/local-modules/typecheck/tests/test_TFunction.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TFunction } from 'typecheck';
 
 describe('typecheck/TFunction', () => {
-  describe('#check(function)', () => {
+  describe('check(function)', () => {
     it('should return the provided value when passed a function', () => {
       const sampleFunction = function () { let a = false; if (a) a ^= 1; };
 

--- a/local-modules/typecheck/tests/test_TFunction.js
+++ b/local-modules/typecheck/tests/test_TFunction.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { TFunction } from 'typecheck';
 
-describe('typecheck.TFunction', () => {
+describe('typecheck/TFunction', () => {
   describe('#check(function)', () => {
     it('should return the provided value when passed a function', () => {
       const sampleFunction = function () { let a = false; if (a) a ^= 1; };

--- a/local-modules/typecheck/tests/test_TFunction.js
+++ b/local-modules/typecheck/tests/test_TFunction.js
@@ -12,7 +12,7 @@ describe('typecheck.TFunction', () => {
     it('should return the provided value when passed a function', () => {
       const sampleFunction = function () { let a = false; if (a) a ^= 1; };
 
-      assert.equal(TFunction.check(sampleFunction), sampleFunction);
+      assert.strictEqual(TFunction.check(sampleFunction), sampleFunction);
     });
 
     it('should throw an Error when passed anything other than a function', () => {

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TInt } from 'typecheck';
 
 describe('typecheck/TInt', () => {
-  describe('#check(value)', () => {
+  describe('check(value)', () => {
     it('should return the provided value when passed a safe integer', () => {
       const value = 9823674;
 
@@ -25,7 +25,7 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('#min(value, inclusiveMinimum)', () => {
+  describe('min(value, inclusiveMinimum)', () => {
     it('should allow value >= inclusiveMinimum', () => {
       assert.doesNotThrow(() => TInt.min(11, 3));
     });
@@ -35,7 +35,7 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('#range(value, inclusiveMinimum, exclusiveMaximum)', () => {
+  describe('range(value, inclusiveMinimum, exclusiveMaximum)', () => {
     it('should allow inclusiveMinimum <= value < exclusiveMaximum', () => {
       assert.doesNotThrow(() => TInt.range(11, 3, 27));
     });
@@ -57,7 +57,7 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('#rangeInc(value, inclusiveMinimum, inclusiveMaximum)', () => {
+  describe('rangeInc(value, inclusiveMinimum, inclusiveMaximum)', () => {
     it('should allow inclusiveMinimum <= value <= inclusiveMaximum', () => {
       assert.doesNotThrow(() => TInt.rangeInc(11, 3, 27));
     });
@@ -75,7 +75,7 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('#unsignedByte(value)', () => {
+  describe('unsignedByte(value)', () => {
     it('should allow integer values from [0..255]', () => {
       assert.doesNotThrow(() => TInt.unsignedByte(0));
       assert.doesNotThrow(() => TInt.unsignedByte(128));

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -13,7 +13,7 @@ describe('typecheck.TInt', () => {
       const value = 9823674;
 
       assert.doesNotThrow(() => TInt.check(value));
-      assert.equal(TInt.check(value), value, 'returns same value it was passed when valid');
+      assert.strictEqual(TInt.check(value), value, 'returns same value it was passed when valid');
     });
 
     it('should throw an Error when passed an unsafe integer', () => {

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { TInt } from 'typecheck';
 
-describe('typecheck.TInt', () => {
+describe('typecheck/TInt', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed a safe integer', () => {
       const value = 9823674;

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TObject } from 'typecheck';
 
 describe('typecheck/TObject', () => {
-  describe('#check(value)', () => {
+  describe('check(value)', () => {
     it('should return the provided value when passed an object', () => {
       const value = { a: 1, b: 2 };
 
@@ -24,7 +24,7 @@ describe('typecheck/TObject', () => {
     });
   });
 
-  describe('#withExactKeys(value, keys)', () => {
+  describe('withExactKeys(value, keys)', () => {
     it('should allow an object with exactly the provided keys', () => {
       const value = { 'a': 1, 'b': 2, 'c': 3 };
 

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -12,7 +12,7 @@ describe('typecheck.TObject', () => {
     it('should return the provided value when passed an object', () => {
       const value = { a: 1, b: 2 };
 
-      assert.equal(TObject.check(value), value);
+      assert.strictEqual(TObject.check(value), value);
     });
 
     it('should throw an Error when passed anything other than an object', () => {

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { TObject } from 'typecheck';
 
-describe('typecheck.TObject', () => {
+describe('typecheck/TObject', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed an object', () => {
       const value = { a: 1, b: 2 };

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -12,7 +12,7 @@ describe('typecheck.TString', () => {
     it('should return the provided value when passed a string', () => {
       const value = 'this better work!';
 
-      assert.equal(TString.check(value), value);
+      assert.strictEqual(TString.check(value), value);
     });
 
     it('should throw an Error when passed anything other than a string', () => {
@@ -43,7 +43,7 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is a string of hex bytes', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value), value);
+      assert.strictEqual(TString.hexBytes(value), value);
     });
 
     it('should throw an Error when anything other than a string of hex bytes is provided', () => {
@@ -57,13 +57,13 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value, 11), value);
+      assert.strictEqual(TString.hexBytes(value, 11), value);
     });
 
     it('should return the provided value if it is a string of hex bytes greater than the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value, 3), value);
+      assert.strictEqual(TString.hexBytes(value, 3), value);
     });
 
     it('should throw an Error if the number of bytes is less than the minimum', () => {
@@ -77,19 +77,19 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value, 11, 128), value);
+      assert.strictEqual(TString.hexBytes(value, 11, 128), value);
     });
 
     it('should return the provided value if it is a string of hex bytes within the required length range', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value, 3, 128), value);
+      assert.strictEqual(TString.hexBytes(value, 3, 128), value);
     });
 
     it('should return the provided value if it is a string of hex bytes equal to the maximum length', () => {
       const value = 'deadbeef7584930215cafe';
 
-      assert.equal(TString.hexBytes(value, 3, 11), value);
+      assert.strictEqual(TString.hexBytes(value, 3, 11), value);
     });
 
     it('should throw an Error if the number of bytes is less than the minimum', () => {
@@ -109,7 +109,7 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is a string with length >= 1', () => {
       const value = 'This better work!';
 
-      assert.equal(TString.nonempty(value), value);
+      assert.strictEqual(TString.nonempty(value), value);
     });
 
     it('should throw an Error if value is a string of length 0', () => {
@@ -123,13 +123,13 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is a string', () => {
       const value = 'This better work!';
 
-      assert.equal(TString.orNull(value), value);
+      assert.strictEqual(TString.orNull(value), value);
     });
 
     it('should return the provided value if it is null', () => {
       const value = null;
 
-      assert.equal(TString.orNull(value), value);
+      assert.strictEqual(TString.orNull(value), value);
     });
 
     it('should throw an Error if value is not a string and is not null', () => {
@@ -145,7 +145,7 @@ describe('typecheck.TString', () => {
     it('should return the provided value if it is an absolute url string', () => {
       const value = 'https://www.example.com';
 
-      assert.equal(TString.urlAbsolute(value), value);
+      assert.strictEqual(TString.urlAbsolute(value), value);
     });
 
     it('should throw an Error if value is not an absolute url', () => {

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TString } from 'typecheck';
 
 describe('typecheck/TString', () => {
-  describe('#check(value)', () => {
+  describe('check(value)', () => {
     it('should return the provided value when passed a string', () => {
       const value = 'this better work!';
 
@@ -25,7 +25,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#check(value, regex)', () => {
+  describe('check(value, regex)', () => {
     it('should allow a string when it matches the provided regex', () => {
       const value = 'deadbeef7584930215cafe';
 
@@ -39,7 +39,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#hexBytes(value)', () => {
+  describe('hexBytes(value)', () => {
     it('should return the provided value if it is a string of hex bytes', () => {
       const value = 'deadbeef7584930215cafe';
 
@@ -53,7 +53,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#hexBytes(value, minBytes)', () => {
+  describe('hexBytes(value, minBytes)', () => {
     it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
@@ -73,7 +73,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#hexBytes(value, inclusiveMinBytes, inclusiveMaxBytes)', () => {
+  describe('hexBytes(value, inclusiveMinBytes, inclusiveMaxBytes)', () => {
     it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
@@ -105,7 +105,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#nonempty(value)', () => {
+  describe('nonempty(value)', () => {
     it('should return the provided value if it is a string with length >= 1', () => {
       const value = 'This better work!';
 
@@ -119,7 +119,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#orNull(value)', () => {
+  describe('orNull(value)', () => {
     it('should return the provided value if it is a string', () => {
       const value = 'This better work!';
 
@@ -141,7 +141,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('#urlAbsolute(value)', () => {
+  describe('urlAbsolute(value)', () => {
     it('should return the provided value if it is an absolute url string', () => {
       const value = 'https://www.example.com';
 

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { TString } from 'typecheck';
 
-describe('typecheck.TString', () => {
+describe('typecheck/TString', () => {
   describe('#check(value)', () => {
     it('should return the provided value when passed a string', () => {
       const value = 'this better work!';

--- a/local-modules/util-base/tests/test_ObjectUtil.js
+++ b/local-modules/util-base/tests/test_ObjectUtil.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { ObjectUtil } from 'util-base';
 
 describe('util-base/ObjectUtil', () => {
-  describe('#hasOwnProperty(value, name)', () => {
+  describe('hasOwnProperty(value, name)', () => {
     it('should return true when asked about an object\'s own propery', () => {
       const value = {};
 

--- a/local-modules/util-base/tests/test_ObjectUtil.js
+++ b/local-modules/util-base/tests/test_ObjectUtil.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { ObjectUtil } from 'util-base';
 
-describe('util-base.ObjectUtil', () => {
+describe('util-base/ObjectUtil', () => {
   describe('#hasOwnProperty(value, name)', () => {
     it('should return true when asked about an object\'s own propery', () => {
       const value = {};

--- a/local-modules/util-client/tests/test_DomUtil.js
+++ b/local-modules/util-client/tests/test_DomUtil.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('util-client.DomUtil', () => {
+describe('util-client/DomUtil', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/util-common/tests/test_CommonBase.js
+++ b/local-modules/util-common/tests/test_CommonBase.js
@@ -23,7 +23,7 @@ class CommonBaseSubclass extends CommonBase {
 }
 
 describe('util-common/CommonBase', () => {
-  describe('#mixInto(class)', () => {
+  describe('mixInto(class)', () => {
     it('should add its properties to the supplied class', () => {
       assert.notProperty(NearlyEmptyClass, 'coerce');
 
@@ -33,7 +33,7 @@ describe('util-common/CommonBase', () => {
     });
   });
 
-  describe('#check(object)', () => {
+  describe('check(object)', () => {
     it('should return the supplied value if it is an instance or subclass of CommonBase', () => {
       const base = new CommonBase();
       const subclass = new CommonBaseSubclass();
@@ -49,7 +49,7 @@ describe('util-common/CommonBase', () => {
     });
   });
 
-  describe('#coerce(value)', () => {
+  describe('coerce(value)', () => {
     it('needs a way to be tested');
   });
 });

--- a/local-modules/util-common/tests/test_CommonBase.js
+++ b/local-modules/util-common/tests/test_CommonBase.js
@@ -22,7 +22,7 @@ class CommonBaseSubclass extends CommonBase {
   }
 }
 
-describe('util-common.CommonBase', () => {
+describe('util-common/CommonBase', () => {
   describe('#mixInto(class)', () => {
     it('should add its properties to the supplied class', () => {
       assert.notProperty(NearlyEmptyClass, 'coerce');

--- a/local-modules/util-common/tests/test_CommonBase.js
+++ b/local-modules/util-common/tests/test_CommonBase.js
@@ -38,8 +38,8 @@ describe('util-common.CommonBase', () => {
       const base = new CommonBase();
       const subclass = new CommonBaseSubclass();
 
-      assert.equal(CommonBase.check(base), base);
-      assert.equal(CommonBaseSubclass.check(subclass), subclass);
+      assert.strictEqual(CommonBase.check(base), base);
+      assert.strictEqual(CommonBaseSubclass.check(subclass), subclass);
     });
 
     it('should throw an Error if the supplied value is not a child instance', () => {

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -12,11 +12,11 @@ describe('util-common.DataUtil', () => {
     it('should return the provided value if it is a primitive', () => {
       const symbol = Symbol('foo');
 
-      assert.equal(DataUtil.deepFreeze(true), true);
-      assert.equal(DataUtil.deepFreeze(37), 37);
-      assert.equal(DataUtil.deepFreeze('a string'), 'a string');
-      assert.equal(DataUtil.deepFreeze(symbol), symbol);
-      assert.equal(DataUtil.deepFreeze(undefined), undefined);
+      assert.strictEqual(DataUtil.deepFreeze(true), true);
+      assert.strictEqual(DataUtil.deepFreeze(37), 37);
+      assert.strictEqual(DataUtil.deepFreeze('a string'), 'a string');
+      assert.strictEqual(DataUtil.deepFreeze(symbol), symbol);
+      assert.strictEqual(DataUtil.deepFreeze(undefined), undefined);
     });
 
     it('should return null if provided a null object', () => {
@@ -56,10 +56,10 @@ describe('util-common.DataUtil', () => {
         assert.isTrue(Number.isSafeInteger(value));
       }
 
-      assert.equal(bytesArray[0], 0xde);
-      assert.equal(bytesArray[1], 0xad);
-      assert.equal(bytesArray[2], 0xbe);
-      assert.equal(bytesArray[3], 0xef);
+      assert.strictEqual(bytesArray[0], 0xde);
+      assert.strictEqual(bytesArray[1], 0xad);
+      assert.strictEqual(bytesArray[2], 0xbe);
+      assert.strictEqual(bytesArray[3], 0xef);
     });
   });
 
@@ -77,7 +77,7 @@ describe('util-common.DataUtil', () => {
     it('should return a hex string if passed an array of byte values', () => {
       const bytesArray = [0xde, 0xad, 0xbe, 0xef];
 
-      assert.equal(DataUtil.hexFromBytes(bytesArray), 'deadbeef');
+      assert.strictEqual(DataUtil.hexFromBytes(bytesArray), 'deadbeef');
     });
   });
 });

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { DataUtil } from 'util-common';
 
-describe('util-common.DataUtil', () => {
+describe('util-common/DataUtil', () => {
   describe('#deepFreeze(value)', () => {
     it('should return the provided value if it is a primitive', () => {
       const symbol = Symbol('foo');

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { DataUtil } from 'util-common';
 
 describe('util-common/DataUtil', () => {
-  describe('#deepFreeze(value)', () => {
+  describe('deepFreeze(value)', () => {
     it('should return the provided value if it is a primitive', () => {
       const symbol = Symbol('foo');
 
@@ -38,7 +38,7 @@ describe('util-common/DataUtil', () => {
     });
   });
 
-  describe('#bytesFromHex(value)', () => {
+  describe('bytesFromHex(value)', () => {
     it('should throw an Error if passed an odd-lengthed string', () => {
       assert.throws(() => DataUtil.bytesFromHex('aabbc'));
     });
@@ -63,7 +63,7 @@ describe('util-common/DataUtil', () => {
     });
   });
 
-  describe('#hexFromBytes(value)', () => {
+  describe('hexFromBytes(value)', () => {
     it('should throw an Error if passed anything but an array of byte values', () => {
       assert.throws(() => DataUtil.hexFromBytes('this better not work!'));
       assert.throws(() => DataUtil.hexFromBytes(37));

--- a/local-modules/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/util-common/tests/test_DeferredLoader.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('util-common.DeferredLoader', () => {
+describe('util-common/DeferredLoader', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/util-common/tests/test_JsonUtil.js
+++ b/local-modules/util-common/tests/test_JsonUtil.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TObject } from 'typecheck';
 import { JsonUtil } from 'util-common';
 
-describe('util-common.JsonUtil', () => {
+describe('util-common/JsonUtil', () => {
   describe('#parseFrozen(jsonString)', () => {
     it('should throw an error if handed anything other than a string', () => {
       assert.throws(() => JsonUtil.parseFrozen([]));

--- a/local-modules/util-common/tests/test_JsonUtil.js
+++ b/local-modules/util-common/tests/test_JsonUtil.js
@@ -9,7 +9,7 @@ import { TObject } from 'typecheck';
 import { JsonUtil } from 'util-common';
 
 describe('util-common/JsonUtil', () => {
-  describe('#parseFrozen(jsonString)', () => {
+  describe('parseFrozen(jsonString)', () => {
     it('should throw an error if handed anything other than a string', () => {
       assert.throws(() => JsonUtil.parseFrozen([]));
       assert.throws(() => JsonUtil.parseFrozen({}));

--- a/local-modules/util-common/tests/test_PromCondition.js
+++ b/local-modules/util-common/tests/test_PromCondition.js
@@ -4,6 +4,6 @@
 
 import { describe, it } from 'mocha';
 
-describe('util-common.PromCondition', () => {
+describe('util-common/PromCondition', () => {
   it('needs a way to be tested');
 });

--- a/local-modules/util-common/tests/test_PromDelay.js
+++ b/local-modules/util-common/tests/test_PromDelay.js
@@ -12,21 +12,21 @@ Chai.use(ChaiAsPromised);
 import { assert } from 'chai';
 
 describe('util-common/PromDelay', () => {
-  describe('#delay(delayMSec)', () => {
+  describe('delay(delayMSec)', () => {
     it('should eventually resolve to true', () => {
       assert.isFulfilled(PromDelay.resolve(10));
       assert.becomes(PromDelay.resolve(10), true);
     });
   });
 
-  describe('#delay(delayMSec, value)', () => {
+  describe('delay(delayMSec, value)', () => {
     it('should eventually resolve to the supplied value', () => {
       assert.isFulfilled(PromDelay.resolve(10, 'floopty'));
       assert.becomes(PromDelay.resolve(10, 'floopty'), 'floopty');
     });
   });
 
-  describe('#reject(delayMSec, reason)', () => {
+  describe('reject(delayMSec, reason)', () => {
     it('should eventually be rejected with the specified reason', () => {
       assert.isRejected(PromDelay.reject(10, 'you smell'));
       assert.isRejected(PromDelay.reject(10, 'you smell'), /^you smell$/);

--- a/local-modules/util-common/tests/test_PromDelay.js
+++ b/local-modules/util-common/tests/test_PromDelay.js
@@ -11,7 +11,7 @@ import { PromDelay } from 'util-common';
 Chai.use(ChaiAsPromised);
 import { assert } from 'chai';
 
-describe('util-common.PromDelay', () => {
+describe('util-common/PromDelay', () => {
   describe('#delay(delayMSec)', () => {
     it('should eventually resolve to true', () => {
       assert.isFulfilled(PromDelay.resolve(10));

--- a/local-modules/util-common/tests/test_PropertyIter.js
+++ b/local-modules/util-common/tests/test_PropertyIter.js
@@ -16,7 +16,7 @@ const TEST_OBJECT = {
   objectItem: {}
 };
 
-describe('util-common.PropertyIter', () => {
+describe('util-common/PropertyIter', () => {
   describe('iterating over all properties', () => {
     it('should return all properties of the object', () => {
       const iter = new PropertyIter(TEST_OBJECT);

--- a/local-modules/util-common/tests/test_Random.js
+++ b/local-modules/util-common/tests/test_Random.js
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import { TString } from 'typecheck';
 import { Random } from 'util-common';
 
-describe('util-common.Random', () => {
+describe('util-common/Random', () => {
   describe('#byteArray(length)', () => {
     it('should return an array of the requested length', () => {
       const length = 17;

--- a/local-modules/util-common/tests/test_Random.js
+++ b/local-modules/util-common/tests/test_Random.js
@@ -10,7 +10,7 @@ import { TString } from 'typecheck';
 import { Random } from 'util-common';
 
 describe('util-common/Random', () => {
-  describe('#byteArray(length)', () => {
+  describe('byteArray(length)', () => {
     it('should return an array of the requested length', () => {
       const length = 17;
       const randomBytes = Random.byteArray(length);
@@ -27,7 +27,7 @@ describe('util-common/Random', () => {
     });
   });
 
-  describe('#hexByteString(length)', () => {
+  describe('hexByteString(length)', () => {
     it('should return a string of hex digits of the requested length', () => {
       const length = 13;
       const string = Random.hexByteString(length);
@@ -36,7 +36,7 @@ describe('util-common/Random', () => {
     });
   });
 
-  describe('#shortLabel(prefix)', () => {
+  describe('shortLabel(prefix)', () => {
     it('should return a probably-random string of the form "[prefix]-[8 * base32ish random character]"', () => {
       const label1A = Random.shortLabel('A');
       const label2A = Random.shortLabel('A');

--- a/local-modules/util-common/tests/test_Random.js
+++ b/local-modules/util-common/tests/test_Random.js
@@ -15,7 +15,7 @@ describe('util-common.Random', () => {
       const length = 17;
       const randomBytes = Random.byteArray(length);
 
-      assert.equal(length, randomBytes.length);
+      assert.strictEqual(length, randomBytes.length);
     });
 
     it('should return different results every time', () => {

--- a/local-modules/util-common/tests/test_Singleton.js
+++ b/local-modules/util-common/tests/test_Singleton.js
@@ -12,7 +12,7 @@ class TestClass extends Singleton {
 }
 
 describe('util-common/Singleton', () => {
-  describe('#theOne()', () => {
+  describe('theOne()', () => {
     it('should return the same object every time it is called', () => {
       const test1 = TestClass.theOne;
       const test2 = TestClass.theOne;

--- a/local-modules/util-common/tests/test_Singleton.js
+++ b/local-modules/util-common/tests/test_Singleton.js
@@ -11,7 +11,7 @@ class TestClass extends Singleton {
   /* nothing new here */
 }
 
-describe('util-common.Singleton', () => {
+describe('util-common/Singleton', () => {
   describe('#theOne()', () => {
     it('should return the same object every time it is called', () => {
       const test1 = TestClass.theOne;

--- a/local-modules/util-common/tests/test_WebsocketCodes.js
+++ b/local-modules/util-common/tests/test_WebsocketCodes.js
@@ -7,10 +7,18 @@ import { describe, it } from 'mocha';
 
 import { WebsocketCodes } from 'util-common';
 
-describe('util-common.WebsocketCodes', () => {
+describe('util-common/WebsocketCodes', () => {
   describe('#close()', () => {
-    it('should return a questioning string if given no close code', () => {
+    it('should return a questioning string', () => {
       const readable = WebsocketCodes.close();
+
+      assert.strictEqual(readable, 'close_?');
+    });
+  });
+
+  describe('#close(null)', () => {
+    it('should return a questioning string', () => {
+      const readable = WebsocketCodes.close(null);
 
       assert.strictEqual(readable, 'close_?');
     });

--- a/local-modules/util-common/tests/test_WebsocketCodes.js
+++ b/local-modules/util-common/tests/test_WebsocketCodes.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { WebsocketCodes } from 'util-common';
 
 describe('util-common/WebsocketCodes', () => {
-  describe('#close()', () => {
+  describe('close()', () => {
     it('should return a questioning string', () => {
       const readable = WebsocketCodes.close();
 
@@ -16,7 +16,7 @@ describe('util-common/WebsocketCodes', () => {
     });
   });
 
-  describe('#close(null)', () => {
+  describe('close(null)', () => {
     it('should return a questioning string', () => {
       const readable = WebsocketCodes.close(null);
 
@@ -24,7 +24,7 @@ describe('util-common/WebsocketCodes', () => {
     });
   });
 
-  describe('#close(code)', () => {
+  describe('close(code)', () => {
     it('should return a fixed format string if passed a known code', () => {
       const output = WebsocketCodes.close(1000);
 

--- a/local-modules/util-common/tests/test_WebsocketCodes.js
+++ b/local-modules/util-common/tests/test_WebsocketCodes.js
@@ -12,7 +12,7 @@ describe('util-common.WebsocketCodes', () => {
     it('should return a questioning string if given no close code', () => {
       const readable = WebsocketCodes.close();
 
-      assert.equal(readable, 'close_?');
+      assert.strictEqual(readable, 'close_?');
     });
   });
 
@@ -20,13 +20,13 @@ describe('util-common.WebsocketCodes', () => {
     it('should return a fixed format string if passed a known code', () => {
       const output = WebsocketCodes.close(1000);
 
-      assert.equal(output, 'close_normal (1000)');
+      assert.strictEqual(output, 'close_normal (1000)');
     });
 
     it('should return a fixed format string if passed an unknown code', () => {
       const output = WebsocketCodes.close(298374893247);
 
-      assert.equal(output, 'close_298374893247');
+      assert.strictEqual(output, 'close_298374893247');
     });
   });
 });


### PR DESCRIPTION
* Did a consistency pass over all the existing tests, to make `describe()` blocks use standardized conventions for top-level and property identification.
* Made separate `it()` blocks for each case of formerly multi-case `it()`s in `FrozenDelta`. Will ultimately do the same to other tests as I notice them.
* Consistently use `assert.strictEqual()` instead of `assert.equal()` as the former is almost always the correct safe choice.
* Added a couple of new tests.
* Fixed a handful of tests that were incorrect.
* Tweaked / corrected documentation and error messages which had been the underlying cause of aforementioned incorrect tests.
* Split out Slack-specific test code into the overlay.