### PR TITLE
`whenChange()` and friends.

### DIFF
--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -59,8 +59,8 @@ export default class TargetHandler {
    * @returns {function} An appropriately-constructed handler.
    */
   _makeMethodHandler(name) {
-    const apiClient  = this._apiClient;  // Avoid re-(re-)lookup on every call.
-    const targetId = this._targetId; // Likewise.
+    const apiClient = this._apiClient;  // Avoid re-(re-)lookup on every call.
+    const targetId  = this._targetId;   // Likewise.
     return (...args) => {
       return apiClient._send(targetId, 'call', name, args);
     };

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -121,7 +121,7 @@ export default class LocalFile extends BaseFile {
    * (Keep in mind that this module is oriented toward development time, not
    * production.)
    */
-  get maxAwaitTimeoutMsec() {
+  get maxTimeoutMsec() {
     return 1 * 60 * 1000; // One minute.
   }
 

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -312,6 +312,7 @@ export default class LocalFile extends BaseFile {
     }
 
     this._revNum++;
+    this._storageRevNums.set(storagePath, this._revNum);
     this._storageToWrite.set(storagePath, newValue);
     this._storageNeedsWrite();
   }

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -126,6 +126,14 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
+   * {Int} Value as required by the superclass. It is defined to be 100msec
+   * here, for reasons similar to as described in `maxTimeoutMsec` above.
+   */
+  get minTimeoutMsec() {
+    return 100;
+  }
+
+  /**
    * Implementation as required by the superclass.
    *
    * @returns {boolean} `true` iff this file exists.

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { BaseFile } from 'content-store';
 import { Logger } from 'see-all';
-import { PromDelay } from 'util-common';
+import { PromCondition, PromDelay } from 'util-common';
 import { FrozenBuffer } from 'util-server';
 
 
@@ -64,6 +64,14 @@ export default class LocalFile extends BaseFile {
     this._storage = null;
 
     /**
+     * {Map<string,Int>|null} Map from `StoragePath` strings to the most recent
+     * revision number that affected the corresponding path. This includes
+     * entries for paths that have been deleted. `null` indicates that the map
+     * is not yet initialized.
+     */
+    this._storageRevNums = null;
+
+    /**
      * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to
      * corresponding stored data, for file contents that have not yet been
      * written to disk.
@@ -92,10 +100,103 @@ export default class LocalFile extends BaseFile {
      */
     this._storageReadyPromise = null;
 
+    /**
+     * Condition that transitions from `false` to `true` when there is a
+     * revision change and there are waiters for same. This remains `true` in
+     * the steady state (when there are no waiters). As soon as the first waiter
+     * comes along, it gets set to `false`.
+     */
+    this._changeCondition = new PromCondition(true);
+
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withPrefix(`[${fileId}]`);
 
     this._log.info(`Path: ${this._storageDir}`);
+  }
+
+  /**
+   * {Int} Value as required by the superclass. It is defined to be one minute
+   * here not because of any inherent time limit in the implementation, but
+   * just to make the limit small enough to be easily observable when testing.
+   * (Keep in mind that this module is oriented toward development time, not
+   * production.)
+   */
+  get maxAwaitTimeoutMsec() {
+    return 1 * 60 * 1000; // One minute.
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {Int} timeoutMsec Same as with `awaitChange()`.
+   * @param {Int} baseRevNum Same as with `awaitChange()`.
+   * @param {string|null} storagePath Same as with `awaitChange()`.
+   * @returns {Int|null} Same as with `awaitChange()`.
+   */
+  async _impl_awaitChange(timeoutMsec, baseRevNum, storagePath) {
+    // Arrange for timeout. **Note:** Needs to be done _before_ reading
+    // storage, as that storage read can take significant time.
+    let timeout = false; // Gets set to `true` when the timeout expires.
+    const timeoutProm = PromDelay.resolve(timeoutMsec);
+    (async () => {
+      await timeoutProm;
+      timeout = true;
+    })();
+
+    await this._readStorageIfNecessary();
+
+    if (baseRevNum > this._revNum) {
+      // Per the superclass docs (and due to the asynch nature of the system),
+      // we don't know that `baseRevNum` was passed in as an in-range value.
+      throw new Error(`Nonexistent \`revNum\`: ${baseRevNum}`);
+    }
+
+    if (storagePath === null) {
+      this._log.detail(`Want change after \`revNum\` ${baseRevNum}.`);
+    } else {
+      this._log.detail(`Want change after \`revNum\` ${baseRevNum}: ${storagePath}`);
+    }
+
+    // Check for the change condition, and iterate until either it's found or
+    // the timeout expires.
+    while (!timeout) {
+      // If `storagePath` is `null`, we are looking for any revision after the
+      // file's overall current revision number. If `path` is non-`null`, we are
+      // looking for a revision since the last one for that specific path.
+      let foundRevNum;
+      if (storagePath === null) {
+        // `storagePath` is `null`. We are looking for any revision after the
+        // file's overall current revision number.
+        foundRevNum = this._revNum;
+      } else {
+        // `storagePath` is non-`null`. We are looking for a revision
+        // specifically on that path.
+        foundRevNum = this._storageRevNums.get(storagePath);
+        if (foundRevNum === undefined) {
+          // A non-existent and never-existed path is effectively unmodified, for
+          // the subsequent logic.
+          foundRevNum = baseRevNum;
+        }
+      }
+
+      if (foundRevNum > baseRevNum) {
+        // Found!
+        this._log.detail(`Noticed change at \`revNum\` ${foundRevNum}.`);
+        return foundRevNum;
+      }
+
+      this._log.detail('Waiting for file to change.');
+
+      // Force the `_changeCondition` to `false` (though it might already be
+      // so set; innocuous if so), and wait either for it to become `true` (that
+      // is, wait for _any_ change to the file) or for the timeout to pass.
+      this._changeCondition.value = false;
+      await Promise.race([this._changeCondition.whenTrue(), timeoutProm]);
+    }
+
+    // The timeout expired.
+    this._log.detail('Timed out.');
+    return null;
   }
 
   /**
@@ -131,6 +232,7 @@ export default class LocalFile extends BaseFile {
 
     this._revNum              = 0;
     this._storage             = new Map();
+    this._storageRevNums      = new Map();
     this._storageToWrite      = new Map();
     this._storageNeedsErasing = true;
     this._storageReadyPromise = Promise.resolve(true);
@@ -250,8 +352,9 @@ export default class LocalFile extends BaseFile {
   async _readStorage() {
     if (!await afs.exists(this._storageDir)) {
       // Directory doesn't actually exist. Just initialize empty storage.
-      this._revNum  = 0;
-      this._storage = new Map();
+      this._revNum         = 0;
+      this._storage        = new Map();
+      this._storageRevNums = new Map();
       this._log.info('New storage.');
       return true;
     }
@@ -259,8 +362,11 @@ export default class LocalFile extends BaseFile {
     // The directory exists. Read its contents.
     this._log.info('Reading storage from disk...');
 
-    const files = await afs.readdir(this._storageDir);
-    const storage = new Map();
+    const files          = await afs.readdir(this._storageDir);
+    const storage        = new Map();
+    const storageRevNums = new Map();
+    let   revNum;
+
     for (const f of files) {
       const buf = await afs.readFile(path.resolve(this._storageDir, f));
       const storagePath = LocalFile._storagePathForFsName(f);
@@ -270,27 +376,37 @@ export default class LocalFile extends BaseFile {
 
     this._log.info('Done reading storage.');
 
-    // Only set the instance variables after all the reading is done.
-    this._storage             = storage;
-    this._storageToWrite      = new Map();
-    this._storageNeedsErasing = false;
-    this._storageIsDirty      = false;
-
     // Parse the file revision number out of its special-named blob, and handle
     // things reasonably gracefully if it's missing or corrupt.
     try {
-      const revNumBuffer = this._storage.get(REVISION_NUMBER_PATH);
-      this._revNum = JSON.parse(revNumBuffer.string);
-      this._log.info(`Starting revision number: ${this._revNum}`);
+      const revNumBuffer = storage.get(REVISION_NUMBER_PATH);
+      revNum = JSON.parse(revNumBuffer.string);
+      this._log.info(`Starting revision number: ${revNum}`);
     } catch (e) {
       // In case of failure, use the size of the storage map as a good enough
       // value for `revNum`. This case probably won't happen in practice except
       // when dealing with corrupt FS contents, but even if it does, this should
       // be fine in that the primary required guarantee is monotonic increase
       // within any given process (and not really across processes).
-      this._revNum = this._storage.size;
-      this._log.info(`Starting with "fake" revision number: ${this._revNum}`);
+      revNum = storage.size;
+      this._log.info(`Starting with "fake" revision number: ${revNum}`);
     }
+
+    // Note the revision number of all paths. Since we don't record this info
+    // to the FS, the best we can do is peg them all at the current revision
+    // number.
+    for (const k of storage.keys()) {
+      storageRevNums.set(k, revNum);
+    }
+
+    // Only set the instance variables after all the reading is done and the
+    // current revision number is known.
+    this._revNum              = revNum;
+    this._storage             = storage;
+    this._storageRevNums      = storageRevNums;
+    this._storageToWrite      = new Map();
+    this._storageNeedsErasing = false;
+    this._storageIsDirty      = false;
 
     return true;
   }
@@ -299,9 +415,13 @@ export default class LocalFile extends BaseFile {
    * Indicates that there are elements of `_storage` that need to be written to
    * disk. This method acts (and returns) promptly. It will kick off a timed
    * callback to actually perform the writing operation(s) if one isn't already
-   * pending.
+   * pending. In addition, it flips `_changeCondition` to `true` (if not
+   * already set as such), which unblocks code that was awaiting any changes.
    */
   _storageNeedsWrite() {
+    // Release anything awaiting a change.
+    this._changeCondition.value = true;
+
     if (this._storageIsDirty) {
       // Already marked dirty, which means there's nothing more to do. When
       // the already-scheduled timer fires, it will pick up the current change.

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -128,12 +128,12 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {Int} timeoutMsec Same as with `awaitChange()`.
-   * @param {Int} baseRevNum Same as with `awaitChange()`.
-   * @param {string|null} storagePath Same as with `awaitChange()`.
-   * @returns {Int|null} Same as with `awaitChange()`.
+   * @param {Int} timeoutMsec Same as with `whenChange()`.
+   * @param {Int} baseRevNum Same as with `whenChange()`.
+   * @param {string|null} storagePath Same as with `whenChange()`.
+   * @returns {Int|null} Same as with `whenChange()`.
    */
-  async _impl_awaitChange(timeoutMsec, baseRevNum, storagePath) {
+  async _impl_whenChange(timeoutMsec, baseRevNum, storagePath) {
     // Arrange for timeout. **Note:** Needs to be done _before_ reading
     // storage, as that storage read can take significant time.
     let timeout = false; // Gets set to `true` when the timeout expires.

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -44,7 +44,7 @@ export default class BaseFile extends CommonBase {
 
   /**
    * {Int} The maximum value allowed (inclusive) as the `timeoutMsec` argument
-   * to calls to `awaitChange()` on this instance.
+   * to calls to `whenChange()` on this instance.
    *
    * @abstract
    */
@@ -53,9 +53,9 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Awaits for a change to be made to a file, either in general or on a
-   * specific path. The return value becomes resolved soon after a change is
-   * made or the specified timeout elapses.
+   * Waits for a change to be made to a file, either in general or on a specific
+   * path. The return value becomes resolved soon after a change is made or the
+   * specified timeout elapses.
    *
    * When watching a path, any change to that path counts, including all of:
    * storing a value at a path not previously stored at; deleting the value at
@@ -76,7 +76,7 @@ export default class BaseFile extends CommonBase {
    *   which the change was made); or `null` if the call is returning due to
    *   timeout.
    */
-  async awaitChange(timeoutMsec, baseRevNum, storagePath = null) {
+  async whenChange(timeoutMsec, baseRevNum, storagePath = null) {
     const maxMsec = this.maxAwaitTimeoutMsec;
 
     if (timeoutMsec === -1) {
@@ -89,7 +89,7 @@ export default class BaseFile extends CommonBase {
     StoragePath.orNull(storagePath);
 
     const result =
-      await this._impl_awaitChange(timeoutMsec, baseRevNum, storagePath);
+      await this._impl_whenChange(timeoutMsec, baseRevNum, storagePath);
 
     if (result === null) {
       return null;
@@ -105,17 +105,17 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Main implementation of `awaitChange()`. It is guaranteed to be called
+   * Main implementation of `whenChange()`. It is guaranteed to be called
    * with valid arguments, _except_ that `baseRevNum` is not guaranteed to
    * refer to an existing revision.
    *
    * @abstract
-   * @param {Int} timeoutMsec Same as with `awaitChange()`.
-   * @param {Int} baseRevNum Same as with `awaitChange()`.
-   * @param {string|null} storagePath Same as with `awaitChange()`.
-   * @returns {Int|null} Same as with `awaitChange()`.
+   * @param {Int} timeoutMsec Same as with `whenChange()`.
+   * @param {Int} baseRevNum Same as with `whenChange()`.
+   * @param {string|null} storagePath Same as with `whenChange()`.
+   * @returns {Int|null} Same as with `whenChange()`.
    */
-  async _impl_awaitChange(timeoutMsec, baseRevNum, storagePath) {
+  async _impl_whenChange(timeoutMsec, baseRevNum, storagePath) {
     this._mustOverride(timeoutMsec, baseRevNum, storagePath);
   }
 

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -65,7 +65,8 @@ export default class BaseFile extends CommonBase {
    *   a change. If the requested change does not occur within this time, then
    *   this method returns `null` instead of a revision number. This value
    *   must be no greater than `maxAwaitTimeoutMsec` as defined on the instance
-   *   being called.
+   *   being called. As a convenience, passing this value as `-1` is equivalent
+   *   to passing `maxAwaitTimeoutMsec`.
    * @param {Int} baseRevNum The revision number which is the base for the
    *   request. The request is to detect a change with respect to this revision.
    * @param {string|null} [storagePath = null] The specific path to watch for
@@ -76,7 +77,14 @@ export default class BaseFile extends CommonBase {
    *   timeout.
    */
   async awaitChange(timeoutMsec, baseRevNum, storagePath = null) {
-    TInt.rangeInc(timeoutMsec, 0, this.maxAwaitTimeoutMsec);
+    const maxMsec = this.maxAwaitTimeoutMsec;
+
+    if (timeoutMsec === -1) {
+      timeoutMsec = maxMsec;
+    } else {
+      TInt.rangeInc(timeoutMsec, 0, maxMsec);
+    }
+
     TInt.min(baseRevNum, 0);
     StoragePath.orNull(storagePath);
 

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -297,6 +297,11 @@ export default class BaseFile extends CommonBase {
    * storing a value at a path not previously stored at; deleting the value at
    * a path; or storing a new value at an already-used path.
    *
+   * **Note:** Subclasses are allowed to silently increase the given
+   * `timeoutMsec` if they have a _minimum_ timeout. In such cases, it is
+   * expected that the minimum is relatively small in terms of human-visible
+   * time (e.g. under a second).
+   *
    * @param {Int} timeoutMsec The maximum amount of time (in msec) to wait for
    *   a change. If the requested change does not occur within this time, then
    *   this method returns `null` instead of a revision number. This value

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -53,73 +53,6 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Waits for a change to be made to a file, either in general or on a specific
-   * path. The return value becomes resolved soon after a change is made or the
-   * specified timeout elapses.
-   *
-   * When watching a path, any change to that path counts, including all of:
-   * storing a value at a path not previously stored at; deleting the value at
-   * a path; or storing a new value at an already-used path.
-   *
-   * @param {Int} timeoutMsec The maximum amount of time (in msec) to wait for
-   *   a change. If the requested change does not occur within this time, then
-   *   this method returns `null` instead of a revision number. This value
-   *   must be no greater than `maxAwaitTimeoutMsec` as defined on the instance
-   *   being called. As a convenience, passing this value as `-1` is equivalent
-   *   to passing `maxAwaitTimeoutMsec`.
-   * @param {Int} baseRevNum The revision number which is the base for the
-   *   request. The request is to detect a change with respect to this revision.
-   * @param {string|null} [storagePath = null] The specific path to watch for
-   *   changes to, or `null` if any file change will suffice.
-   * @returns {Int|null} If a change was detected, the revision number at which
-   *   it was detected (which might be larger than the actual revision number at
-   *   which the change was made); or `null` if the call is returning due to
-   *   timeout.
-   */
-  async whenChange(timeoutMsec, baseRevNum, storagePath = null) {
-    const maxMsec = this.maxAwaitTimeoutMsec;
-
-    if (timeoutMsec === -1) {
-      timeoutMsec = maxMsec;
-    } else {
-      TInt.rangeInc(timeoutMsec, 0, maxMsec);
-    }
-
-    TInt.min(baseRevNum, 0);
-    StoragePath.orNull(storagePath);
-
-    const result =
-      await this._impl_whenChange(timeoutMsec, baseRevNum, storagePath);
-
-    if (result === null) {
-      return null;
-    }
-
-    // For a non-`null` result, validate it and update `_lastRevNum`.
-    TInt.min(result, baseRevNum + 1);
-    if (result > this._lastRevNum) {
-      this._lastRevNum = result;
-    }
-
-    return result;
-  }
-
-  /**
-   * Main implementation of `whenChange()`. It is guaranteed to be called
-   * with valid arguments, _except_ that `baseRevNum` is not guaranteed to
-   * refer to an existing revision.
-   *
-   * @abstract
-   * @param {Int} timeoutMsec Same as with `whenChange()`.
-   * @param {Int} baseRevNum Same as with `whenChange()`.
-   * @param {string|null} storagePath Same as with `whenChange()`.
-   * @returns {Int|null} Same as with `whenChange()`.
-   */
-  async _impl_whenChange(timeoutMsec, baseRevNum, storagePath) {
-    this._mustOverride(timeoutMsec, baseRevNum, storagePath);
-  }
-
-  /**
    * Indicates whether or not this file exists in the store. Calling this method
    * will _not_ cause a non-existent file to come into existence.
    *
@@ -353,5 +286,72 @@ export default class BaseFile extends CommonBase {
    */
   async _impl_revNum() {
     this._mustOverride();
+  }
+
+  /**
+   * Waits for a change to be made to a file, either in general or on a specific
+   * path. The return value becomes resolved soon after a change is made or the
+   * specified timeout elapses.
+   *
+   * When watching a path, any change to that path counts, including all of:
+   * storing a value at a path not previously stored at; deleting the value at
+   * a path; or storing a new value at an already-used path.
+   *
+   * @param {Int} timeoutMsec The maximum amount of time (in msec) to wait for
+   *   a change. If the requested change does not occur within this time, then
+   *   this method returns `null` instead of a revision number. This value
+   *   must be no greater than `maxAwaitTimeoutMsec` as defined on the instance
+   *   being called. As a convenience, passing this value as `-1` is equivalent
+   *   to passing `maxAwaitTimeoutMsec`.
+   * @param {Int} baseRevNum The revision number which is the base for the
+   *   request. The request is to detect a change with respect to this revision.
+   * @param {string|null} [storagePath = null] The specific path to watch for
+   *   changes to, or `null` if any file change will suffice.
+   * @returns {Int|null} If a change was detected, the revision number at which
+   *   it was detected (which might be larger than the actual revision number at
+   *   which the change was made); or `null` if the call is returning due to
+   *   timeout.
+   */
+  async whenChange(timeoutMsec, baseRevNum, storagePath = null) {
+    const maxMsec = this.maxAwaitTimeoutMsec;
+
+    if (timeoutMsec === -1) {
+      timeoutMsec = maxMsec;
+    } else {
+      TInt.rangeInc(timeoutMsec, 0, maxMsec);
+    }
+
+    TInt.min(baseRevNum, 0);
+    StoragePath.orNull(storagePath);
+
+    const result =
+      await this._impl_whenChange(timeoutMsec, baseRevNum, storagePath);
+
+    if (result === null) {
+      return null;
+    }
+
+    // For a non-`null` result, validate it and update `_lastRevNum`.
+    TInt.min(result, baseRevNum + 1);
+    if (result > this._lastRevNum) {
+      this._lastRevNum = result;
+    }
+
+    return result;
+  }
+
+  /**
+   * Main implementation of `whenChange()`. It is guaranteed to be called
+   * with valid arguments, _except_ that `baseRevNum` is not guaranteed to
+   * refer to an existing revision.
+   *
+   * @abstract
+   * @param {Int} timeoutMsec Same as with `whenChange()`.
+   * @param {Int} baseRevNum Same as with `whenChange()`.
+   * @param {string|null} storagePath Same as with `whenChange()`.
+   * @returns {Int|null} Same as with `whenChange()`.
+   */
+  async _impl_whenChange(timeoutMsec, baseRevNum, storagePath) {
+    this._mustOverride(timeoutMsec, baseRevNum, storagePath);
   }
 }

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -48,7 +48,7 @@ export default class BaseFile extends CommonBase {
    *
    * @abstract
    */
-  get maxAwaitTimeoutMsec() {
+  get maxTimeoutMsec() {
     this._mustOverride();
   }
 
@@ -305,9 +305,9 @@ export default class BaseFile extends CommonBase {
    * @param {Int} timeoutMsec The maximum amount of time (in msec) to wait for
    *   a change. If the requested change does not occur within this time, then
    *   this method returns `null` instead of a revision number. This value
-   *   must be no greater than `maxAwaitTimeoutMsec` as defined on the instance
-   *   being called. As a convenience, passing this value as `-1` is equivalent
-   *   to passing `maxAwaitTimeoutMsec`.
+   *   must be no greater than `maxTimeoutMsec` as defined on the instance being
+   *   called. As a convenience, passing this value as `-1` is equivalent to
+   *   passing `maxTimeoutMsec`.
    * @param {Int} baseRevNum The revision number which is the base for the
    *   request. The request is to detect a change with respect to this revision.
    * @param {string|null} [storagePath = null] The specific path to watch for
@@ -318,7 +318,7 @@ export default class BaseFile extends CommonBase {
    *   timeout.
    */
   async whenChange(timeoutMsec, baseRevNum, storagePath = null) {
-    const maxMsec = this.maxAwaitTimeoutMsec;
+    const maxMsec = this.maxTimeoutMsec;
 
     if (timeoutMsec === -1) {
       timeoutMsec = maxMsec;

--- a/local-modules/content-store/StoragePath.js
+++ b/local-modules/content-store/StoragePath.js
@@ -75,6 +75,26 @@ export default class StoragePath extends UtilityClass {
   }
 
   /**
+   * Validates that the given value is either a valid storage path string or
+   * `null`. Throws an error if not.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is in fact a valid storage path string.
+   */
+  static orNull(value) {
+    if (value === null) {
+      return value;
+    }
+
+    try {
+      return StoragePath.check(value);
+    } catch (e) {
+      // More specific error.
+      return TypeError.badValue(value, 'StoragePath|null');
+    }
+  }
+
+  /**
    * Splits a storage path into individual components. Resulting components are
    * just the names and do not contain any slash separators. This operation is
    * the inverse of `join()`.

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -254,7 +254,7 @@ export default class DocControl extends CommonBase {
       // It's essential to get the file revision number before asking for the
       // document revision number: Due to the asynch nature of the system, it's
       // possible for the document revision to be taken with regard to a later
-      // file revision, and this ordering guarantees that the `awaitChange()` we
+      // file revision, and this ordering guarantees that the `whenChange()` we
       // do will properly return promptly when that situation occurs.
       const fileRevNum = await this._file.revNum();
       const docRevNum  = await this._currentRevNum();
@@ -276,7 +276,7 @@ export default class DocControl extends CommonBase {
       // Wait for the file to change (or for the storage layer to timeout), and
       // then iterate to see if in fact the change updated the document revision
       // number.
-      await this._file.awaitChange(-1, fileRevNum, Paths.REVISION_NUMBER);
+      await this._file.whenChange(-1, fileRevNum, Paths.REVISION_NUMBER);
     }
   }
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.15.0
+version = 0.15.1


### PR DESCRIPTION
This PR adds `whenChange()` to the `content-store` interface (along with other related bits), which is a way to "long poll" for changes to a file. This is then used to replace a bunch of logic in `doc-server` which makes it (a) simpler, and (b) resilient with regard to the possibility that more than one process is managing any given document.

As an architectural note, the intent is that _most_ of the time, multiple clients for a given document should end up talking to the same server, while expecting that _some_ of the time this won't actually happen, both due to edge-case events (e.g., a change in the number of active servers which alters how documents get bucketed to servers) as well as due to larger system architecture (e.g., maintaining separate sets of servers segregated by geographic region, meaning that two simultaneous editors of the same document in different regions will necessarily be interacting with different servers).