### PR TITLE
Follow-up format tweak, tangentially related tweak, and async fix.

### DIFF
--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -120,7 +120,7 @@ export default class DocControl extends CommonBase {
     }
 
     const revNum = (contents === null) ? 0 : 1;
-    await this._doc.opNew(Paths.VERSION_NUMBER, Coder.encode(revNum));
+    await this._doc.opNew(Paths.REVISION_NUMBER, Coder.encode(revNum));
 
     // Any cached snapshots are no longer valid.
     this._snapshots = new Map();
@@ -217,7 +217,7 @@ export default class DocControl extends CommonBase {
     }
 
     const revNumEncoded =
-      await this._doc.pathReadOrNull(Paths.VERSION_NUMBER);
+      await this._doc.pathReadOrNull(Paths.REVISION_NUMBER);
 
     if (revNumEncoded === null) {
       this._log.info('Corrupt document: Missing revision number.');
@@ -581,7 +581,7 @@ export default class DocControl extends CommonBase {
    *   set.
    */
   async _currentRevNum() {
-    const encoded = await this._doc.pathReadOrNull(Paths.VERSION_NUMBER);
+    const encoded = await this._doc.pathReadOrNull(Paths.REVISION_NUMBER);
     return (encoded === null) ? null : Coder.decode(encoded);
   }
 
@@ -594,7 +594,7 @@ export default class DocControl extends CommonBase {
   async _writeRevNum(revNum) {
     RevisionNumber.check(revNum);
 
-    await this._doc.opForceWrite(Paths.VERSION_NUMBER, Coder.encode(revNum));
+    await this._doc.opForceWrite(Paths.REVISION_NUMBER, Coder.encode(revNum));
     return true;
   }
 }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -15,8 +15,8 @@ export default class Paths {
   }
 
   /** {string} `StoragePath` string for the document revision number. */
-  static get VERSION_NUMBER() {
-    return '/version_number';
+  static get REVISION_NUMBER() {
+    return '/revision_number';
   }
 
   /**

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -391,6 +391,6 @@ export default class LocalDoc extends BaseDoc {
    * @returns {string} The `StoragePath` string corresponding to `fsName`.
    */
   static _storagePathForFsName(fsName) {
-    return `/${fsName.replace(/~/g, '/').replace(/\.*$/, '')}`;
+    return `/${fsName.replace(/~/g, '/').replace(/\..*$/, '')}`;
   }
 }

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -35,9 +35,6 @@ export default class LocalDoc extends BaseDoc {
   constructor(docId, docPath) {
     super(docId);
 
-    /** {string} Path to the change storage for this document. */
-    this._path = `${docPath}.json`;
-
     /**
      * {string} Path to the directory containing stored values for this
      * document.

--- a/local-modules/doc-store-local/LocalDoc.js
+++ b/local-modules/doc-store-local/LocalDoc.js
@@ -368,15 +368,16 @@ export default class LocalDoc extends BaseDoc {
    * Converts a `StoragePath` string to the name of the file at which to find
    * the data for that path. In particular, we don't want the hiererarchical
    * structure of the path to turn into nested directories, so slashes (`/`) get
-   * converted to periods (`.`), the latter which is not a valid character for
-   * a storage path component.
+   * converted to tildes (`~`), the latter which is not a valid character for
+   * a storage path component. This also appends the filetype suffix `.blob`.
    *
    * @param {string} storagePath The storage path.
-   * @returns {string} The file name to use when accessing `path`.
+   * @returns {string} The fully-qualified file name to use when accessing
+   *   `path`.
    */
   _fsPathForStorage(storagePath) {
     // `slice(1)` trims off the initial slash.
-    const fileName = storagePath.slice(1).replace(/\//g, '.');
+    const fileName = `${storagePath.slice(1).replace(/\//g, '~')}.blob`;
     return path.resolve(this._storageDir, fileName);
   }
 
@@ -390,6 +391,6 @@ export default class LocalDoc extends BaseDoc {
    * @returns {string} The `StoragePath` string corresponding to `fsName`.
    */
   static _storagePathForFsName(fsName) {
-    return `/${fsName.replace(/\./g, '/')}`;
+    return `/${fsName.replace(/~/g, '/').replace(/\.*$/, '')}`;
   }
 }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.14.1
+version = 0.14.2


### PR DESCRIPTION
Batting cleanup here (more or less):

* Update the document format to use `/revision_number` for the revision number (not `version_number`).
* Put a filename extension (`.blob`) on the stored data values, and switch to using `~` instead of `.` as the path separator in those files. (That is, `.` is just used for the extension.)
* Fix a race that could happen when two clients requested the same document at the same time.