### PR TITLE
Very nearly all-in on `async` / `await`.

### DIFF
--- a/client/js/tests/main.js
+++ b/client/js/tests/main.js
@@ -19,6 +19,7 @@ const elem = document.createElement('p');
 elem.innerHTML = 'Running&hellip;';
 document.body.appendChild(elem);
 
-Tests.runAll().then((result) => {
+(async () => {
+  const result = await Tests.runAll();
   elem.innerHTML = result;
-});
+})();

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -66,22 +66,6 @@ taking into account recent additions to the language.
   }
   ```
 
-* Utility classes &mdash; Utility classes are classes which only serve as a
-  collection of functionality exposed as static methods (and sometimes static
-  properties). Utility classes should be defined as `extends UtilityClass` both
-  to document the intent and to provide enforced guarantees.
-
-  **Note:** Preferably, utility classes are _not_ a vector for exposing
-  application state and are merely holders of "pure" functionality. For a
-  utility-like class that maintains and/or exposes state, it is better to use
-  a singleton.
-
-* Singleton classes &mdash; Singleton classes are classes which should only
-  ever have a single instance within the system. These should be defined as
-  `extends Singleton` both to document the intent and to provide enforced
-  guarantees. Additionally, instead of explicitly constructing singletons,
-  the convention is to use the static property `theOne` on the so-defined class.
-
 * Immediate-async blocks &mdash; When programming in the `async`/`await` style,
   sometimes it's useful to to "spawn" an independent thread of control which
   doesn't block the main execution of a method. Were JavaScript more mature,
@@ -119,3 +103,19 @@ taking into account recent additions to the language.
     ...
   }
   ```
+
+* Utility classes &mdash; Utility classes are classes which only serve as a
+  collection of functionality exposed as static methods (and sometimes static
+  properties). Utility classes should be defined as `extends UtilityClass` both
+  to document the intent and to provide enforced guarantees.
+
+  **Note:** Preferably, utility classes are _not_ a vector for exposing
+  application state and are merely holders of "pure" functionality. For a
+  utility-like class that maintains and/or exposes state, it is better to use
+  a singleton.
+
+* Singleton classes &mdash; Singleton classes are classes which should only
+  ever have a single instance within the system. These should be defined as
+  `extends Singleton` both to document the intent and to provide enforced
+  guarantees. Additionally, instead of explicitly constructing singletons,
+  the convention is to use the static property `theOne` on the so-defined class.

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -81,3 +81,41 @@ taking into account recent additions to the language.
   `extends Singleton` both to document the intent and to provide enforced
   guarantees. Additionally, instead of explicitly constructing singletons,
   the convention is to use the static property `theOne` on the so-defined class.
