### PR TITLE
More "file" and "content" naming.

### DIFF
--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -28,7 +28,7 @@ export default class LocalContentStore extends BaseContentStore {
     /** {Map<string, LocalFile>} Map from file IDs to file instances. */
     this._files = new Map();
 
-    /** {string} The directory for file storage. */
+    /** {string} The directory for content storage. */
     this._dir = path.resolve(Dirs.VAR_DIR, 'content');
 
     /**

--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -12,7 +12,7 @@ import { Dirs } from 'server-env';
 import LocalFile from './LocalFile';
 
 /** {Logger} Logger for this module. */
-const log = new Logger('local-doc');
+const log = new Logger('local-content');
 
 /**
  * Content storage implementation that stores everything in the

--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -26,18 +26,18 @@ export default class LocalContentStore extends BaseContentStore {
     super();
 
     /** {Map<string, LocalFile>} Map from file IDs to file instances. */
-    this._docs = new Map();
+    this._files = new Map();
 
     /** {string} The directory for file storage. */
-    this._dir = path.resolve(Dirs.VAR_DIR, 'docs');
+    this._dir = path.resolve(Dirs.VAR_DIR, 'content');
 
     /**
-     * {boolean} `true` iff the file storage directory is known to exist. Set to
-     * `true` in `_ensureDocDirectory()`.
+     * {boolean} `true` iff the content storage directory is known to exist. Set
+     * to `true` in `_ensureContentDirectory()`.
      */
     this._ensuredDir = false;
 
-    log.info(`Content storage directory: ${this._dir}`);
+    log.info(`Content directory: ${this._dir}`);
   }
 
   /**
@@ -47,16 +47,16 @@ export default class LocalContentStore extends BaseContentStore {
    * @returns {BaseFile} Accessor for the file in question.
    */
   async _impl_getFile(fileId) {
-    const already = this._docs.get(fileId);
+    const already = this._files.get(fileId);
 
     if (already) {
       return already;
     }
 
-    await this._ensureDocDirectory();
+    await this._ensureContentDirectory();
 
     const result = new LocalFile(fileId, this._filePath(fileId));
-    this._docs.set(fileId, result);
+    this._files.set(fileId, result);
     return result;
   }
 
@@ -78,16 +78,16 @@ export default class LocalContentStore extends BaseContentStore {
    * break if something removes the file storage directory without restarting
    * the server.
    */
-  async _ensureDocDirectory() {
+  async _ensureContentDirectory() {
     if (this._ensuredDir) {
       return;
     }
 
     if (await afs.exists(this._dir)) {
-      log.detail('File storage directory already exists.');
+      log.detail('Content directory already exists.');
     } else {
       await afs.mkdir(this._dir);
-      log.info('Created file storage directory.');
+      log.info('Created content directory.');
     }
 
     this._ensuredDir = true;

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -12,7 +12,7 @@ import { FrozenBuffer } from 'util-server';
 
 
 /** {Logger} Logger for this module. */
-const log = new Logger('local-doc');
+const log = new Logger('local-file');
 
 /**
  * {int} How long to wait (in msec) after a file becomes dirty and before it

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -80,7 +80,7 @@ export default class LocalFile extends BaseFile {
     this._log = log.withPrefix(`[${fileId}]`);
 
     this._log.info('Constructed.');
-    this._log.detail(`Path: ${this._docPath}`);
+    this._log.detail(`Path: ${this._storageDir}`);
   }
 
   /**

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -30,15 +30,15 @@ export default class LocalFile extends BaseFile {
    * Constructs an instance.
    *
    * @param {string} fileId The ID of the file this instance represents.
-   * @param {string} docPath The filesystem path for file storage.
+   * @param {string} filePath The filesystem path for file storage.
    */
-  constructor(fileId, docPath) {
+  constructor(fileId, filePath) {
     super(fileId);
 
     /**
      * {string} Path to the directory containing stored values for this file.
      */
-    this._storageDir = docPath;
+    this._storageDir = filePath;
 
     /**
      * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -79,8 +79,7 @@ export default class LocalFile extends BaseFile {
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withPrefix(`[${fileId}]`);
 
-    this._log.info('Constructed.');
-    this._log.detail(`Path: ${this._storageDir}`);
+    this._log.info(`Path: ${this._storageDir}`);
   }
 
   /**

--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -33,28 +33,28 @@ describe('content-store-local/LocalFile', () => {
     // }, 2000);
   });
 
-  describe('constructor(fileId, docPath)', () => {
+  describe('constructor(fileId, filePath)', () => {
     it('should create a local dir for storing files at the specified path', () => {
-      const doc = new LocalFile('0', filePath());
+      const file = new LocalFile('0', filePath());
 
-      assert.isNotNull(doc);
+      assert.isNotNull(file);
     });
   });
 
   describe('create()', () => {
     it('should erase the file if called on a non-empty file', async () => {
-      const doc = new LocalFile('0', filePath());
+      const file = new LocalFile('0', filePath());
       const storagePath = '/abc';
       const value = FrozenBuffer.coerce('x');
 
       // Baseline assumption.
-      await doc.create();
-      await doc.opForceWrite(storagePath, value);
-      assert.strictEqual(await doc.pathReadOrNull(storagePath), value);
+      await file.create();
+      await file.opForceWrite(storagePath, value);
+      assert.strictEqual(await file.pathReadOrNull(storagePath), value);
 
       // The real test.
-      await doc.create();
-      assert.strictEqual(await doc.pathReadOrNull(storagePath), null);
+      await file.create();
+      assert.strictEqual(await file.pathReadOrNull(storagePath), null);
     });
   });
 });

--- a/local-modules/content-store/BaseContentStore.js
+++ b/local-modules/content-store/BaseContentStore.js
@@ -27,10 +27,10 @@ export default class BaseContentStore extends Singleton {
    *
    * This implementation is a no-op. Subclasses may choose to override this if
    * there is any validation required beyond the syntactic validation of
-   * `DocumentId.check()`.
+   * `FileId.check()`.
    *
    * @param {string} fileId_unused The file ID to validate. Only ever passed
-   *   as a value that has been validated by `DocumentId.check()`.
+   *   as a value that has been validated by `FileId.check()`.
    * @throws {Error} Arbitrary error indicating an invalid file ID.
    */
   async _impl_checkFileId(fileId_unused) {


### PR DESCRIPTION
This PR is a follow-on from my last one, wherein I clean up a few more names that I missed on the earlier pass, and made the terminology (mostly in log messages) ever so slightly more consistent.