### PR TITLE
Webpack v2.

### DIFF
--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -66,9 +66,6 @@ const webpackOptions = {
     new webpack.ProgressPlugin(new ProgressMessage(log).handler),
     // This is a shim for turning on debug in loaders, added in Webpack 2 to
     // simulate the behavior of the now-removed top-level `debug` option.
-    // TODO: Remove this when loaders can be more directly optioned into having
-    // debugging turned on.
-    new webpack.LoaderOptionsPlugin({ debug: true })
   ],
   resolve: {
     alias: {
@@ -108,7 +105,7 @@ const webpackOptions = {
           options: {
             compilerOptions: {
               // A reasonably conservative choice, and also recapitulates what
-              // Quill's Webpack config does.
+              // Parchment's `tsconfig.json` specifies.
               target: 'es5',
               // Parchment specifies this as `true`, but we need it to be `false`
               // because we _aren't_ building it as a standalone library.

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -63,9 +63,7 @@ const webpackOptions = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.ProgressPlugin(new ProgressMessage(log).handler),
-    // This is a shim for turning on debug in loaders, added in Webpack 2 to
-    // simulate the behavior of the now-removed top-level `debug` option.
+    new webpack.ProgressPlugin(new ProgressMessage(log).handler)
   ],
   resolve: {
     alias: {

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -85,7 +85,7 @@ const webpackOptions = {
     root: path.resolve(Dirs.SERVER_DIR, 'node_modules')
   },
   module: {
-    loaders: [
+    use: [
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -92,7 +92,7 @@ const webpackOptions = {
         use: [{
           loader: 'babel-loader',
           options: {
-            presets: ['es2015', 'es2016', 'es2017'].map(function (name) {
+            presets: ['es2015', 'es2016', 'es2017'].map((name) => {
               return require.resolve(`babel-preset-${name}`);
             }),
           }

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -85,7 +85,7 @@ const webpackOptions = {
     root: path.resolve(Dirs.SERVER_DIR, 'node_modules')
   },
   module: {
-    use: [
+    loaders: [
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -239,7 +239,7 @@ export default class ClientBundle {
       // This request came in before bundles have ever been built. Instead of
       // trying to get too fancy, we just wait a second and retry (which itself
       // might end up waiting some more).
-      setTimeout(() => { this._requestHandler.bind(req, res, next); }, 1000);
+      setTimeout(() => { this._requestHandler(req, res, next); }, 1000);
       return;
     }
 

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -13,7 +13,7 @@
     "babel-preset-es2017": "^6.22.0",
     "html-loader": "^0.4.4",
     "memory-fs": "^0.4.1",
-    "ts-loader": "^1.3.0",
+    "ts-loader": "^2.0.3",
     "typescript": "^2.1.4",
     "webpack": "^2.5.1",
 

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -15,7 +15,7 @@
     "memory-fs": "^0.4.1",
     "ts-loader": "^1.3.0",
     "typescript": "^2.1.4",
-    "webpack": "^1.13.2",
+    "webpack": "^2.5.1",
 
     "see-all": "local",
     "server-env": "local",

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "babel-core": "^6.22.0",
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.0.0",
     "babel-polyfill": "^6.22.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",


### PR DESCRIPTION
This migrates the project to Webpack v2, including (a) tweaking the configuration object and (b) updating a couple dependencies.

This was a bit of a yak shave in that what I originally aimed to do was add some bits to the Webpack config to enable actual bundling of client-side test code. So it goes.