### PR TITLE
"Files" and "content" and not "docs" at the storage layer.

### DIFF
--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -67,7 +67,9 @@ export default class LocalContentStore extends BaseContentStore {
    * @returns {string} The corresponding filesystem path.
    */
   _filePath(fileId) {
-    return path.resolve(this._dir, fileId);
+    // The URI encoding helps keep this code resilient with respect to possible
+    // variance in the allowed syntax for `fileId`s.
+    return path.resolve(this._dir, encodeURIComponent(fileId));
   }
 
   /**

--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -15,8 +15,8 @@ import LocalFile from './LocalFile';
 const log = new Logger('local-doc');
 
 /**
- * File storage implementation that stores everything in the locally-accessible
- * filesystem.
+ * Content storage implementation that stores everything in the
+ * locally-accessible filesystem.
  */
 export default class LocalContentStore extends BaseContentStore {
   /**
@@ -37,7 +37,7 @@ export default class LocalContentStore extends BaseContentStore {
      */
     this._ensuredDir = false;
 
-    log.info(`File storage directory: ${this._dir}`);
+    log.info(`Content storage directory: ${this._dir}`);
   }
 
   /**

--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -15,8 +15,8 @@ import LocalFile from './LocalFile';
 const log = new Logger('local-doc');
 
 /**
- * Document storage implementation that stores everything in the
- * locally-accessible filesystem.
+ * File storage implementation that stores everything in the locally-accessible
+ * filesystem.
  */
 export default class LocalContentStore extends BaseContentStore {
   /**
@@ -25,29 +25,29 @@ export default class LocalContentStore extends BaseContentStore {
   constructor() {
     super();
 
-    /** {Map<string, LocalFile>} Map from document IDs to document instances. */
+    /** {Map<string, LocalFile>} Map from file IDs to file instances. */
     this._docs = new Map();
 
-    /** {string} The directory for document storage. */
+    /** {string} The directory for file storage. */
     this._dir = path.resolve(Dirs.VAR_DIR, 'docs');
 
     /**
-     * {boolean} `true` iff the document directory is known to exist. Set to
+     * {boolean} `true` iff the file storage directory is known to exist. Set to
      * `true` in `_ensureDocDirectory()`.
      */
     this._ensuredDir = false;
 
-    log.info(`Document directory: ${this._dir}`);
+    log.info(`File storage directory: ${this._dir}`);
   }
 
   /**
    * Implementation as required by the superclass.
    *
-   * @param {string} docId The ID of the document to access.
-   * @returns {BaseFile} Accessor for the document in question.
+   * @param {string} fileId The ID of the file to access.
+   * @returns {BaseFile} Accessor for the file in question.
    */
-  async _impl_getDocument(docId) {
-    const already = this._docs.get(docId);
+  async _impl_getFile(fileId) {
+    const already = this._docs.get(fileId);
 
     if (already) {
       return already;
@@ -55,26 +55,26 @@ export default class LocalContentStore extends BaseContentStore {
 
     await this._ensureDocDirectory();
 
-    const result = new LocalFile(docId, this._documentPath(docId));
-    this._docs.set(docId, result);
+    const result = new LocalFile(fileId, this._filePath(fileId));
+    this._docs.set(fileId, result);
     return result;
   }
 
   /**
-   * Gets the filesystem path for the document with the given ID.
+   * Gets the filesystem path for the file with the given ID.
    *
-   * @param {string} docId The document ID.
+   * @param {string} fileId The file ID.
    * @returns {string} The corresponding filesystem path.
    */
-  _documentPath(docId) {
-    return path.resolve(this._dir, docId);
+  _filePath(fileId) {
+    return path.resolve(this._dir, fileId);
   }
 
   /**
-   * Ensures the document storage directory exists. This will only ever check
-   * once (on first document construction attempt), which notably means that
-   * things will break if something removes the document directory without
-   * restarting the server.
+   * Ensures the file storage directory exists. This will only ever check once
+   * (on first file construction attempt), which notably means that things will
+   * break if something removes the file storage directory without restarting
+   * the server.
    */
   async _ensureDocDirectory() {
     if (this._ensuredDir) {
@@ -82,10 +82,10 @@ export default class LocalContentStore extends BaseContentStore {
     }
 
     if (await afs.exists(this._dir)) {
-      log.detail('Document directory already exists.');
+      log.detail('File storage directory already exists.');
     } else {
       await afs.mkdir(this._dir);
-      log.info('Created document directory.');
+      log.info('Created file storage directory.');
     }
 
     this._ensuredDir = true;

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -15,42 +15,41 @@ import { FrozenBuffer } from 'util-server';
 const log = new Logger('local-doc');
 
 /**
- * {int} How long to wait (in msec) after a document becomes dirty and before it
+ * {int} How long to wait (in msec) after a file becomes dirty and before it
  * gets written to disk. This keeps the system from thrashing the disk while
- * a document is being actively updated.
+ * a file is being actively updated.
  */
 const DIRTY_DELAY_MSEC = 5 * 1000; // 5 seconds.
 
 /**
- * Document implementation that stores everything in the
- * locally-accessible filesystem.
+ * File implementation that stores everything in the locally-accessible
+ * filesystem.
  */
 export default class LocalFile extends BaseFile {
   /**
    * Constructs an instance.
    *
-   * @param {string} docId The ID of the document this instance represents.
-   * @param {string} docPath The filesystem path for document storage.
+   * @param {string} fileId The ID of the file this instance represents.
+   * @param {string} docPath The filesystem path for file storage.
    */
-  constructor(docId, docPath) {
-    super(docId);
+  constructor(fileId, docPath) {
+    super(fileId);
 
     /**
-     * {string} Path to the directory containing stored values for this
-     * document.
+     * {string} Path to the directory containing stored values for this file.
      */
     this._storageDir = docPath;
 
     /**
      * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to
-     * corresponding stored data, for the entire document. `null` indicates that
+     * corresponding stored data, for the entire file. `null` indicates that
      * the map is not yet initialized.
      */
     this._storage = null;
 
     /**
      * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to
-     * corresponding stored data, for document contents that have not yet been
+     * corresponding stored data, for file contents that have not yet been
      * written to disk.
      */
     this._storageToWrite = new Map();
@@ -77,8 +76,8 @@ export default class LocalFile extends BaseFile {
      */
     this._storageReadyPromise = null;
 
-    /** {Logger} Logger specific to this document's ID. */
-    this._log = log.withPrefix(`[${docId}]`);
+    /** {Logger} Logger specific to this file's ID. */
+    this._log = log.withPrefix(`[${fileId}]`);
 
     this._log.info('Constructed.');
     this._log.detail(`Path: ${this._docPath}`);
@@ -87,18 +86,18 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
-   * @returns {boolean} `true` iff this document exists.
+   * @returns {boolean} `true` iff this file exists.
    */
   async _impl_exists() {
     if (this._storage !== null) {
-      // Whether or not the file exists, the document is considered to exist
-      // because it has a non-empty in-memory model. (For example, it might have
-      // been `create()`d but not yet stored to disk.)
+      // Whether or not the file exists, the file is considered to exist because
+      // it has a non-empty in-memory model. (For example, it might have been
+      // `create()`d but not yet stored to disk.)
       return true;
     } else {
-      // If the file exists, then the document exists. It might turn out to be
-      // the case that the file contents are invalid; however, by definition
-      // that is taken to be an _existing_ but _empty_ file.
+      // If the file exists, then the file exists. It might turn out to be the
+      // case that the file contents are invalid; however, by definition that is
+      // taken to be an _existing_ but _empty_ file.
       return afs.exists(this._storageDir);
     }
   }
@@ -201,7 +200,7 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
-   * Reads the document storage if it has not yet been loaded.
+   * Reads the file storage if it has not yet been loaded.
    */
   async _readStorageIfNecessary() {
     if (this._storageReadyPromise === null) {

--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -33,17 +33,17 @@ describe('content-store-local/LocalFile', () => {
     // }, 2000);
   });
 
-  describe('constructor(docId, docPath)', () => {
+  describe('constructor(fileId, docPath)', () => {
     it('should create a local dir for storing files at the specified path', () => {
-      const doc = new LocalFile('0', documentPath());
+      const doc = new LocalFile('0', filePath());
 
       assert.isNotNull(doc);
     });
   });
 
   describe('create()', () => {
-    it('should erase the document if called on a non-empty document', async () => {
-      const doc = new LocalFile('0', documentPath());
+    it('should erase the file if called on a non-empty file', async () => {
+      const doc = new LocalFile('0', filePath());
       const storagePath = '/abc';
       const value = FrozenBuffer.coerce('x');
 
@@ -59,6 +59,6 @@ describe('content-store-local/LocalFile', () => {
   });
 });
 
-function documentPath() {
+function filePath() {
   return path.join(storeDir, 'test_file');
 }

--- a/local-modules/content-store/BaseContentStore.js
+++ b/local-modules/content-store/BaseContentStore.js
@@ -2,11 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { DocumentId } from 'doc-common';
 import { TString } from 'typecheck';
 import { Singleton } from 'util-common';
 
 import BaseFile from './BaseFile';
+import FileId from './FileId';
 
 /**
  * Base class for file storage access. Subclasses must override several methods
@@ -47,7 +47,7 @@ export default class BaseContentStore extends Singleton {
    */
   async getFile(fileId) {
     TString.nonempty(fileId);
-    await this._impl_checkFileId(DocumentId.check(fileId));
+    await this._impl_checkFileId(FileId.check(fileId));
     return BaseFile.check(await this._impl_getFile(fileId));
   }
 

--- a/local-modules/content-store/BaseContentStore.js
+++ b/local-modules/content-store/BaseContentStore.js
@@ -9,57 +9,57 @@ import { Singleton } from 'util-common';
 import BaseFile from './BaseFile';
 
 /**
- * Base class for document storage access. Subclasses must override several
- * methods defined by this class, as indicated in the documentation. Methods to
- * override are all named with the prefix `_impl_`.
+ * Base class for file storage access. Subclasses must override several methods
+ * defined by this class, as indicated in the documentation. Methods to override
+ * are all named with the prefix `_impl_`.
  *
  * **Note:** This is a subclass of `Singleton`, that is, the system is set up
- * to only ever expect there to be one document store instance. (Technically,
- * this inheritence relationship allows for the possibility of having singleton
+ * to only ever expect there to be one file store instance. (Technically, this
+ * inheritence relationship allows for the possibility of having singleton
  * instances of several subclasses of this class, but in practice that's not
  * what happens.)
  */
 export default class BaseContentStore extends Singleton {
   /**
-   * Checks a document ID for validity. Returns regularly (with no value) if
-   * all is well, or throws an error if the ID is invalid. Only ever called on
-   * a non-empty string.
+   * Checks a file ID for validity. Returns regularly (with no value) if all is
+   * well, or throws an error if the ID is invalid. Only ever called on a
+   * non-empty string.
    *
    * This implementation is a no-op. Subclasses may choose to override this if
    * there is any validation required beyond the syntactic validation of
    * `DocumentId.check()`.
    *
-   * @param {string} docId_unused The document ID to validate. Only ever passed
+   * @param {string} fileId_unused The file ID to validate. Only ever passed
    *   as a value that has been validated by `DocumentId.check()`.
-   * @throws {Error} Arbitrary error indicating an invalid document ID.
+   * @throws {Error} Arbitrary error indicating an invalid file ID.
    */
-  async _impl_checkDocId(docId_unused) {
+  async _impl_checkFileId(fileId_unused) {
     // This space intentionally left blank.
   }
 
   /**
-   * Gets the accessor for the document with the given ID. The document need not
-   * exist prior to calling this method.
+   * Gets the accessor for the file with the given ID. The file need not exist
+   * prior to calling this method.
    *
-   * @param {string} docId The ID of the document to access. Must be a valid
-   *   document ID as defined by the concrete subclass.
-   * @returns {BaseFile} Accessor for the document in question.
+   * @param {string} fileId The ID of the file to access. Must be a valid file
+   *   ID as defined by the concrete subclass.
+   * @returns {BaseFile} Accessor for the file in question.
    */
-  async getDocument(docId) {
-    TString.nonempty(docId);
-    await this._impl_checkDocId(DocumentId.check(docId));
-    return BaseFile.check(await this._impl_getDocument(docId));
+  async getFile(fileId) {
+    TString.nonempty(fileId);
+    await this._impl_checkFileId(DocumentId.check(fileId));
+    return BaseFile.check(await this._impl_getFile(fileId));
   }
 
   /**
-   * Main implementation of `getDocument()`. Only ever called with a known-valid
-   * `docId`.
+   * Main implementation of `getFile()`. Only ever called with a known-valid
+   * `fileId`.
    *
    * @abstract
-   * @param {string} docId The ID of the document to access.
-   * @returns {BaseFile} Accessor for the document in question.
+   * @param {string} fileId The ID of the file to access.
+   * @returns {BaseFile} Accessor for the file in question.
    */
-  async _impl_getDocument(docId) {
-    return this._mustOverride(docId);
+  async _impl_getFile(fileId) {
+    return this._mustOverride(fileId);
   }
 }

--- a/local-modules/content-store/BaseContentStore.js
+++ b/local-modules/content-store/BaseContentStore.js
@@ -9,13 +9,13 @@ import BaseFile from './BaseFile';
 import FileId from './FileId';
 
 /**
- * Base class for file storage access. Subclasses must override several methods
- * defined by this class, as indicated in the documentation. Methods to override
- * are all named with the prefix `_impl_`.
+ * Base class for content storage access. Subclasses must override several
+ * methods defined by this class, as indicated in the documentation. Methods to
+ * override are all named with the prefix `_impl_`.
  *
  * **Note:** This is a subclass of `Singleton`, that is, the system is set up
- * to only ever expect there to be one file store instance. (Technically, this
- * inheritence relationship allows for the possibility of having singleton
+ * to only ever expect there to be one content store instance. (Technically,
+ * this inheritence relationship allows for the possibility of having singleton
  * instances of several subclasses of this class, but in practice that's not
  * what happens.)
  */

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -9,11 +9,11 @@ import { FrozenBuffer } from 'util-server';
 import StoragePath from './StoragePath';
 
 /**
- * Base class representing access to a particular document. Subclasses must
- * override several methods defined by this class, as indicated in the
- * documentation. Methods to override are all named with the prefix `_impl_`.
+ * Base class representing access to a particular file. Subclasses must override
+ * several methods defined by this class, as indicated in the documentation.
+ * Methods to override are all named with the prefix `_impl_`.
  *
- * The model that this class embodies is that a document is a random-access
+ * The model that this class embodies is that a file is a random-access
  * key-value store with keys having a path-like structure and values being
  * arbitrary binary data.
  */
@@ -21,27 +21,25 @@ export default class BaseFile extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {string} docId The ID of the document this instance represents.
+   * @param {string} fileId The ID of the file this instance represents.
    */
-  constructor(docId) {
+  constructor(fileId) {
     super();
 
-    /** {string} The ID of the document that this instance represents. */
-    this._id = TString.nonempty(docId);
+    /** {string} The ID of the file that this instance represents. */
+    this._id = TString.nonempty(fileId);
   }
 
-  /** {string} The ID of the document that this instance represents. */
+  /** {string} The ID of the file that this instance represents. */
   get id() {
     return this._id;
   }
 
   /**
-   * Indicates whether or not this document exists in the store. Calling this
-   * method will _not_ cause a non-existent document to come into existence.
+   * Indicates whether or not this file exists in the store. Calling this method
+   * will _not_ cause a non-existent file to come into existence.
    *
-   * **Note:** Documents that exist always contain at least one change.
-   *
-   * @returns {boolean} `true` iff this document exists.
+   * @returns {boolean} `true` iff this file exists.
    */
   async exists() {
     const result = this._impl_exists();
@@ -52,16 +50,16 @@ export default class BaseFile extends CommonBase {
    * Main implementation of `exists()`.
    *
    * @abstract
-   * @returns {boolean} `true` iff this document exists.
+   * @returns {boolean} `true` iff this file exists.
    */
   async _impl_exists() {
     return this._mustOverride();
   }
 
   /**
-   * Creates this document if it does not already exist, or re-creates it if it
-   * does already exist. After this call, the document both exists and is
-   * empty (that is, has no stored values).
+   * Creates this file if it does not already exist, or re-creates it if it does
+   * already exist. After this call, the file both exists and is empty (that is,
+   * has no stored values).
    */
   async create() {
     // This is just a simple pass-through. The point is to maintain the
@@ -108,7 +106,7 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Performs a forced-modification operation on the document. This is the main
+   * Performs a forced-modification operation on the file. This is the main
    * implementation of `opForceDelete()` and `opForceWrite()`. Arguments are
    * guaranteed by the superclass to be valid. Passing `null` for `newValue`
    * corresponds to the `opForceDelete()` operation.
@@ -181,7 +179,7 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Performs a modification operation on the document. This is the main
+   * Performs a modification operation on the file. This is the main
    * implementation of `opDelete()`, `opNew()`, and `opReplace()`. Arguments are
    * guaranteed by the superclass to be valid. Passing `null` for `oldValue`
    * corresponds to the `opNew()` operation. Passing `null` for `newValue`

--- a/local-modules/content-store/FileId.js
+++ b/local-modules/content-store/FileId.js
@@ -1,0 +1,39 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Hooks } from 'hooks-server';
+import { TypeError } from 'typecheck';
+
+/**
+ * Type representation of file IDs. The values themselves are always just
+ * strings. This is just where the type checker code lives.
+ *
+ * At a minimum a file ID has to be a non-empty string. Beyond that, the
+ * required syntax is determined via `hooks-common`.
+ *
+ * **Note:** By default, the syntax for a file ID is the same as that for a
+ * document ID. Furthermore, document IDs are generally passed as-is to become
+ * file IDs. That said, there are salient differences:
+ *
+ * * File IDs are a server-only concept.
+ * * It is possible (though not as of this writing done) for there to be files
+ *   in the system that do _not_ correspond to exposed documents.
+ */
+export default class FileId {
+  /**
+   * Checks a value of type `FileId`.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static check(value) {
+    if (   (typeof value !== 'string')
+        || (value.length === 0)
+        || !Hooks.isFileId(value)) {
+      return TypeError.badValue(value, 'FileId');
+    }
+
+    return value;
+  }
+}

--- a/local-modules/content-store/StoragePath.js
+++ b/local-modules/content-store/StoragePath.js
@@ -17,7 +17,7 @@ const PATH_REGEX = /^(\/[a-zA-Z0-9_]+)+$/;
 /**
  * Utility class for handling storage paths. A storage path is a
  * hierarchical-filesystem-like path which provides a stable name for a chunk of
- * data within a document. A valid path is a string consisting of one or more
+ * data within a file. A valid path is a string consisting of one or more
  * components, where each component is a slash (`/`) followed by a sequence of
  * one or more characters in the usual "identifier" set (`[a-zA-Z0-9_]`).
  *

--- a/local-modules/content-store/main.js
+++ b/local-modules/content-store/main.js
@@ -5,6 +5,7 @@
 import BaseContentStore from './BaseContentStore';
 import BaseFile from './BaseFile';
 import Coder from './Coder';
+import FileId from './FileId';
 import StoragePath from './StoragePath';
 
-export { BaseContentStore, BaseFile, Coder, StoragePath };
+export { BaseContentStore, BaseFile, Coder, FileId, StoragePath };

--- a/local-modules/content-store/package.json
+++ b/local-modules/content-store/package.json
@@ -5,7 +5,6 @@
 
   "dependencies": {
     "api-common": "local",
-    "doc-common": "local",
     "hooks-server": "local",
     "typecheck": "local",
     "util-common": "local",

--- a/local-modules/content-store/package.json
+++ b/local-modules/content-store/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "api-common": "local",
     "doc-common": "local",
+    "hooks-server": "local",
     "typecheck": "local",
     "util-common": "local",
     "util-server": "local"

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -174,7 +174,7 @@ export default class DocServer extends Singleton {
     // Make a temporary logger specific to this doc.
     const docLog = log.withPrefix(`[${docId}]`);
 
-    const docStorage   = await Hooks.docStore.getDocument(docId);
+    const docStorage   = await Hooks.docStore.getFile(docId);
     const result       = new DocControl(docStorage, this._formatVersion);
     const docStatus    = await result.validationStatus();
     const docNeedsInit = (docStatus !== DocControl.STATUS_OK);

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -174,7 +174,7 @@ export default class DocServer extends Singleton {
     // Make a temporary logger specific to this doc.
     const docLog = log.withPrefix(`[${docId}]`);
 
-    const docStorage   = await Hooks.docStore.getFile(docId);
+    const docStorage   = await Hooks.contentStore.getFile(docId);
     const result       = new DocControl(docStorage, this._formatVersion);
     const docStatus    = await result.validationStatus();
     const docNeedsInit = (docStatus !== DocControl.STATUS_OK);

--- a/local-modules/hooks-common/Hooks.js
+++ b/local-modules/hooks-common/Hooks.js
@@ -31,7 +31,7 @@ export default class Hooks {
    * no more than 32 characters and only use ASCII alphanumerics plus dash (`-`)
    * and underscore (`_`).
    *
-   * @param {string} id The (alleged) author ID to check.
+   * @param {string} id The (alleged) document ID to check.
    * @returns {boolen} `true` iff `id` is syntactically valid.
    */
   static isDocumentId(id) {

--- a/local-modules/hooks-server/BearerTokens.js
+++ b/local-modules/hooks-server/BearerTokens.js
@@ -56,7 +56,7 @@ export default class BearerTokens extends Singleton {
    * the list of `rootTokens` changes, or (on the margin) could conceivably have
    * changed.
    *
-   * The default implementation is for the promise to become resolved every
+   * The default implementation is for the promise to become resolved after
    * ten minutes even though by default the root tokens never get updated, just
    * so that the update logic gets excercised in the default configuration.
    *

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { LocalContentStore } from 'content-store-local';
+import { Hooks as HooksCommon } from 'hooks-common';
 
 import BearerTokens from './BearerTokens';
 
@@ -55,6 +56,20 @@ export default class Hooks {
    */
   static get docStore() {
     return LocalContentStore.theOne;
+  }
+
+  /**
+   * Checks whether the given value is syntactically valid as a file ID.
+   * This method is only ever called with a non-empty string.
+   *
+   * The default implementation of this method is to defer to the hook
+   * `hooks-common.Hooks.isDocumentId()`.
+   *
+   * @param {string} id The (alleged) file ID to check.
+   * @returns {boolen} `true` iff `id` is syntactically valid.
+   */
+  static isFileId(id) {
+    return HooksCommon.isDocumentId(id);
   }
 
   /**

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -50,11 +50,11 @@ export default class Hooks {
   }
 
   /**
-   * The object which provides access to document storage. This is an instance
+   * The object which provides access to content storage. This is an instance
    * of a subclass of `BaseContentStore`, as defined by the `content-store`
    * module.
    */
-  static get docStore() {
+  static get contentStore() {
     return LocalContentStore.theOne;
   }
 

--- a/local-modules/hooks-server/package.json
+++ b/local-modules/hooks-server/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "api-server": "local",
     "content-store-local": "local",
+    "hooks-common": "local",
     "util-common": "local"
   }
 }

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -31,6 +31,24 @@ describe('hooks-server/Hooks', () => {
     });
   });
 
+  describe('isFileId(id)', () => {
+    it('should accept 32-character alphanum ASCII strings', () => {
+      assert.isTrue(Hooks.isFileId('123abc7890ABC456789012'));
+    });
+
+    it('should allow underscores and hyphens', () => {
+      assert.isTrue(Hooks.isFileId('123456789_123456789-12'));
+    });
+
+    it('should not allow non-ASCII characters', () => {
+      assert.isFalse(Hooks.isFileId('123456789•123456789•12'));
+    });
+
+    it('should not allow non-alphanum characters', () => {
+      assert.isFalse(Hooks.isFileId('123456789\t123456789+12'));
+    });
+  });
+
   describe('.listenPort', () => {
     it('should return the documented value', () => {
       assert.strictEqual(Hooks.listenPort, 8080);

--- a/local-modules/hooks-server/tests/test_Hooks.js
+++ b/local-modules/hooks-server/tests/test_Hooks.js
@@ -25,9 +25,9 @@ describe('hooks-server/Hooks', () => {
     });
   });
 
-  describe('.docStore', () => {
+  describe('.contentStore', () => {
     it('should return an instance of BaseContentStore', () => {
-      assert.instanceOf(Hooks.docStore, BaseContentStore);
+      assert.instanceOf(Hooks.contentStore, BaseContentStore);
     });
   });
 


### PR DESCRIPTION
This PR mostly fixes terminology in the wake of the disambiguating rename of `doc-store` to `content-store`. At the low layer, the things-being-stored are now consistently referred to as "files," and the layer is consistently referred to as being about "content." I also teased apart the definition of `FileId` as distinct from `DocumentId`.

**Bonus:** Minor improvement in the resiliency of `content-store-local` with regard to possible changes to the allowed file ID (and document ID) syntax.