### PR TITLE
More async-readiness, avec shaved yak.

### DIFF
--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -15,7 +15,7 @@ export default class VersionNumber {
    * @param {*} value Value to check.
    * @param {Int} [max] Maximum acceptable value (inclusive). If `undefined`,
    *   there is no upper limit.
-   * @returns {Int} `value` or `ifAbsent`.
+   * @returns {Int} `value`.
    */
   static check(value, max = undefined) {
     if (   (typeof value !== 'number')
@@ -29,6 +29,22 @@ export default class VersionNumber {
     }
 
     return value;
+  }
+
+  /**
+   * Checks a value of type `VersionNumber`, which must furthermore be no more
+   * than an indicated value (inclusive).
+   *
+   * @param {*} value Value to check.
+   * @param {Int} maxInc Maximum acceptable value (inclusive).
+   * @returns {Int} `value`.
+   */
+  static maxInc(value, maxInc) {
+    try {
+      return TInt.rangeInc(value, 0, maxInc);
+    } catch (e) {
+      return TypeError.badValue(value, 'VersionNumber', `value <= ${maxInc}`);
+    }
   }
 
   /**
@@ -70,6 +86,10 @@ export default class VersionNumber {
    * Returns the version number after the given one. This is the same as
    * `verNum + 1` _except_ that `null` (the version "number" for an empty
    * document) is a valid input for which `0` is the return value.
+   *
+   * **Note:** Unlike the rest of the methods in this class, this one isn't a
+   * simple data validator. (TODO: This arrangement is error prone and should
+   * be reconsidered.)
    *
    * @param {Int|null} verNum Starting version number.
    * @returns {Int} The version number immediately after `verNum`

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -15,17 +15,9 @@ export default class VersionNumber {
    * @param {*} value Value to check.
    * @param {Int} [max] Maximum acceptable value (inclusive). If `undefined`,
    *   there is no upper limit.
-   * @param {*} [ifAbsent] Default value. If passed and `value` is `undefined`
-   *   or `null`, this method will return this value instead of throwing an
-   *   error.
    * @returns {Int} `value` or `ifAbsent`.
    */
-  static check(value, max = undefined, ifAbsent = undefined) {
-    if (   ((value === undefined) || (value === null))
-        && (ifAbsent !== undefined)) {
-      return ifAbsent;
-    }
-
+  static check(value, max = undefined) {
     if (   (typeof value !== 'number')
         || !Number.isSafeInteger(value)
         || (value < 0)) {

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -57,6 +57,24 @@ export default class VersionNumber {
   }
 
   /**
+   * Checks a value of type `VersionNumber`, which must furthermore be within an
+   * indicated inclusive-inclusive range.
+   *
+   * @param {*} value Value to check.
+   * @param {Int} minInc Minimum acceptable value (inclusive).
+   * @param {Int} maxInc Maximum acceptable value (inclusive).
+   * @returns {Int} `value`.
+   */
+  static rangeInc(value, minInc, maxInc) {
+    try {
+      return VersionNumber.check(TInt.rangeInc(value, minInc, maxInc));
+    } catch (e) {
+      // More appropriate error.
+      return TypeError.badValue(value, 'VersionNumber', `${minInc} <= value <= ${maxInc}`);
+    }
+  }
+
+  /**
    * Returns the version number after the given one. This is the same as
    * `verNum + 1` _except_ that `null` (the version "number" for an empty
    * document) is a valid input for which `0` is the return value.

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -13,22 +13,14 @@ export default class VersionNumber {
    * Checks a value of type `VersionNumber`.
    *
    * @param {*} value Value to check.
-   * @param {Int} [max] Maximum acceptable value (inclusive). If `undefined`,
-   *   there is no upper limit.
    * @returns {Int} `value`.
    */
-  static check(value, max = undefined) {
-    if (   (typeof value !== 'number')
-        || !Number.isSafeInteger(value)
-        || (value < 0)) {
+  static check(value) {
+    try {
+      return TInt.min(value, 0);
+    } catch (e) {
       return TypeError.badValue(value, 'VersionNumber');
     }
-
-    if ((max !== undefined) && TInt.check(max) && (value > max)) {
-      return TypeError.badValue(value, 'VersionNumber', `value <= ${max}`);
-    }
-
-    return value;
   }
 
   /**

--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -55,4 +55,16 @@ export default class VersionNumber {
       return TypeError.badValue(value, 'VersionNumber|null');
     }
   }
+
+  /**
+   * Returns the version number after the given one. This is the same as
+   * `verNum + 1` _except_ that `null` (the version "number" for an empty
+   * document) is a valid input for which `0` is the return value.
+   *
+   * @param {Int|null} verNum Starting version number.
+   * @returns {Int} The version number immediately after `verNum`
+   */
+  static after(verNum) {
+    return (verNum === null) ? 0 : (VersionNumber.check(verNum) + 1);
+  }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -327,6 +327,6 @@ export default class DocControl extends CommonBase {
    */
   _validateVerNum(verNum) {
     const current = this._currentVerNum();
-    return VersionNumber.check(verNum, current);
+    return VersionNumber.maxInc(verNum, current);
   }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -246,9 +246,10 @@ export default class DocControl extends CommonBase {
   /**
    * Constructs a delta consisting of the composition of the deltas from the
    * given initial version through and including the current latest delta.
-   * It is valid to pass `nextVerNum`, in which case this method returns an
-   * empty delta. It is invalid to specify a non-existent version _other_ than
-   * `nextVerNum`.
+   * It is valid to pass one version beyond the current version number (that is,
+   * `VersionNumber.after(this._currentVerNum())`, in which case this method
+   * returns an empty delta. It is invalid to specify a non-existent version
+   * _other_ than one beyond the current version.
    *
    * @param {Int} startInclusive Version number for the first delta to include
    *   in the result.
@@ -256,7 +257,7 @@ export default class DocControl extends CommonBase {
    *   `startInclusive` through and including the current latest delta.
    */
   async _composeVersionsFrom(startInclusive) {
-    const nextVerNum = this._doc.nextVerNum();
+    const nextVerNum = VersionNumber.after(this._currentVerNum());
     startInclusive = VersionNumber.check(startInclusive, nextVerNum);
 
     if (startInclusive === nextVerNum) {

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -94,7 +94,7 @@ export default class DocServer extends Singleton {
       log.info(`New document: ${docId}`);
 
       // Initialize the document with static content (for now).
-      docStorage.changeAppend(Timestamp.now(), DEFAULT_DOCUMENT, null);
+      docStorage.changeAppend(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
     }
 
     const result = new DocControl(docStorage);

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -93,5 +93,5 @@ function addChangeToDocument(doc) {
   const ts = Timestamp.now();
   const changes = [{ 'insert': 'hold on to your butts!' }];
 
-  doc.changeAppend(ts, changes, null);
+  doc.changeAppend(doc.nextVerNum(), ts, changes, null);
 }

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 import { after, before, describe, it } from 'mocha';
 import path from 'path';
 
-import { Timestamp } from 'doc-common';
+import { Timestamp, VersionNumber } from 'doc-common';
 import { LocalDoc } from 'doc-store-local';
 
 const STORE_PREFIX = 'arugula-test-';
@@ -93,5 +93,5 @@ function addChangeToDocument(doc) {
   const ts = Timestamp.now();
   const changes = [{ 'insert': 'hold on to your butts!' }];
 
-  doc.changeAppend(doc.nextVerNum(), ts, changes, null);
+  doc.changeAppend(VersionNumber.after(doc.currentVerNum()), ts, changes, null);
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -145,14 +145,23 @@ export default class BaseDoc extends CommonBase {
 
   /**
    * Appends a change. The arguments to this method are ultimately passed in
-   * order to the constructor for `DocumentChange`, with an appropriate version
-   * number prepended as the first argument.
+   * order to the constructor for `DocumentChange`. This will throw an exception
+   * if the given `verNum` (first argument) turns out not to be the actual
+   * appropriate next version.
    *
-   * @param {...*} changeArgs Constructor arguments to `DocumentChange`, except
-   *   without the version number.
+   * **Note:** The reason `verNum` is passed explicitly instead of just
+   * assumed to be correct is that, due to the asynchronous nature of the
+   * execution of this method, the calling code cannot know for sure whether or
+   * not _its_ concept of the appropriate `verNum` is actually the right value
+   * by the time the change is being appended. If `verNum` were simply assumed,
+   * what you might see is a `delta` that was intended to apply to (say)
+   * `verNum - 1` but which got recorded as being applied to `verNum` and would
+   * hence be incorrect.
+   *
+   * @param {...*} changeArgs Constructor arguments to `DocumentChange`.
    */
   changeAppend(...changeArgs) {
-    const change = new DocumentChange(this.nextVerNum(), ...changeArgs);
+    const change = new DocumentChange(...changeArgs);
     this._impl_changeAppend(change);
   }
 

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -46,8 +46,7 @@ export default class BaseDoc extends CommonBase {
   /**
    * Main implementation of `exists()`.
    *
-   * **Note:** This method must be overridden by subclasses.
-   *
+   * @abstract
    * @returns {boolean} `true` iff this document exists.
    */
   async _impl_exists() {
@@ -68,7 +67,7 @@ export default class BaseDoc extends CommonBase {
   /**
    * Main implementation of `create()`.
    *
-   * **Note:** This method must be overridden by subclasses.
+   * @abstract
    */
   async _impl_create() {
     this._mustOverride();
@@ -89,8 +88,7 @@ export default class BaseDoc extends CommonBase {
   /**
    * Main implementation of `currentVerNum()`.
    *
-   * **Note:** This accessor must be overridden by subclasses.
-   *
+   * @abstract
    * @returns {Int|null} The version number of this document or `null` if the
    *   document is empty.
    */
@@ -121,8 +119,7 @@ export default class BaseDoc extends CommonBase {
    * valid version number (in that it is a non-negative integer), but which
    * might be out of range or represent a "hole" in the set of changes.
    *
-   * **Note:** This method must be overridden by subclasses.
-   *
+   * @abstract
    * @param {Int} verNum The version number for the desired change.
    * @returns {DocumentChange|null|undefined} The change with `verNum` as
    *   indicated or a nullish value if there is no such change.
@@ -165,8 +162,7 @@ export default class BaseDoc extends CommonBase {
    * is imperative to synchronously validate the version number just before
    * accepting the change.
    *
-   * **Note:** This method must be overridden by subclasses.
-   *
+   * @abstract
    * @param {DocumentChange} change The change to write.
    */
   _impl_changeAppend(change) {

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -79,7 +79,7 @@ export default class BaseDoc extends CommonBase {
    * which `this.changeRead(n)` is valid. If the document has no changes at all,
    * this method returns `null`.
    *
-   * @returns {int|null} The version number of this document or `null` if the
+   * @returns {Int|null} The version number of this document or `null` if the
    *   document is empty.
    */
   currentVerNum() {
@@ -91,30 +91,18 @@ export default class BaseDoc extends CommonBase {
    *
    * **Note:** This accessor must be overridden by subclasses.
    *
-   * @returns {int} The version number of this document.
+   * @returns {Int|null} The version number of this document or `null` if the
+   *   document is empty.
    */
   _impl_currentVerNum() {
     return this._mustOverride();
   }
 
   /**
-   * The version number of the next change to be appended to this document.
-   *
-   * **Note:** This is different than just `currentVerNum() + 1` in that
-   * `currentVerNum()` is `null` (not `-1`) on an empty document.
-   *
-   * @returns {int} The version number of the next change.
-   */
-  nextVerNum() {
-    const current = this.currentVerNum();
-    return (current === null) ? 0 : (current + 1);
-  }
-
-  /**
    * Reads a change, by version number. It is an error to request a change that
    * does not exist on the document.
    *
-   * @param {int} verNum The version number for the desired change.
+   * @param {Int} verNum The version number for the desired change.
    * @returns {DocumentChange} The change with `verNum` as indicated.
    */
   changeRead(verNum) {
@@ -135,7 +123,7 @@ export default class BaseDoc extends CommonBase {
    *
    * **Note:** This method must be overridden by subclasses.
    *
-   * @param {int} verNum The version number for the desired change.
+   * @param {Int} verNum The version number for the desired change.
    * @returns {DocumentChange|null|undefined} The change with `verNum` as
    *   indicated or a nullish value if there is no such change.
    */

--- a/local-modules/doc-store/BaseDocStore.js
+++ b/local-modules/doc-store/BaseDocStore.js
@@ -55,8 +55,7 @@ export default class BaseDocStore extends Singleton {
    * Main implementation of `getDocument()`. Only ever called with a known-valid
    * `docId`.
    *
-   * **Note:** This method must be overridden by subclasses.
-   *
+   * @abstract
    * @param {string} docId The ID of the document to access.
    * @returns {BaseDoc} Accessor for the document in question.
    */

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CommonBase } from 'util-common';
+
 import LogStream from './LogStream';
 
 /** Set of valid severity levels. */
@@ -10,7 +12,7 @@ const LEVELS = new Set(['debug', 'error', 'warn', 'info', 'detail']);
 /**
  * Base class for loggers. Subclasses must implement `_logImpl()`.
  */
-export default class BaseLogger {
+export default class BaseLogger extends CommonBase {
   /**
    * Logs a message at the given severity level.
    *
@@ -157,12 +159,11 @@ export default class BaseLogger {
    * Actual logging implementation.
    *
    * @abstract
-   * @param {string} level_unused Severity level. Guaranteed to be a valid
-   *   level.
-   * @param {array} message_unused Array of arguments to log.
+   * @param {string} level Severity level. Guaranteed to be a valid level.
+   * @param {array} message Array of arguments to log.
    */
-  _logImpl(level_unused, message_unused) {
-    throw new Error('Subclass must override `_logImpl()`.');
+  _logImpl(level, message) {
+    this._mustOverride(level, message);
   }
 
   /**

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -154,8 +154,9 @@ export default class BaseLogger {
   }
 
   /**
-   * Actual logging implementation. Subclasses must override this.
+   * Actual logging implementation.
    *
+   * @abstract
    * @param {string} level_unused Severity level. Guaranteed to be a valid
    *   level.
    * @param {array} message_unused Array of arguments to log.

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -16,7 +16,7 @@ export default class TInt {
    * Checks a value of type `Int`.
    *
    * @param {*} value Value to check.
-   * @returns {number} `value`.
+   * @returns {Int} `value`.
    */
   static check(value) {
     if ((typeof value !== 'number') || !Number.isSafeInteger(value)) {
@@ -31,11 +31,12 @@ export default class TInt {
    * indicated value (inclusive).
    *
    * @param {*} value Value to check.
-   * @param {number} maxInc Maximum acceptable value (inclusive).
-   * @returns {number} `value`.
+   * @param {Int} maxInc Maximum acceptable value (inclusive).
+   * @returns {Int} `value`.
    */
   static maxInc(value, maxInc) {
     TInt.check(value);
+    TInt.check(maxInc);
     if (value > maxInc) {
       return TypeError.badValue(value, 'Int', `value <= ${maxInc}`);
     }
@@ -48,11 +49,12 @@ export default class TInt {
    * indicated value (inclusive).
    *
    * @param {*} value Value to check.
-   * @param {number} minInc Minimum acceptable value (inclusive).
-   * @returns {number} `value`.
+   * @param {Int} minInc Minimum acceptable value (inclusive).
+   * @returns {Int} `value`.
    */
   static min(value, minInc) {
     TInt.check(value);
+    TInt.check(minInc);
     if (value < minInc) {
       return TypeError.badValue(value, 'Int', `value >= ${minInc}`);
     }
@@ -68,12 +70,14 @@ export default class TInt {
    * respective errors convey different information.
    *
    * @param {*} value Value to check.
-   * @param {number} minInc Minimum acceptable value (inclusive).
-   * @param {number} maxExc Maximum acceptable value (exclusive).
-   * @returns {number} `value`.
+   * @param {Int} minInc Minimum acceptable value (inclusive).
+   * @param {Int} maxExc Maximum acceptable value (exclusive).
+   * @returns {Int} `value`.
    */
   static range(value, minInc, maxExc) {
     TInt.check(value);
+    TInt.check(minInc);
+    TInt.check(maxExc);
     if ((value < minInc) || (value >= maxExc)) {
       return TypeError.badValue(value, 'Int', `${minInc} <= value < ${maxExc}`);
     }
@@ -89,12 +93,14 @@ export default class TInt {
    * errors convey different information.
    *
    * @param {*} value Value to check.
-   * @param {number} minInc Minimum acceptable value (inclusive).
-   * @param {number} maxInc Maximum acceptable value (inclusive).
-   * @returns {number} `value`.
+   * @param {Int} minInc Minimum acceptable value (inclusive).
+   * @param {Int} maxInc Maximum acceptable value (inclusive).
+   * @returns {Int} `value`.
    */
   static rangeInc(value, minInc, maxInc) {
     TInt.check(value);
+    TInt.check(minInc);
+    TInt.check(maxInc);
     if ((value < minInc) || (value > maxInc)) {
       return TypeError.badValue(value, 'Int', `${minInc} <= value <= ${maxInc}`);
     }
@@ -103,10 +109,11 @@ export default class TInt {
   }
 
   /**
-   * Checks a value of type `Int`, which must furthermore be within the range [0..255].
+   * Checks a value of type `Int`, which must furthermore be within the
+   * inclusive range `0..255`.
    *
-   * @param {number} value The integer value to check.
-   * @returns {number} `value`.
+   * @param {*} value Value to check.
+   * @returns {Int} `value`.
    */
   static unsignedByte(value) {
     return TInt.rangeInc(value, 0, 255);

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -27,6 +27,23 @@ export default class TInt {
   }
 
   /**
+   * Checks a value of type `Int`, which must furthermore be no more than an
+   * indicated value (inclusive).
+   *
+   * @param {*} value Value to check.
+   * @param {number} maxInc Maximum acceptable value (inclusive).
+   * @returns {number} `value`.
+   */
+  static maxInc(value, maxInc) {
+    TInt.check(value);
+    if (value > maxInc) {
+      return TypeError.badValue(value, 'Int', `value <= ${maxInc}`);
+    }
+
+    return value;
+  }
+
+  /**
    * Checks a value of type `Int`, which must furthermore be at least an
    * indicated value (inclusive).
    *

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -25,6 +25,17 @@ describe('typecheck/TInt', () => {
     });
   });
 
+  describe('maxInc(value, maxInc)', () => {
+    it('should allow value <= maxInc', () => {
+      assert.doesNotThrow(() => TInt.maxInc(4, 4));
+      assert.doesNotThrow(() => TInt.maxInc(4, 5));
+    });
+
+    it('should throw an error when value > maxInc', () => {
+      assert.throws(() => TInt.maxInc(4, 3));
+    });
+  });
+
   describe('min(value, inclusiveMinimum)', () => {
     it('should allow value >= inclusiveMinimum', () => {
       assert.doesNotThrow(() => TInt.min(11, 3));

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -7,6 +7,8 @@ import { TObject } from 'typecheck';
 /**
  * Base class which provides a couple conveniences beyond what baseline
  * JavaScript has.
+ *
+ * @abstract
  */
 export default class CommonBase {
   /**
@@ -84,6 +86,7 @@ export default class CommonBase {
    * Subclass-specifc implementation of `coerce()`. Subclasses can override this
    * as needed.
    *
+   * @abstract
    * @param {*} value Value to coerce. This is guaranteed _not_ to be an
    *   instance of this class.
    * @returns {this} `value` or its coercion to the class that this was

--- a/local-modules/util-common/Singleton.js
+++ b/local-modules/util-common/Singleton.js
@@ -20,6 +20,8 @@ import CommonBase from './CommonBase';
  * the system is running. (That is, it is often either incorrect or at least
  * inappropriate to initialize an effective-singleton at the time the class is
  * being `import`ed.)
+ *
+ * @abstract
  */
 export default class Singleton extends CommonBase {
   /**


### PR DESCRIPTION
This PR started as a bit more work to make the doc interfaces asynch-friendly, but ended up with yak shaves on type checking and documentation. Details:

* Made the "current" version number explicit in the innards of change application. (This was within the original scope of the PR.)
* Make `nextVerNum()` unnecessary as a method. (Likewise, this is one less method to worry about asynch-ifying.)
* Simplify and somewhat flesh out `VersionNumber` (which is a data validator for document version numbers).
* Clean up (and very slightly expand) the `TInt` type checker.
* Use `@abstract` instead of prose to describe abstract methods, and consistently use the `_mustOverride()` utility method. (Total yak shave territory.)