### PR TITLE
Build and serve a test bundle.

### DIFF
--- a/client/assets/boot-for-test.js
+++ b/client/assets/boot-for-test.js
@@ -1,0 +1,22 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// This file is included by the `/client-test` debugging endpoint and is used
+// to actually kick off the tests.
+
+// Disable Eslint, because this file is delivered as-is and has to be fairly
+// conservative.
+/* eslint-disable */
+
+// We wrap everything in an immediately-executed function so as to avoid
+// polluting the global namespace.
+(function () {
+  // Add the main JavaScript bundle to the page. Once loaded, this continues
+  // the test-running procedure. You can find its main entrypoint in
+  // `client/js/tests/main.js`.
+  var baseUrl = window.location.origin;
+  var elem = document.createElement('script');
+  elem.src = baseUrl + '/static/js/test.bundle.js';
+  document.head.appendChild(elem);
+}());

--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -37,6 +37,6 @@
   // Add the main JavaScript bundle to the page. Once loaded, this continues
   // the boot process. You can find its main entrypoint in `client/js/main.js`.
   var elem = document.createElement('script');
-  elem.src = baseUrl + '/static/main.bundle.js';
+  elem.src = baseUrl + '/static/js/main.bundle.js';
   document.head.appendChild(elem);
 }());

--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -37,6 +37,6 @@
   // Add the main JavaScript bundle to the page. Once loaded, this continues
   // the boot process. You can find its main entrypoint in `client/js/main.js`.
   var elem = document.createElement('script');
-  elem.src = baseUrl + '/static/bundle.js';
+  elem.src = baseUrl + '/static/main.bundle.js';
   document.head.appendChild(elem);
 }());

--- a/client/js/tests/main.js
+++ b/client/js/tests/main.js
@@ -1,0 +1,18 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/*
+ * Top-level entry point for client tests.
+ */
+
+import { Logger } from 'see-all';
+import { BrowserSink } from 'see-all-browser';
+
+// Init logging.
+BrowserSink.init();
+const log = new Logger('page-init');
+log.detail('Starting...');
+
+// TODO: Something real.
+log.detail('TODO');

--- a/client/js/tests/main.js
+++ b/client/js/tests/main.js
@@ -15,4 +15,4 @@ const log = new Logger('page-init');
 log.detail('Starting...');
 
 // TODO: Something real.
-log.detail('TODO');
+log.info('TODO');

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
   },
 
   "main": "js/main.js",
+  "testMain": "js/tests/main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -100,8 +100,8 @@ export default class Application {
     app.use('/static/quill',
       express.static(path.resolve(Dirs.CLIENT_DIR, 'node_modules/quill/dist')));
 
-    // Use Webpack to serve a JS bundle.
-    app.get('/static/main.bundle.js', new ClientBundle().requestHandler);
+    // Use the client bundler (which uses Webpack) to serve JS bundles.
+    app.get('/static/js/main.bundle.js', new ClientBundle().requestHandler);
 
     // Find HTML files and other static assets in `client/assets`. This includes
     // the top-level `index.html` and `favicon`, as well as stuff under

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -101,7 +101,7 @@ export default class Application {
       express.static(path.resolve(Dirs.CLIENT_DIR, 'node_modules/quill/dist')));
 
     // Use Webpack to serve a JS bundle.
