### PR TITLE
New class for a new day

### DIFF
--- a/local-modules/typecheck-server/TBuffer.js
+++ b/local-modules/typecheck-server/TBuffer.js
@@ -1,0 +1,24 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TypeError } from 'typecheck';
+
+/**
+ * Type checker for type `Buffer`.
+ */
+export default class TBuffer {
+  /**
+   * Checks a value of type `Buffer`.
+   *
+   * @param {*} value The (alleged) `Buffer`.
+   * @returns {Buffer} `value`.
+   */
+  static check(value) {
+    if (!Buffer.isBuffer(value)) {
+      return TypeError.badValue(value, 'Buffer');
+    }
+
+    return value;
+  }
+}

--- a/local-modules/typecheck-server/main.js
+++ b/local-modules/typecheck-server/main.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import TBuffer from './TBuffer';
+
+export { TBuffer };

--- a/local-modules/typecheck-server/package.json
+++ b/local-modules/typecheck-server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typecheck-server",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "typecheck": "local"
+  }
+}

--- a/local-modules/util-server/FrozenBuffer.js
+++ b/local-modules/util-server/FrozenBuffer.js
@@ -1,0 +1,127 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import crypto from 'crypto';
+
+import { TInt, TypeError } from 'typecheck';
+import { TBuffer } from 'typecheck-server';
+import { CommonBase } from 'util-common';
+
+/** {string} Name of the hashing algorithm to use. */
+const HASH_NAME = 'sha256';
+
+/**
+ * Immutable buffer of data.
+ */
+export default class FrozenBuffer extends CommonBase {
+  /**
+   * Main coercion implementation, per the superclass documentation. In this
+   * case, it merely tries to construct an instance with the given argument.
+   *
+   * @param {Buffer|string} value The value to coerce.
+   * @returns {FrozenBuffer} The corresponding instance.
+   */
+  static _impl_coerce(value) {
+    // Note: The base class implementation guarantees that we won't get called
+    // on an instance of this class.
+    return new FrozenBuffer(value);
+  }
+
+  /**
+   * Constructs an instance. If constructed from a string, this converts it via
+   * UTF-8 encoding.
+   *
+   * @param {Buffer|string} value Contents of the buffer.
+   */
+  constructor(value) {
+    const isString = (typeof value === 'string');
+    const isBuffer = Buffer.isBuffer(value);
+
+    if (!(isString || isBuffer)) {
+      TypeError.badValue(value, 'Buffer|string');
+    }
+
+    super();
+
+    /** {string|null} String value, if constructed from a string. */
+    this._string = isString ? value : null;
+
+    /**
+     * {Buffer|null} Buffer value, if constructed from a buffer or if the
+     * string value has been converted. Guranteed to not be exposed outside
+     * this class. In particular, if the constructor was given a buffer for
+     * `value`, we clone it here to guarantee safe use.
+     */
+    this._buffer = isBuffer ? Buffer.from(value) : value;
+
+    /**
+     * {string|null} Hash code of the data, or `null` if not yet calculated.
+     */
+    this._hash = null;
+
+    Object.seal(this);
+  }
+
+  /** {string} The hash of the data. */
+  get hash() {
+    if (this._hash === null) {
+      const hash = crypto.createHash(HASH_NAME);
+
+      if (this._buffer !== null) {
+        hash.update(this._buffer);
+      } else {
+        hash.update(this._string, 'utf8');
+      }
+
+      this._hash = `${HASH_NAME}-${hash.digest('hex')}`;
+    }
+
+    return this._hash;
+  }
+
+  /** {Int} The length of the buffer in bytes. */
+  get length() {
+    const buf = this._ensureBuffer();
+    return buf.length;
+  }
+
+  /**
+   * {string} The contents of this buffer as a string. Buffer bytes are
+   * interpreted via UTF-8 decoding.
+   */
+  get string() {
+    if (this._string === null) {
+      this._string = this._buffer.toString('utf8');
+    }
+
+    return this._string;
+  }
+
+  /**
+   * Copies the contents of the buffer, or a portion thereof, into another
+   * buffer. Arguments and return value are all the same as the built-in method
+   * `Buffer.copy()`.
+   *
+   * @param {Buffer} target Destination of the copy.
+   * @param {Int} [targetStart = 0] Offset within `target` for the start of the
+   *   copy.
+   * @param {Int} [sourceStart = 0] Offset within `this` for the start of the
+   *   copy.
+   * @param {Int} [sourceEnd = this.length] Offset within `this` for the end of
+   *   the copy (exclusive).
+   * @returns {Int} The number of bytes copied. This will be `sourceEnd -
+   *   sourceStart` unless the target does not have that much space at
+   *   `targetStart`. In the latter case, a copy is made of whatever will fit
+   *   and the actual number of bytes copied is returned.
+   */
+  copy(target, targetStart = 0, sourceStart = 0, sourceEnd = this.length) {
+    TBuffer.check(target);
+    TInt.check(targetStart);
+    TInt.check(sourceStart);
+    TInt.check(sourceEnd);
+
+    const buf = this._ensureBuffer();
+    return buf.copy(target, targetStart, sourceStart, sourceEnd);
+  }
+}

