### PR TITLE
Make `currentVerNum()` be `async`, and adjust accordingly.

### DIFF
--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -68,7 +68,7 @@ export default class DocControl extends CommonBase {
    * @returns {Snapshot} The corresponding snapshot.
    */
   async snapshot(verNum = null) {
-    const currentVerNum = this._doc.currentVerNum();
+    const currentVerNum = await this._doc.currentVerNum();
     verNum = (verNum === null)
       ? currentVerNum
       : VersionNumber.maxInc(verNum, currentVerNum);
@@ -129,7 +129,7 @@ export default class DocControl extends CommonBase {
    *  of the document.
    */
   async deltaAfter(baseVerNum) {
-    const currentVerNum = this._doc.currentVerNum();
+    const currentVerNum = await this._doc.currentVerNum();
     VersionNumber.maxInc(baseVerNum, currentVerNum);
 
     if (baseVerNum !== currentVerNum) {
@@ -172,7 +172,7 @@ export default class DocControl extends CommonBase {
    *   delta has been applied to the document.
    */
   async applyDelta(baseVerNum, delta, authorId) {
-    const currentVerNum = this._doc.currentVerNum();
+    const currentVerNum = await this._doc.currentVerNum();
     VersionNumber.maxInc(baseVerNum, currentVerNum);
 
     delta = FrozenDelta.check(delta);
@@ -211,7 +211,7 @@ export default class DocControl extends CommonBase {
     // (because of the `await`).
     const dClient     = delta;
     const vBaseNum    = baseVerNum;
-    const vCurrentNum = this._doc.currentVerNum();
+    const vCurrentNum = await this._doc.currentVerNum();
 
     // (1)
     const dServer = await this._composeVersions(
@@ -247,9 +247,9 @@ export default class DocControl extends CommonBase {
    * given initial version through and including the current latest delta,
    * composed from a given base. It is valid to pass as either version number
    * parameter one version beyond the current version number (that is,
-   * `VersionNumber.after(this._doc.currentVerNum())`. It is invalid to specify
-   * a non-existent version _other_ than one beyond the current version. If
-   * `startInclusive === endExclusive`, then this method returns `baseDelta`.
+   * `VersionNumber.after(await this._doc.currentVerNum())`. It is invalid to
+   * specify a non-existent version _other_ than one beyond the current version.
+   * If `startInclusive === endExclusive`, then this method returns `baseDelta`.
    *
    * @param {FrozenDelta} baseDelta Base delta onto which the indicated deltas
    *   get composed.
@@ -262,7 +262,7 @@ export default class DocControl extends CommonBase {
    *   `endExclusive`.
    */
   async _composeVersions(baseDelta, startInclusive, endExclusive) {
-    const nextVerNum = VersionNumber.after(this._doc.currentVerNum());
+    const nextVerNum = VersionNumber.after(await this._doc.currentVerNum());
     startInclusive = VersionNumber.rangeInc(startInclusive, 0, nextVerNum);
     endExclusive =
       VersionNumber.rangeInc(endExclusive, startInclusive, nextVerNum);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -68,7 +68,7 @@ export default class DocControl extends CommonBase {
    * @returns {Snapshot} The corresponding snapshot.
    */
   async snapshot(verNum = null) {
-    const currentVerNum = this._currentVerNum();
+    const currentVerNum = this._doc.currentVerNum();
     verNum = (verNum === null)
       ? currentVerNum
       : VersionNumber.maxInc(verNum, currentVerNum);
@@ -129,7 +129,7 @@ export default class DocControl extends CommonBase {
    *  of the document.
    */
   async deltaAfter(baseVerNum) {
-    const currentVerNum = this._currentVerNum();
+    const currentVerNum = this._doc.currentVerNum();
     VersionNumber.maxInc(baseVerNum, currentVerNum);
 
     if (baseVerNum !== currentVerNum) {
@@ -172,7 +172,7 @@ export default class DocControl extends CommonBase {
    *   delta has been applied to the document.
    */
   async applyDelta(baseVerNum, delta, authorId) {
-    const currentVerNum = this._currentVerNum();
+    const currentVerNum = this._doc.currentVerNum();
     VersionNumber.maxInc(baseVerNum, currentVerNum);
 
     delta = FrozenDelta.check(delta);
@@ -212,7 +212,7 @@ export default class DocControl extends CommonBase {
     const dClient     = delta;
     const vBaseNum    = baseVerNum;
     const vBase       = (await this.snapshot(vBaseNum)).contents;
-    const vCurrentNum = this._currentVerNum();
+    const vCurrentNum = this._doc.currentVerNum();
 
     // (1)
     const dServer = await this._composeVersions(
@@ -247,8 +247,8 @@ export default class DocControl extends CommonBase {
    * given initial version through and including the current latest delta,
    * composed from a given base. It is valid to pass as either version number
    * parameter one version beyond the current version number (that is,
-   * `VersionNumber.after(this._currentVerNum())`. It is invalid to specify a
-   * non-existent version _other_ than one beyond the current version. If
+   * `VersionNumber.after(this._doc.currentVerNum())`. It is invalid to specify
+   * a non-existent version _other_ than one beyond the current version. If
    * `startInclusive === endExclusive`, then this method returns `baseDelta`.
    *
    * @param {FrozenDelta} baseDelta Base delta onto which the indicated deltas
@@ -262,7 +262,7 @@ export default class DocControl extends CommonBase {
    *   `endExclusive`.
    */
   async _composeVersions(baseDelta, startInclusive, endExclusive) {
-    const nextVerNum = VersionNumber.after(this._currentVerNum());
+    const nextVerNum = VersionNumber.after(this._doc.currentVerNum());
     startInclusive = VersionNumber.rangeInc(startInclusive, 0, nextVerNum);
     endExclusive =
       VersionNumber.rangeInc(endExclusive, startInclusive, nextVerNum);
@@ -313,15 +313,5 @@ export default class DocControl extends CommonBase {
     }
 
     return verNum;
-  }
-
-  /**
-   * Gets the version number corresponding to the current (latest) version of
-   * the document.
-   *
-   * @returns {Int|null} The version number.
-   */
-  _currentVerNum() {
-    return this._doc.currentVerNum();
   }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -211,7 +211,6 @@ export default class DocControl extends CommonBase {
     // (because of the `await`).
     const dClient     = delta;
     const vBaseNum    = baseVerNum;
-    const vBase       = (await this.snapshot(vBaseNum)).contents;
     const vCurrentNum = this._doc.currentVerNum();
 
     // (1)
@@ -235,7 +234,8 @@ export default class DocControl extends CommonBase {
     const vNext = vNextSnapshot.contents;
 
     // (4)
-    const vExpected   = FrozenDelta.coerce(vBase).compose(dClient);
+    const vBase       = (await this.snapshot(vBaseNum)).contents;
+    const vExpected   = vBase.compose(dClient);
     const dCorrection = FrozenDelta.coerce(vExpected.diff(vNext));
     const vResultNum  = vNextNum;
 

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -77,7 +77,29 @@ export default class LocalDoc extends BaseDoc {
    * @returns {boolean} `true` iff this document exists.
    */
   async _impl_exists() {
-    return afs.exists(this._path);
+    // Start by checking the existence of the file. We do this first, so that
+    // the subsequent logic can be synchronous.
+    const fileExists = await afs.exists(this._path);
+
+    if (this._changes !== null) {
+      // Whether or not the file exists, the document is considered to exist
+      // because it has a non-empty in-memory model. (For example, it might have
+      // been `create()`d but not yet stored to disk.)
+      return true;
+    } else if (!fileExists) {
+      // The file doesn't exist, and (per above) there's no in-memory model.
+      return false;
+    } else {
+      // The file exists, but we don't know if it's valid. Let the document
+      // reader code make that determination. An error in reading indicates that
+      // the document doesn't effectively exist.
+      try {
+        await this._readIfNecessary();
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
   }
 
   /**

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -84,9 +84,9 @@ export default class LocalDoc extends BaseDoc {
   /**
    * Implementation as required by the superclass.
    *
-   * @returns {int} The version number of this document.
+   * @returns {Int|null} The version number of this document.
    */
-  _impl_currentVerNum() {
+  async _impl_currentVerNum() {
     this._readIfNecessary();
     const len = this._changes.length;
     return (len === 0) ? null : (len - 1);

--- a/local-modules/doc-store-local/tests/test_LocalDoc.js
+++ b/local-modules/doc-store-local/tests/test_LocalDoc.js
@@ -44,18 +44,18 @@ describe('doc-store-local/LocalDoc', () => {
   describe('changeAppend(change)', () => {
     it('should increment the version after a change is applied', async () => {
       const doc = new LocalDoc('0', '0', documentPath());
-      const oldVersion = doc.currentVerNum();
+      const oldVersion = await doc.currentVerNum();
 
       // Docs start off with a null version number.
       assert.isNull(oldVersion);
       await addChangeToDocument(doc);
 
-      let newVersion = doc.currentVerNum();
+      let newVersion = await doc.currentVerNum();
 
       assert.strictEqual(newVersion, 0);
 
       await addChangeToDocument(doc);
-      newVersion = doc.currentVerNum();
+      newVersion = await doc.currentVerNum();
       assert.strictEqual(newVersion, 1);
     });
 
@@ -77,10 +77,10 @@ describe('doc-store-local/LocalDoc', () => {
       const doc = new LocalDoc('0', '0', documentPath());
 
       await addChangeToDocument(doc);
-      assert.strictEqual(doc.currentVerNum(), 0); // Baseline assumption.
+      assert.strictEqual(await doc.currentVerNum(), 0); // Baseline assumption.
 
       await doc.create();
-      assert.isNull(doc.currentVerNum()); // The real test.
+      assert.isNull(await doc.currentVerNum()); // The real test.
     });
   });
 });
@@ -93,5 +93,6 @@ async function addChangeToDocument(doc) {
   const ts = Timestamp.now();
   const changes = [{ 'insert': 'hold on to your butts!' }];
 
-  await doc.changeAppend(VersionNumber.after(doc.currentVerNum()), ts, changes, null);
+  await doc.changeAppend(
+    VersionNumber.after(await doc.currentVerNum()), ts, changes, null);
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -74,9 +74,18 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
-   * The version number of this document. This is the largest value `n` for
-   * which `this.changeRead(n)` is valid. If the document has no changes at all,
-   * this method returns `null`.
+   * Gets the current version number of this document. This is the largest value
+   * `n` for which `this.changeRead(n)` is definitely valid. If the document has
+   * no changes at all, this method returns `null`.
+   *
+   * With regard to "definitely" above, at the moment a call to this method is
+   * complete, it is possible for there to _already_ be document changes in
+   * flight, which will be serviced asynchronously. This notably means that,
+   * should the result of a call to this method be subsequently used as part of
+   * an _asynchronous_ call, by the time that _that_ call is executed, the
+   * current version number may no longer be the same. Hence, it is imperative
+   * for code to _not_ assume a stable version number when any asynchrony is
+   * possible.
    *
    * @returns {Int|null} The version number of this document or `null` if the
    *   document is empty.

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -90,7 +90,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {Int|null} The version number of this document or `null` if the
    *   document is empty.
    */
-  currentVerNum() {
+  async currentVerNum() {
     return VersionNumber.orNull(this._impl_currentVerNum());
   }
 

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -91,7 +91,7 @@ export default class BaseDoc extends CommonBase {
    *   document is empty.
    */
   async currentVerNum() {
-    return VersionNumber.orNull(this._impl_currentVerNum());
+    return VersionNumber.orNull(await this._impl_currentVerNum());
   }
 
   /**
@@ -101,7 +101,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {Int|null} The version number of this document or `null` if the
    *   document is empty.
    */
-  _impl_currentVerNum() {
+  async _impl_currentVerNum() {
     return this._mustOverride();
   }
 

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -34,7 +34,8 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
-   * Indicates whether or not this document exists in the store.
+   * Indicates whether or not this document exists in the store. Calling this
+   * method will _not_ cause a non-existent document to come into existence.
    *
    * @returns {boolean} `true` iff this document exists.
    */


### PR DESCRIPTION
This PR fixes the last remaining bit of the document storage interface to be defined as `async`, namely `BaseDoc.currentVerNum()`. Beyond that, this PR includes two follow-on bits:

* Clean up `DocControl`, and do minor rearranging for better parallelism. **Note:** This code still has a version skew hazard that will be addressed in a subsequent PR.
* Push asynchrony deeper into `LocalDoc`, in particular getting the document file reading to be properly (instead of just nominally) asynch. **Note:** There is still more work along these lines to be done in this file. 