### PR TITLE
Singletons and utility classes.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -126,7 +126,7 @@ export default class TopControl {
       // Make the editor instance, after style addition and hook action are
       // complete.
       Promise.all([styleDone, hookDone]).then((res_unused) => {
-        this._quill = QuillMaker.make(this._node);
+        this._quill = QuillMaker.theOne.make(this._node);
         log.detail('Made editor instance.');
 
         // Hook up the `DocClient` (which intermediates between the server and

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -65,3 +65,19 @@ taking into account recent additions to the language.
     return 'frobnicator';
   }
   ```
+
+* Utility classes &mdash; Utility classes are classes which only serve as a
+  collection of functionality exposed as static methods (and sometimes static
+  properties). Utility classes should be defined as `extends UtilityClass` both
+  to document the intent and to provide enforced guarantees.
+
+  **Note:** Preferably, utility classes are _not_ a vector for exposing
+  application state and are merely holders of "pure" functionality. For a
+  utility-like class that maintains and/or exposes state, it is better to use
+  a singleton.
+
+* Singleton classes &mdash; Singleton classes are classes which should only
+  ever have a single instance within the system. These should be defined as
+  `extends Singleton` both to document the intent and to provide enforced
+  guarantees. Additionally, instead of explicitly constructing singletons,
+  the convention is to use the static property `theOne` on the so-defined class.

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -117,7 +117,7 @@ export default class Decoder {
    * @returns {object} The converted value.
    */
   static _decodeInstance(tag, payload) {
-    const clazz = Registry.find(tag);
+    const clazz = Registry.theOne.find(tag);
     const args = Decoder._decodeArray(payload);
 
     if (!clazz) {

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -2,13 +2,19 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common';
+
 import Registry from './Registry';
 
 /**
  * Decoding of values that had been transpored over the API (or were read in
  * from disk or databases).
+ *
+ * **TODO:** If and when `Registry` stops being a singleton, this class should
+ * correspondingly stop being a utility class, since it will no longer be the
+ * case that there is a unique registry to query.
  */
-export default class Decoder {
+export default class Decoder extends UtilityClass {
   /**
    * Converts JSON-encoded text to a usable value. See `decode()` for
    * details.

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -2,15 +2,19 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { ObjectUtil } from 'util-common';
+import { ObjectUtil, UtilityClass } from 'util-common';
 
 import Registry from './Registry';
 
 /**
  * Encoding of values for transport over the API (or for storage on disk or in
  * databases).
+ *
+ * **TODO:** If and when `Registry` stops being a singleton, this class should
+ * correspondingly stop being a utility class, since it will no longer be the
+ * case that there is a unique registry to query.
  */
-export default class Encoder {
+export default class Encoder extends UtilityClass {
   /**
    * Converts an arbitrary value to JSON-encoded text. See `encode()` for
    * details.

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -10,7 +10,7 @@ import Registry from './Registry';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
-Registry.register(Message);
-Registry.register(SplitKey);
+Registry.theOne.register(Message);
+Registry.theOne.register(SplitKey);
 
 export { BaseKey, Decoder, Encoder, Message, Registry, SplitKey };

--- a/local-modules/api-common/tests/test_Decoder.js
+++ b/local-modules/api-common/tests/test_Decoder.js
@@ -12,7 +12,7 @@ import MockApiObject from './MockApiObject';
 describe('api-common/Decoder', () => {
   before(() => {
     try {
-      Registry.register(MockApiObject);
+      Registry.theOne.register(MockApiObject);
     } catch (e) {
       // nothing to do here, the try/catch is just in case some other test
       // file has already registered the mock API object.

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -83,31 +83,31 @@ describe('api-common/Registry', () => {
 
   describe('register(class)', () => {
     it('should require classes with an APP_NAME property, fromName() class method, and toApi() instance method', () => {
-      assert.throws(() => Registry.register(true));
-      assert.throws(() => Registry.register(37));
-      assert.throws(() => Registry.register('this better not work!'));
-      assert.throws(() => Registry.register({ }));
-      assert.throws(() => Registry.register([]));
-      assert.throws(() => Registry.register(null));
-      assert.throws(() => Registry.register(undefined));
-      assert.throws(() => Registry.register(NoApiName));
-      assert.throws(() => Registry.register(NoToApi));
-      assert.throws(() => Registry.register(NoFromApi));
+      assert.throws(() => Registry.theOne.register(true));
+      assert.throws(() => Registry.theOne.register(37));
+      assert.throws(() => Registry.theOne.register('this better not work!'));
+      assert.throws(() => Registry.theOne.register({ }));
+      assert.throws(() => Registry.theOne.register([]));
+      assert.throws(() => Registry.theOne.register(null));
+      assert.throws(() => Registry.theOne.register(undefined));
+      assert.throws(() => Registry.theOne.register(NoApiName));
+      assert.throws(() => Registry.theOne.register(NoToApi));
+      assert.throws(() => Registry.theOne.register(NoFromApi));
 
-      assert.doesNotThrow(() => Registry.register(RegistryTestApiObject));
+      assert.doesNotThrow(() => Registry.theOne.register(RegistryTestApiObject));
     });
   });
 
   describe('find(className)', () => {
     it('should throw an error if an unregistered class is requested', () => {
       const randomName = Random.hexByteString(32);
-      assert.throws(() => Registry.find(randomName));
+      assert.throws(() => Registry.theOne.find(randomName));
     });
 
     it('should return the named class if it is registered', () => {
-      Registry.register(FindTestApiObject);
+      Registry.theOne.register(FindTestApiObject);
 
-      const testClass = Registry.find(FindTestApiObject.API_NAME);
+      const testClass = Registry.theOne.find(FindTestApiObject.API_NAME);
       const testObject = new testClass();
 
       assert.instanceOf(testObject, FindTestApiObject);

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -23,7 +23,7 @@ export default class ApiLog extends Singleton {
     this._console = new Logger('api');
 
     /** {string} Path of API log file. */
-    this._path = path.resolve(Dirs.LOG_DIR, 'api.log');
+    this._path = path.resolve(Dirs.theOne.LOG_DIR, 'api.log');
 
     Object.freeze(this);
   }

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -80,7 +80,7 @@ export default class Application {
   _addRequestLogging() {
     // Stream to write to, when logging to a file.
     const accessStream = fs.createWriteStream(
-      path.resolve(Dirs.LOG_DIR, 'access.log'),
+      path.resolve(Dirs.theOne.LOG_DIR, 'access.log'),
       { flags: 'a' });
 
     RequestLogger.addLoggers(this._app, log.infoStream, accessStream);
@@ -98,7 +98,7 @@ export default class Application {
     // Map Quill files into `/static/quill`. This is used for CSS files but not
     // for the JS code; the JS code is included in the overall JS bundle file.
     app.use('/static/quill',
-      express.static(path.resolve(Dirs.CLIENT_DIR, 'node_modules/quill/dist')));
+      express.static(path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/quill/dist')));
 
     // Use the client bundler (which uses Webpack) to serve JS bundles. The
     // `:name` parameter gets interpreted by the client bundler to select which
@@ -108,7 +108,7 @@ export default class Application {
     // Find HTML files and other static assets in `client/assets`. This includes
     // the top-level `index.html` and `favicon`, as well as stuff under
     // `static/`.
-    app.use('/', express.static(path.resolve(Dirs.CLIENT_DIR, 'assets')));
+    app.use('/', express.static(path.resolve(Dirs.theOne.CLIENT_DIR, 'assets')));
 
     // Use the `api-server` module to handle POST and websocket requests at
     // `/api`.

--- a/local-modules/app-setup/RequestLogger.js
+++ b/local-modules/app-setup/RequestLogger.js
@@ -5,6 +5,8 @@
 import chalk from 'chalk';
 import morgan from 'morgan';
 
+import { UtilityClass } from 'util-common';
+
 /**
  * HTTP request logging functions. This includes logging to an HTTP `access.log`
  * type file in a reasonably-usual format as well as logging to a developer
@@ -12,7 +14,7 @@ import morgan from 'morgan';
  * built-in `dev` style, intended to produce concise logs for display on a
  * developer's console.
  */
-export default class RequestLogger {
+export default class RequestLogger extends UtilityClass {
   /**
    * Add all the loggers for the given application.
    *

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -9,7 +9,7 @@ import webpack from 'webpack';
 
 import { Logger } from 'see-all';
 import { Dirs } from 'server-env';
-import { JsonUtil } from 'util-common';
+import { JsonUtil, Singleton } from 'util-common';
 
 import ProgressMessage from './ProgressMessage';
 
@@ -185,11 +185,13 @@ const watchOptions = {
  * Wrapper around Webpack which can do both one-off builds as well as run
  * Webpack's "dev mode." Includes a request handler for hookup to Express.
  */
-export default class ClientBundle {
+export default class ClientBundle extends Singleton {
   /**
-   * Constructs an instance.
+   * Constructs the instance.
    */
   constructor() {
+    super();
+
     /**
      * {memory_fs} Memory FS used to hold the immediate results of compilation.
      */

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -22,7 +22,7 @@ const log = new Logger('client-bundle');
  */
 const clientPackage =
   JsonUtil.parseFrozen(
-    fs.readFileSync(path.resolve(Dirs.CLIENT_DIR, 'package.json')));
+    fs.readFileSync(path.resolve(Dirs.theOne.CLIENT_DIR, 'package.json')));
 
 /**
  * Options passed to the `webpack` compiler constructor. Of particular note,
@@ -41,16 +41,16 @@ const clientPackage =
  * for details and discussion.
  */
 const webpackOptions = {
-  context: Dirs.SERVER_DIR, // Used for resolving loaders and the like.
+  context: Dirs.theOne.SERVER_DIR, // Used for resolving loaders and the like.
   devtool: '#inline-source-map',
   entry: {
     main: [
       'babel-polyfill',
-      path.resolve(Dirs.CLIENT_DIR, clientPackage.main)
+      path.resolve(Dirs.theOne.CLIENT_DIR, clientPackage.main)
     ],
     test: [
       'babel-polyfill',
-      path.resolve(Dirs.CLIENT_DIR, clientPackage.testMain)
+      path.resolve(Dirs.theOne.CLIENT_DIR, clientPackage.testMain)
     ]
   },
   output: {
@@ -71,17 +71,17 @@ const webpackOptions = {
       // a prebuilt bundle. We rewrite it here to refer instead to the unbundled
       // source.
       'quill':
-        path.resolve(Dirs.CLIENT_DIR, 'node_modules/quill/quill.js'),
+        path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/quill/quill.js'),
 
       // Likewise, `parchment`.
       'parchment':
-        path.resolve(Dirs.CLIENT_DIR, 'node_modules/parchment/src/parchment.ts'),
+        path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/parchment/src/parchment.ts'),
 
       // On the client side, we use a built-in module called `test-all` as a
       // substitute for `mocha`. This alias makes it so that testing code can
       // still write `import ... from 'mocha';`.
       'mocha':
-        path.resolve(Dirs.CLIENT_DIR, 'node_modules/test-all')
+        path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/test-all')
     },
     // All the extensions listed here except `.ts` are in the default list.
     // Webpack doesn't offer a way to simply add to the defaults (alas).

--- a/local-modules/client-tests-loader/ClientTestsLoader.js
+++ b/local-modules/client-tests-loader/ClientTestsLoader.js
@@ -3,11 +3,12 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ClientTests } from 'testing-server';
+import { UtilityClass } from 'util-common';
 
 /**
  * Webpack loader for the client test files.
  */
-export default class ClientTestsLoader {
+export default class ClientTestsLoader extends UtilityClass {
   /**
    * Load the synthesized client test file.
    *

--- a/local-modules/content-store-local/LocalContentStore.js
+++ b/local-modules/content-store-local/LocalContentStore.js
@@ -29,7 +29,7 @@ export default class LocalContentStore extends BaseContentStore {
     this._files = new Map();
 
     /** {string} The directory for content storage. */
-    this._dir = path.resolve(Dirs.VAR_DIR, 'content');
+    this._dir = path.resolve(Dirs.theOne.VAR_DIR, 'content');
 
     /**
      * {boolean} `true` iff the content storage directory is known to exist. Set

--- a/local-modules/content-store/Coder.js
+++ b/local-modules/content-store/Coder.js
@@ -4,12 +4,13 @@
 
 import { Decoder, Encoder } from 'api-common';
 import { FrozenBuffer } from 'util-server';
+import { UtilityClass } from 'util-common';
 
 /**
  * Utility class for converting between arbitrary values and their stored
  * form as `FrozenBuffer`s.
  */
-export default class Coder {
+export default class Coder extends UtilityClass {
   /**
    * Encodes an arbitrary value using API coding, and converts it to a
    * `FrozenBuffer`.

--- a/local-modules/content-store/FileId.js
+++ b/local-modules/content-store/FileId.js
@@ -4,6 +4,7 @@
 
 import { Hooks } from 'hooks-server';
 import { TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * Type representation of file IDs. The values themselves are always just
@@ -20,7 +21,7 @@ import { TypeError } from 'typecheck';
  * * It is possible (though not as of this writing done) for there to be files
  *   in the system that do _not_ correspond to exposed documents.
  */
-export default class FileId {
+export default class FileId extends UtilityClass {
   /**
    * Checks a value of type `FileId`.
    *

--- a/local-modules/content-store/StoragePath.js
+++ b/local-modules/content-store/StoragePath.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray, TString, TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * {RegEx} Regular expression which passes for all valid path component strings.
@@ -24,7 +25,7 @@ const PATH_REGEX = /^(\/[a-zA-Z0-9_]+)+$/;
  * * Example path: `/foo_1/bar/baz/23`
  * * Example component: `puffin_biscuit_7`
  */
-export default class StoragePath {
+export default class StoragePath extends UtilityClass {
   /**
    * Validates that the given value is a valid storage path string. Throws an
    * error if not.

--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -36,7 +36,7 @@ export default class DevMode {
    */
   constructor() {
     /** Base product output directory. */
-    this._outDir = Dirs.BASE_DIR;
+    this._outDir = Dirs.theOne.BASE_DIR;
     log.info('Product directory:', this._outDir);
 
     /** The mappings from source to target directories, for the client code. */

--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -9,7 +9,7 @@ import path from 'path';
 
 import { Logger } from 'see-all';
 import { Dirs } from 'server-env';
-import { PromDelay } from 'util-common';
+import { PromDelay, Singleton } from 'util-common';
 
 /** Logger. */
 const log = new Logger('dev-mode');
@@ -30,11 +30,13 @@ const MAP_FILE_NAME = 'source-map.txt';
  *   should they change. This is expected to be paired with a wrapper script
  *   that notices when the process exits and kicks off a rebuild.
  */
-export default class DevMode {
+export default class DevMode extends Singleton {
   /**
-   * Constructs an instance. Use `start()` to run it.
+   * Constructs the instance. Use `start()` to run it.
    */
   constructor() {
+    super();
+
     /** Base product output directory. */
     this._outDir = Dirs.theOne.BASE_DIR;
     log.info('Product directory:', this._outDir);

--- a/local-modules/doc-common/AuthorId.js
+++ b/local-modules/doc-common/AuthorId.js
@@ -4,6 +4,7 @@
 
 import { Hooks } from 'hooks-common';
 import { TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * Type representation of author IDs. The values themselves are always just
@@ -13,7 +14,7 @@ import { TypeError } from 'typecheck';
  * At a minimum a non-null author ID has to be a non-empty string. Beyond that,
  * the required syntax is determined via `hooks-common`.
  */
-export default class AuthorId {
+export default class AuthorId extends UtilityClass {
   /**
    * Checks a value of type `AuthorId`.
    *

--- a/local-modules/doc-common/DocumentId.js
+++ b/local-modules/doc-common/DocumentId.js
@@ -4,6 +4,7 @@
 
 import { Hooks } from 'hooks-common';
 import { TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * Type representation of document IDs. The values themselves are always just
@@ -12,7 +13,7 @@ import { TypeError } from 'typecheck';
  * At a minimum a document ID has to be a non-empty string. Beyond that, the
  * required syntax is determined via `hooks-common`.
  */
-export default class DocumentId {
+export default class DocumentId extends UtilityClass {
   /**
    * Checks a value of type `DocumentId`.
    *

--- a/local-modules/doc-common/RevisionNumber.js
+++ b/local-modules/doc-common/RevisionNumber.js
@@ -3,12 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TInt, TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * Type representation of revision numbers. The values themselves are always
  * just non-negative integers. This is just where the type checker code lives.
  */
-export default class RevisionNumber {
+export default class RevisionNumber extends UtilityClass {
   /**
    * Checks a value of type `RevisionNumber`.
    *

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -14,11 +14,11 @@ import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
 // Register classes with the API.
-Registry.register(DeltaResult);
-Registry.register(DocumentChange);
-Registry.register(FrozenDelta);
-Registry.register(Snapshot);
-Registry.register(Timestamp);
+Registry.theOne.register(DeltaResult);
+Registry.theOne.register(DocumentChange);
+Registry.theOne.register(FrozenDelta);
+Registry.theOne.register(Snapshot);
+Registry.theOne.register(Timestamp);
 
 export {
   AuthorId,

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -66,7 +66,7 @@ export default class DocServer extends Singleton {
      * {FrozenBuffer} The document format version to use for new documents and
      * to expect in existing documents.
      */
-    this._formatVersion = Coder.encode(ProductInfo.INFO.version);
+    this._formatVersion = Coder.encode(ProductInfo.theOne.INFO.version);
   }
 
   /**

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -3,12 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { RevisionNumber } from 'doc-common';
+import { UtilityClass } from 'util-common';
 
 /**
  * Utility class that just provides the common `StoragePath` strings used
  * by the document storage format.
  */
-export default class Paths {
+export default class Paths extends UtilityClass {
   /** {string} `StoragePath` string for the document format version. */
   static get FORMAT_VERSION() {
     return '/format_version';

--- a/local-modules/proppy/Proppy.js
+++ b/local-modules/proppy/Proppy.js
@@ -4,6 +4,8 @@
 
 import fs from 'fs';
 
+import { UtilityClass } from 'util-common';
+
 /**
  * Property file reader. This accepts a syntax which is similar to traditional
  * Java `.properties` files, except considerably simpler, more
@@ -34,7 +36,7 @@ import fs from 'fs';
  * The result of parsing a property file is always a frozen object which maps
  * `<key>` to `<value>` for each such pair defined in the file.
  */
-export default class Proppy {
+export default class Proppy extends UtilityClass {
   /**
    * Reads a property file from the given buffer.
    *

--- a/local-modules/proppy/package.json
+++ b/local-modules/proppy/package.json
@@ -1,5 +1,9 @@
 {
   "name": "proppy",
   "version": "1.0.0",
-  "main": "main.js"
+  "main": "main.js",
+
+  "dependencies": {
+    "util-common": "local"
+  }
 }

--- a/local-modules/quill-util/QuillMaker.js
+++ b/local-modules/quill-util/QuillMaker.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Hooks } from 'hooks-client';
+import { Singleton } from 'util-common';
 
 import QuillProm from './QuillProm';
 
@@ -30,7 +31,7 @@ let toolbarConfig = null;
  * Bottleneck for constructing Quill instances. This class exists merely to make
  * it easy to configure this behavior via an overlay.
  */
-export default class QuillMaker {
+export default class QuillMaker extends Singleton {
   /**
    * Makes an instance of `Quill`. More specifically, because we want to use
    * a promise chain to get at the edit events, this makes an instance of our
@@ -39,7 +40,7 @@ export default class QuillMaker {
    * @param {string} id DOM id of the element to attach to.
    * @returns {QuillProm} instance of `Quill`.
    */
-  static make(id) {
+  make(id) {
     if (toolbarConfig === null) {
       toolbarConfig = Object.freeze(
         Hooks.theOne.quillToolbarConfig(DEFAULT_TOOLBAR_CONFIG));

--- a/local-modules/quill-util/QuillUtil.js
+++ b/local-modules/quill-util/QuillUtil.js
@@ -4,6 +4,8 @@
 
 import Quill from 'quill';
 
+import { UtilityClass } from 'util-common';
+
 const POSITION_NOT_FOUND = Object.freeze({
   blot: null,
   blotOffset: 0,
@@ -16,7 +18,7 @@ const POSITION_NOT_FOUND = Object.freeze({
  * Miscellaneous helpers for interacting with Quill that didn't fit anywhere
  * else.
  */
-export default class QuillUtil {
+export default class QuillUtil extends UtilityClass {
   /**
    * Return value for `.quillContextForPixelPosition()` for cases where the
    * pixel is not in the Quill context. All properties are nulled/zeroed except

--- a/local-modules/quill-util/package.json
+++ b/local-modules/quill-util/package.json
@@ -7,6 +7,7 @@
     "quill": "^1.1.7",
 
     "doc-common": "local",
-    "hooks-client": "local"
+    "hooks-client": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -3,25 +3,19 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SeeAll } from 'see-all';
+import { Singleton } from 'util-common';
 
 /**
  * Implementation of the `see-all` logging sink protocol for use in a web
  * browser context. It logs everything to the browser window console.
  */
-export default class ClientSink {
+export default class ClientSink extends Singleton {
   /**
    * Registers an instance of this class as a logging sink with the main
    * `see-all` module.
    */
   static init() {
-    SeeAll.add(new ClientSink());
-  }
-
-  /**
-   * Constructs an instance.
-   */
-  constructor() {
-    // Nothing to do.
+    SeeAll.theOne.add(ClientSink.theOne);
   }
 
   /**

--- a/local-modules/see-all-client/package.json
+++ b/local-modules/see-all-client/package.json
@@ -4,6 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
-    "see-all": "local"
+    "see-all": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -22,7 +22,7 @@ export default class FileSink {
     /** {string} Path of the file to log to. */
     this._path = path;
 
-    SeeAll.add(this);
+    SeeAll.theOne.add(this);
   }
 
   /**

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -28,7 +28,7 @@ export default class RecentSink {
     /** The log contents. */
     this._log = [];
 
-    SeeAll.add(this);
+    SeeAll.theOne.add(this);
   }
 
   /**

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -7,6 +7,7 @@ import util from 'util';
 import chalk from 'chalk';
 
 import { SeeAll } from 'see-all';
+import { Singleton } from 'util-common';
 
 /**
  * Number of columns to reserve for log line prefixes. Prefixes under this
@@ -18,20 +19,13 @@ const PREFIX_COLS = 24;
  * Implementation of the `see-all` logging sink protocol for use in a server
  * context. It logs everything to the console.
  */
-export default class ServerSink {
+export default class ServerSink extends Singleton {
   /**
    * Registers an instance of this class as a logging sink with the main
    * `see-all` module.
    */
   static init() {
-    SeeAll.add(new ServerSink());
-  }
-
-  /**
-   * Constructs an instance.
-   */
-  constructor() {
-    // Nothing to do.
+    SeeAll.theOne.add(ServerSink.theOne);
   }
 
   /**

--- a/local-modules/see-all-server/package.json
+++ b/local-modules/see-all-server/package.json
@@ -7,6 +7,7 @@
     "ansi-html": "^0.0.7",
     "chalk": "^1.1.1",
 
-    "see-all": "local"
+    "see-all": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/see-all/SeeAll.js
+++ b/local-modules/see-all/SeeAll.js
@@ -2,13 +2,15 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Singleton } from 'util-common';
+
 import AllSinks from './AllSinks';
 
 /**
  * Registry for loggers. This is an uninstantiable class with just static
  * methods.
  */
-export default class SeeAll {
+export default class SeeAll extends Singleton {
   /**
    * Adds a logging sink to the system. May be called more than once. Each sink
    * added via this method gets called as `sink.log(nowMsec, level, tag,
@@ -18,7 +20,7 @@ export default class SeeAll {
    *
    * @param {object} sink The underlying logger to use.
    */
-  static add(sink) {
+  add(sink) {
     AllSinks.theOne.add(sink);
   }
 }

--- a/local-modules/server-env/Dirs.js
+++ b/local-modules/server-env/Dirs.js
@@ -5,48 +5,43 @@
 import fs from 'fs';
 import path from 'path';
 
-/** {string|null} Base directory of the product. Set up by `init()`. */
-let baseDir = null;
+import { Singleton } from 'util-common';
 
 
 /**
  * Various filesystem directories.
  */
-export default class Dirs {
+export default class Dirs extends Singleton {
   /**
-   * Initializes this class. This is not meant to be called publicly (though it
-   * is innocuous if done so).
+   * Constructs the instance.
    */
-  static init() {
-    if (baseDir !== null) {
-      // Already initialized.
-      return;
-    }
+  constructor() {
+    super();
 
-    baseDir = Dirs._findBaseDir();
+    /** {string} Base directory of the product. */
+    this._baseDir = Dirs._findBaseDir();
   }
 
   /**
    * The base directory for the product. This is where the code lives, as well
    * as working files when running in development mode.
    */
-  static get BASE_DIR() {
-    Dirs.init();
-    return baseDir;
+  get BASE_DIR() {
+    return this._baseDir;
   }
 
   /**
    * The client directory. This contains both code and assets.
    */
-  static get CLIENT_DIR() {
-    return path.resolve(Dirs.BASE_DIR, 'client');
+  get CLIENT_DIR() {
+    return path.resolve(this.BASE_DIR, 'client');
   }
 
   /**
    * The client code directory.
    */
-  static get CLIENT_CODE_DIR() {
-    return path.resolve(Dirs.BASE_DIR, 'client/js');
+  get CLIENT_CODE_DIR() {
+    return path.resolve(this.BASE_DIR, 'client/js');
   }
 
   /**
@@ -54,8 +49,8 @@ export default class Dirs {
    * existence of the directory (that is, it will create the directory if
    * necessary).
    */
-  static get LOG_DIR() {
-    const result = path.resolve(Dirs.VAR_DIR, 'log');
+  get LOG_DIR() {
+    const result = path.resolve(this.VAR_DIR, 'log');
 
     Dirs._ensureDir(result);
     return result;
@@ -64,8 +59,8 @@ export default class Dirs {
   /**
    * The server directory. This contains the server code.
    */
-  static get SERVER_DIR() {
-    return path.resolve(Dirs.BASE_DIR, 'server');
+  get SERVER_DIR() {
+    return path.resolve(this.BASE_DIR, 'server');
   }
 
   /**
@@ -73,11 +68,11 @@ export default class Dirs {
    * kept. Accessing this value guarantees the existence of the directory (that
    * is, it will create the directory if necessary).
    */
-  static get VAR_DIR() {
+  get VAR_DIR() {
     // TODO: In production, this will want to be somewhere other than under the
     // product deployment base directory. This might reasonably be configured
     // via an item in `hooks-server`.
-    const result = path.resolve(Dirs.BASE_DIR, 'var');
+    const result = path.resolve(this.BASE_DIR, 'var');
 
     Dirs._ensureDir(result);
     return result;

--- a/local-modules/server-env/PidFile.js
+++ b/local-modules/server-env/PidFile.js
@@ -6,37 +6,34 @@ import fs from 'fs';
 import path from 'path';
 
 import { Logger } from 'see-all';
+import { Singleton } from 'util-common';
 
 import Dirs from './Dirs';
 
 /** Logger. */
 const log = new Logger('pid');
 
-/** Path for the PID file. Set in `init()`. */
-let pidPath = null;
-
 /**
  * This writes a PID file when `init()` is called, and tries to remove it when
  * the app is shutting down. This clas is _not_ meant to be instantiated.
  */
-export default class PidFile {
+export default class PidFile extends Singleton {
   /**
    * Write the PID file, and arrange for its timely erasure.
    */
-  static init() {
-    if (pidPath !== null) {
-      throw new Error('Already set up.');
-    }
+  constructor() {
+    super();
 
-    pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
+    /** {string} Path for the PID file. */
+    this._pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
 
     // Erase the file on exit.
-    process.once('exit',    PidFile._erasePid);
-    process.once('SIGINT',  PidFile._handleSignal.bind(null, 'SIGINT'));
-    process.once('SIGTERM', PidFile._handleSignal.bind(null, 'SIGTERM'));
+    process.once('exit',    this._erasePid.bind(this));
+    process.once('SIGINT',  this._handleSignal.bind(this, 'SIGINT'));
+    process.once('SIGTERM', this._handleSignal.bind(this, 'SIGTERM'));
 
     // Write the PID file.
-    fs.writeFileSync(pidPath, `${process.pid}\n`);
+    fs.writeFileSync(this._pidPath, `${process.pid}\n`);
 
     log.info(`PID: ${process.pid}`);
   }
@@ -47,18 +44,18 @@ export default class PidFile {
    *
    * @param {string} id Signal ID.
    */
-  static _handleSignal(id) {
+  _handleSignal(id) {
     log.info(`Received signal: ${id}`);
-    PidFile._erasePid();
+    this._erasePid();
     process.kill(process.pid, id);
   }
 
   /**
    * Erases the PID file if it exists.
    */
-  static _erasePid() {
+  _erasePid() {
     try {
-      fs.unlinkSync(pidPath);
+      fs.unlinkSync(this._pidPath);
       log.info(`Removed PID file.`);
     } catch (e) {
       // Ignore errors. We're about to exit anyway.

--- a/local-modules/server-env/PidFile.js
+++ b/local-modules/server-env/PidFile.js
@@ -28,7 +28,7 @@ export default class PidFile {
       throw new Error('Already set up.');
     }
 
-    pidPath = path.resolve(Dirs.VAR_DIR, 'pid.txt');
+    pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
 
     // Erase the file on exit.
     process.once('exit',    PidFile._erasePid);

--- a/local-modules/server-env/ProductInfo.js
+++ b/local-modules/server-env/ProductInfo.js
@@ -5,35 +5,30 @@
 import path from 'path';
 
 import { Proppy } from 'proppy';
+import { Singleton } from 'util-common';
 
 import Dirs from './Dirs';
-
-/** {object|null} Product info object. Set up by `init()`. */
-let productInfo = null;
 
 
 /**
  * Product metainformation.
  */
-export default class ProductInfo {
+export default class ProductInfo extends Singleton {
   /**
-   * Initializes this class. This is not meant to be called publicly (though it
-   * is innocuous if done so).
+   * Constructs the instance.
    */
-  static init() {
-    if (productInfo !== null) {
-      // Already initialized.
-      return;
-    }
+  constructor() {
+    super();
 
-    productInfo = Proppy.parseFile(
+    /** {object} Product info object. */
+    this._productInfo = Proppy.parseFile(
       path.resolve(Dirs.theOne.BASE_DIR, 'product-info.txt'));
   }
 
   /**
    * The product info object, as parsed from `product-info.txt`.
    */
-  static get INFO() {
-    return productInfo;
+  get INFO() {
+    return this._productInfo;
   }
 }

--- a/local-modules/server-env/ProductInfo.js
+++ b/local-modules/server-env/ProductInfo.js
@@ -27,7 +27,7 @@ export default class ProductInfo {
     }
 
     productInfo = Proppy.parseFile(
-      path.resolve(Dirs.BASE_DIR, 'product-info.txt'));
+      path.resolve(Dirs.theOne.BASE_DIR, 'product-info.txt'));
   }
 
   /**

--- a/local-modules/server-env/ServerEnv.js
+++ b/local-modules/server-env/ServerEnv.js
@@ -11,11 +11,12 @@ import ProductInfo from './ProductInfo';
  */
 export default class ServerEnv {
   /**
-   * Initializes this module. This sets up the info for the `Dirs` class,
-   * sets up the PID file, and gathers the product metainfo.
+   * Initializes this module. This sets up the info for the `Dirs` class, sets
+   * up the PID file, and gathers the product metainfo.
    */
   static init() {
-    PidFile.init(Dirs.theOne.BASE_DIR);
+    Dirs.theOne;
+    PidFile.theOne;
     ProductInfo.init();
   }
 }

--- a/local-modules/server-env/ServerEnv.js
+++ b/local-modules/server-env/ServerEnv.js
@@ -17,6 +17,6 @@ export default class ServerEnv {
   static init() {
     Dirs.theOne;
     PidFile.theOne;
-    ProductInfo.init();
+    ProductInfo.theOne;
   }
 }

--- a/local-modules/server-env/ServerEnv.js
+++ b/local-modules/server-env/ServerEnv.js
@@ -15,8 +15,7 @@ export default class ServerEnv {
    * sets up the PID file, and gathers the product metainfo.
    */
   static init() {
-    Dirs.init();
-    PidFile.init(Dirs.BASE_DIR);
+    PidFile.init(Dirs.theOne.BASE_DIR);
     ProductInfo.init();
   }
 }

--- a/local-modules/server-env/package.json
+++ b/local-modules/server-env/package.json
@@ -5,6 +5,7 @@
 
   "dependencies": {
     "proppy": "local",
-    "see-all": "local"
+    "see-all": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/server-env/tests/test_Dirs.js
+++ b/local-modules/server-env/tests/test_Dirs.js
@@ -13,7 +13,7 @@ import { Dirs } from 'server-env';
 describe('server-env/Dirs', () => {
   describe('.BASE_DIR', () => {
     it('should return a directory path that exists', () => {
-      const baseDir = Dirs.BASE_DIR;
+      const baseDir = Dirs.theOne.BASE_DIR;
 
       assert.isTrue(fs.existsSync(baseDir));
     });
@@ -21,50 +21,50 @@ describe('server-env/Dirs', () => {
 
   describe('.CLIENT_DIR', () => {
     it('should return a known subdirectory off of `BASE_DIR`', () => {
-      const baseDir = Dirs.BASE_DIR;
+      const baseDir = Dirs.theOne.BASE_DIR;
       const clientDir = path.join(baseDir, 'client');
 
-      assert.strictEqual(clientDir, Dirs.CLIENT_DIR);
+      assert.strictEqual(clientDir, Dirs.theOne.CLIENT_DIR);
       assert.isTrue(fs.existsSync(clientDir));
     });
   });
 
   describe('.CLIENT_CODE_DIR', () => {
     it('should return a known subdirectory off of `CLIENT_DIR`', () => {
-      const clientDir = Dirs.CLIENT_DIR;
+      const clientDir = Dirs.theOne.CLIENT_DIR;
       const codeDir = path.join(clientDir, 'js');
 
-      assert.strictEqual(codeDir, Dirs.CLIENT_CODE_DIR);
+      assert.strictEqual(codeDir, Dirs.theOne.CLIENT_CODE_DIR);
       assert.isTrue(fs.existsSync(codeDir));
     });
   });
 
   describe('.LOG_DIR', () => {
     it('should return a known subdirectory off of `VAR_DIR`', () => {
-      const varDir = Dirs.VAR_DIR;
+      const varDir = Dirs.theOne.VAR_DIR;
       const logDir = path.join(varDir, 'log');
 
-      assert.strictEqual(logDir, Dirs.LOG_DIR);
+      assert.strictEqual(logDir, Dirs.theOne.LOG_DIR);
       assert.isTrue(fs.existsSync(logDir));
     });
   });
 
   describe('.SERVER_DIR', () => {
     it('should return a known subdirectory off of BASE_DIR', () => {
-      const baseDir = Dirs.BASE_DIR;
+      const baseDir = Dirs.theOne.BASE_DIR;
       const serverDir = path.join(baseDir, 'server');
 
-      assert.strictEqual(serverDir, Dirs.SERVER_DIR);
+      assert.strictEqual(serverDir, Dirs.theOne.SERVER_DIR);
       assert.isTrue(fs.existsSync(serverDir));
     });
   });
 
   describe('.VAR_DIR', () => {
     it('should return a known subdirectory off of BASE_DIR', () => {
-      const baseDir = Dirs.BASE_DIR;
+      const baseDir = Dirs.theOne.BASE_DIR;
       const varDir = path.join(baseDir, 'var');
 
-      assert.strictEqual(varDir, Dirs.VAR_DIR);
+      assert.strictEqual(varDir, Dirs.theOne.VAR_DIR);
       assert.isTrue(fs.existsSync(varDir));
     });
   });

--- a/local-modules/server-env/tests/test_PidFile.js
+++ b/local-modules/server-env/tests/test_PidFile.js
@@ -2,33 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { assert } from 'chai';
+//import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import fs from 'fs';
-import path from 'path';
-
-import { Dirs } from 'server-env';
-
-// See comment below for why this is commented out.
-//import { PidFile } from 'server-env';
-
 describe('server-env/PidFile', () => {
-  describe('init(basePath)', () => {
-    it('should create a pid.txt file at a known position off of baseDir', () => {
-      // **TODO:** We have a small problem here in that the test runner is
-      // launched by the server and the server startup calls `PidFile.init(dir)`
-      // and that call can't be made more than once. So we are doing kind of a
-      // bad testing thing and using intimate knowledge of how `PidFile` works
-      // rather than relying on documented API behavior.
-      //PidFile.init(Dirs.theOne.BASE_DIR);
-
-      const varDir = Dirs.theOne.VAR_DIR;
-      const pidFilePath = path.join(varDir, 'pid.txt');
-
-      assert.isTrue(fs.existsSync(pidFilePath));
-    });
-
-    it('should rm the pid.txt file when the process exits');
-  });
+  it('needs a way to be tested');
 });

--- a/local-modules/server-env/tests/test_PidFile.js
+++ b/local-modules/server-env/tests/test_PidFile.js
@@ -21,9 +21,9 @@ describe('server-env/PidFile', () => {
       // and that call can't be made more than once. So we are doing kind of a
       // bad testing thing and using intimate knowledge of how `PidFile` works
       // rather than relying on documented API behavior.
-      //PidFile.init(Dirs.BASE_DIR);
+      //PidFile.init(Dirs.theOne.BASE_DIR);
 
-      const varDir = Dirs.VAR_DIR;
+      const varDir = Dirs.theOne.VAR_DIR;
       const pidFilePath = path.join(varDir, 'pid.txt');
 
       assert.isTrue(fs.existsSync(pidFilePath));

--- a/local-modules/server-env/tests/test_ProductInfo.js
+++ b/local-modules/server-env/tests/test_ProductInfo.js
@@ -8,13 +8,10 @@ import { describe, it } from 'mocha';
 import { ProductInfo } from 'server-env';
 import { TObject } from 'typecheck';
 
-// see comment below for why this is commented out
-//import { PidFile } from 'server-env';
-
 describe('server-env/ProductInfo', () => {
   describe('.INFO', () => {
     it('should return an object full of product info', () => {
-      const info = ProductInfo.INFO;
+      const info = ProductInfo.theOne.INFO;
 
       // TODO: This list of keys is currently an amalgam of those from Bayou
       // and those from a privately-used overlay. Ugh. Not good. This should

--- a/local-modules/testing-client/Tests.js
+++ b/local-modules/testing-client/Tests.js
@@ -7,7 +7,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { assert } from 'chai';
 
 import { Logger } from 'see-all';
-import { PromDelay } from 'util-common';
+import { PromDelay, UtilityClass } from 'util-common';
 
 // If we tweak the Webpack config to point the module `mocha` at the browser-ish
 // build, then the following `import` will cause `window.mocha` to be defined.
@@ -29,7 +29,7 @@ chai.use(chaiAsPromised);
 /**
  * Client-side helper for setting up and running test code.
  */
-export default class Tests {
+export default class Tests extends UtilityClass {
   /**
    * Runs all of the tests.
    *

--- a/local-modules/testing-server/ClientTests.js
+++ b/local-modules/testing-server/ClientTests.js
@@ -3,13 +3,14 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Dirs } from 'server-env';
+import { UtilityClass } from 'util-common';
 
 import Utils from './Utils';
 
 /**
  * Driver for the Mocha framework, for client tests.
  */
-export default class ClientTests {
+export default class ClientTests extends UtilityClass {
   /**
    * Returns a list of the test files for client modules that are used by the
    * product.

--- a/local-modules/testing-server/ClientTests.js
+++ b/local-modules/testing-server/ClientTests.js
@@ -20,8 +20,8 @@ export default class ClientTests extends UtilityClass {
   static allTestFiles() {
     // TODO: Complain about modules that have no tests at all.
 
-    const moduleNames = Utils.localModulesIn(Dirs.CLIENT_DIR);
-    const testFiles = Utils.allTestFiles(Dirs.CLIENT_DIR, moduleNames);
+    const moduleNames = Utils.localModulesIn(Dirs.theOne.CLIENT_DIR);
+    const testFiles = Utils.allTestFiles(Dirs.theOne.CLIENT_DIR, moduleNames);
 
     return testFiles;
   }

--- a/local-modules/testing-server/Mocks.js
+++ b/local-modules/testing-server/Mocks.js
@@ -2,11 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common';
+
 /**
  * A collection of methods for creating mock objects needed for Bayou unit
  * testing.
  */
-export default class Mocks {
+export default class Mocks extends UtilityClass {
   static nodeRequest(uri = 'http://www.example.com',
                      method = 'GET',
                      headers = { host: 'example.com' },

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -29,8 +29,8 @@ export default class ServerTests extends UtilityClass {
   static runAll(callback = null) {
     // TODO: Complain about modules that have no tests at all.
 
-    const moduleNames = Utils.localModulesIn(Dirs.SERVER_DIR);
-    const testFiles = Utils.allTestFiles(Dirs.SERVER_DIR, moduleNames);
+    const moduleNames = Utils.localModulesIn(Dirs.theOne.SERVER_DIR);
+    const testFiles = Utils.allTestFiles(Dirs.theOne.SERVER_DIR, moduleNames);
     const mocha = new Mocha();
 
     for (const f of testFiles) {

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -7,6 +7,7 @@ import chaiAsPromised from 'chai-as-promised';
 import Mocha from 'mocha';
 
 import { Dirs } from 'server-env';
+import { UtilityClass } from 'util-common';
 
 import Utils from './Utils';
 
@@ -16,7 +17,7 @@ chai.use(chaiAsPromised);
 /**
  * Driver for the Mocha framework, for server tests.
  */
-export default class ServerTests {
+export default class ServerTests extends UtilityClass {
   /**
    * Builds a list of all bayou-local tests, adds them to a test runner,
    * and then executes the tests.

--- a/local-modules/testing-server/Utils.js
+++ b/local-modules/testing-server/Utils.js
@@ -5,10 +5,12 @@
 import fs from 'fs';
 import path from 'path';
 
+import { UtilityClass } from 'util-common';
+
 /**
  * Utilities for this module.
  */
-export default class Utils {
+export default class Utils extends UtilityClass {
   /**
    * Gets a list of the names of Bayou local modules under the given subproduct
    * base directory.

--- a/local-modules/testing-server/package.json
+++ b/local-modules/testing-server/package.json
@@ -8,6 +8,7 @@
     "chai-as-promised": "^6.0.0",
     "mocha": "^3.3.0",
 
-    "server-env": "local"
+    "server-env": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/typecheck-server/TBuffer.js
+++ b/local-modules/typecheck-server/TBuffer.js
@@ -3,11 +3,12 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TypeError } from 'typecheck';
+import { UtilityClass } from 'util-common';
 
 /**
  * Type checker for type `Buffer`.
  */
-export default class TBuffer {
+export default class TBuffer extends UtilityClass {
   /**
    * Checks a value of type `Buffer`.
    *

--- a/local-modules/typecheck-server/package.json
+++ b/local-modules/typecheck-server/package.json
@@ -4,6 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
-    "typecheck": "local"
+    "typecheck": "local",
+    "util-common": "local"
   }
 }

--- a/local-modules/typecheck/TArray.js
+++ b/local-modules/typecheck/TArray.js
@@ -2,12 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 import TypeError from './TypeError';
 
 /**
  * Type checker for type `Array`.
  */
-export default class TArray {
+export default class TArray extends UtilityClass {
   /**
    * Checks a value of type `Array`. Optionally checks the type of each element.
    *

--- a/local-modules/typecheck/TBoolean.js
+++ b/local-modules/typecheck/TBoolean.js
@@ -2,12 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 import TypeError from './TypeError';
 
 /**
  * Type checker for type `Boolean`.
  */
-export default class TBoolean {
+export default class TBoolean extends UtilityClass {
   /**
    * Checks a value of type `Boolean`.
    *

--- a/local-modules/typecheck/TFunction.js
+++ b/local-modules/typecheck/TFunction.js
@@ -2,12 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 import TypeError from './TypeError';
 
 /**
  * Type checker for type `Function`.
  */
-export default class TFunction {
+export default class TFunction extends UtilityClass {
   /**
    * Checks a value of type `Function`.
    *

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 import TypeError from './TypeError';
 
 /**
@@ -11,7 +13,7 @@ import TypeError from './TypeError';
  * class follows the module's convention of using a `T` name prefix, so as to
  * keep things more straightforward.
  */
-export default class TInt {
+export default class TInt extends UtilityClass {
   /**
    * Checks a value of type `Int`.
    *

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { ObjectUtil } from 'util-common-base';
+import { ObjectUtil, UtilityClass } from 'util-common-base';
 
 import TypeError from './TypeError';
 
 /**
  * Type checker for type `Object`.
  */
-export default class TObject {
+export default class TObject extends UtilityClass {
   /**
    * Checks a value of type `Object`.
    *

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -4,12 +4,14 @@
 
 import url from 'url';
 
+import { UtilityClass } from 'util-common-base';
+
 import TypeError from './TypeError';
 
 /**
  * Type checker for type `String`.
  */
-export default class TString {
+export default class TString extends UtilityClass {
   /**
    * Checks a value of type `String`. Optionally validates contents against
    * a regex.

--- a/local-modules/util-client/DomUtil.js
+++ b/local-modules/util-client/DomUtil.js
@@ -2,10 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common';
+
 /**
  * DOM helper utilities.
  */
-export default class DomUtil {
+export default class DomUtil extends UtilityClass {
   /**
    * Adds a stylesheet to the given document by URL, returning a promise that
    * resolves when it is fully loaded.

--- a/local-modules/util-client/package.json
+++ b/local-modules/util-client/package.json
@@ -1,5 +1,9 @@
 {
   "name": "util-client",
   "version": "1.0.0",
-  "main": "main.js"
+  "main": "main.js",
+
+  "dependencies": {
+    "util-common": "local"
+  }
 }

--- a/local-modules/util-common-base/ObjectUtil.js
+++ b/local-modules/util-common-base/ObjectUtil.js
@@ -2,10 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import UtilityClass from './UtilityClass';
+
 /**
  * `Object` helper utilities.
  */
-export default class ObjectUtil {
+export default class ObjectUtil extends UtilityClass {
   /**
    * Calls `value.hasOwnProperty()` safely.
    *

--- a/local-modules/util-common-base/UtilityClass.js
+++ b/local-modules/util-common-base/UtilityClass.js
@@ -1,0 +1,19 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Base class for "utility" classes. A utility class is one which is not
+ * meant to be instantiated, but rather is merely a collection of `static`
+ * methods. This (base) class enforces non-instantiability and also helps
+ * serve as documentation for the intent of how a class is defined.
+ */
+export default class UtilityClass {
+  /**
+   * Always throws an error. That is, utility classes are not ever supposed to
+   * be instantiated.
+   */
+  constructor() {
+    throw new Error('Utility classes are not instantiable.');
+  }
+}

--- a/local-modules/util-common-base/main.js
+++ b/local-modules/util-common-base/main.js
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import ObjectUtil from './ObjectUtil';
+import UtilityClass from './UtilityClass';
 
-export { ObjectUtil };
+export { ObjectUtil, UtilityClass };

--- a/local-modules/util-common/DataUtil.js
+++ b/local-modules/util-common/DataUtil.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray, TInt, TString } from 'typecheck';
-import { ObjectUtil } from 'util-common-base';
+import { ObjectUtil, UtilityClass } from 'util-common-base';
 
 /**
  * "Data value" helper utilities. A "data value" is defined as any JavaScript
@@ -14,7 +14,7 @@ import { ObjectUtil } from 'util-common-base';
  * properties, or objects with a prototype other than `Object.prototype` or
  * `Array.prototype`.
  */
-export default class DataUtil {
+export default class DataUtil extends UtilityClass {
   /**
    * Makes a deep-frozen clone of the given data value, or return the value
    * itself if it is already deep-frozen.

--- a/local-modules/util-common/JsonUtil.js
+++ b/local-modules/util-common/JsonUtil.js
@@ -2,10 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 /**
  * JSON helper utilities.
  */
-export default class JsonUtil {
+export default class JsonUtil extends UtilityClass {
   /**
    * Like `JSON.parse()`, except the result is always deep-frozen.
    *

--- a/local-modules/util-common/PromDelay.js
+++ b/local-modules/util-common/PromDelay.js
@@ -2,12 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 /**
- * Construction of promises which become resolved after a specified delay.
- * This class isn't meant to be instantiable; it just exists to hold static
- * methods.
+ * Utility that constructs of promises which become resolved after a specified
+ * delay.
  */
-export default class PromDelay {
+export default class PromDelay extends UtilityClass {
   /**
    * Returns a promise that, after a specified delay, resolves to an indicated
    * value. If that value is _also_ a promise, then the result of this function

--- a/local-modules/util-common/Random.js
+++ b/local-modules/util-common/Random.js
@@ -5,6 +5,7 @@
 import secureRandom from 'secure-random';
 
 import { TInt } from 'typecheck';
+import { UtilityClass } from 'util-common-base';
 
 import DataUtil from './DataUtil';
 
@@ -22,7 +23,7 @@ const ID_CHARS = 'abcdefghjkmnpqrstuwxyz0123456789';
  * platform's RNG. That module works both in client and server environments,
  * using appropriate underlying facilities in each.
  */
-export default class Random {
+export default class Random extends UtilityClass {
   /**
    * Gets a random byte value (range `0` to `255` inclusive).
    *

--- a/local-modules/util-common/WebsocketCodes.js
+++ b/local-modules/util-common/WebsocketCodes.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common-base';
+
 /**
  * Map of close codes to nominally official constant names. See
  * <https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent>.
@@ -25,10 +27,8 @@ const CLOSE_CODES = {
 
 /**
  * Translator of websocket status codes to human-oriented strings.
- *
- * **Note:** This class is not intended to be instantiated.
  */
-export default class WebsocketCodes {
+export default class WebsocketCodes extends UtilityClass {
   /**
    * Get a friendly string for the given close reason code. This will always
    * include the number and will also include the name if known.

--- a/server/main.js
+++ b/server/main.js
@@ -103,7 +103,7 @@ function run() {
   ServerEnv.init();
 
   // A little spew to identify us.
-  const info = ProductInfo.INFO;
+  const info = ProductInfo.theOne.INFO;
   for (const k of Object.keys(info)) {
     log.info(`${k} = ${info[k]}`);
   }

--- a/server/main.js
+++ b/server/main.js
@@ -111,7 +111,7 @@ function run() {
   if (devMode) {
     // We're in dev mode. This starts the system that live-syncs the client
     // source.
-    new DevMode().start();
+    DevMode.theOne.start();
   }
 
   Hooks.theOne.run();

--- a/server/main.js
+++ b/server/main.js
@@ -157,7 +157,7 @@ function serverTest() {
 
 // Initialize logging.
 ServerSink.init();
-new FileSink(path.resolve(Dirs.LOG_DIR, 'general.log'));
+new FileSink(path.resolve(Dirs.theOne.LOG_DIR, 'general.log'));
 
 if (clientBundleMode) {
   clientBundle();


### PR DESCRIPTION
This PR consists of a full pass over the code, to become more consistent with respect to the definition of singleton and utility classes. This also included defining `UtilityClass` as an explicit class for utility classes to derive from instead of just being documented as such in the class header comments.

In many cases, the only changes were to add `extends Singleton` or `extends UtilityClass`, along with minor tweaks to the code. However, a couple cases warranted extra tweakage. Notably, in some cases utility classes got converted into singletons (because they kept or allowed access to state), which meant that the use sites of those classes needed to start referring to `ClassName.theOne.whatever` instead of just `ClassName.whatever`.