### PR TITLE
Version methods instead of getters.

### DIFF
--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -42,10 +42,12 @@ export default class DocControl extends CommonBase {
   }
 
   /**
-   * The version number corresponding to the current (latest) version of the
-   * document.
+   * Gets the version number corresponding to the current (latest) version of
+   * the document.
+   *
+   * @returns {int} The version number.
    */
-  get currentVerNum() {
+  currentVerNum() {
     return this._doc.currentVerNum();
   }
 
@@ -67,7 +69,7 @@ export default class DocControl extends CommonBase {
    * sequence of changes, each modifying version N of the document to produce
    * version N+1.
    *
-   * @param {number} [verNum = this.currentVerNum] The version number of the
+   * @param {number} [verNum = this.currentVerNum()] The version number of the
    *   change. The result is the change which produced that version. E.g., `0`
    *   is a request for the first change (the change from the empty document).
    * @returns {DocumentChange} An object representing that change.
@@ -80,7 +82,7 @@ export default class DocControl extends CommonBase {
   /**
    * Returns a snapshot of the full document contents.
    *
-   * @param {number} [verNum = this.currentVerNum] Indicates which version to
+   * @param {number} [verNum = this.currentVerNum()] Indicates which version to
    *   get.
    * @returns {Snapshot} The corresponding snapshot.
    */
@@ -150,7 +152,7 @@ export default class DocControl extends CommonBase {
    *   `baseVerNum`.
    */
   deltaAfter(baseVerNum) {
-    const currentVerNum = this.currentVerNum;
+    const currentVerNum = this.currentVerNum();
     baseVerNum = this._validateVerNum(baseVerNum, false);
 
     if (baseVerNum !== currentVerNum) {
@@ -197,14 +199,14 @@ export default class DocControl extends CommonBase {
     delta = FrozenDelta.coerce(delta);
     authorId = TString.orNull(authorId);
 
-    if (baseVerNum === this.currentVerNum) {
+    if (baseVerNum === this.currentVerNum()) {
       // The easy case: Apply a delta to the current version (unless it's empty,
       // in which case we don't have to make a new version at all; that's
       // handled by `_appendDelta()`).
       this._appendDelta(delta, authorId);
       return {
-        delta:  FrozenDelta.EMPTY, // That is, there was no correction.
-        verNum: this.currentVerNum // `_appendDelta()` updates the version.
+        delta:  FrozenDelta.EMPTY,   // That is, there was no correction.
+        verNum: this.currentVerNum() // `_appendDelta()` updates the version.
       };
     }
 
@@ -231,7 +233,7 @@ export default class DocControl extends CommonBase {
     const dClient    = delta;
     const vBaseNum   = baseVerNum;
     const vBase      = this.snapshot(vBaseNum).contents;
-    const vCurrentNum = this.currentVerNum;
+    const vCurrentNum = this.currentVerNum();
 
     // (1)
     const dServer = this._composeVersions(vBaseNum + 1);
@@ -253,7 +255,7 @@ export default class DocControl extends CommonBase {
     // (3)
     this._appendDelta(dNext, authorId);
     const vNext = this.snapshot().contents;  // This lets the snapshot get cached.
-    const vNextNum = this.currentVerNum;     // This will be different than `vCurrentNum`.
+    const vNextNum = this.currentVerNum();   // This will be different than `vCurrentNum`.
 
     // (4)
     const vExpected = FrozenDelta.coerce(vBase).compose(dClient);
@@ -332,7 +334,7 @@ export default class DocControl extends CommonBase {
    * @returns {number} The version number.
    */
   _validateVerNum(verNum, wantCurrent) {
-    const current = this.currentVerNum;
+    const current = this.currentVerNum();
 
     if (wantCurrent) {
       return VersionNumber.check(verNum, current, current);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -57,10 +57,12 @@ export default class DocControl extends CommonBase {
   }
 
   /**
-   * The version number corresponding to the very next change that will be
+   * Gets the version number corresponding to the very next change that will be
    * made to the document.
+   *
+   * @returns {int} The version number.
    */
-  get nextVerNum() {
+  nextVerNum() {
     return this._doc.nextVerNum();
   }
 
@@ -253,7 +255,7 @@ export default class DocControl extends CommonBase {
     }
 
     // (3)
-    this._appendDelta(dNext, authorId);
+    this._appendDelta(dNext, authorId);      // This updates the version number.
     const vNext = this.snapshot().contents;  // This lets the snapshot get cached.
     const vNextNum = this.currentVerNum();   // This will be different than `vCurrentNum`.
 
@@ -277,17 +279,20 @@ export default class DocControl extends CommonBase {
    *
    * @param {number} startInclusive Version number for the first delta to
    *   include in the result.
-   * @param {number} [endExclusive = this.nextVerNum] Version number for just
+   * @param {number} [endExclusive = this.nextVerNum()] Version number for just
    *   after the last delta to include, or alternatively thought, of the first
    *   version to exclude from the result.
    * @returns {FrozenDelta} The composed delta consisting of versions
    *   `startInclusive` through but not including `endExclusive`.
    */
-  _composeVersions(startInclusive, endExclusive = this.nextVerNum) {
+  _composeVersions(startInclusive, endExclusive = this.nextVerNum()) {
+    // TODO: The `endExclusive` default above will have to be altered once
+    // `nextVerNum()` starts returning a promise.
+
     // Validate parameters.
     startInclusive = VersionNumber.check(startInclusive);
     endExclusive =
-      TInt.rangeInc(endExclusive, startInclusive, this.nextVerNum);
+      TInt.rangeInc(endExclusive, startInclusive, this.nextVerNum());
 
     if (startInclusive === endExclusive) {
       return FrozenDelta.EMPTY;
@@ -319,7 +324,7 @@ export default class DocControl extends CommonBase {
     }
 
     const change =
-      new DocumentChange(this.nextVerNum, Timestamp.now(), delta, authorId);
+      new DocumentChange(this.nextVerNum(), Timestamp.now(), delta, authorId);
     this._doc.changeAppend(change);
     this._changeCondition.value = true;
   }

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -37,11 +37,13 @@ export default class DocForAuthor {
   }
 
   /**
-   * The version number corresponding to the very next change that will be
+   * Gets the version number corresponding to the very next change that will be
    * made to the document.
+   *
+   * @returns {int} The version number.
    */
-  get nextVerNum() {
-    return this._doc.nextVerNum;
+  nextVerNum() {
+    return this._doc.nextVerNum();
   }
 
   /**

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -27,11 +27,13 @@ export default class DocForAuthor {
   }
 
   /**
-   * The version number corresponding to the current (latest) version of the
-   * document.
+   * Gets the version number corresponding to the current (latest) version of
+   * the document.
+   *
+   * @returns {int} The version number.
    */
-  get currentVerNum() {
-    return this._doc.currentVerNum;
+  currentVerNum() {
+    return this._doc.currentVerNum();
   }
 
   /**
@@ -46,7 +48,7 @@ export default class DocForAuthor {
    * Returns a particular change to the document. See the equivalent
    * `DocControl` method for details.
    *
-   * @param {number} [verNum = this.currentVerNum] The version number of the
+   * @param {number} [verNum = this.currentVerNum()] The version number of the
    *   change.
    * @returns {DocumentChange} An object representing that change.
    */
@@ -69,7 +71,7 @@ export default class DocForAuthor {
    * Returns a snapshot of the full document contents. See the equivalent
    * `DocControl` method for details.
    *
-   * @param {number} [verNum = this.currentVerNum] Which version to get.
+   * @param {number} [verNum = this.currentVerNum()] Which version to get.
    * @returns {Snapshot} The corresponding snapshot.
    */
   snapshot(verNum) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.11.5
+version = 0.11.6

--- a/scripts/build
+++ b/scripts/build
@@ -317,7 +317,7 @@ function do-install {
 
     if [[ ${boxDir} == '' ]]; then
         # No boxed dependencies. Normal install.
-        npm install || return 1
+        npm install --cache="${outDir}/npm-cache" || return 1
     else
         # We were asked to use the boxed dependencies.
         if [[ ${dir} =~ ^(.*)-src$ ]]; then


### PR DESCRIPTION
This PR switches two getters in the `doc-server` API to instead be methods. This is going to make it a bit more sensible when they transition from acting synchronously to returning promises.

**Bonus:** Fixed a potential issue with npm cache pollution.