### PR TITLE
Fill in the new storage implementation.

### DIFF
--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -75,7 +75,7 @@ export default class LocalDoc extends BaseDoc {
      * to disk. This is set to `true` when updates are made and back to `false`
      * once the writing has been done.
      */
-    this._storageDirty = false;
+    this._storageIsDirty = false;
 
     /**
      * {Promise<true>|null} Promise which resolves to `true` if `_storage` is
@@ -439,7 +439,7 @@ export default class LocalDoc extends BaseDoc {
     this._storage             = storage;
     this._dirtyValues         = new Map();
     this._storageNeedsErasing = false;
-    this._storageDirty        = false;
+    this._storageIsDirty      = false;
 
     return true;
   }
@@ -451,7 +451,7 @@ export default class LocalDoc extends BaseDoc {
    * pending.
    */
   _storageNeedsWrite() {
-    if (this._storageDirty) {
+    if (this._storageIsDirty) {
       // Already marked dirty, which means there's nothing more to do. When
       // the already-scheduled timer fires, it will pick up the current change.
       this._log.detail('Storage already marked dirty.');
@@ -460,7 +460,7 @@ export default class LocalDoc extends BaseDoc {
 
     // Mark the storage dirty, and queue up the writer.
 
-    this._storageDirty = true;
+    this._storageIsDirty = true;
 
     if (this._storageNeedsErasing) {
       this._log.info(`Storage will be erased.`);
@@ -493,7 +493,7 @@ export default class LocalDoc extends BaseDoc {
     const storageNeedsErasing = this._storageNeedsErasing;
     const dirtyValues         = this._dirtyValues;
 
-    this._storageDirty        = false;
+    this._storageIsDirty      = false;
     this._storageNeedsErasing = false;
     this._dirtyValues         = new Map();
 
@@ -537,7 +537,7 @@ export default class LocalDoc extends BaseDoc {
     // Check to see if more updates happened while the writing was being done.
     // If so, recurse to iterate.
 
-    if (this._storageDirty) {
+    if (this._storageIsDirty) {
       return this._waitThenWriteStorage();
     }
 

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -62,7 +62,7 @@ export default class LocalDoc extends BaseDoc {
      * corresponding stored data, for document contents that have not yet been
      * written to disk.
      */
-    this._dirtyValues = new Map();
+    this._storageToWrite = new Map();
 
     /**
      * {boolean} Whether or not the storage directory should be totally erased
@@ -157,7 +157,7 @@ export default class LocalDoc extends BaseDoc {
     }
 
     this._storage             = new Map();
-    this._dirtyValues         = new Map();
+    this._storageToWrite      = new Map();
     this._storageNeedsErasing = true;
     this._storageReadyPromise = Promise.resolve(true);
 
@@ -437,7 +437,7 @@ export default class LocalDoc extends BaseDoc {
 
     // Only set the instance variables after all the reading is done.
     this._storage             = storage;
-    this._dirtyValues         = new Map();
+    this._storageToWrite      = new Map();
     this._storageNeedsErasing = false;
     this._storageIsDirty      = false;
 
@@ -465,7 +465,7 @@ export default class LocalDoc extends BaseDoc {
     if (this._storageNeedsErasing) {
       this._log.info(`Storage will be erased.`);
     }
-    this._log.info(`Value(s) to write: ${this._dirtyValues.size}`);
+    this._log.info(`Value(s) to write: ${this._storageToWrite.size}`);
 
     // **TODO:** If we want to catch write errors (e.g. filesystem full), here
     // is where we need to do it.
@@ -491,11 +491,11 @@ export default class LocalDoc extends BaseDoc {
     // if the dirty flag got flipped back on, and if so iterate.
 
     const storageNeedsErasing = this._storageNeedsErasing;
-    const dirtyValues         = this._dirtyValues;
+    const dirtyValues         = this._storageToWrite;
 
     this._storageIsDirty      = false;
     this._storageNeedsErasing = false;
-    this._dirtyValues         = new Map();
+    this._storageToWrite      = new Map();
 
     // Erase and/or create the storage directory as needed.
 

--- a/local-modules/doc-store-local/LocalDocStore.js
+++ b/local-modules/doc-store-local/LocalDocStore.js
@@ -79,7 +79,7 @@ export default class LocalDocStore extends BaseDocStore {
    * @returns {string} The corresponding filesystem path.
    */
   _documentPath(docId) {
-    return path.resolve(this._dir, `${docId}.json`);
+    return path.resolve(this._dir, docId);
   }
 
   /**

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -248,17 +248,17 @@ export default class BaseDoc extends CommonBase {
    * method returns `false`. All other problems are indicated by throwing
    * errors.
    *
-   * @param {string} path Path to write to.
+   * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer} oldValue Value expected to be stored at `path` at the
    *   moment of deletion.
    * @returns {boolean} `true` if the delete is successful, or `false` if it
    *   failed due to `path` having an unexpected value.
    */
-  async opDelete(path, oldValue) {
-    StoragePath.check(path);
+  async opDelete(storagePath, oldValue) {
+    StoragePath.check(storagePath);
     FrozenBuffer.check(oldValue);
 
-    return this._impl_write(path, oldValue, null);
+    return this._impl_write(storagePath, oldValue, null);
   }
 
   /**
@@ -266,16 +266,16 @@ export default class BaseDoc extends CommonBase {
    * value stored at the path. If there is already a value, this method returns
    * `false`. All other problems are indicated by throwing errors.
    *
-   * @param {string} path Path to write to.
+   * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer} newValue Value to write.
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to `path` already having a value.
    */
-  async opNew(path, newValue) {
-    StoragePath.check(path);
+  async opNew(storagePath, newValue) {
+    StoragePath.check(storagePath);
     FrozenBuffer.check(newValue);
 
-    return this._impl_write(path, null, newValue);
+    return this._impl_write(storagePath, null, newValue);
   }
 
   /**
@@ -284,19 +284,19 @@ export default class BaseDoc extends CommonBase {
    * failure, this method returns `false`. All other problems are indicated by
    * throwing errors.
    *
-   * @param {string} path Path to write to.
+   * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer} oldValue Value expected to be stored at `path` at the
    *   moment of writing.
    * @param {FrozenBuffer} newValue Value to write.
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
-  async opReplace(path, oldValue, newValue) {
-    StoragePath.check(path);
+  async opReplace(storagePath, oldValue, newValue) {
+    StoragePath.check(storagePath);
     FrozenBuffer.check(oldValue);
     FrozenBuffer.check(newValue);
 
-    return this._impl_write(path, oldValue, newValue);
+    return this._impl_write(storagePath, oldValue, newValue);
   }
 
   /**
@@ -307,7 +307,7 @@ export default class BaseDoc extends CommonBase {
    * `opDelete()` operation.
    *
    * @abstract
-   * @param {string} path Path to write to.
+   * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer|null} oldValue Value expected to be stored at `path`
    *   at the moment of writing, or `null` if `path` is expected to have nothing
    *   stored at it.
@@ -316,7 +316,7 @@ export default class BaseDoc extends CommonBase {
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
-  async _impl_op(path, oldValue, newValue) {
-    return this._mustOverride(path, oldValue, newValue);
+  async _impl_op(storagePath, oldValue, newValue) {
+    return this._mustOverride(storagePath, oldValue, newValue);
   }
 }

--- a/local-modules/util-server/FrozenBuffer.js
+++ b/local-modules/util-server/FrozenBuffer.js
@@ -135,6 +135,20 @@ export default class FrozenBuffer extends CommonBase {
   }
 
   /**
+   * Tests whether this and another instance have the same contents.
+   *
+   * @param {FrozenBuffer} other Buffer to compare to.
+   * @returns {boolean} `true` iff `this` and `other` have the same contents.
+   */
+  equals(other) {
+    FrozenBuffer.check(other);
+
+    const thisBuf = this._ensureBuffer();
+    const otherBuf = other._ensureBuffer();
+    return thisBuf.equals(otherBuf);
+  }
+
+  /**
    * Gets a fresh `Buffer` with the contents of this instance.
    *
    * @returns {Buffer} A buffer whose contents match this instance's.

--- a/local-modules/util-server/FrozenBuffer.js
+++ b/local-modules/util-server/FrozenBuffer.js
@@ -135,6 +135,15 @@ export default class FrozenBuffer extends CommonBase {
   }
 
   /**
+   * Gets a fresh `Buffer` with the contents of this instance.
+   *
+   * @returns {Buffer} A buffer whose contents match this instance's.
+   */
+  toBuffer() {
+    return Buffer.from(this._ensureBuffer());
+  }
+
+  /**
    * Ensures that `_buffer` has been set.
    *
    * @returns {Buffer} The value of `_buffer`.


### PR DESCRIPTION
This PR is another step in the process of reworking the lowest level of the storage interface. As with the last PR, this one implements code which is not yet used (except trivially). There is a _bit_ of duplication of effort in the now, which will — of course — be addressed in a later PR in the series.