--- a/local-modules/util-server/FrozenBuffer.js
+++ b/local-modules/util-server/FrozenBuffer.js
@@ -56,14 +56,23 @@ export default class FrozenBuffer extends CommonBase {
     this._buffer = isBuffer ? Buffer.from(value) : value;
 
     /**
-     * {string|null} Hash code of the data, or `null` if not yet calculated.
+     * {string|null} Hashcode of the data, or `null` if not yet calculated.
      */
     this._hash = null;
 
     Object.seal(this);
   }
 
-  /** {string} The hash of the data. */
+  /** {string} Name of the hashing algorithm used by this instance. */
+  get hashName() {
+    return HASH_NAME;
+  }
+
+  /**
+   * {string} Hashcode of the data. This is a string of the form
+   * `<algorithm>-<hex>`, where the former names the hashing algorithm used and
+   * the latter is the lowercase-hex value of the hashcode per se.
+   */
   get hash() {
     if (this._hash === null) {
       const hash = crypto.createHash(HASH_NAME);

--- a/local-modules/util-server/FrozenBuffer.js
+++ b/local-modules/util-server/FrozenBuffer.js
@@ -133,4 +133,17 @@ export default class FrozenBuffer extends CommonBase {
     const buf = this._ensureBuffer();
     return buf.copy(target, targetStart, sourceStart, sourceEnd);
   }
+
+  /**
+   * Ensures that `_buffer` has been set.
+   *
+   * @returns {Buffer} The value of `_buffer`.
+   */
+  _ensureBuffer() {
+    if (this._buffer === null) {
+      this._buffer = Buffer.from(this._string, 'utf8');
+    }
+
+    return this._buffer;
+  }
 }

--- a/local-modules/util-server/main.js
+++ b/local-modules/util-server/main.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import FrozenBuffer from './FrozenBuffer';
+
+export { FrozenBuffer };

--- a/local-modules/util-server/package.json
+++ b/local-modules/util-server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "util-server",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "typecheck": "local",
+    "typecheck-server": "local",
+    "util-common": "local"
+  }
+}


### PR DESCRIPTION
This PR introduces a new `FrozenBuffer` class, which is pretty much what it says. The idea is that we will be able to plumb instances of this class from the storage layer up through the higher layers of document interpretation, instead of using plain strings. Even though all we store right now are UTF-8-encoded strings, this arrangement will help us evolve beyond that when the time comes; and in the mean time we will still have all the good immutability guarantees that one would hope for with interface-crossing data-bearing objects.

**Note:** This PR introduces two new server-side modules, each of which has but a single export right now. I expect that both of these will probably grow over time.