+
+* Immediate-async blocks &mdash; When programming in the `async`/`await` style,
+  sometimes it's useful to to "spawn" an independent thread of control which
+  doesn't block the main execution of a method. Were JavaScript more mature,
+  this would probably be represented by syntax along the lines of:
+
+  ```javascript
+  // DO NOT DO THIS! _NOT_ ACTUAL JAVASCRIPT SYNTAX.
+  function blort() {
+    const x = async {
+      // These don't block the outer function from running. `x` is a promise
+      // that resolves to `thing3` once the asynchronous operations are
+      // complete.
+      await thing1;
+      await thing2;
+      return thing3;
+    }
+    ...
+  }
+  ```
+
+  Though a bit more verbose and less obvious, the same result can be achieved
+  with an immediately-invoked anonymous function. This pattern is used
+  throughout the project:
+
+  ```javascript
+  function blort() {
+    const x = (async () => {
+      // These don't block the outer function from running. `x` is a promise
+      // that resolves to `thing3` once the asynchronous operations are
+      // complete.
+      await thing1;
+      await thing2;
+      return thing3;
+    })();
+    ...
+  }
+  ```

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -70,24 +70,23 @@ export default class TargetHandler {
    * Sets up the method handler table. This gets called as a byproduct of the
    * first property lookup.
    */
-  _becomeReady() {
+  async _becomeReady() {
     if (this._readyState !== 'not') {
       return;
     }
 
     this._readyState = 'readying';
 
-    this._apiClient.meta.schemaFor(this._targetId).then((schema) => {
-      const methods = this._methods;
+    const schema = await this._apiClient.meta.schemaFor(this._targetId);
+    const methods = this._methods;
 
-      for (const name in schema[this._targetId]) {
-        if (!VERBOTEN_METHODS.has(name)) {
-          methods.set(name, this._makeMethodHandler(name));
-        }
+    for (const name in schema[this._targetId]) {
+      if (!VERBOTEN_METHODS.has(name)) {
+        methods.set(name, this._makeMethodHandler(name));
       }
+    }
 
-      this._readyState = 'ready';
-    });
+    this._readyState = 'ready';
   }
 
   /**

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -136,79 +136,82 @@ export default class Connection extends CommonBase {
    * **Note:** Subclasses are expected to call this.
    *
    * @param {string} msg Incoming message, in JSON string form.
-   * @returns {Promise} Promise for the response. If there is an error, the
-   *   promise will _resolve_ to the error response (as opposed to being
-   *   rejected).
+   * @returns {string} Response to the message, in JSON string form. This
+   *   resolves after the message has been handled. If there was an error in
+   *   handling the message, this will be an error response (as opposed to the
+   *   method throwing an error). The intent is that this method _never_ throws
+   *   errors.
    */
-  handleJsonMessage(msg) {
-    return new Promise((res, rej_unused) => {
-      msg = this._decodeMessage(msg); // Not supposed to ever throw.
-      const startTime = this._apiLog.incomingMessage(this._connectionId, msg);
+  async handleJsonMessage(msg) {
+    msg = this._decodeMessage(msg); // Not supposed to ever throw.
 
-      // Function to send a response. Arrow syntax so that `this` is usable.
-      const respond = (result, error) => {
-        const response = { id: msg.id };
-        if (error) {
-          response.error = error.message;
-        } else {
-          response.result = result;
-        }
+    const startTime = this._apiLog.incomingMessage(this._connectionId, msg);
+    let result = null;
+    let error = null;
 
-        // We resolve the promise successfully, whether or not the actual
-        // handling of the message resulted in an error. That is, at this layer,
-        // we can succeed in transporting a value which indicates a higher-level
-        // error.
-        res(Encoder.encodeJson(response));
-
-        if (error) {
-          // Augment the logged response with the error's stack trace. This
-          // clause cleans it up so that it is an array of separate lines and
-          // so that we omit the uninteresting parts of the file paths.
-          response.errorStack = error.stack.match(/^ +at .*$/mg).map((line) => {
-            // Lines that name functions are expected to be of the form:
-            // * `    at func.name (/path/to/file:NN:NN)`
-            // where `func.name` might actually be `new func.name` or
-            // `func.name [as other.name]` (or both).
-            let match = line.match(/^ +at ([^()]+) \(([^()]+)\)$/);
-            let funcName;
-            let filePath;
-
-            if (match) {
-              funcName = match[1];
-              filePath = match[2];
-            } else {
-              // Anonymous functions (including top-level code) have the form:
-              // * `    at /path/to/file:NN:NN`
-              match = line.match(/^ +at ([^()]*)$/);
-              funcName = '(anon)';
-              filePath = match[1];
-            }
-
-            const fileSplit = filePath.match(/\/?[^/]+/g) || ['?'];
-            const splitLen  = fileSplit.length;
-            const fileName  = (splitLen < 2)
-              ? fileSplit[0]
-              : `...${fileSplit[splitLen - 2]}${fileSplit[splitLen - 1]}`;
-
-            return `${funcName} (${fileName})`;
-          });
-        }
-
-        this._apiLog.fullCall(this._connectionId, startTime, msg, response);
-      };
-
-      if (msg.isError()) {
-        respond(null, new Error(msg.errorMessage));
-      } else {
-        try {
-          this._actOnMessage(msg)
-            .then((result) => { respond(result, null); })
-            .catch((error) => { respond(null, error);  });
-        } catch (e) {
-          respond(null, e);
-        }
+    if (msg.isError()) {
+      error = new Error(msg.errorMessage);
+    } else {
+      try {
+        result = await this._actOnMessage(msg);
+      } catch (e) {
+        error = e;
       }
-    });
+    }
+
+    return this._makeResponse(msg, startTime, result, error);
+  }
+
+  _makeResponse(msg, startTime, result, error) {
+    const response = { id: msg.id };
+    if (error) {
+      response.error = error.message;
+    } else {
+      response.result = result;
+    }
+
+    // We resolve the promise successfully, whether or not the actual
+    // handling of the message resulted in an error. That is, at this layer,
+    // we can succeed in transporting a value which indicates a higher-level
+    // error.
+    const responseJson = Encoder.encodeJson(response);
+
+    if (error) {
+      // Augment the logged response with the error's stack trace. This
+      // clause cleans it up so that it is an array of separate lines and
+      // so that we omit the uninteresting parts of the file paths.
+      response.errorStack = error.stack.match(/^ +at .*$/mg).map((line) => {
+        // Lines that name functions are expected to be of the form:
+        // * `    at func.name (/path/to/file:NN:NN)`
+        // where `func.name` might actually be `new func.name` or
+        // `func.name [as other.name]` (or both).
+        let match = line.match(/^ +at ([^()]+) \(([^()]+)\)$/);
+        let funcName;
+        let filePath;
+
+        if (match) {
+          funcName = match[1];
+          filePath = match[2];
+        } else {
+          // Anonymous functions (including top-level code) have the form:
+          // * `    at /path/to/file:NN:NN`
+          match = line.match(/^ +at ([^()]*)$/);
+          funcName = '(anon)';
+          filePath = match[1];
+        }
+
+        const fileSplit = filePath.match(/\/?[^/]+/g) || ['?'];
+        const splitLen  = fileSplit.length;
+        const fileName  = (splitLen < 2)
+          ? fileSplit[0]
+          : `...${fileSplit[splitLen - 2]}${fileSplit[splitLen - 1]}`;
+
+        return `${funcName} (${fileName})`;
+      });
+    }
+
+    this._apiLog.fullCall(this._connectionId, startTime, msg, response);
+    return responseJson;
   }
 
   /**

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -102,13 +102,15 @@ export default class MetaHandler {
     // Store the challenge, and arrange for its expiry.
 
     this._activeChallenges.set(challenge, { id, response });
-    PromDelay.resolve(CHALLENGE_TIMEOUT_MSEC).then(() => {
+
+    (async () => {
+      await PromDelay.resolve(CHALLENGE_TIMEOUT_MSEC);
       if (this._activeChallenges.delete(challenge)) {
         // `delete` returns `true` to indicate that the value was found. In this
         // case, it means that it expired.
         this._log.info(`Challenge expired: ${id} ${challenge}`);
       }
-    });
+    })();
 
     // **Note:** It's probably okay to log the expected response, but may be
     // worth thinking a bit more about. (Attention: Security professionals!)

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -89,17 +89,17 @@ export default class PostConnection extends Connection {
   /**
    * Handles an `end` event coming from the request input stream.
    */
-  _handleEnd() {
+  async _handleEnd() {
     this._log.info('Received message.');
 
     const msg = Buffer.concat(this._chunks).toString('utf8');
-    this.handleJsonMessage(msg).then((response) => {
-      this._res
-        .status(200)
-        .type('application/json')
-        .send(response);
-      this.close();
-    });
+    const response = await this.handleJsonMessage(msg);
+
+    this._res
+      .status(200)
+      .type('application/json')
+      .send(response);
+    this.close();
   }
 
   /**

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -36,10 +36,10 @@ export default class WsConnection extends Connection {
    *
    * @param {string} msg Incoming message, in JSON string form.
    */
-  _handleMessage(msg) {
-    this.handleJsonMessage(msg).then((response) => {
-      this._ws.send(response);
-    });
+  async _handleMessage(msg) {
+    const response = await this.handleJsonMessage(msg);
+
+    this._ws.send(response);
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -52,6 +52,13 @@ export default class Application {
     // Bind `rootAccess` into the `context` using the root token(s), and arrange
     // for their update should the token(s) change.
     this._bindRoot();
+    (async () => {
+      for (;;) {
+        await Hooks.theOne.bearerTokens.whenRootTokensChange();
+        log.info('Root tokens updated.');
+        this._bindRoot();
+      }
+    })();
 
     /** The underlying webserver run by this instance. */
     this._app = express();
@@ -155,11 +162,5 @@ export default class Application {
       }
       this._rootTokens = rootTokens;
     }
-
-    // Wait for the token(s) to change, and then call this method recursively.
-    Hooks.theOne.bearerTokens.whenRootTokensChange().then(() => {
-      log.info('Root tokens updated.');
-      this._bindRoot();
-    });
   }
 }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -318,26 +318,24 @@ export default class DebugTools {
   }
 
   /**
-   * Returns a promise for an existing document based on the usual debugging
-   * request argument. If the document doesn't exist, the promise will get
-   * rejected with a reasonably-descriptive message.
+   * Returns an existing document based on the usual debugging request argument.
+   * If the document doesn't exist, this method throws a reasonably-descriptive
+   * message.
    *
    * @param {object} req HTTP request.
    * @returns {Promise<DocControl>} Promise for the requested document.
    */
-  _getExistingDoc(req) {
+  async _getExistingDoc(req) {
     const documentId = req.params.documentId;
-    const docPromise = DocServer.theOne.getDocOrNull(documentId);
+    const doc        = await DocServer.theOne.getDocOrNull(documentId);
 
-    return docPromise.then((doc) => {
-      if (doc === null) {
-        const error = new Error();
-        error.debugMsg = `No such document: ${documentId}`;
-        throw error;
-      }
+    if (doc === null) {
+      const error = new Error();
+      error.debugMsg = `No such document: ${documentId}`;
+      throw error;
+    }
 
-      return doc;
-    });
+    return doc;
   }
 
   /**
@@ -352,17 +350,16 @@ export default class DebugTools {
   }
 
   /**
-   * Makes and returns a promise for a new authorization key for the given
-   * document / author combo.
+   * Makes and returns a new authorization key for the given document / author
+   * combo, as a JSON-encoded string.
    *
    * @param {string} documentId The document ID.
    * @param {string} authorId The author ID.
-   * @returns {Promise<string>} Promise for a new `SplitKey` encoded as JSON.
+   * @returns {string} A new `SplitKey` encoded as JSON.
    */
-  _makeEncodedKey(documentId, authorId) {
-    return this._rootAccess.makeAccessKey(authorId, documentId).then((key) => {
-      return Encoder.encodeJson(key);
-    });
+  async _makeEncodedKey(documentId, authorId) {
+    const key = await this._rootAccess.makeAccessKey(authorId, documentId);
+    return Encoder.encodeJson(key);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -208,37 +208,34 @@ export default class DebugTools {
    *
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
-   * @returns {Promise} Promise whose rejection indicates an error to be
-   *   reported back to the user.
    */
-  _handle_edit(req, res) {
+  async _handle_edit(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
+    const key        = await this._makeEncodedKey(documentId, authorId);
 
-    return this._makeEncodedKey(documentId, authorId).then((key) => {
-      // These are already strings (JSON-encoded even, in the case of `key`),
-      // but we still have to JSON-encode _those_ strings, so as to make them
-      // proper JS source within the <script> block below.
-      const quotedKey        = JSON.stringify(key);
-      const quotedDocumentId = JSON.stringify(documentId);
-      const quotedAuthorId   = JSON.stringify(authorId);
+    // These are already strings (JSON-encoded even, in the case of `key`),
+    // but we still have to JSON-encode _those_ strings, so as to make them
+    // proper JS source within the <script> block below.
+    const quotedKey        = JSON.stringify(key);
+    const quotedDocumentId = JSON.stringify(documentId);
+    const quotedAuthorId   = JSON.stringify(authorId);
 
-      // TODO: Probably want to use a real template.
-      const head =
-        '<title>Editor</title>\n' +
-        '<script>\n' +
-        `  BAYOU_KEY         = ${quotedKey};\n` +
-        '  BAYOU_NODE        = "#editor";\n' +
-        `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
-        `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
-        '</script>\n' +
-        '<script src="/boot-for-debug.js"></script>\n';
-      const body =
-        '<h1>Editor</h1>\n' +
-        '<div id="editor"><p>Loading&hellip;</p></div>\n';
+    // TODO: Probably want to use a real template.
+    const head =
+      '<title>Editor</title>\n' +
+      '<script>\n' +
+      `  BAYOU_KEY         = ${quotedKey};\n` +
+      '  BAYOU_NODE        = "#editor";\n' +
+      `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
+      `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
+      '</script>\n' +
+      '<script src="/boot-for-debug.js"></script>\n';
+    const body =
+      '<h1>Editor</h1>\n' +
+      '<div id="editor"><p>Loading&hellip;</p></div>\n';
 
-      this._htmlResponse(res, head, body);
-    });
+    this._htmlResponse(res, head, body);
   }
 
   /**
@@ -247,16 +244,13 @@ export default class DebugTools {
    *
    * @param {object} req HTTP request.
    * @param {object} res HTTP response handler.
-   * @returns {Promise} Promise whose rejection indicates an error to be
-   *   reported back to the user.
    */
-  _handle_key(req, res) {
+  async _handle_key(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
+    const key        = await this._makeEncodedKey(documentId, authorId);
 
-    return this._makeEncodedKey(documentId, authorId).then((key) => {
-      this._jsonResponse(res, key);
-    });
+    this._jsonResponse(res, key);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -274,12 +274,12 @@ export default class DocControl extends CommonBase {
     // Force the `_changeCondition` to `false` (though it might already be
     // so set; innocuous if so), and wait for it to become `true`.
     this._changeCondition.value = false;
-    return this._changeCondition.whenTrue().then((value_unused) => {
-      // Just recurse to do the work. Under normal circumstances it will return
-      // promptly. This arrangement gracefully handles edge cases, though, such
-      // as a triggered change turning out to be due to a no-op.
-      return this.deltaAfter(baseRevNum);
-    });
+    await this._changeCondition.whenTrue();
+
+    // Just recurse to do the work. Under normal circumstances it will return
+    // promptly. This arrangement gracefully handles edge cases, though, such
+    // as a triggered change turning out to be due to a no-op.
+    return this.deltaAfter(baseRevNum);
   }
 
   /**

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -48,8 +48,11 @@ export default class LogStream {
     this._logger.log(this._level, chunk);
 
     if (callback) {
-      // Use `then()` to make the callback happen in its own tick/turn.
-      Promise.resolve(true).then((value_unused) => { callback(); });
+      // Make the callback happen in its own tick/turn.
+      (async () => {
+        await Promise.resolve(true);
+        callback();
+      })();
     }
   }
 

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -22,11 +22,10 @@ export default class ServerTests extends UtilityClass {
    * Builds a list of all bayou-local tests, adds them to a test runner,
    * and then executes the tests.
    *
-   * @param {function|null} [callback = null] Callback which is called when
-   *   testing is complete. Gets passed a `failures` value. Ignored if passed
-   *   as `null`.
+   * @returns {number} Count of test failures, which resolves after testing is
+   *   complete.
    */
-  static runAll(callback = null) {
+  static async runAll() {
     // TODO: Complain about modules that have no tests at all.
 
     const moduleNames = Utils.localModulesIn(Dirs.theOne.SERVER_DIR);
@@ -37,10 +36,8 @@ export default class ServerTests extends UtilityClass {
       mocha.addFile(f);
     }
 
-    mocha.run((failures) => {
-      if (callback !== null) {
-        callback(failures);
-      }
+    return new Promise((res, rej_unused) => {
+      mocha.run((failures) => { res(failures); });
     });
   }
 }

--- a/server/main.js
+++ b/server/main.js
@@ -126,13 +126,14 @@ function run() {
 /**
  * Does a client bundling.
  */
-function clientBundle() {
-  new ClientBundle().build().then((res_unused) => {
+async function clientBundle() {
+  try {
+    await new ClientBundle().build();
     process.exit(0);
-  }, (rej) => {
-    log.error(rej);
+  } catch (e) {
+    log.error(e);
     process.exit(1);
-  });
+  }
 }
 
 /**

--- a/server/main.js
+++ b/server/main.js
@@ -139,21 +139,20 @@ async function clientBundle() {
 /**
  * Does a server testing run.
  */
-function serverTest() {
+async function serverTest() {
   // TODO: Arguably this call shouldn't be necessary. (That is, the test code
   // that cares about server env stuff should arrange for its appropriate
   // initialization and perhaps even teardown.)
   ServerEnv.init();
 
-  ServerTests.runAll((failures) => {
-    const anyFailed = (failures !== 0);
-    const msg = anyFailed
-      ? `Failed: ${failures}`
-      : 'All good! Yay!';
+  const failures = await ServerTests.runAll();
+  const anyFailed = (failures !== 0);
+  const msg = anyFailed
+    ? `Failed: ${failures}`
+    : 'All good! Yay!';
 
-    console.log(msg); // eslint-disable-line no-console
-    process.exit(anyFailed ? 1 : 0);
-  });
+  console.log(msg); // eslint-disable-line no-console
+  process.exit(anyFailed ? 1 : 0);
 }
 
 // Initialize logging.


### PR DESCRIPTION
This PR consists of rework of almost every case where we used `somePromise.then(...)` to instead use `await somePromise`. Most often this meant recasting the method in which the code appeared to be an `async` method. Sometimes it meant a bit more invasive work. All in all, I think the results are much more readable than what we started with, _despite_ the need for a bit of circumlocution when spawning independent "threads" of control (said circumlocution which is now documented in the coding conventions file).

I intentionally _didn't_ update the `ApiClient` state machine in this PR, because that one is going to require a bit more thought. In addition, there are still a few remaining cases of `new Promise(...)` which could probably be reworked into a nicer / cleaner form.