### PR TITLE
Fix the simultaneous-append hazard.

### DIFF
--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -115,15 +115,17 @@ export default class DocControl extends CommonBase {
   }
 
   /**
-   * Returns a promise for a snapshot of any version after the given
-   * `baseVerNum`, and relative to that version. If called when `baseVerNum`
-   * is the current version, this will not resolve the result promise until at
-   * least one change has been made.
+   * Returns a promise for a version &mdash; any version &mdash; of the document
+   * after the given `baseVerNum`, with the return result represented as a delta
+   * relative to that given version. If called when `baseVerNum` is the current
+   * version, this will not resolve the result promise until at least one change
+   * has been made.
    *
    * @param {Int} baseVerNum Version number for the document.
    * @returns {DeltaResult} Delta and associated version number. The result's
-   *  `delta` can be applied to version `baseVerNum` to produce version `verNum`
-   *  of the document.
+   *   `verNum` is guaranteed to be at least one more than `baseVerNum` (and
+   *   could possibly be even larger.) The result's `delta` can be applied to
+   *   version `baseVerNum` to produce version `verNum` of the document.
    */
   async deltaAfter(baseVerNum) {
     const currentVerNum = await this._doc.currentVerNum();

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -215,8 +215,8 @@ export default class DocControl extends CommonBase {
     }
 
     // (3)
-    const vNextNum = await this._appendDelta(vBaseNum, dNext, authorId);
-    const vNextSnapshot = await this.snapshot();
+    const vNextNum = await this._appendDelta(vCurrentNum, dNext, authorId);
+    const vNextSnapshot = await this.snapshot(vNextNum);
     const vNext = vNextSnapshot.contents;
 
     // (4)

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -6,13 +6,24 @@ import { DeltaResult, DocumentChange, FrozenDelta, Snapshot, Timestamp, VersionN
   from 'doc-common';
 import { BaseDoc } from 'doc-store';
 import { TString } from 'typecheck';
-import { CommonBase, PromCondition } from 'util-common';
+import { CommonBase, PromCondition, PromDelay } from 'util-common';
 
+/** {number} Initial amount of time (in msec) between append retries. */
+const INITIAL_APPEND_RETRY_MSEC = 50;
+
+/** {number} Growth factor for append retry delays. */
+const APPEND_RETRY_GROWTH_FACTOR = 5;
+
+/**
+ * {number} Maximum amount of time to spend (in msec) retrying append
+ * operations.
+ */
+const MAX_APPEND_TIME_MSEC = 20 * 1000; // 20 seconds.
 
 /**
  * Controller for a given document. There is only ever exactly one instance of
  * this class per document, no matter how many active editors there are on that
- * document.
+ * document. (This guarantee is provided by `DocServer`.)
  */
 export default class DocControl extends CommonBase {
   /**
@@ -158,17 +169,76 @@ export default class DocControl extends CommonBase {
    *   delta has been applied to the document.
    */
   async applyDelta(baseVerNum, delta, authorId) {
-    const currentVerNum = await this._doc.currentVerNum();
-    VersionNumber.maxInc(baseVerNum, currentVerNum);
+    // Very basic argument validation. Once in the guts of the thing, we will
+    // discover (and properly complain) if there are deeper problems with them.
+    VersionNumber.check(baseVerNum);
+    FrozenDelta.check(delta);
+    TString.orNull(authorId);
 
-    delta = FrozenDelta.check(delta);
-    authorId = TString.orNull(authorId);
+    // We try performing the apply, and then we iterate if it failed _and_ the
+    // reason is simply that there were any changes that got made while we were
+    // in the middle of the attempt. Any other problems are transparently thrown
+    // to the caller.
+    let retryDelayMsec = INITIAL_APPEND_RETRY_MSEC;
+    let retryTotalMsec = 0;
+    for (;;) {
+      const snapshotProm = this.snapshot();
+      const result = await this._applyDeltaTo(
+        baseVerNum, delta, authorId, snapshotProm);
 
-    if (baseVerNum === currentVerNum) {
+      if (result !== null) {
+        return result;
+      }
+
+      // A `null` result from the call means that we lost an append race (that
+      // is, there was version skew between the snapshot and the latest reality
+      // at the moment of attempted appending), so we delay briefly and iterate.
+
+      if (retryTotalMsec >= MAX_APPEND_TIME_MSEC) {
+        // ...except if these attempts have taken wayyyy too long. If we land
+        // here, it's probably due to a bug (but not a total given).
+        throw new Error('Too many failed attempts in `applyDelta()`.');
+      }
+
+      await PromDelay.resolve(retryDelayMsec);
+      retryTotalMsec += retryDelayMsec;
+      retryDelayMsec *= APPEND_RETRY_GROWTH_FACTOR;
+    }
+  }
+
+  /**
+   * Main implementation of `applyDelta()`, which takes as an additional
+   * argument a promise for a snapshot which represents the latest version at
+   * the moment it resolves. This method attempts to perform change application
+   * relative to that snapshot. If it succeeds (that is, if the snapshot still
+   * is the latest at the moment of attempted application), then this method
+   * returns a proper result of `applyDelta()`. If it fails due to the snapshot
+   * being out-of-date, then this method returns `null`. All other problems are
+   * reported by throwing an exception.
+   *
+   * @param {Int} baseVerNum Same as for `applyDelta()`.
+   * @param {FrozenDelta} delta Same as for `applyDelta()`.
+   * @param {string|null} authorId Same as for `applyDelta()`.
+   * @param {Promise<Snapshot>} snapshotProm Promise for the latest snapshot.
+   * @returns {DeltaResult|null} Result for the outer call to `applyDelta()`,
+   *   or `null` if the application failed due to an out-of-date `snapshot`.
+   */
+  async _applyDeltaTo(baseVerNum, delta, authorId, snapshotProm) {
+    const snapshot = await snapshotProm;
+    VersionNumber.maxInc(baseVerNum, snapshot.verNum);
+
+    if (baseVerNum === snapshot.verNum) {
       // The easy case: Apply a delta to the current version (unless it's empty,
       // in which case we don't have to make a new version at all; that's
       // handled by `_appendDelta()`).
+
       const verNum = await this._appendDelta(baseVerNum, delta, authorId);
+
+      if (verNum === null) {
+        // Turns out we lost an append race.
+        return null;
+      }
+
       return new DeltaResult(verNum, FrozenDelta.EMPTY);
     }
 
@@ -191,13 +261,10 @@ export default class DocControl extends CommonBase {
     //    `vExpected` with `dCorrection` to arrive at `vNext`.
 
     // Assign variables from parameter and instance variables that correspond
-    // to the description immediately above. **Note:** We re-fetch the current
-    // version number here instead of just using `currentVerNum` above, because
-    // it is possible for the document to have been updated in the mean time
-    // (because of the `await`).
+    // to the description immediately above.
     const dClient     = delta;
     const vBaseNum    = baseVerNum;
-    const vCurrentNum = await this._doc.currentVerNum();
+    const vCurrentNum = snapshot.verNum;
 
     // (1)
     const dServer = await this._composeVersions(
@@ -216,8 +283,13 @@ export default class DocControl extends CommonBase {
 
     // (3)
     const vNextNum = await this._appendDelta(vCurrentNum, dNext, authorId);
-    const vNextSnapshot = await this.snapshot(vNextNum);
-    const vNext = vNextSnapshot.contents;
+
+    if (vNextNum === null) {
+      // Turns out we lost an append race.
+      return null;
+    }
+
+    const vNext = (await this.snapshot(vNextNum)).contents;
 
     // (4)
     const vBase       = (await this.snapshot(vBaseNum)).contents;
@@ -277,16 +349,20 @@ export default class DocControl extends CommonBase {
 
   /**
    * Appends a new delta to the document. Also forces `_changeCondition`
-   * `true` to release any waiters.
+   * `true` to release any waiters. On success, this returns the version number
+   * of the document after the append. On a failure due to `baseVerNum` not
+   * being current at the moment of application, this returns `null`. All other
+   * errors are reported via thrown errors. See `_applyDeltaTo()` above and
+   * `BaseDoc.changeAppend()` for further discussion.
    *
    * **Note:** If the delta is a no-op, then this method does nothing.
    *
-   * @param {Int} baseVerNum Version number which this is to apply to. It must
-   *   be the current document version number at the moment the change is
-   *   ultimately applied. See `BaseDoc.changeAppend()` for further discussion.
-   * @param {object} delta The delta to append.
+   * @param {Int} baseVerNum Version number which this is to apply to.
+   * @param {FrozenDelta} delta The delta to append.
    * @param {string|null} authorId The author of the delta.
-   * @returns {Int} The version number after appending `delta`.
+   * @returns {Int|null} The version number after appending `delta`, or `null`
+   *   if `baseVerNum` is out-of-date at the moment of attempted application
+   *   _and_ the `delta` is non-empty.
    */
   async _appendDelta(baseVerNum, delta, authorId) {
     if (delta.isEmpty()) {
@@ -299,7 +375,7 @@ export default class DocControl extends CommonBase {
 
     if (!appendResult) {
       // We lost an append race.
-      throw new Error('Incorrect version number for delta.');
+      return null;
     }
 
     this._changeCondition.value = true;

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -212,15 +212,15 @@ export default class LocalDoc extends BaseDoc {
 
     this._log.detail('Writing to disk...');
     await afs.writeFile(this._path, encoded, { encoding: 'utf8' });
-    this._log.info(`Wrote version ${changes.length}.`);
+    this._log.info(`Wrote version ${changeCount - 1}.`);
 
     // The tricky bit: We need to check to see if the document got modified
     // during the file write operation, because if we don't and just reset the
     // dirty flag, we will fail to write the new version until the _next_ time
     // the document changes. We check two things to make the determination:
     //
-    // * The version number (length of changes array). Different lengths mean
-    //   we are still dirty.
+    // * The length of the changes array. Different lengths mean we are still
+    //   dirty.
     //
     // * The first change as stored in the instance. If this isn't the same as
     //   what we wrote, it means that the document was re-created.

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -137,13 +137,17 @@ export default class LocalDoc extends BaseDoc {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {DocumentChange} change The change to write.
+   * @param {DocumentChange} change The change to append.
+   * @returns {boolean} `true` if the append was successful, or `false` if it
+   *   was not due to `change` having an incorrect `verNum`.
    */
   async _impl_changeAppend(change) {
     await this._readIfNecessary();
 
     if (change.verNum !== this._changes.length) {
-      throw new Error(`Invalid version number: ${change.verNum}.`);
+      // Not the right `verNum`. This is typically because there was an append
+      // race, and this is the losing side.
+      return false;
     }
 
     this._changes[change.verNum] = change;
@@ -151,6 +155,8 @@ export default class LocalDoc extends BaseDoc {
     // **Note:** This call _synchronously_ (and promptly) indicates that writing
     // needs to happen, but the actual writing takes place asynchronously.
     this._needsWrite();
+
+    return true;
   }
 
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.12.2
+version = 0.13.0


### PR DESCRIPTION
With the introduction of an asynchronous document access and control interface, handling document updates got a bit more complicated. In particular, it became possible for two separate document updates to be "in flight" at the same time, whereas before any given document update ran from start to completion without the possibility of any intervening action.

This PR resolves one specific "hazard" that got exposed to client code with this restructuring. Specifically, from the client perspective it became possible for a _valid_ call to `applyDelta()` to get rejected for (what amounted to) a spurious reason, namely that the call happened to run concurrently with another `applyDelta()` call and that other call happened to finish first. When this happened, the "losing" call would terminate with an exception, which was clearly undesirable.

Rather than force the client to have retry logic (which would more or less be the "POSIX philosophy" answer), it seemed to me that it would be better to fix it on the server side of the API boundary. So that's what I did here.

I implemented the fix as a retry loop with exponential backoff, however other cleverer solutions are also possible, should we ever need to revisit the issue. Specifically, we might want to consider an explicit "append queue" which gets serviced in-order; this might have a couple useful benefits over the current approach (guaranteed fairness, more obvious when it's getting clogged).

I bumped the major version — lucky 0.13 now — mostly as an indicator that we can reasonably expect document synch to work end-to-end once again (knock on wood).

**Bonuses:**
* Fixed the merge code to use the right base document version. (This probably fixed one of the "mysterious failures" we'd seen from time to time.)
* Fixed the version logging in `local-doc`.
* Fixed and clarified a handful of doc comments.