### PR TITLE
Lurching toward asynchrony

### DIFF
--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -175,25 +175,21 @@ export default class DocClient extends StateMachine {
 
   /**
    * Validates a `gotApplyDelta` event. This represents a successful result
-   * from the API call `applyDelta()`. Keys are as defined by that API, with
-   * the addition of `expectedContents` which represents the expected result of
-   * merge (which will be the case if there are no other intervening changes).
+   * from the API call `applyDelta()`.
    *
    * @param {Delta|array|object} expectedContents The expected result of the
    *   merge. This will be the actual result if there are no other intervening
    *   changes (indicated by the fact that `delta` is empty). Must be a value
    *   which can be coerced to a `FrozenDelta`.
-   * @param {number} verNum The version number of the resulting document.
-   * @param {Delta|array|object} delta The delta from `expectedContents`. Must
-   *   be a value which can be coerced to a `FrozenDelta`.
+   * @param {CorrectedChange} correctedChange The correction to the expected
+   *   result as returned from `applyDelta()`.
    * @returns {array} Replacement arguments which always have `FrozenDelta`s for
    *   the delta-ish arguments.
    */
-  _check_gotApplyDelta(expectedContents, verNum, delta) {
+  _check_gotApplyDelta(expectedContents, correctedChange) {
     return [
       FrozenDelta.coerce(expectedContents),
-      TInt.min(verNum, 0),
-      FrozenDelta.coerce(delta)
+      correctedChange
     ];
   }
 
@@ -622,7 +618,7 @@ export default class DocClient extends StateMachine {
 
     // Send the delta, and handle the response.
     this._docProxy.applyDelta(this._doc.verNum, delta).then((value) => {
-      this.q_gotApplyDelta(expectedContents, value.verNum, value.delta);
+      this.q_gotApplyDelta(expectedContents, value);
     }).catch((error) => {
       this.q_apiError('applyDelta', error);
     });
@@ -637,16 +633,16 @@ export default class DocClient extends StateMachine {
    * @param {FrozenDelta} expectedContents The expected result of the merge. This
    *   will be the actual result if there are no other intervening changes
    *   (indicated by the fact that `delta` is empty).
-   * @param {number} verNum The version number of the resulting document.
-   * @param {FrozenDelta} delta The delta from `expectedContents`.
+   * @param {CorrectedChange} correctedChange The correction to the expected
+   *   result as returned from `applyDelta()`.
    */
-  _handle_merging_gotApplyDelta(expectedContents, verNum, delta) {
-    // These variable names correspond to the terminology used on the server
-    // side. See `Document.js`.
-    const vExpected = expectedContents;
-    const dCorrection = delta;
+  _handle_merging_gotApplyDelta(expectedContents, correctedChange) {
+    // These are the same variable names as used on the server side. See below
+    // for more detail.
+    const dCorrection = correctedChange.delta;
+    const vResultNum  = correctedChange.verNum;
 
-    this._log.detail(`Correction from server: v${verNum}`, dCorrection);
+    this._log.detail(`Correction from server: v${vResultNum}`, dCorrection);
 
     if (dCorrection.isEmpty()) {
       // There is no change from what we expected. This means that no other
@@ -658,7 +654,7 @@ export default class DocClient extends StateMachine {
       // from Quill) while the server request was in flight, they will be picked
       // up promptly due to the handling of the `wantChanges` event which will
       // get fired off immediately.
-      const snapshot = new Snapshot(verNum, vExpected);
+      const snapshot = new Snapshot(vResultNum, expectedContents);
       this._updateDocWithSnapshot(snapshot, false);
       this._becomeIdle();
       return;
@@ -670,7 +666,7 @@ export default class DocClient extends StateMachine {
       // Thanfully, the local user hasn't made any other changes while we
       // were waiting for the server to get back to us. We need to tell
       // Quill about the changes, but we don't have to do additional merging.
-      this._updateDocWithDelta(verNum, dCorrection);
+      this._updateDocWithDelta(vResultNum, dCorrection);
       this._becomeIdle();
       return;
     }
@@ -683,11 +679,11 @@ export default class DocClient extends StateMachine {
     // provided by the server.
     //
     // Using the same terminology as used on the server side (see
-    // `server/Document.js`), we start with `vExpected` (the document we
-    // would have had if the server hadn't included extra changes) and
-    // `dCorrection` (the delta given back to us from the server which can
-    // be applied to `vExpected` to get the _actual_ next version). From
-    // that, here's what we do:
+    // `DocControl.js`), we start with `vExpected` (the document we would have
+    // had if the server hadn't included extra changes) and `dCorrection` (the
+    // delta given back to us from the server which can be applied to
+    // `vExpected` to get the _actual_ next version). From that, here's what we
+    // do:
     //
     // 1. Get all of the changes that the user made (that is, that Quill
     //    recorded) while the server update was in progress. This is
@@ -714,7 +710,7 @@ export default class DocClient extends StateMachine {
     // `false` indicates that `dMore` should be taken to have been applied
     // second (lost any insert races or similar).
     const dIntegratedCorrection = dMore.transform(dCorrection, false);
-    this._updateDocWithDelta(verNum, dCorrection, dIntegratedCorrection);
+    this._updateDocWithDelta(vResultNum, dCorrection, dIntegratedCorrection);
 
     // (3)
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -181,7 +181,7 @@ export default class DocClient extends StateMachine {
    *   merge. This will be the actual result if there are no other intervening
    *   changes (indicated by the fact that `delta` is empty). Must be a value
    *   which can be coerced to a `FrozenDelta`.
-   * @param {CorrectedChange} correctedChange The correction to the expected
+   * @param {DeltaResult} correctedChange The correction to the expected
    *   result as returned from `applyDelta()`.
    * @returns {array} Replacement arguments which always have `FrozenDelta`s for
    *   the delta-ish arguments.
@@ -633,7 +633,7 @@ export default class DocClient extends StateMachine {
    * @param {FrozenDelta} expectedContents The expected result of the merge. This
    *   will be the actual result if there are no other intervening changes
    *   (indicated by the fact that `delta` is empty).
-   * @param {CorrectedChange} correctedChange The correction to the expected
+   * @param {DeltaResult} correctedChange The correction to the expected
    *   result as returned from `applyDelta()`.
    */
   _handle_merging_gotApplyDelta(expectedContents, correctedChange) {

--- a/local-modules/doc-common/CorrectedChange.js
+++ b/local-modules/doc-common/CorrectedChange.js
@@ -1,0 +1,71 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { FrozenDelta } from 'doc-common';
+import { CommonBase } from 'util-common';
+
+import VersionNumber from './VersionNumber';
+
+/**
+ * Representation of a corrected result of applying a delta. Instances of this
+ * class are returned from `applyDelta()` as defined by the various `doc-server`
+ * classes. See those for more details.
+ *
+ * Instances of this class are immutable.
+ */
+export default class CorrectedChange extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} verNum The version number of the document produced by the
+   *   `applyDelta()` operation.
+   * @param {FrozenDelta} delta The delta from the _expected_ change result to
+   *   the _actual_ change result. The expectation is what was implied by the
+   *   original arguments to `applyDelta()`.
+   */
+  constructor(verNum, delta) {
+    super();
+
+    /** The produced version number. */
+    this._verNum = VersionNumber.check(verNum);
+
+    /** The actual change, as a delta. */
+    this._delta = FrozenDelta.check(delta);
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'CorrectedChange';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._verNum, this._delta];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {Int} verNum Same as with the regular constructor.
+   * @param {FrozenDelta} delta Same as with the regular constructor.
+   * @returns {CorrectedChange} The constructed instance.
+   */
+  static fromApi(verNum, delta) {
+    return new CorrectedChange(verNum, delta);
+  }
+
+  /** {Int} The produced version number. */
+  get verNum() {
+    return this._verNum;
+  }
+
+  /** {FrozenDelta} The actual change, as a delta. */
+  get delta() {
+    return this._delta;
+  }
+}

--- a/local-modules/doc-common/DeltaResult.js
+++ b/local-modules/doc-common/DeltaResult.js
@@ -8,21 +8,24 @@ import { CommonBase } from 'util-common';
 import VersionNumber from './VersionNumber';
 
 /**
- * Representation of a corrected result of applying a delta. Instances of this
- * class are returned from `applyDelta()` as defined by the various `doc-server`
- * classes. See those for more details.
+ * Delta-bearing result of an API call, which also comes with a version number.
+ * Instances of this class are returned from calls to `applyDelta()` and
+ * `deltaAfter()` as defined by the various `doc-server` classes. See those for
+ * more details.
+ *
+ * Note that the meaning of the `delta` value is different depending on which
+ * method the result came from. In particular, there is an implied "expected"
+ * result from `applyDelta()` which this instance's `delta` is with respect to.
  *
  * Instances of this class are immutable.
  */
-export default class CorrectedChange extends CommonBase {
+export default class DeltaResult extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} verNum The version number of the document produced by the
-   *   `applyDelta()` operation.
-   * @param {FrozenDelta} delta The delta from the _expected_ change result to
-   *   the _actual_ change result. The expectation is what was implied by the
-   *   original arguments to `applyDelta()`.
+   * @param {Int} verNum Version number of the document.
+   * @param {FrozenDelta} delta Delta which can be applied in context to
+   *   produce the document with the indicated version number.
    */
   constructor(verNum, delta) {
     super();
@@ -36,7 +39,7 @@ export default class CorrectedChange extends CommonBase {
 
   /** Name of this class in the API. */
   static get API_NAME() {
-    return 'CorrectedChange';
+    return 'DeltaResult';
   }
 
   /**
@@ -53,10 +56,10 @@ export default class CorrectedChange extends CommonBase {
    *
    * @param {Int} verNum Same as with the regular constructor.
    * @param {FrozenDelta} delta Same as with the regular constructor.
-   * @returns {CorrectedChange} The constructed instance.
+   * @returns {DeltaResult} The constructed instance.
    */
   static fromApi(verNum, delta) {
-    return new CorrectedChange(verNum, delta);
+    return new DeltaResult(verNum, delta);
   }
 
   /** {Int} The produced version number. */
@@ -64,7 +67,10 @@ export default class CorrectedChange extends CommonBase {
     return this._verNum;
   }
 
-  /** {FrozenDelta} The actual change, as a delta. */
+  /**
+   * {FrozenDelta} Delta used to produce the document with version number
+   * `verNum`.
+   */
   get delta() {
     return this._delta;
   }

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -66,7 +66,7 @@ export default class DocumentChange extends CommonBase {
   /**
    * Constructs an instance from API arguments.
    *
-   * @param {number} verNum Same as with the regular constructor.
+   * @param {Int} verNum Same as with the regular constructor.
    * @param {Timestamp} timestamp Same as with the regular constructor.
    * @param {Delta|array|object} delta Same as with the regular constructor.
    * @param {string|null} authorId Same as with the regular constructor.
@@ -76,22 +76,22 @@ export default class DocumentChange extends CommonBase {
     return new DocumentChange(verNum, timestamp, delta, authorId);
   }
 
-  /** The produced version number. */
+  /** {Int} The produced version number. */
   get verNum() {
     return this._verNum;
   }
 
-  /** The time of the change. */
+  /** {Timestamp} The time of the change. */
   get timestamp() {
     return this._timestamp;
   }
 
-  /** The actual change, as a delta. */
+  /** {FrozenDelta} The actual change, as a delta. */
   get delta() {
     return this._delta;
   }
 
-  /** The author ID string. */
+  /** {string|null} The author ID string. */
   get authorId() {
     return this._authorId;
   }

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -22,9 +22,9 @@ export default class DocumentChange extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {number} verNum The version number of the document produced by this
-   *   change. If this instance represents the first change to a document, then
-   *   this value will be `0`.
+   * @param {Int} verNum The version number of the document produced by this
+   *   change. If this instance represents the first change to a document,
+   *   then this value will be `0`.
    * @param {Timestamp} timestamp The time of the change, as msec since the Unix
    *   Epoch.
    * @param {Delta|array|object} delta The document change per se, compared to

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -13,8 +13,8 @@ export default class VersionNumber {
    * Checks a value of type `VersionNumber`.
    *
    * @param {*} value Value to check.
-   * @param {number} [max] Maximum acceptable value (inclusive). If
-   *   `undefined`, there is no upper limit.
+   * @param {Int} [max] Maximum acceptable value (inclusive). If `undefined`,
+   *   there is no upper limit.
    * @param {*} [ifAbsent] Default value. If passed and `value` is `undefined`,
    *   this method will return this value instead of throwing an error.
    * @returns {Int} `value` or `ifAbsent`.

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -5,6 +5,7 @@
 import { Registry } from 'api-common';
 
 import AuthorId from './AuthorId';
+import CorrectedChange from './CorrectedChange';
 import DocumentChange from './DocumentChange';
 import DocumentId from './DocumentId';
 import FrozenDelta from './FrozenDelta';
@@ -13,6 +14,7 @@ import Timestamp from './Timestamp';
 import VersionNumber from './VersionNumber';
 
 // Register classes with the API.
+Registry.register(CorrectedChange);
 Registry.register(DocumentChange);
 Registry.register(FrozenDelta);
 Registry.register(Snapshot);
@@ -20,6 +22,7 @@ Registry.register(Timestamp);
 
 export {
   AuthorId,
+  CorrectedChange,
   DocumentChange,
   DocumentId,
   FrozenDelta,

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -5,7 +5,7 @@
 import { Registry } from 'api-common';
 
 import AuthorId from './AuthorId';
-import CorrectedChange from './CorrectedChange';
+import DeltaResult from './DeltaResult';
 import DocumentChange from './DocumentChange';
 import DocumentId from './DocumentId';
 import FrozenDelta from './FrozenDelta';
@@ -14,7 +14,7 @@ import Timestamp from './Timestamp';
 import VersionNumber from './VersionNumber';
 
 // Register classes with the API.
-Registry.register(CorrectedChange);
+Registry.register(DeltaResult);
 Registry.register(DocumentChange);
 Registry.register(FrozenDelta);
 Registry.register(Snapshot);
@@ -22,7 +22,7 @@ Registry.register(Timestamp);
 
 export {
   AuthorId,
-  CorrectedChange,
+  DeltaResult,
   DocumentChange,
   DocumentId,
   FrozenDelta,

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -2,8 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
-  from 'doc-common';
+import { FrozenDelta, Snapshot, Timestamp, VersionNumber } from 'doc-common';
 import { BaseDoc } from 'doc-store';
 import { TBoolean, TInt, TString } from 'typecheck';
 import { CommonBase, PromCondition } from 'util-common';
@@ -74,7 +73,7 @@ export default class DocControl extends CommonBase {
   /**
    * Returns a snapshot of the full document contents.
    *
-   * @param {number} [verNum = this.currentVerNum()] Indicates which version to
+   * @param {Int} [verNum = this.currentVerNum()] Indicates which version to
    *   get.
    * @returns {Snapshot} The corresponding snapshot.
    */
@@ -89,10 +88,10 @@ export default class DocControl extends CommonBase {
       // up a first version here and change `verNum` to `0`, which will
       // propagate through the rest of the code and end up making everything all
       // work out.
-      const firstChange = new DocumentChange(0, Timestamp.now(),
+      this._doc.changeAppend(
+        Timestamp.now(),
         [{ insert: '(Recreated document due to format version skew.)\n' }],
         null);
-      this._doc.changeAppend(firstChange);
       verNum = 0;
     }
 
@@ -138,7 +137,7 @@ export default class DocControl extends CommonBase {
    * is the current version, this will not resolve the result promise until at
    * least one change has been made.
    *
-   * @param {number} baseVerNum Version number for the document.
+   * @param {Int} baseVerNum Version number for the document.
    * @returns {Promise} A promise which ultimately resolves to an object that
    *   maps `verNum` to the new version and `delta` to a change with respect to
    *   `baseVerNum`.
@@ -179,7 +178,7 @@ export default class DocControl extends CommonBase {
    * is to say, what the client would get if the delta were applied with no
    * intervening changes.
    *
-   * @param {number} baseVerNum Version number which `delta` is with respect to.
+   * @param {Int} baseVerNum Version number which `delta` is with respect to.
    * @param {object} delta Delta indicating what has changed with respect to
    *   `baseVerNum`.
    * @param {string|null} authorId Author of `delta`, or `null` if the change
@@ -312,9 +311,7 @@ export default class DocControl extends CommonBase {
       return;
     }
 
-    const change =
-      new DocumentChange(this._nextVerNum(), Timestamp.now(), delta, authorId);
-    this._doc.changeAppend(change);
+    this._doc.changeAppend(Timestamp.now(), delta, authorId);
     this._changeCondition.value = true;
   }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -184,15 +184,33 @@ export default class DocControl extends CommonBase {
    *   to `baseVerNum`.
    * @param {string|null} authorId Author of `delta`, or `null` if the change
    *   is to be considered authorless.
-   * @returns {CorrectedChange} Correction to the implied expected result of
-   *   this operation. The `delta` of this result can be applied to the expected
-   *   result to get the actual result.
+   * @returns {Promise<CorrectedChange>} Promise for the correction to the
+   *   implied expected result of this operation. The `delta` of this result can
+   *   be applied to the expected result to get the actual result. The promise
+   *   resolves sometime after the delta has been applied to the document.
    */
   applyDelta(baseVerNum, delta, authorId) {
     baseVerNum = this._validateVerNum(baseVerNum, false);
     delta = FrozenDelta.check(delta);
     authorId = TString.orNull(authorId);
 
+    // TODO: This `Promise.resolve()` cladding suffices to provide the
+    // documented asynchronous API; however, the innards of this method should
+    // actually be more async in their nature.
+    return Promise.resolve(this._applyDelta(baseVerNum, delta, authorId));
+  }
+
+  /**
+   * Main implementation of `applyDelta()`, see which for details. This method
+   * is fully synchronous.
+   *
+   * @param {Int} baseVerNum Same as for `applyDelta()`.
+   * @param {FrozenDelta} delta Same as for `applyDelta()`.
+   * @param {string|null} authorId Same as for `applyDelta()`.
+   * @returns {CorrectedChange} Same as for `applyDelta()`, except not a
+   *   promise.
+   */
+  _applyDelta(baseVerNum, delta, authorId) {
     if (baseVerNum === this.currentVerNum()) {
       // The easy case: Apply a delta to the current version (unless it's empty,
       // in which case we don't have to make a new version at all; that's

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CorrectedChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
+import { DeltaResult, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
 import { BaseDoc } from 'doc-store';
 import { TBoolean, TInt, TString } from 'typecheck';
@@ -174,7 +174,7 @@ export default class DocControl extends CommonBase {
    *   to `baseVerNum`.
    * @param {string|null} authorId Author of `delta`, or `null` if the change
    *   is to be considered authorless.
-   * @returns {Promise<CorrectedChange>} Promise for the correction to the
+   * @returns {Promise<DeltaResult>} Promise for the correction to the
    *   implied expected result of this operation. The `delta` of this result can
    *   be applied to the expected result to get the actual result. The promise
    *   resolves sometime after the delta has been applied to the document.
@@ -197,7 +197,7 @@ export default class DocControl extends CommonBase {
    * @param {Int} baseVerNum Same as for `applyDelta()`.
    * @param {FrozenDelta} delta Same as for `applyDelta()`.
    * @param {string|null} authorId Same as for `applyDelta()`.
-   * @returns {CorrectedChange} Same as for `applyDelta()`, except not a
+   * @returns {DeltaResult} Same as for `applyDelta()`, except not a
    *   promise.
    */
   _applyDelta(baseVerNum, delta, authorId) {
@@ -206,7 +206,7 @@ export default class DocControl extends CommonBase {
       // in which case we don't have to make a new version at all; that's
       // handled by `_appendDelta()`).
       this._appendDelta(delta, authorId);
-      return new CorrectedChange(
+      return new DeltaResult(
         this._currentVerNum(),  // `_appendDelta()` updates the version.
         FrozenDelta.EMPTY);
     }
@@ -247,7 +247,7 @@ export default class DocControl extends CommonBase {
 
     if (dNext.isEmpty()) {
       // It turns out that nothing changed.
-      return new CorrectedChange(vCurrentNum, FrozenDelta.EMPTY);
+      return new DeltaResult(vCurrentNum, FrozenDelta.EMPTY);
     }
 
     // (3)
@@ -260,7 +260,7 @@ export default class DocControl extends CommonBase {
     const dCorrection = FrozenDelta.coerce(vExpected.diff(vNext));
     const vResultNum  = vNextNum;
 
-    return new CorrectedChange(vResultNum, dCorrection);
+    return new DeltaResult(vResultNum, dCorrection);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -134,15 +134,15 @@ export default class DocControl extends CommonBase {
    *   `baseVerNum`.
    */
   deltaAfter(baseVerNum) {
-    const currentVerNum = this._currentVerNum();
-    const nextVerNum    = currentVerNum + 1;
-
     baseVerNum = this._validateVerNum(baseVerNum, false);
+
+    const currentVerNum = this._currentVerNum();
 
     if (baseVerNum !== currentVerNum) {
       // We can fulfill the result immediately. Compose all the deltas from
       // the version after the base through the current version.
-      const delta = this._composeVersions(baseVerNum + 1, nextVerNum);
+      const delta =
+        this._composeVersions(baseVerNum + 1, this._doc.nextVerNum());
 
       // We don't just return a plain value (that is, we still return a promise)
       // because of the usual hygenic recommendation to always return either

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -180,8 +180,8 @@ export default class DocControl extends CommonBase {
    * intervening changes.
    *
    * @param {Int} baseVerNum Version number which `delta` is with respect to.
-   * @param {object} delta Delta indicating what has changed with respect to
-   *   `baseVerNum`.
+   * @param {FrozenDelta} delta Delta indicating what has changed with respect
+   *   to `baseVerNum`.
    * @param {string|null} authorId Author of `delta`, or `null` if the change
    *   is to be considered authorless.
    * @returns {CorrectedChange} Correction to the implied expected result of
@@ -190,7 +190,7 @@ export default class DocControl extends CommonBase {
    */
   applyDelta(baseVerNum, delta, authorId) {
     baseVerNum = this._validateVerNum(baseVerNum, false);
-    delta = FrozenDelta.coerce(delta);
+    delta = FrozenDelta.check(delta);
     authorId = TString.orNull(authorId);
 
     if (baseVerNum === this.currentVerNum()) {

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -129,9 +129,9 @@ export default class DocControl extends CommonBase {
    * least one change has been made.
    *
    * @param {Int} baseVerNum Version number for the document.
-   * @returns {Promise} A promise which ultimately resolves to an object that
-   *   maps `verNum` to the new version and `delta` to a change with respect to
-   *   `baseVerNum`.
+   * @returns {Promise<DeltaResult>} Promise for a delta and associated version
+   *   number. The result's `delta` can be applied to version `baseVerNum` to
+   *   produce version `verNum` of the document.
    */
   deltaAfter(baseVerNum) {
     baseVerNum = this._validateVerNum(baseVerNum, false);
@@ -147,7 +147,7 @@ export default class DocControl extends CommonBase {
       // We don't just return a plain value (that is, we still return a promise)
       // because of the usual hygenic recommendation to always return either
       // an immediate result or a promise from any given function.
-      return Promise.resolve({ verNum: currentVerNum, delta });
+      return Promise.resolve(new DeltaResult(currentVerNum, delta));
     }
 
     // Force the `_changeCondition` to `false` (though it might already be

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -5,7 +5,7 @@
 import { DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionNumber }
   from 'doc-common';
 import { BaseDoc } from 'doc-store';
-import { TInt, TString } from 'typecheck';
+import { TBoolean, TInt, TString } from 'typecheck';
 import { CommonBase, PromCondition } from 'util-common';
 
 
@@ -71,13 +71,13 @@ export default class DocControl extends CommonBase {
    * sequence of changes, each modifying version N of the document to produce
    * version N+1.
    *
-   * @param {number} [verNum = this.currentVerNum()] The version number of the
-   *   change. The result is the change which produced that version. E.g., `0`
-   *   is a request for the first change (the change from the empty document).
+   * @param {Int} verNum The version number of the change. The result is the
+   *   change which produced that version. E.g., `0` is a request for the first
+   *   change (the change from the empty document).
    * @returns {DocumentChange} An object representing that change.
    */
   change(verNum) {
-    verNum = this._validateVerNum(verNum, true);
+    verNum = this._validateVerNum(verNum, false);
     return this._doc.changeRead(verNum);
   }
 
@@ -339,6 +339,8 @@ export default class DocControl extends CommonBase {
    * @returns {number} The version number.
    */
   _validateVerNum(verNum, wantCurrent) {
+    TBoolean.check(wantCurrent);
+
     const current = this.currentVerNum();
 
     if (wantCurrent) {

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -293,7 +293,7 @@ export default class DocControl extends CommonBase {
     // Validate parameters.
     startInclusive = VersionNumber.check(startInclusive);
     endExclusive =
-      TInt.rangeInc(endExclusive, startInclusive, this._nextVerNum());
+      TInt.rangeInc(endExclusive, startInclusive, this._doc.nextVerNum());
 
     if (startInclusive === endExclusive) {
       return FrozenDelta.EMPTY;
@@ -326,16 +326,6 @@ export default class DocControl extends CommonBase {
 
     this._doc.changeAppend(Timestamp.now(), delta, authorId);
     this._changeCondition.value = true;
-  }
-
-  /**
-   * Gets the version number corresponding to the very next change that will be
-   * made to the document.
-   *
-   * @returns {Int} The version number.
-   */
-  _nextVerNum() {
-    return this._doc.nextVerNum();
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -248,10 +248,11 @@ export default class DocControl extends CommonBase {
     const vNextNum = this.currentVerNum();   // This will be different than `vCurrentNum`.
 
     // (4)
-    const vExpected = FrozenDelta.coerce(vBase).compose(dClient);
+    const vExpected   = FrozenDelta.coerce(vBase).compose(dClient);
     const dCorrection = FrozenDelta.coerce(vExpected.diff(vNext));
+    const vResultNum  = vNextNum;
 
-    return new CorrectedChange(vNextNum, dCorrection);
+    return new CorrectedChange(vResultNum, dCorrection);
   }
 
   /**

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -50,8 +50,7 @@ export default class DocForAuthor {
    * Returns a particular change to the document. See the equivalent
    * `DocControl` method for details.
    *
-   * @param {number} [verNum = this.currentVerNum()] The version number of the
-   *   change.
+   * @param {Int} verNum The version number of the change.
    * @returns {DocumentChange} An object representing that change.
    */
   change(verNum) {

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -74,7 +74,9 @@ export default class DocForAuthor {
    * `baseVerNum`. See the equivalent `DocControl` method for details.
    *
    * @param {Int} baseVerNum Version number for the document.
-   * @returns {Promise} A promise for a new version.
+   * @returns {Promise<DeltaResult>} Promise for a delta and associated version
+   *   number. The result's `delta` can be applied to version `baseVerNum` to
+   *   produce version `verNum` of the document.
    */
   deltaAfter(baseVerNum) {
     return this._doc.deltaAfter(baseVerNum);

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -62,7 +62,7 @@ export default class DocForAuthor {
    * Returns a snapshot of the full document contents. See the equivalent
    * `DocControl` method for details.
    *
-   * @param {number} [verNum = this.currentVerNum()] Which version to get.
+   * @param {Int} [verNum = this.currentVerNum()] Which version to get.
    * @returns {Snapshot} The corresponding snapshot.
    */
   snapshot(verNum) {
@@ -73,7 +73,7 @@ export default class DocForAuthor {
    * Returns a promise for a snapshot of any version after the given
    * `baseVerNum`. See the equivalent `DocControl` method for details.
    *
-   * @param {number} baseVerNum Version number for the document.
+   * @param {Int} baseVerNum Version number for the document.
    * @returns {Promise} A promise for a new version.
    */
   deltaAfter(baseVerNum) {

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -88,7 +88,7 @@ export default class DocForAuthor {
    * @param {number} baseVerNum Version number which `delta` is with respect to.
    * @param {object} delta Delta indicating what has changed with respect to
    *   `baseVerNum`.
-   * @returns {object} Object indicating the new latest version.
+   * @returns {CorrectedChange} Correction from the implied expected result.
    */
   applyDelta(baseVerNum, delta) {
     return this._doc.applyDelta(baseVerNum, delta, this._authorId);

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -88,7 +88,7 @@ export default class DocForAuthor {
    * @param {number} baseVerNum Version number which `delta` is with respect to.
    * @param {FrozenDelta} delta Delta indicating what has changed with respect
    *   to `baseVerNum`.
-   * @returns {Promise<CorrectedChange>} Promise for the correction from the
+   * @returns {Promise<DeltaResult>} Promise for the correction from the
    *   implied expected result to get the actual result.
    */
   applyDelta(baseVerNum, delta) {

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -86,8 +86,8 @@ export default class DocForAuthor {
    * details.
    *
    * @param {number} baseVerNum Version number which `delta` is with respect to.
-   * @param {object} delta Delta indicating what has changed with respect to
-   *   `baseVerNum`.
+   * @param {FrozenDelta} delta Delta indicating what has changed with respect
+   *   to `baseVerNum`.
    * @returns {CorrectedChange} Correction from the implied expected result.
    */
   applyDelta(baseVerNum, delta) {

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -88,7 +88,8 @@ export default class DocForAuthor {
    * @param {number} baseVerNum Version number which `delta` is with respect to.
    * @param {FrozenDelta} delta Delta indicating what has changed with respect
    *   to `baseVerNum`.
-   * @returns {CorrectedChange} Correction from the implied expected result.
+   * @returns {Promise<CorrectedChange>} Promise for the correction from the
+   *   implied expected result to get the actual result.
    */
   applyDelta(baseVerNum, delta) {
     return this._doc.applyDelta(baseVerNum, delta, this._authorId);

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -37,16 +37,6 @@ export default class DocForAuthor {
   }
 
   /**
-   * Gets the version number corresponding to the very next change that will be
-   * made to the document.
-   *
-   * @returns {int} The version number.
-   */
-  nextVerNum() {
-    return this._doc.nextVerNum();
-  }
-
-  /**
    * Returns a particular change to the document. See the equivalent
    * `DocControl` method for details.
    *

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -4,7 +4,7 @@
 
 import weak from 'weak';
 
-import { DocumentChange, Timestamp } from 'doc-common';
+import { Timestamp } from 'doc-common';
 import { DEFAULT_DOCUMENT, Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
 import { TBoolean, TString } from 'typecheck';
@@ -95,9 +95,7 @@ export default class DocServer extends Singleton {
       log.info(`New document: ${docId}`);
 
       // Initialize the document with static content (for now).
-      const firstChange =
-        new DocumentChange(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
-      docStorage.changeAppend(firstChange);
+      docStorage.changeAppend(Timestamp.now(), DEFAULT_DOCUMENT, null);
     }
 
     const result = new DocControl(docStorage);

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -100,6 +100,9 @@ export default class BaseDoc extends CommonBase {
   /**
    * The version number of the next change to be appended to this document.
    *
+   * **Note:** This is different than just `currentVerNum() + 1` in that
+   * `currentVerNum()` is `null` (not `-1`) on an empty document.
+   *
    * @returns {int} The version number of the next change.
    */
   nextVerNum() {

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -141,20 +141,15 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
-   * Appends a change. This uses the change's `verNum` to determine the change
-   * number. This _must_ be the `nextVerNum()`, otherwise this method will throw
-   * an error.
+   * Appends a change. The arguments to this method are ultimately passed in
+   * order to the constructor for `DocumentChange`, with an appropriate version
+   * number prepended as the first argument.
    *
-   * @param {DocumentChange} change The change to append.
+   * @param {...*} changeArgs Constructor arguments to `DocumentChange`, except
+   *   without the version number.
    */
-  changeAppend(change) {
-    DocumentChange.check(change);
-    const verGot = change.verNum;
-    const verExpect = this.nextVerNum();
-    if (verGot !== verExpect) {
-      throw new Error(
-        `Incorrect \`verNum\` for change. Got ${verGot}, expected ${verExpect}`);
-    }
+  changeAppend(...changeArgs) {
+    const change = new DocumentChange(this.nextVerNum(), ...changeArgs);
     this._impl_changeAppend(change);
   }
 


### PR DESCRIPTION
This PR consists of a bunch of tightening up of the exposed `doc-server` API, including removal of exposed methods that weren't used, changing return types to be more structured, and promise-ifying things just a bit. The ultimate aim here is to make the API fully asynchronous, but there is still a bunch of work yet to do.