### PR TITLE
More testing fun

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -6,7 +6,6 @@ import express from 'express';
 import util from 'util';
 
 import { Encoder } from 'api-common';
-import { BayouMocha } from 'bayou-mocha';
 import { AuthorId, DocumentId } from 'doc-common';
 import { DocServer } from 'doc-server';
 import { Logger } from 'see-all';
@@ -66,7 +65,6 @@ export default class DebugTools {
     this._bindHandler('log');
     this._bindHandler('snapshot', ':documentId');
     this._bindHandler('snapshot', ':documentId/:verNum');
-    this._bindHandler('test');
 
     router.use(this._error.bind(this));
   }
@@ -275,18 +273,6 @@ export default class DebugTools {
 
       this._textResponse(res, result);
     });
-  }
-
-  /**
-   * Runs unit tests
-   *
-   * @param {object} req_unused HTTP request.
-   * @param {object} res HTTP response handler.
-   */
-  _handle_test(req_unused, res) {
-    BayouMocha.runAllTests();
-
-    this._textResponse(res, 'Unit tests are running. See server console output for results.');
   }
 
   /**

--- a/local-modules/app-setup/package.json
+++ b/local-modules/app-setup/package.json
@@ -11,7 +11,6 @@
 
     "api-common": "local",
     "api-server": "local",
-    "bayou-mocha": "local",
     "client-bundle": "local",
     "doc-common": "local",
     "doc-server": "local",

--- a/local-modules/bayou-mocha/BayouMocha.js
+++ b/local-modules/bayou-mocha/BayouMocha.js
@@ -9,11 +9,18 @@ import path from 'path';
 const mocha = new Mocha();
 
 /**
- * Builds a list of all bayou-local tests, adds them to a test runner,
- * and then executes the tests.
+ * Driver for the Mocha test framework.
  */
 export default class BayouMocha {
-  static runAllTests() {
+  /**
+   * Builds a list of all bayou-local tests, adds them to a test runner,
+   * and then executes the tests.
+   *
+   * @param {function|null} [callback = null] Callback which is called when
+   *   testing is complete. Gets passed a `failures` value. Ignored if passed
+   *   as `null`.
+   */
+  static runAllTests(callback = null) {
     const bayouModules = BayouMocha.bayouModules();
     const testPaths = BayouMocha.testPathsForModules(bayouModules);
 
@@ -26,8 +33,10 @@ export default class BayouMocha {
       });
     });
 
