### PR TITLE
File revision number.

### DIFF
--- a/local-modules/content-store/BaseContentStore.js
+++ b/local-modules/content-store/BaseContentStore.js
@@ -60,6 +60,6 @@ export default class BaseContentStore extends Singleton {
    * @returns {BaseFile} Accessor for the file in question.
    */
   async _impl_getFile(fileId) {
-    return this._mustOverride(fileId);
+    this._mustOverride(fileId);
   }
 }

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -262,7 +262,7 @@ export default class BaseFile extends CommonBase {
    * @returns {Int} The instantaneously current revision number of the file.
    */
   async revNum() {
-    const result = TInt.min(this._impl_revNum(), this._lastRevNum);
+    const result = TInt.min(await this._impl_revNum(), this._lastRevNum);
 
     this._lastRevNum = result;
     return result;

--- a/local-modules/util-common-base/UtilityClass.js
+++ b/local-modules/util-common-base/UtilityClass.js
@@ -7,6 +7,8 @@
  * meant to be instantiated, but rather is merely a collection of `static`
  * methods. This (base) class enforces non-instantiability and also helps
  * serve as documentation for the intent of how a class is defined.
+ *
+ * @abstract
  */
 export default class UtilityClass {
   /**

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -94,7 +94,7 @@ export default class CommonBase {
    *   method was called on.
    */
   static _impl_coerce(value) {
-    return this._mustOverride(value);
+    this._mustOverride(value);
   }
 
   /**


### PR DESCRIPTION
This PR adds the concept of "revision number" of a file at the `content-store` layer. This will ultimately be used to help drive long-poll requests for content changes.

**Bonus:** Cleaned up a handful of bits surrounding classes and methods declared `@abstract`.