### PR TITLE
`asych`ify `{Base,Local}DocStore`.

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -36,3 +36,32 @@ taking into account recent additions to the language.
   word, all lower case, though capitalized as appropriate for prose or
   `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
   variable that contains an instance of one (or something related).
+
+* When documenting functions marked `async`, the implicit promise returned by
+  the function should _not_ be represented in its prose or `@returns`
+  documentation. For example:
+
+  ```javascript
+  /**
+   * Returns the frobnicator string.
+   *
+   * @returns {string} The frobnicator.
+   */
+  async function frob() {
+    return 'frobnicator';
+  }
+  ```
+
+  As a counterexample:
+
+  ```javascript
+  // DO NOT DO THIS!
+  /**
+   * Eventually returns the frobnicator string.
+   *
+   * @returns {Promise<string>} Promise for the frobnicator.
+   */
+  async function frob() {
+    return 'frobnicator';
+  }
+  ```

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -43,10 +43,9 @@ export default class DocServer extends Singleton {
    * document doesn't exist, it gets initialized.
    *
    * @param {string} docId The document ID.
-   * @returns {Promise<DocControl>} Promise for the corresponding document
-   *   accessor.
+   * @returns {DocControl} The corresponding document accessor.
    */
-  getDoc(docId) {
+  async getDoc(docId) {
     return this._getDoc(docId, true);
   }
 
@@ -55,10 +54,10 @@ export default class DocServer extends Singleton {
    * document doesn't exist, this returns `null`.
    *
    * @param {string} docId The document ID.
-   * @returns {Promise<DocControl|null>} Promise for the corresponding document
-   *   accessor, or for `null` if there is no such document.
+   * @returns {DocControl|null} The corresponding document accessor, or `null`
+   *   if there is no such document.
    */
-  getDocOrNull(docId) {
+  async getDocOrNull(docId) {
     return this._getDoc(docId, false);
   }
 
@@ -68,11 +67,11 @@ export default class DocServer extends Singleton {
    * @param {string} docId The document ID.
    * @param {boolean} initIfMissing If `true`, initializes a nonexistent doc
    *   instead of returning `null`.
-   * @returns {Promise<DocControl|null>} A promise for the corresponding
-   *   document accessor, or `null` if there is no such document _and_ we were
-   *   not asked to fill in missing docs.
+   * @returns {DocControl|null} The corresponding document accessor, or `null`
+   *   if there is no such document _and_ we were not asked to fill in missing
+   *   docs.
    */
-  _getDoc(docId, initIfMissing) {
+  async _getDoc(docId, initIfMissing) {
     TString.nonempty(docId);
     TBoolean.check(initIfMissing);
 
@@ -82,7 +81,7 @@ export default class DocServer extends Singleton {
       return Promise.resolve(weak.get(already));
     }
 
-    const docStorage = Hooks.docStore.getDocument(docId);
+    const docStorage = await Hooks.docStore.getDocument(docId);
 
     if (docStorage.exists()) {
       log.info(`Retrieving document: ${docId}`);
@@ -101,7 +100,7 @@ export default class DocServer extends Singleton {
     const result = new DocControl(docStorage);
     const resultRef = weak(result, this._reapDocument.bind(this, docId));
     this._controls.set(docId, resultRef);
-    return Promise.resolve(result);
+    return result;
   }
 
   /**

--- a/local-modules/doc-store-local/LocalDocStore.js
+++ b/local-modules/doc-store-local/LocalDocStore.js
@@ -56,7 +56,7 @@ export default class LocalDocStore extends BaseDocStore {
    * @param {string} docId The ID of the document to access.
    * @returns {BaseDoc} Accessor for the document in question.
    */
-  _impl_getDocument(docId) {
+  async _impl_getDocument(docId) {
     const already = this._docs.get(docId);
 
     if (already) {

--- a/local-modules/doc-store-local/package.json
+++ b/local-modules/doc-store-local/package.json
@@ -8,6 +8,8 @@
     "doc-store": "local",
     "see-all": "local",
     "server-env": "local",
-    "util-common": "local"
+    "util-common": "local",
+
+    "async-file": "^2.0.2"
   }
 }

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -46,7 +46,7 @@ describe('doc-store-local/LocalDoc', () => {
       const doc = new LocalDoc('0', '0', documentPath());
       const oldVersion = doc.currentVerNum();
 
-      // Docs start off with a null version number
+      // Docs start off with a null version number.
       assert.isNull(oldVersion);
       addChangeToDocument(doc);
 

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -86,7 +86,7 @@ describe('doc-store-local/LocalDoc', () => {
 });
 
 function documentPath() {
-  return storeDir + path.sep + 'test_file';
+  return path.join(storeDir, 'test_file');
 }
 
 function addChangeToDocument(doc) {

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -35,7 +35,7 @@ describe('doc-store-local/LocalDoc', () => {
 
   describe('constructor(formatVersion, docId, docPath)', () => {
     it('should create a local dir for storing files at the specified path', () => {
-      const doc = new LocalDoc('0', '0', _documentPath());
+      const doc = new LocalDoc('0', '0', documentPath());
 
       assert.isNotNull(doc);
     });
@@ -43,18 +43,18 @@ describe('doc-store-local/LocalDoc', () => {
 
   describe('changeAppend(change)', () => {
     it('should increment the version after a change is applied', () => {
-      const doc = new LocalDoc('0', '0', _documentPath());
+      const doc = new LocalDoc('0', '0', documentPath());
       const oldVersion = doc.currentVerNum();
 
       // Docs start off with a null version number
       assert.isNull(oldVersion);
-      _addChangeToDocument(doc);
+      addChangeToDocument(doc);
 
       let newVersion = doc.currentVerNum();
 
       assert.strictEqual(newVersion, 0);
 
-      _addChangeToDocument(doc);
+      addChangeToDocument(doc);
       newVersion = doc.currentVerNum();
       assert.strictEqual(newVersion, 1);
     });
@@ -64,9 +64,9 @@ describe('doc-store-local/LocalDoc', () => {
     // when to check.
     //
     // it('should exist on disk after a write', () => {
-    //   const doc = new LocalDoc('0', '0', _documentPath());
+    //   const doc = new LocalDoc('0', '0', documentPath());
     //
-    //   _addChangeToDocument(doc);
+    //   addChangeToDocument(doc);
     //
     //   assert.isTrue(doc.exists());
     // });
@@ -74,9 +74,9 @@ describe('doc-store-local/LocalDoc', () => {
 
   describe('create()', () => {
     it('should erase the document if called on a non-empty document', () => {
-      const doc = new LocalDoc('0', '0', _documentPath());
+      const doc = new LocalDoc('0', '0', documentPath());
 
-      _addChangeToDocument(doc);
+      addChangeToDocument(doc);
       assert.strictEqual(doc.currentVerNum(), 0); // Baseline assumption.
 
       doc.create();
@@ -85,11 +85,11 @@ describe('doc-store-local/LocalDoc', () => {
   });
 });
 
-function _documentPath() {
+function documentPath() {
   return storeDir + path.sep + 'test_file';
 }
 
-function _addChangeToDocument(doc) {
+function addChangeToDocument(doc) {
   const ts = Timestamp.now();
   const changes = [{ 'insert': 'hold on to your butts!' }];
 

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { DocumentId } from 'doc-common';
 import { TString } from 'typecheck';
 import { Singleton } from 'util-common';
 
@@ -25,9 +26,11 @@ export default class BaseDocStore extends Singleton {
    * a non-empty string.
    *
    * This implementation is a no-op. Subclasses may choose to override this if
-   * there is more syntax and/or semantics to their document IDs.
+   * there is any validation required beyond the syntactic validation of
+   * `DocumentId.check()`.
    *
-   * @param {string} docId_unused The document ID to validate.
+   * @param {string} docId_unused The document ID to validate. Only ever passed
+   *   as a value that has been validated by `DocumentId.check()`.
    * @throws {Error} Arbitrary error indicating an invalid document ID.
    */
   async _impl_checkDocId(docId_unused) {
@@ -44,7 +47,7 @@ export default class BaseDocStore extends Singleton {
    */
   async getDocument(docId) {
     TString.nonempty(docId);
-    await this._impl_checkDocId(docId);
+    await this._impl_checkDocId(DocumentId.check(docId));
     return BaseDoc.check(await this._impl_getDocument(docId));
   }
 

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -28,6 +28,7 @@ export default class BaseDocStore extends Singleton {
    * there is more syntax and/or semantics to their document IDs.
    *
    * @param {string} docId_unused The document ID to validate.
+   * @throws {Error} Arbitrary error indicating an invalid document ID.
    */
   _impl_checkDocId(docId_unused) {
     // This space intentionally left blank.
@@ -37,11 +38,11 @@ export default class BaseDocStore extends Singleton {
    * Gets the accessor for the document with the given ID. The document need not
    * exist prior to calling this method.
    *
-   * @param {string} docId The ID of the document to access. Must be a nonempty
-   *   string.
+   * @param {string} docId The ID of the document to access. Must be a valid
+   *   document ID as defined by the concrete subclass.
    * @returns {BaseDoc} Accessor for the document in question.
    */
-  getDocument(docId) {
+  async getDocument(docId) {
     TString.nonempty(docId);
     this._impl_checkDocId(docId);
     return BaseDoc.check(this._impl_getDocument(docId));

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -25,7 +25,7 @@ export default class BaseDocStore extends Singleton {
    * a non-empty string.
    *
    * This implementation is a no-op. Subclasses may choose to override this if
-   * there is more syntax to their document IDs.
+   * there is more syntax and/or semantics to their document IDs.
    *
    * @param {string} docId_unused The document ID to validate.
    */

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -45,7 +45,7 @@ export default class BaseDocStore extends Singleton {
   async getDocument(docId) {
     TString.nonempty(docId);
     await this._impl_checkDocId(docId);
-    return BaseDoc.check(this._impl_getDocument(docId));
+    return BaseDoc.check(await this._impl_getDocument(docId));
   }
 
   /**
@@ -57,7 +57,7 @@ export default class BaseDocStore extends Singleton {
    * @param {string} docId The ID of the document to access.
    * @returns {BaseDoc} Accessor for the document in question.
    */
-  _impl_getDocument(docId) {
+  async _impl_getDocument(docId) {
     return this._mustOverride(docId);
   }
 }

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -30,7 +30,7 @@ export default class BaseDocStore extends Singleton {
    * @param {string} docId_unused The document ID to validate.
    * @throws {Error} Arbitrary error indicating an invalid document ID.
    */
-  _impl_checkDocId(docId_unused) {
+  async _impl_checkDocId(docId_unused) {
     // This space intentionally left blank.
   }
 
@@ -44,7 +44,7 @@ export default class BaseDocStore extends Singleton {
    */
   async getDocument(docId) {
     TString.nonempty(docId);
-    this._impl_checkDocId(docId);
+    await this._impl_checkDocId(docId);
     return BaseDoc.check(this._impl_getDocument(docId));
   }
 


### PR DESCRIPTION
The main thrust of this PR is making the document construction/retrieval portion of the `doc-store` interface fully asynchronous, more specifically defining the methods in question as `async` and adjusting the surrounding code accordingly. Somewhat notably, I started including a new module `async-file`, which is a name-compatible wrapper for Node's built-in `fs` module, but with function signatures geared towards use with `await` (that is, the functions return promises instead of accepting callback arguments).

**Bonuses:**
* I defined conventions for documenting `async` functions.
* I tweaked a couple tests while I was in the area.