### PR TITLE
Validate deltas, and related cleanup.

### DIFF
--- a/local-modules/doc-common/Snapshot.js
+++ b/local-modules/doc-common/Snapshot.js
@@ -31,9 +31,14 @@ export default class Snapshot extends CommonBase {
 
     // Explicitly check that the `contents` delta has the form of a "document,"
     // that is, the only operations are `insert`s. For very large documents,
-    // this might turn out to be a prohibitively slow operation, so... TODO:
-    // Evaluate how expensive this is in practice, and figure out a better
-    // tactic if need be.
+    // this might turn out to be a prohibitively slow operation, so...
+    //
+    // **TODO:** Evaluate how expensive this is in practice, and figure out a
+    // better tactic if need be.
+    //
+    // **TODO:** There is more to being valid than just being `isDocument()`,
+    // i.e. the ops themselves have to be valid in the contents of this project.
+    // That validity should also be enforced.
     if (!this._contents.isDocument()) {
       throw new Error(
         'Expected `contents` to be a "document" (insert-only delta).');

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -309,8 +309,8 @@ export default class DocControl extends CommonBase {
     // 5. Return the version number of `vNext` along with the delta
     //    `dCorrection`.
 
-    // (0) Assign variables from parameter and instance variables that
-    // correspond to the description immediately above.
+    // (0) Assign incoming arguments to variables that correspond to the
+    //     description immediately above.
     const dClient   = delta;
     const vBase     = base;
     const vExpected = expected;
@@ -327,7 +327,9 @@ export default class DocControl extends CommonBase {
     const dNext = FrozenDelta.coerce(dServer.transform(dClient, true));
 
     if (dNext.isEmpty()) {
-      // It turns out that nothing changed.
+      // It turns out that nothing changed. **Note:** It is unclear whether this
+      // can actually happen in practice, given that we already return early
+      // (in `applyDelta()`) if we are asked to apply an empty delta.
       return new DeltaResult(vCurrent.verNum, FrozenDelta.EMPTY);
     }
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.13.0
+version = 0.13.1


### PR DESCRIPTION
The main point of this PR is to get `applyDelta()` to validate the `delta` it's given instead of blithely passing through and storing invalid values. _Not_ doing this was a contributing factor to the difficulty of analyzing a couple of earlier bugs. In addition, this is objectively a correct and necessary place for validation to occur, assuming the usual adversarial model of the client.

Beyond the main change here, this PR contains cleanups and documentation/comment fixes.