### PR TITLE
`changeAppend()` is now an `async` method.

### DIFF
--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -80,7 +80,7 @@ export default class DocControl extends CommonBase {
       // up a first version here and change `verNum` to `0`, which will
       // propagate through the rest of the code and end up making everything all
       // work out.
-      this._doc.changeAppend(
+      await this._doc.changeAppend(
         0,
         Timestamp.now(),
         [{ insert: '(Recreated document due to format version skew.)\n' }],
@@ -298,16 +298,16 @@ export default class DocControl extends CommonBase {
    * @returns {Int} The version number after appending `delta`.
    */
   async _appendDelta(baseVerNum, delta, authorId) {
+    const verNum = VersionNumber.after(baseVerNum);
     authorId = TString.orNull(authorId);
     delta = FrozenDelta.coerce(delta);
 
     if (!delta.isEmpty()) {
-      this._doc.changeAppend(
-        VersionNumber.after(baseVerNum), Timestamp.now(), delta, authorId);
+      await this._doc.changeAppend(verNum, Timestamp.now(), delta, authorId);
       this._changeCondition.value = true;
     }
 
-    return this._currentVerNum();
+    return verNum;
   }
 
   /**

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -94,7 +94,7 @@ export default class DocServer extends Singleton {
       log.info(`New document: ${docId}`);
 
       // Initialize the document with static content (for now).
-      docStorage.changeAppend(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
+      await docStorage.changeAppend(0, Timestamp.now(), DEFAULT_DOCUMENT, null);
     }
 
     const result = new DocControl(docStorage);

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -110,7 +110,7 @@ export default class LocalDoc extends BaseDoc {
    *
    * @param {DocumentChange} change The change to write.
    */
-  _impl_changeAppend(change) {
+  async _impl_changeAppend(change) {
     this._readIfNecessary();
 
     if (change.verNum !== this._changes.length) {

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -42,19 +42,19 @@ describe('doc-store-local/LocalDoc', () => {
   });
 
   describe('changeAppend(change)', () => {
-    it('should increment the version after a change is applied', () => {
+    it('should increment the version after a change is applied', async () => {
       const doc = new LocalDoc('0', '0', documentPath());
       const oldVersion = doc.currentVerNum();
 
       // Docs start off with a null version number.
       assert.isNull(oldVersion);
-      addChangeToDocument(doc);
+      await addChangeToDocument(doc);
 
       let newVersion = doc.currentVerNum();
 
       assert.strictEqual(newVersion, 0);
 
-      addChangeToDocument(doc);
+      await addChangeToDocument(doc);
       newVersion = doc.currentVerNum();
       assert.strictEqual(newVersion, 1);
     });
@@ -63,10 +63,10 @@ describe('doc-store-local/LocalDoc', () => {
     // or send an event when written so there's no way for the test code to know
     // when to check.
     //
-    // it('should exist on disk after a write', () => {
+    // it('should exist on disk after a write', async () => {
     //   const doc = new LocalDoc('0', '0', documentPath());
     //
-    //   addChangeToDocument(doc);
+    //   await addChangeToDocument(doc);
     //
     //   assert.isTrue(doc.exists());
     // });
@@ -76,7 +76,7 @@ describe('doc-store-local/LocalDoc', () => {
     it('should erase the document if called on a non-empty document', async () => {
       const doc = new LocalDoc('0', '0', documentPath());
 
-      addChangeToDocument(doc);
+      await addChangeToDocument(doc);
       assert.strictEqual(doc.currentVerNum(), 0); // Baseline assumption.
 
       await doc.create();
@@ -89,9 +89,9 @@ function documentPath() {
   return path.join(storeDir, 'test_file');
 }
 
-function addChangeToDocument(doc) {
+async function addChangeToDocument(doc) {
   const ts = Timestamp.now();
   const changes = [{ 'insert': 'hold on to your butts!' }];
 
-  doc.changeAppend(VersionNumber.after(doc.currentVerNum()), ts, changes, null);
+  await doc.changeAppend(VersionNumber.after(doc.currentVerNum()), ts, changes, null);
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -148,7 +148,7 @@ export default class BaseDoc extends CommonBase {
    */
   async changeAppend(...changeArgs) {
     const change = new DocumentChange(...changeArgs);
-    this._impl_changeAppend(change);
+    await this._impl_changeAppend(change);
   }
 
   /**
@@ -166,7 +166,7 @@ export default class BaseDoc extends CommonBase {
    * @abstract
    * @param {DocumentChange} change The change to write.
    */
-  _impl_changeAppend(change) {
+  async _impl_changeAppend(change) {
     this._mustOverride(change);
   }
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -130,6 +130,11 @@ export default class BaseDoc extends CommonBase {
    * if the given `verNum` (first argument) turns out not to be the actual
    * appropriate next version.
    *
+   * **Note:** The (implicit) return value from this method is a promise that
+   * resolves once the append operation is complete, or becomes rejected with
+   * a reason describing the problem such as, notably, the `verNum` being
+   * invalid.
+   *
    * **Note:** The reason `verNum` is passed explicitly instead of just
    * assumed to be correct is that, due to the asynchronous nature of the
    * execution of this method, the calling code cannot know for sure whether or
@@ -141,7 +146,7 @@ export default class BaseDoc extends CommonBase {
    *
    * @param {...*} changeArgs Constructor arguments to `DocumentChange`.
    */
-  changeAppend(...changeArgs) {
+  async changeAppend(...changeArgs) {
     const change = new DocumentChange(...changeArgs);
     this._impl_changeAppend(change);
   }


### PR DESCRIPTION
With this PR, the only remaining synchronous method in the document storage interface is `currentVerNum()`. Beyond that, though, there is still a bit of hardening needed in the client code of this layer.