-    app.get('/static/bundle.js', new ClientBundle().requestHandler);
+    app.get('/static/main.bundle.js', new ClientBundle().requestHandler);
 
     // Find HTML files and other static assets in `client/assets`. This includes
     // the top-level `index.html` and `favicon`, as well as stuff under

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -100,8 +100,10 @@ export default class Application {
     app.use('/static/quill',
       express.static(path.resolve(Dirs.CLIENT_DIR, 'node_modules/quill/dist')));
 
-    // Use the client bundler (which uses Webpack) to serve JS bundles.
-    app.get('/static/js/main.bundle.js', new ClientBundle().requestHandler);
+    // Use the client bundler (which uses Webpack) to serve JS bundles. The
+    // `:name` parameter gets interpreted by the client bundler to select which
+    // bundle to serve.
+    app.get('/static/js/:name.bundle.js', new ClientBundle().requestHandler);
 
     // Find HTML files and other static assets in `client/assets`. This includes
     // the top-level `index.html` and `favicon`, as well as stuff under

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -198,9 +198,16 @@ export default class DebugTools {
   _handle_clientTest(req_unused, res) {
     // TODO: Something real.
     const tests = ClientTests.allTestFiles();
-    const result = `Tests: ${JSON.stringify(tests, null, 2)}\n`;
 
-    this._textResponse(res, result);
+    // TODO: Probably want to use a real template.
+    const head =
+      '<title>Client Tests</title>\n' +
+      '<script src="/boot-for-test.js"></script>\n';
+    const body =
+      '<h1>Client Tests</h1>\n' +
+      `<pre>Tests: ${JSON.stringify(tests, null, 2)}</pre>\n`;
+
+    this._htmlResponse(res, head, body);
   }
 
   /**

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -44,14 +44,16 @@ const webpackOptions = {
   context: Dirs.CLIENT_CODE_DIR,
   debug: true,
   devtool: '#inline-source-map',
-  entry: [
-    require.resolve('babel-polyfill'),
-    path.resolve(Dirs.CLIENT_DIR, clientPackage.main)
-  ],
+  entry: {
+    main: [
+      require.resolve('babel-polyfill'),
+      path.resolve(Dirs.CLIENT_DIR, clientPackage.main)
+    ]
+  },
   output: {
     // Absolute output path of `/` because we write to a memory filesystem.
     path: '/',
-    filename: 'bundle.js',
+    filename: '[name].bundle.js',
     publicPath: '/static/'
   },
   plugins: [
@@ -192,8 +194,8 @@ export default class ClientBundle {
     // Find the written bundle in the memory FS, read it, and then delete it.
     // See comments in `_newCompiler()`, above, for rationale.
     try {
-      this._currentBundle = this._fs.readFileSync('/bundle.js');
-      this._fs.unlinkSync('/bundle.js');
+      this._currentBundle = this._fs.readFileSync('/main.bundle.js');
+      this._fs.unlinkSync('/main.bundle.js');
     } catch (e) {
       // File not found. This will happen when it turns out there were no
       // changes to the bundle. But it might happen in other cases too.

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -48,6 +48,10 @@ const webpackOptions = {
     main: [
       require.resolve('babel-polyfill'),
       path.resolve(Dirs.CLIENT_DIR, clientPackage.main)
+    ],
+    test: [
+      require.resolve('babel-polyfill'),
+      path.resolve(Dirs.CLIENT_DIR, clientPackage.testMain)
     ]
   },
   output: {
@@ -134,13 +138,15 @@ export default class ClientBundle {
    * Constructs an instance.
    */
   constructor() {
-    /** Memory FS used to hold the immediate results of compilation. */
+    /**
+     * {memory_fs} Memory FS used to hold the immediate results of compilation.
+     */
     this._fs = new memory_fs();
 
-    /** Current (most recently built) compiled bundle. */
-    this._currentBundle = null;
+    /** {Map<string,Buffer>} Current (most recently built) compiled bundles. */
+    this._currentBundles = new Map();
 
-    /** Dev mode running? */
+    /** {boolean} Dev mode running? */
     this._devModeRunning = false;
   }
 
@@ -154,7 +160,9 @@ export default class ClientBundle {
 
     // We use a `memory_fs` to hold the immediate results of compilation, to
     // make it possible to detect when things go awry before anything gets
-    // stored to the real FS.
+    // cached or (heaven forfend) sent out over the network. Once a compilation
+    // is successful, we grab the result into `_currentBundles` and erase it
+    // from the memory FS.
     compiler.outputFileSystem = this._fs;
 
     return compiler;
@@ -189,12 +197,12 @@ export default class ClientBundle {
       return;
     }
 
-    log.info('Compiled new JS bundle.');
+    log.info('Compiled new JS bundles.');
 
     // Find the written bundle in the memory FS, read it, and then delete it.
     // See comments in `_newCompiler()`, above, for rationale.
     try {
-      this._currentBundle = this._fs.readFileSync('/main.bundle.js');
+      this._currentBundles.set('main', this._fs.readFileSync('/main.bundle.js'));
       this._fs.unlinkSync('/main.bundle.js');
     } catch (e) {
       // File not found. This will happen when it turns out there were no
@@ -211,9 +219,10 @@ export default class ClientBundle {
    * @param {object} res The HTTP response handler.
    */
   _requestHandler(req, res) {
-    if (this._currentBundle) {
+    const bundle = this._currentBundles.get('main');
+    if (bundle) {
       res.type('application/javascript');
-      res.send(this._currentBundle);
+      res.send(bundle);
     } else {
       // This request came in before a bundle has ever been built. Instead of
       // trying to get too fancy, we just wait a second and retry (which itself
@@ -223,19 +232,19 @@ export default class ClientBundle {
   }
 
   /**
-   * Performs a single build. Returns a promise for the built artifact.
+   * Performs a single build. Returns a promise for the built artifacts.
    *
-   * @returns {Promise<Buffer>} The built artifact.
+   * @returns {Promise<Map<string,Buffer>>} The built artifact.
    */
   build() {
     const result = new Promise((res, rej) => {
       const compiler = this._newCompiler();
       compiler.run((error, stats) => {
         this._handleCompilation(error, stats);
-        if (this._currentBundle) {
-          res(this._currentBundle);
+        if (this._currentBundles) {
+          res(this._currentBundles);
         } else {
-          rej('Trouble building client bundle.');
+          rej('Trouble building client bundles.');
         }
       });
     });


### PR DESCRIPTION
This PR adds to our Webpack stuff the ability to build and serve multiple different JS bundles. This gets used to start serving a new `test` bundle which is just stubbed out for now but which is intended to be the one that holds all of the client test code plus all of the code being tested. This arrangement isn't necessarily what we want in the long term (e.g., maybe we want separate bundles for the test code and the code-being-tested, where the latter is also the code-being-used-for-realsies), but I think it's good enough for now.
