### PR TITLE
Use new-style storage for version numbers, and sorta-kinda for changes.

### DIFF
--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -20,6 +20,16 @@ import VersionNumber from './VersionNumber';
  */
 export default class DocumentChange extends CommonBase {
   /**
+   * Gets the appropriate first change to a document (empty delta, no author)
+   * for the current moment in time.
+   *
+   * @returns {FrozenDelta} An appropriate initial change.
+   */
+  static firstChange() {
+    return new DocumentChange(0, Timestamp.now(), FrozenDelta.EMPTY, null);
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {Int} verNum The version number of the document produced by this

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -95,7 +95,7 @@ export default class DocControl extends CommonBase {
    * @returns {Snapshot} The corresponding snapshot.
    */
   async snapshot(verNum = null) {
-    const currentVerNum = await this._doc.currentVerNum();
+    const currentVerNum = await this._currentVerNum();
     verNum = (verNum === null)
       ? currentVerNum
       : VersionNumber.maxInc(verNum, currentVerNum);
@@ -144,7 +144,7 @@ export default class DocControl extends CommonBase {
    *   version `baseVerNum` to produce version `verNum` of the document.
    */
   async deltaAfter(baseVerNum) {
-    const currentVerNum = await this._doc.currentVerNum();
+    const currentVerNum = await this._currentVerNum();
     VersionNumber.maxInc(baseVerNum, currentVerNum);
 
     if (baseVerNum !== currentVerNum) {
@@ -361,7 +361,7 @@ export default class DocControl extends CommonBase {
    * given initial version through and including the current latest delta,
    * composed from a given base. It is valid to pass as either version number
    * parameter one version beyond the current version number (that is,
-   * `VersionNumber.after(await this._doc.currentVerNum())`. It is invalid to
+   * `VersionNumber.after(await this._currentVerNum())`. It is invalid to
    * specify a non-existent version _other_ than one beyond the current version.
    * If `startInclusive === endExclusive`, then this method returns `baseDelta`.
    *
@@ -376,7 +376,7 @@ export default class DocControl extends CommonBase {
    *   `endExclusive`.
    */
   async _composeVersions(baseDelta, startInclusive, endExclusive) {
-    const nextVerNum = VersionNumber.after(await this._doc.currentVerNum());
+    const nextVerNum = VersionNumber.after(await this._currentVerNum());
     startInclusive = VersionNumber.rangeInc(startInclusive, 0, nextVerNum);
     endExclusive =
       VersionNumber.rangeInc(endExclusive, startInclusive, nextVerNum);
@@ -448,12 +448,12 @@ export default class DocControl extends CommonBase {
   /**
    * Gets the current document version number.
    *
-   * @returns {VersionNumber} The version number.
+   * @returns {VersionNumber|null} The version number, or `null` if it is not
+   *   set.
    */
   async _currentVerNum() {
-    const encoded = await this._doc.pathRead(VERSION_PATH);
-
-    return Decoder.decodeJson(encoded.string);
+    const encoded = await this._doc.pathReadOrNull(VERSION_PATH);
+    return (encoded === null) ? null : Decoder.decodeJson(encoded.string);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -48,10 +48,10 @@ export default class DocControl extends CommonBase {
     this._doc = BaseDoc.check(docStorage);
 
     /**
-     * Mapping from version numbers to corresponding document snapshots.
-     * Sparse.
+     * {Map<VersionNumber,Snapshot>} Mapping from version numbers to
+     * corresponding document snapshots. Sparse.
      */
-    this._snapshots = {};
+    this._snapshots = new Map();
 
     /**
      * Condition that transitions from `false` to `true` when there is a version
@@ -103,7 +103,7 @@ export default class DocControl extends CommonBase {
     // composition.
     let base = null;
     for (let i = verNum; i >= 0; i--) {
-      const v = this._snapshots[i];
+      const v = this._snapshots.get(i);
       if (v) {
         base = v;
         break;
@@ -125,7 +125,7 @@ export default class DocControl extends CommonBase {
 
     this._log.detail(`Made snapshot for version ${verNum}.`);
 
-    this._snapshots[verNum] = result;
+    this._snapshots.set(verNum, result);
     return result;
   }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -11,11 +11,10 @@ import { TString } from 'typecheck';
 import { CommonBase, PromCondition, PromDelay } from 'util-common';
 import { FrozenBuffer } from 'util-server';
 
+import Paths from './Paths';
+
 /** {Logger} Logger for this module. */
 const log = new Logger('doc-control');
-
-/** {string} `StoragePath` string for where the document version number goes. */
-const VERSION_PATH = '/version_number';
 
 /** {number} Initial amount of time (in msec) between append retries. */
 const INITIAL_APPEND_RETRY_MSEC = 50;
@@ -452,7 +451,7 @@ export default class DocControl extends CommonBase {
    *   set.
    */
   async _currentVerNum() {
-    const encoded = await this._doc.pathReadOrNull(VERSION_PATH);
+    const encoded = await this._doc.pathReadOrNull(Paths.VERSION_NUMBER);
     return (encoded === null) ? null : Decoder.decodeJson(encoded.string);
   }
 
@@ -467,7 +466,7 @@ export default class DocControl extends CommonBase {
 
     const encoded = FrozenBuffer.coerce(Encoder.encodeJson(verNum));
 
-    await this._doc.opForceWrite(VERSION_PATH, encoded);
+    await this._doc.opForceWrite(Paths.VERSION_NUMBER, encoded);
     return true;
   }
 }

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -13,9 +13,7 @@ import { Singleton } from 'util-common';
 import { FrozenBuffer } from 'util-server';
 
 import DocControl from './DocControl';
-
-/** {string} `StoragePath` string for where the document format version goes. */
-const FORMAT_PATH = '/format_version';
+import Paths from './Paths';
 
 /** {FrozenDelta} Message used as document instead of migrating old versions. */
 const MIGRATION_NOTE = FrozenDelta.coerce(
@@ -106,7 +104,8 @@ export default class DocServer extends Singleton {
     if (docExists) {
       docLog.info('Retrieving from storage.');
 
-      const formatVersion = await docStorage.pathReadOrNull(FORMAT_PATH);
+      const formatVersion =
+        await docStorage.pathReadOrNull(Paths.FORMAT_VERSION);
       let docIsValid = false;
 
       if (formatVersion === null) {
@@ -139,7 +138,7 @@ export default class DocServer extends Singleton {
 
       // Initialize the document.
       await docStorage.create();
-      await docStorage.opNew(FORMAT_PATH, this._formatVersion);
+      await docStorage.opNew(Paths.FORMAT_VERSION, this._formatVersion);
 
       // Static content for the first change (for now).
       const delta = docNeedsMigrate ? MIGRATION_NOTE : DEFAULT_DOCUMENT;

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -144,7 +144,8 @@ export default class DocServer extends Singleton {
       await docStorage.create();
       await docStorage.opNew(Paths.FORMAT_VERSION, this._formatVersion);
 
-      // Static content for the first change (for now).
+      // Empty first change (per documented interface) and static content for
+      // the first contentful change (for now).
       const delta = docNeedsMigrate ? MIGRATION_NOTE : DEFAULT_DOCUMENT;
       const change = new DocumentChange(1, Timestamp.now(), delta, null);
       await docStorage.opNew(Paths.forVerNum(0), Coder.encode(DocumentChange.firstChange()));

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { VersionNumber } from 'doc-common';
+
 /**
  * Utility class that just provides the common `StoragePath` strings used
  * by the document storage format.
@@ -15,5 +17,18 @@ export default class Paths {
   /** {string} `StoragePath` string for the document version number. */
   static get VERSION_NUMBER() {
     return '/version_number';
+  }
+
+  /**
+   * Gets the `StoragePath` string corresponding to the indicated version
+   * number, specifically to store the document change that results in that
+   * version.
+   *
+   * @param {VersionNumber} verNum The version number.
+   * @returns {string} The corresponding `StoragePath` string.
+   */
+  static forVerNum(verNum) {
+    VersionNumber.check(verNum);
+    return `/change/${verNum}`;
   }
 }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -1,0 +1,19 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Utility class that just provides the common `StoragePath` strings used
+ * by the document storage format.
+ */
+export default class Paths {
+  /** {string} `StoragePath` string for the document format version. */
+  static get FORMAT_VERSION() {
+    return '/format_version';
+  }
+
+  /** {string} `StoragePath` string for the document version number. */
+  static get VERSION_NUMBER() {
+    return '/version_number';
+  }
+}

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "weak": "^1.0.1",
 
+    "api-common": "local",
     "doc-common": "local",
     "doc-store": "local",
     "hooks-server": "local",

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -12,6 +12,7 @@
     "see-all": "local",
     "server-env": "local",
     "typecheck": "local",
-    "util-common": "local"
+    "util-common": "local",
+    "util-server": "local"
   }
 }

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -214,13 +214,29 @@ export default class LocalDoc extends BaseDoc {
   }
 
   /**
+  * Implementation as required by the superclass.
+   *
+   * @param {string} storagePath Path to write to.
+   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
+   *   at `path` is to be deleted.
+   * @returns {boolean} `true` once the write operation is complete.
+   */
+  async _impl_forceOp(storagePath, newValue) {
+    await this._readStorageIfNecessary();
+
+    this._storeOrDeleteValue(storagePath, newValue);
+    return true;
+  }
+
+  /**
    * Implementation as required by the superclass.
    *
    * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer|null} oldValue Value expected to be stored at `path`
    *   at the moment of writing, or `null` if `path` is expected to have nothing
    *   stored at it.
-   * @param {FrozenBuffer} newValue Value to write.
+   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
+   *   at `path` is to be deleted.
    * @returns {boolean} `true` if the write is successful, or `false` if it
    *   failed due to value mismatch.
    */
@@ -238,10 +254,26 @@ export default class LocalDoc extends BaseDoc {
       }
     }
 
-    this._storage.set(storagePath, newValue);
+    this._storeOrDeleteValue(storagePath, newValue);
+    return true;
+  }
+
+  /**
+   * Helper for the update methods, which performs the actual updating.
+   *
+   * @param {string} storagePath Path to write to.
+   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
+   *   at `path` is to be deleted.
+   */
+  _storeOrDeleteValue(storagePath, newValue) {
+    if (newValue === null) {
+      this._storage.delete(storagePath);
+    } else {
+      this._storage.set(storagePath, newValue);
+    }
+
     this._storageToWrite.set(storagePath, newValue);
     this._storageNeedsWrite();
-    return true;
   }
 
   /**

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -167,17 +167,6 @@ export default class LocalDoc extends BaseDoc {
   /**
    * Implementation as required by the superclass.
    *
-   * @returns {Int|null} The version number of this document.
-   */
-  async _impl_currentVerNum() {
-    await this._readChangesIfNecessary();
-    const len = this._changes.length;
-    return (len === 0) ? null : (len - 1);
-  }
-
-  /**
-   * Implementation as required by the superclass.
-   *
    * @param {Int} verNum The version number for the desired change.
    * @returns {DocumentChange} The change with `verNum` as indicated.
    */

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -94,45 +94,6 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
-   * Gets the current version number of this document. This is the largest value
-   * `n` for which `this.changeRead(n)` is definitely valid. It is only valid
-   * to call this method on a document that exists and has valid data.
-   *
-   * With regard to "definitely" above, at the moment a call to this method is
-   * complete, it is possible for there to _already_ be document changes in
-   * flight, which will be serviced asynchronously. This notably means that,
-   * should the result of a call to this method be subsequently used as part of
-   * an _asynchronous_ call, by the time that _that_ call is executed, the
-   * current version number may no longer be the same. Hence, it is imperative
-   * for code to _not_ assume a stable version number when any asynchrony is
-   * possible.
-   *
-   * @returns {Int} The current version number of this document.
-   */
-  async currentVerNum() {
-    const result = VersionNumber.orNull(await this._impl_currentVerNum());
-
-    if (result === null) {
-      throw new Error('Document is empty, invalid, or in need of migration.');
-    }
-
-    return result;
-  }
-
-  /**
-   * Main implementation of `currentVerNum()`. This method can be called without
-   * error whether or not the document exists (as opposed to `currentVerNum()`);
-   * for a non-existent or empty document, this method returns `null`.
-   *
-   * @abstract
-   * @returns {Int|null} The version number of this document or `null` if the
-   *   document is empty, invalid, or in need of migration.
-   */
-  async _impl_currentVerNum() {
-    return this._mustOverride();
-  }
-
-  /**
    * Reads a change, by version number. It is an error to request a change that
    * does not exist on the document. If called on a non-existent document, this
    * method does _not_ cause that document to be created.

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -218,6 +218,49 @@ export default class BaseDoc extends CommonBase {
   }
 
   /**
+   * Deletes the value at the indicated path, if any, and without regard to
+   * what value it might have stored.
+   *
+   * @param {string} storagePath Path to write to.
+   * @returns {boolean} `true` once the operation is complete.
+   */
+  async opForceDelete(storagePath) {
+    StoragePath.check(storagePath);
+
+    return this._impl_forceOp(storagePath, null);
+  }
+
+  /**
+   * Writes a value at the indicated path, without regard to whether there was
+   * a value already at the path, nor what value was already stored if any.
+   *
+   * @param {string} storagePath Path to write to.
+   * @param {FrozenBuffer} newValue Value to write.
+   * @returns {boolean} `true` once the operation is complete.
+   */
+  async opForceWrite(storagePath, newValue) {
+    StoragePath.check(storagePath);
+
+    return this._impl_forceOp(storagePath, newValue);
+  }
+
+  /**
+   * Performs a forced-modification operation on the document. This is the main
+   * implementation of `opForceDelete()` and `opForceWrite()`. Arguments are
+   * guaranteed by the superclass to be valid. Passing `null` for `newValue`
+   * corresponds to the `opForceDelete()` operation.
+   *
+   * @abstract
+   * @param {string} storagePath Path to write to.
+   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
+   *   at `path` is to be deleted.
+   * @returns {boolean} `true` once the write operation is complete.
+   */
+  async _impl_forceOp(storagePath, newValue) {
+    return this._mustOverride(storagePath, newValue);
+  }
+
+  /**
    * Deletes the value at the indicated path, failing if it is not the indicated
    * value at the time of deletion. If the expected value doesn't match, this
    * method returns `false`. All other problems are indicated by throwing

--- a/local-modules/doc-store/BaseDoc.js
+++ b/local-modules/doc-store/BaseDoc.js
@@ -2,8 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { DocumentChange, FrozenDelta, Timestamp, VersionNumber }
-  from 'doc-common';
+import { DocumentChange, VersionNumber } from 'doc-common';
 import { TBoolean, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 import { FrozenBuffer } from 'util-server';
@@ -20,16 +19,6 @@ import StoragePath from './StoragePath';
  * zero-based integer sequence. Changes are random-access.
  */
 export default class BaseDoc extends CommonBase {
-  /**
-   * Gets the appropriate first change to a document (empty delta) for the
-   * current moment in time.
-   *
-   * @returns {FrozenDelta} An appropriate initial change.
-   */
-  static _firstChange() {
-    return new DocumentChange(0, Timestamp.now(), FrozenDelta.EMPTY, null);
-  }
-
   /**
    * Constructs an instance.
    *
@@ -78,7 +67,7 @@ export default class BaseDoc extends CommonBase {
    * is empty.)
    */
   async create() {
-    this._impl_create(BaseDoc._firstChange());
+    this._impl_create(DocumentChange.firstChange());
   }
 
   /**

--- a/local-modules/doc-store/Coder.js
+++ b/local-modules/doc-store/Coder.js
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Decoder, Encoder } from 'api-common';
+import { FrozenBuffer } from 'util-server';
+
+/**
+ * Utility class for converting between arbitrary values and their stored
+ * form as `FrozenBuffer`s.
+ */
+export default class Coder {
+  /**
+   * Encodes an arbitrary value using API coding, and converts it to a
+   * `FrozenBuffer`.
+   *
+   * @param {*} value Value to encode.
+   * @returns {FrozenBuffer} Encoded and bufferized value.
+   */
+  static encode(value) {
+    return FrozenBuffer.coerce(Encoder.encodeJson(value));
+  }
+
+  /**
+   * Decodes a buffer, interpreting it via the API coding.
+   *
+   * @param {FrozenBuffer} encoded Value to decode.
+   * @returns {*} Decoded value.
+   */
+  static decode(encoded) {
+    FrozenBuffer.check(encoded);
+    return Decoder.decodeJson(encoded.string);
+  }
+}

--- a/local-modules/doc-store/main.js
+++ b/local-modules/doc-store/main.js
@@ -4,6 +4,7 @@
 
 import BaseDoc from './BaseDoc';
 import BaseDocStore from './BaseDocStore';
+import Coder from './Coder';
 import StoragePath from './StoragePath';
 
-export { BaseDoc, BaseDocStore, StoragePath };
+export { BaseDoc, BaseDocStore, Coder, StoragePath };

--- a/local-modules/doc-store/package.json
+++ b/local-modules/doc-store/package.json
@@ -4,6 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
+    "api-common": "local",
     "doc-common": "local",
     "typecheck": "local",
     "util-common": "local",

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.14.0
+version = 0.14.1


### PR DESCRIPTION
This PR is another step along the path of migrating the low-level document storage away toward a generic key-value (and eventually CAS) model. The main things happening here are that a document's version number is now represented in the new storage style, as are all of the individual changes. In the latter case, though, changes are being stored both in the old and new ways, and it's still the old way that's used when reading them in; as usual, this will get cleaned up in a later PR in this series.