### PR TITLE
Top-level client unit test file, dynamically constructed.

### DIFF
--- a/client/js/tests/client-tests
+++ b/client/js/tests/client-tests
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+The contents of this file don't matter. Its name triggers special-case logic
+in `client-bundle` which in turn calls on `client-tests-loader` to build
+a dynamic module that references all of the client test code.

--- a/client/js/tests/main.js
+++ b/client/js/tests/main.js
@@ -9,6 +9,8 @@
 import { Logger } from 'see-all';
 import { BrowserSink } from 'see-all-browser';
 
+import ClientTests from './client-tests';
+
 // Init logging.
 BrowserSink.init();
 const log = new Logger('page-init');
@@ -16,3 +18,5 @@ log.detail('Starting...');
 
 // TODO: Something real.
 log.info('TODO');
+log.info('tests', ClientTests);
+ClientTests.run();

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -83,6 +83,7 @@ const webpackOptions = {
   module: {
     rules: [
       {
+        // The bulk of this project's code is written in modern JavaScript.
         test: /\.js$/,
         use: [{
           loader: 'babel-loader',
@@ -94,6 +95,7 @@ const webpackOptions = {
         }]
       },
       {
+        // Parchment (a dependency of Quill) is written in TypeScript.
         test: /\.ts$/,
         use: [{
           loader: 'ts-loader',
@@ -112,10 +114,10 @@ const webpackOptions = {
           }
         }]
       },
-      // Quill uses `require()` to access `.svg` assets. The configuration here
-      // recapitulates how Quill is set up to process those assets. See
-      // <https://github.com/quilljs/quill/blob/develop/_develop/webpack.config.js>.
       {
+        // Quill uses `require()` to access `.svg` assets. The configuration here
+        // recapitulates how Quill is set up to process those assets. See
+        // <https://github.com/quilljs/quill/blob/develop/_develop/webpack.config.js>.
         test: /\.svg$/,
         use: [{
           loader: 'html-loader',
@@ -123,7 +125,15 @@ const webpackOptions = {
             minimize: true
           }
         }]
-      }
+      },
+      {
+        // This handles dynamic construction of the main test-collector file.
+        test: /\/client-tests$/,
+        use: [{
+          loader: 'client-tests-loader'
+        }]
+      },
+
     ]
   }
 };

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -17,6 +17,7 @@
     "typescript": "^2.1.4",
     "webpack": "^2.5.1",
 
+    "client-tests-loader": "local",
     "see-all": "local",
     "server-env": "local",
     "util-common": "local"

--- a/local-modules/client-tests-loader/ClientTestsLoader.js
+++ b/local-modules/client-tests-loader/ClientTestsLoader.js
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { ClientTests } from 'bayou-mocha';
+
+/**
+ * Webback loader for the client test files.
+ */
+export default class ClientTestsLoader {
+  /**
+   * Load the synthesized client test file.
+   *
+   * @param {string} sourceText_unused The source of the file to load.
+   * @returns {string} Result of loading.
+   */
+  static load(sourceText_unused) {
+    const allFiles = ClientTests.allTestFiles();
+
+    // Double stringified because we're emitting quoted source code.
+    // TODO: This should do something real with the set of test files.
+    const quoteQuoted = JSON.stringify(JSON.stringify(allFiles, null, 2));
+
+    return "import { Logger } from 'see-all';\n" +
+      // TODO: The following line breaks because tests require modules `chai`
+      // and `mocha`, and adding those to the client dependencies will currently
+      // result in a client bundle failure.
+      // "import test_AuthorId from 'doc-common/tests/test_AuthorId';\n" +
+      "const log = new Logger('client-tests');\n" +
+      'export default class ClientTests {\n' +
+      `  static run() { log.info(${quoteQuoted}); }\n` +
+      '}\n';
+  }
+}

--- a/local-modules/client-tests-loader/main.js
+++ b/local-modules/client-tests-loader/main.js
@@ -1,0 +1,10 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import ClientTestsLoader from './ClientTestsLoader';
+
+// This module is used by Webpack, which makes specific requirements about what
+// is exported by loaders. This is why we have a simple `export default` here
+// instead of the more usual (for this project) set of named `export {...}`s.
+export default ClientTestsLoader.load;

--- a/local-modules/client-tests-loader/package.json
+++ b/local-modules/client-tests-loader/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "client-tests-loader",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "bayou-mocha": "local"
+  }
+}


### PR DESCRIPTION
Here's what's going on: We add a new file under `client/js/tests` called
simply `client-tests`, which isn't actually a JS file. Instead, its name is
listed explicitly in our Webpack config to trigger the use of a custom loader
called `client-tests-loader`. This loader is responsible for dynamically
constructing JS source that refers to all of our client-side test files.

As of this commit, the mechanism is in place for doing the synthesizing and
loading, but the generated file does not yet refer to any of the actual
test files. (See TODOs for a bit of an explanation why.)