### PR TITLE
Stub out new storage primitives.

### DIFF
--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -58,10 +58,10 @@ export default class LocalDoc extends BaseDoc {
     this._changesPromise = null;
 
     /**
-     * Does the document need to be written to disk? This is set to `true` on
-     * updates and back to `false` once the write has been done.
+     * Does the change array need to be written to disk? This is set to `true`
+     * on updates and back to `false` once the write has been done.
      */
-    this._dirty = false;
+    this._changesDirty = false;
 
     /**
      * Does the document need to be "migrated?" In this case, `true` indicates
@@ -197,7 +197,7 @@ export default class LocalDoc extends BaseDoc {
    * to actually perform the writing operation if one isn't already pending.
    */
   _changesNeedWrite() {
-    if (this._dirty) {
+    if (this._changesDirty) {
       // Already marked dirty, which means there's nothing more to do. When
       // the already-scheduled timer fires, it will pick up the current change.
       this._log.detail('Already marked dirty.');
@@ -206,7 +206,7 @@ export default class LocalDoc extends BaseDoc {
 
     // Mark the document dirty, and queue up the writer.
 
-    this._dirty = true;
+    this._changesDirty = true;
     this._log.detail(`Marked dirty at version ${this._changes.length}.`);
 
     // **TODO:** If we want to catch write errors (e.g. filesystem full), here
@@ -261,7 +261,7 @@ export default class LocalDoc extends BaseDoc {
     }
 
     // The usual case: Everything is fine.
-    this._dirty = false;
+    this._changesDirty = false;
     return true;
   }
 

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -180,7 +180,7 @@ export default class LocalDoc extends BaseDoc {
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
-  async _impl_write(path, oldValue, newValue) {
+  async _impl_op(path, oldValue, newValue) {
     // TODO: Implement this!
 
     // This keeps the linter happy.

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -170,6 +170,25 @@ export default class LocalDoc extends BaseDoc {
   }
 
   /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} path Path to write to.
+   * @param {FrozenBuffer} value Value to write.
+   * @returns {boolean} `true` if the write is successful, or `false` if it
+   *   failed due to the existence of a value mismatch.
+   */
+  async _impl_writeNew(path, value) {
+    // TODO: Implement this!
+
+    // This keeps the linter happy.
+    if ((path === value) || false) {
+      return false;
+    }
+
+    throw new Error('TODO');
+  }
+
+  /**
    * Indicates that the document is "dirty" and needs to be written. This
    * method acts (and returns) promptly. It will kick off a timed callback
    * to actually perform the writing operation if one isn't already pending.

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -107,7 +107,7 @@ export default class LocalDoc extends BaseDoc {
 
     // **Note:** This call _synchronously_ (and promptly) indicates that writing
     // needs to happen, but the actual writing takes place asynchronously.
-    this._needsWrite();
+    this._changesNeedWrite();
   }
 
   /**
@@ -154,7 +154,7 @@ export default class LocalDoc extends BaseDoc {
 
     // **Note:** This call _synchronously_ (and promptly) indicates that writing
     // needs to happen, but the actual writing takes place asynchronously.
-    this._needsWrite();
+    this._changesNeedWrite();
 
     return true;
   }
@@ -196,7 +196,7 @@ export default class LocalDoc extends BaseDoc {
    * method acts (and returns) promptly. It will kick off a timed callback
    * to actually perform the writing operation if one isn't already pending.
    */
-  _needsWrite() {
+  _changesNeedWrite() {
     if (this._dirty) {
       // Already marked dirty, which means there's nothing more to do. When
       // the already-scheduled timer fires, it will pick up the current change.
@@ -211,7 +211,7 @@ export default class LocalDoc extends BaseDoc {
 
     // **TODO:** If we want to catch write errors (e.g. filesystem full), here
     // is where we need to do it.
-    this._waitThenWrite();
+    this._waitThenWriteChanges();
   }
 
   /**
@@ -224,7 +224,7 @@ export default class LocalDoc extends BaseDoc {
    *
    * @returns {true} `true`, upon successful writing.
    */
-  async _waitThenWrite() {
+  async _waitThenWriteChanges() {
     // Wait for the prescribed amount of time.
     await PromDelay.resolve(DIRTY_DELAY_MSEC);
 
@@ -257,7 +257,7 @@ export default class LocalDoc extends BaseDoc {
       // The document was modified while writing was underway. We just recurse
       // to guarantee that the new version isn't lost.
       this._log.info('Document modified during write operation.');
-      return this._waitThenWrite();
+      return this._waitThenWriteChanges();
     }
 
     // The usual case: Everything is fine.

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -173,15 +173,18 @@ export default class LocalDoc extends BaseDoc {
    * Implementation as required by the superclass.
    *
    * @param {string} path Path to write to.
-   * @param {FrozenBuffer} value Value to write.
+   * @param {FrozenBuffer|null} oldValue Value expected to be stored at `path`
+   *   at the moment of writing, or `null` if `path` is expected to have nothing
+   *   stored at it.
+   * @param {FrozenBuffer} newValue Value to write.
    * @returns {boolean} `true` if the write is successful, or `false` if it
-   *   failed due to the existence of a value mismatch.
+   *   failed due to value mismatch.
    */
-  async _impl_writeNew(path, value) {
+  async _impl_write(path, oldValue, newValue) {
     // TODO: Implement this!
 
     // This keeps the linter happy.
-    if ((path === value) || false) {
+    if ((path + oldValue + newValue) === null) {
       return false;
     }
 

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -319,5 +319,4 @@ export default class BaseDoc extends CommonBase {
   async _impl_op(path, oldValue, newValue) {
     return this._mustOverride(path, oldValue, newValue);
   }
-
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -6,6 +6,9 @@ import { DocumentChange, FrozenDelta, Timestamp, VersionNumber }
   from 'doc-common';
 import { TBoolean, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
+import { FrozenBuffer } from 'util-server';
+
+import StoragePath from './StoragePath';
 
 /**
  * Base class representing access to a particular document. Subclasses must
@@ -237,5 +240,37 @@ export default class BaseDoc extends CommonBase {
    */
   async _impl_needsMigration() {
     return this._mustOverride();
+  }
+
+  /**
+   * Writes a value at the indicated path, failing if there is already any
+   * value at the path other than the given one. In case of value-mismatch
+   * failure, this method returns `false`. All other problems are indicated by
+   * throwing errors.
+   *
+   * @param {string} path Path to write to.
+   * @param {FrozenBuffer} value Value to write.
+   * @returns {boolean} `true` if the write is successful, or `false` if it
+   *   failed due to the existence of a value mismatch.
+   */
+  async writeNew(path, value) {
+    StoragePath.check(path);
+    FrozenBuffer.check(value);
+
+    return this._impl_writeNew(path, value);
+  }
+
+  /**
+   * Main implementation of `writeNew()`. Arguments are guaranteed by the
+   * superclass to be valid.
+   *
+   * @abstract
+   * @param {string} path Path to write to.
+   * @param {FrozenBuffer} value Value to write.
+   * @returns {boolean} `true` if the write is successful, or `false` if it
+   *   failed due to the existence of a value mismatch.
+   */
+  async _impl_writeNew(path, value) {
+    return this._mustOverride(path, value);
   }
 }

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -254,7 +254,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {boolean} `true` if the delete is successful, or `false` if it
    *   failed due to `path` having an unexpected value.
    */
-  async writeDelete(path, oldValue) {
+  async opDelete(path, oldValue) {
     StoragePath.check(path);
     FrozenBuffer.check(oldValue);
 
@@ -271,7 +271,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to `path` already having a value.
    */
-  async writeNew(path, newValue) {
+  async opNew(path, newValue) {
     StoragePath.check(path);
     FrozenBuffer.check(newValue);
 
@@ -291,7 +291,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
-  async writeReplace(path, oldValue, newValue) {
+  async opReplace(path, oldValue, newValue) {
     StoragePath.check(path);
     FrozenBuffer.check(oldValue);
     FrozenBuffer.check(newValue);
@@ -300,10 +300,11 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
-   * Main implementation of `writeDelete()`, `writeNew()`, and `writeReplace()`.
-   * Arguments are guaranteed by the superclass to be valid. `null` for
-   * `oldValue` corresponds to a `writeNew()` operation. `null` for `newValue`
-   * corresponds to a `writeDelete()` operation.
+   * Performs an operation on the document. This is the main implementation of
+   * `opDelete()`, `opNew()`, and `opReplace()`. Arguments are guaranteed by the
+   * superclass to be valid. Passing `null` for `oldValue` corresponds to the
+   * `opNew()` operation. Passing `null` for `newValue` corresponds to the
+   * `opDelete()` operation.
    *
    * @abstract
    * @param {string} path Path to write to.
@@ -315,7 +316,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
-  async _impl_write(path, oldValue, newValue) {
+  async _impl_op(path, oldValue, newValue) {
     return this._mustOverride(path, oldValue, newValue);
   }
 

--- a/local-modules/doc-store/StoragePath.js
+++ b/local-modules/doc-store/StoragePath.js
@@ -1,0 +1,91 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray, TString, TypeError } from 'typecheck';
+
+/**
+ * {RegEx} Regular expression which passes for all valid path component strings.
+ */
+const COMPONENT_REGEX = /^[a-zA-Z0-9_]+$/;
+
+/**
+ * {RegEx} Regular expression which passes for all valid path strings.
+ */
+const PATH_REGEX = /^(\/[a-zA-Z0-9_]+)+$/;
+
+/**
+ * Utility class for handling storage paths. A storage path is a
+ * hierarchical-filesystem-like path which provides a stable name for a chunk of
+ * data within a document. A valid path is a string consisting of one or more
+ * components, where each component is a slash (`/`) followed by a sequence of
+ * one or more characters in the usual "identifier" set (`[a-zA-Z0-9_]`).
+ *
+ * * Example path: `/foo_1/bar/baz/23`
+ * * Example component: `puffin_biscuit_7`
+ */
+export default class StoragePath {
+  /**
+   * Validates that the given value is a valid storage path string. Throws an
+   * error if not.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is in fact a valid storage path string.
+   */
+  static check(value) {
+    TString.nonempty(value);
+
+    if (!PATH_REGEX.test(value)) {
+      return TypeError.badValue(value, 'StoragePath');
+    }
+
+    return value;
+  }
+
+  /**
+   * Validates that the given value is a valid storage path component. Throws an
+   * error if not. Components are as defined in the class-level documentation
+   * and notably must _not_ contain any slashes (`/`).
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is in fact a valid storage path component.
+   */
+  static checkComponent(value) {
+    TString.nonempty(value);
+
+    if (!COMPONENT_REGEX.test(value)) {
+      return TypeError.badValue(value, 'StoragePath component');
+    }
+
+    return value;
+  }
+
+  /**
+   * Joins an array of components into a single storage path string. Components
+   * must _not_ include slashes (`/`). This operation is the inverse of
+   * `split()`.
+   *
+   * @param {array<string>} components Array of path components.
+   * @returns {string} Unified storage path of all the `components`.
+   */
+  static join(components) {
+    TArray.check(components, StoragePath.checkComponent);
+    return `/${components.join('/')}`;
+  }
+
+  /**
+   * Splits a storage path into individual components. Resulting components are
+   * just the names and do not contain any slash separators. This operation is
+   * the inverse of `join()`.
+   *
+   * @param {string} path Storage path.
+   * @returns {Array<string>} Array consisting of the components of `path`.
+   */
+  static split(path) {
+    StoragePath.check(path);
+
+    // Slice off the initial `/` because otherwise, the first element of the
+    // result is an empty string.
+    return path.slice(1).split('/');
+  }
+}

--- a/local-modules/doc-store/main.js
+++ b/local-modules/doc-store/main.js
@@ -4,5 +4,6 @@
 
 import BaseDoc from './BaseDoc';
 import BaseDocStore from './BaseDocStore';
+import StoragePath from './StoragePath';
 
-export { BaseDoc, BaseDocStore };
+export { BaseDoc, BaseDocStore, StoragePath };

--- a/local-modules/doc-store/package.json
+++ b/local-modules/doc-store/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "doc-common": "local",
     "typecheck": "local",
-    "util-common": "local"
+    "util-common": "local",
+    "util-server": "local"
   }
 }


### PR DESCRIPTION
This PR adds a stubbed-out interface which kicks off the process of making the `doc-store` module increasingly agnostic with respect to how a document is structured. None of this new code is used yet; I just figured it would be better to introduce it and start using it in separate PRs, even though the first uses very well might induce changes in the interface.
