### PR TITLE
`changeRead()` is now an `async` method.

### DIFF
--- a/local-modules/doc-common/VersionNumber.js
+++ b/local-modules/doc-common/VersionNumber.js
@@ -24,6 +24,22 @@ export default class VersionNumber {
   }
 
   /**
+   * Checks a value of type `VersionNumber`, which must furthermore be less
+   * than an indicated value.
+   *
+   * @param {*} value Value to check.
+   * @param {Int} maxExc Maximum acceptable value (exclusive).
+   * @returns {Int} `value`.
+   */
+  static maxExc(value, maxExc) {
+    try {
+      return TInt.range(value, 0, maxExc);
+    } catch (e) {
+      return TypeError.badValue(value, 'VersionNumber', `value < ${maxExc}`);
+    }
+  }
+
+  /**
    * Checks a value of type `VersionNumber`, which must furthermore be no more
    * than an indicated value (inclusive).
    *

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -6,6 +6,7 @@ import afs from 'async-file';
 import fs from 'fs';
 
 import { Decoder, Encoder } from 'api-common';
+import { VersionNumber } from 'doc-common';
 import { BaseDoc } from 'doc-store';
 import { Logger } from 'see-all';
 import { TObject } from 'typecheck';
@@ -94,12 +95,13 @@ export default class LocalDoc extends BaseDoc {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {int} verNum The version number for the desired change.
-   * @returns {DocumentChange|null|undefined} The change with `verNum` as
-   *   indicated or a nullish value if there is no such change.
+   * @param {Int} verNum The version number for the desired change.
+   * @returns {DocumentChange} The change with `verNum` as indicated.
    */
-  _impl_changeRead(verNum) {
+  async _impl_changeRead(verNum) {
     this._readIfNecessary();
+
+    VersionNumber.maxExc(verNum, this._changes.length);
     return this._changes[verNum];
   }
 

--- a/local-modules/doc-store-local/package.json
+++ b/local-modules/doc-store-local/package.json
@@ -5,6 +5,7 @@
 
   "dependencies": {
     "api-common": "local",
+    "doc-common": "local",
     "doc-store": "local",
     "see-all": "local",
     "server-env": "local",

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -103,28 +103,24 @@ export default class BaseDoc extends CommonBase {
    * @param {Int} verNum The version number for the desired change.
    * @returns {DocumentChange} The change with `verNum` as indicated.
    */
-  changeRead(verNum) {
+  async changeRead(verNum) {
     VersionNumber.check(verNum);
-    const result = this._impl_changeRead(verNum);
 
-    if (!result) {
-      throw new Error(`No change ${verNum} on document \`${this.id}\``);
-    }
-
+    const result = await this._impl_changeRead(verNum);
     return DocumentChange.check(result);
   }
 
   /**
    * Main implementation of `changeRead()`. Guaranteed to be called with a
    * valid version number (in that it is a non-negative integer), but which
-   * might be out of range or represent a "hole" in the set of changes.
+   * might be out of range. This method should throw an exception if `verNum`
+   * turns out not to refer to an existing change.
    *
    * @abstract
    * @param {Int} verNum The version number for the desired change.
-   * @returns {DocumentChange|null|undefined} The change with `verNum` as
-   *   indicated or a nullish value if there is no such change.
+   * @returns {DocumentChange} The change with `verNum` as indicated.
    */
-  _impl_changeRead(verNum) {
+  async _impl_changeRead(verNum) {
     return this._mustOverride(verNum);
   }
 


### PR DESCRIPTION
This PR makes `BaseDoc.changeRead()` into an `async` method, and adjusts all the surrounding code. One nice outcome is that, should the storage substrate ever allow for parallel change fetching, that parallelism will be preserved in the higher-level logic.