### PR TITLE
Finish promise-ifying the `doc-server` interface.

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -289,9 +289,9 @@ export default class DebugTools {
 
     return this._getExistingDoc(req).then((doc) => {
       const args = (verNum === undefined) ? [] : [verNum];
-      const snapshot = doc.snapshot(...args);
+      return doc.snapshot(...args);
+    }).then((snapshot) => {
       const result = Encoder.encodeJson(snapshot, true);
-
       this._textResponse(res, result);
     });
   }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -181,7 +181,8 @@ export default class DebugTools {
     const verNum = req.params.verNum;
 
     return this._getExistingDoc(req).then((doc) => {
-      const change = doc.change(verNum);
+      return doc.change(verNum);
+    }).then((change) => {
       const result = Encoder.encodeJson(change, true);
       this._textResponse(res, result);
     });

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -15,12 +15,14 @@ export default class VersionNumber {
    * @param {*} value Value to check.
    * @param {Int} [max] Maximum acceptable value (inclusive). If `undefined`,
    *   there is no upper limit.
-   * @param {*} [ifAbsent] Default value. If passed and `value` is `undefined`,
-   *   this method will return this value instead of throwing an error.
+   * @param {*} [ifAbsent] Default value. If passed and `value` is `undefined`
+   *   or `null`, this method will return this value instead of throwing an
+   *   error.
    * @returns {Int} `value` or `ifAbsent`.
    */
   static check(value, max = undefined, ifAbsent = undefined) {
-    if ((value === undefined) && (ifAbsent !== undefined)) {
+    if (   ((value === undefined) || (value === null))
+        && (ifAbsent !== undefined)) {
       return ifAbsent;
     }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -54,11 +54,15 @@ export default class DocControl extends CommonBase {
    * @param {Int} verNum The version number of the change. The result is the
    *   change which produced that version. E.g., `0` is a request for the first
    *   change (the change from the empty document).
-   * @returns {DocumentChange} An object representing that change.
+   * @returns {Promise<DocumentChange>} Promise for the requested change.
    */
   change(verNum) {
     verNum = this._validateVerNum(verNum, false);
-    return this._doc.changeRead(verNum);
+
+    // TODO: This `Promise.resolve()` cladding suffices to provide the
+    // documented asynchronous API; however, the innards of this method should
+    // actually be more async in their nature.
+    return Promise.resolve(this._doc.changeRead(verNum));
   }
 
   /**

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -62,10 +62,11 @@ export default class DocForAuthor {
    * Returns a snapshot of the full document contents. See the equivalent
    * `DocControl` method for details.
    *
-   * @param {Int} [verNum = this.currentVerNum()] Which version to get.
-   * @returns {Snapshot} The corresponding snapshot.
+   * @param {Int|null} [verNum = null] Which version to get. If passed as
+   *   `null`, indicates the latest (most recent) version.
+   * @returns {Promise<Snapshot>} Promise for the requested snapshot.
    */
-  snapshot(verNum) {
+  snapshot(verNum = null) {
     return this._doc.snapshot(verNum);
   }
 

--- a/local-modules/doc-server/DocForAuthor.js
+++ b/local-modules/doc-server/DocForAuthor.js
@@ -41,7 +41,7 @@ export default class DocForAuthor {
    * `DocControl` method for details.
    *
    * @param {Int} verNum The version number of the change.
-   * @returns {DocumentChange} An object representing that change.
+   * @returns {Promise<DocumentChange>} Promise for the requested change.
    */
   change(verNum) {
     return this._doc.change(verNum);


### PR DESCRIPTION
This PR makes the `doc-server` methods `.change()` and `.snapshot()` return promises instead of behaving synchronously. This is _just_ a change in top-level interface and not anything deeper. Later PRs will push the asynchronous implementation further down into the guts of the system, ultimately resulting in `doc-store` having a promise-based interface.