-    mocha.run(failures_unused => {
-      // process.on('exit', () => process.exit(failures));
+    mocha.run((failures) => {
+      if (callback !== null) {
+        callback(failures);
+      }
     });
   }
 

--- a/local-modules/hooks-server/tests/test_BearerToken.js
+++ b/local-modules/hooks-server/tests/test_BearerToken.js
@@ -8,18 +8,18 @@ import { describe, it } from 'mocha';
 import { BearerToken } from 'api-server';
 import { BearerTokens } from 'hooks-server';
 
-const BEARER_TOKEN = BearerTokens.theOne;
+const BEARER_TOKENS = BearerTokens.theOne;
 
 describe('hooks-server/BearerTokens', () => {
   describe('isToken(tokenString)', () => {
     it('should accept any value', () => {
-      assert.isTrue(BEARER_TOKEN.isToken('abc123'));
+      assert.isTrue(BEARER_TOKENS.isToken('abc123'));
     });
   });
 
   describe('.rootTokens', () => {
     it('should return an array of BearerToken', () => {
-      const tokens = BEARER_TOKEN.rootTokens;
+      const tokens = BEARER_TOKENS.rootTokens;
 
       assert.isArray(tokens);
 
@@ -32,7 +32,7 @@ describe('hooks-server/BearerTokens', () => {
   describe('tokenId(tokenString)', () => {
     it('should return the first 16 characters of the string passed to it', () => {
       const fakeTokenString = 'abcdefghijklmnopqrstuvwxyz';
-      const tokenId = BEARER_TOKEN.tokenId(fakeTokenString);
+      const tokenId = BEARER_TOKENS.tokenId(fakeTokenString);
 
       assert.strictEqual(tokenId, fakeTokenString.slice(0, 16));
     });
@@ -40,7 +40,7 @@ describe('hooks-server/BearerTokens', () => {
 
   describe('whenRootTokensChange()', () => {
     it('should return a promise', () => {
-      const changePromise = BEARER_TOKEN.whenRootTokensChange();
+      const changePromise = BEARER_TOKENS.whenRootTokensChange();
 
       assert.property(changePromise, 'then');
       assert.isFunction(changePromise.then);

--- a/local-modules/util-common/Singleton.js
+++ b/local-modules/util-common/Singleton.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { ObjectUtil } from 'util-base';
+
 import CommonBase from './CommonBase';
 
 /**
@@ -27,8 +29,13 @@ export default class Singleton extends CommonBase {
    */
   static get theOne() {
     // **Note:** In the context of static methods, `this` refers to the class
-    // that was called upon.
-    return this._theOne || new this();
+    // that was called upon. We use `hasOwnProperty()` because it's possible to
+    // subclass a singleton class, and we don't want to return a superclass
+    // instance here.
+
+    return ObjectUtil.hasOwnProperty(this, '_theOne')
+      ? this._theOne
+      : new this();
   }
 
   /**
@@ -38,7 +45,8 @@ export default class Singleton extends CommonBase {
   constructor() {
     super();
 
-    if (this.constructor._theOne) {
+    // See the note in `theOne` above in re `hasOwnProperty`.
+    if (ObjectUtil.hasOwnProperty(this.constructor, '_theOne')) {
       throw new Error('Cannot re-instantiate singleton class.');
     }
 

--- a/scripts/build
+++ b/scripts/build
@@ -33,14 +33,17 @@ argError=0
 # Need help?
 showHelp=0
 
+# Boxed dependency directory, if any.
+boxDir=''
+
 # Try building a client bundle?
 clientBundle=0
 
 # Overlay source directory, if any.
 overlayDir=''
 
-# Boxed dependency directory, if any.
-boxDir=''
+# Run server tests?
+serverTest=0
 
 # Options to pass to `out-dir-setup`.
 outOpts=()
@@ -50,6 +53,8 @@ while (( $# != 0 )); do
     if [[ ${opt} == '--' ]]; then
         shift
         break
+    elif [[ ${opt} =~ ^--boxes=(.*) ]]; then
+        boxDir="${BASH_REMATCH[1]}"
     elif [[ ${opt} == '--clean' ]]; then
         outOpts+=("${opt}")
     elif [[ ${opt} == '--client-bundle' ]]; then
@@ -61,8 +66,8 @@ while (( $# != 0 )); do
         outOpts+=("${opt}")
     elif [[ ${opt} =~ ^--overlay=(.*) ]]; then
         overlayDir="${BASH_REMATCH[1]}"
-    elif [[ ${opt} =~ ^--boxes=(.*) ]]; then
-        boxDir="${BASH_REMATCH[1]}"
+    elif [[ ${opt} == '--server-test' ]]; then
+        serverTest=1
     elif [[ ${opt} =~ ^- ]]; then
         echo "Unknown option: ${opt}" 1>&2
         argError=1
@@ -90,6 +95,8 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Place output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
+    echo '  --server-test'
+    echo '    On successful build, also try running the server tests.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -460,6 +467,10 @@ fi
 
 if (( ${clientBundle} )); then
     "${outDir}/bin/run" --client-bundle || exit 1
+fi
+
+if (( ${serverTest} )); then
+    "${outDir}/bin/run" --server-test || exit 1
 fi
 
 echo 'Done!'


### PR DESCRIPTION
This PR adds a `--server-test` option to the main `build` script. I removed the debug endpoint `/debug/test` as it's redundant with running server tests on the commandline. That said, we will probably add a debug endpoint for running the _client_ tests at some point.

**Bonus:** Fixed a wacky edge case in `Singleton` which only came up because of how the tests operate. (That is, didn't affect the main code as things currently stand.)