### PR TITLE
Partially implement `transact()`.

### DIFF
--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -70,6 +70,26 @@ export default class FileOp extends CommonBase {
   }
 
   /**
+   * Validates a category string. Throws an error given an invalid category.
+   *
+   * @param {*} category The (alleged) category string.
+   * @returns {string} `category` but only if valid.
+   */
+  static validateCategory(category) {
+    switch (category) {
+      case CAT_PREREQUISITE:
+      case CAT_READ:
+      case CAT_REVISION:
+      case CAT_WRITE: {
+        return category;
+      }
+      default: {
+        throw new Error(`Invalid category: ${category}`);
+      }
+    }
+  }
+
+  /**
    * Constructs a `checkPathEmpty` operation. This is a prerequisite operation
    * that verifies that a given storage path is not bound to any value. This is
    * the opposite of the `checkPathExists` operation.
@@ -223,7 +243,7 @@ export default class FileOp extends CommonBase {
     super();
 
     /** {string} The operation category. */
-    this._category = TString.nonempty(category);
+    this._category = FileOp.validateCategory(category);
 
     /** {string} The operation name. */
     this._name = TString.nonempty(name);

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -230,6 +230,8 @@ export default class FileOp extends CommonBase {
 
     /** {Map<string,*>} Arguments to the operation. */
     this._args = new Map(args);
+
+    Object.freeze(this);
   }
 
   /** {string} The operation category. */

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -43,6 +43,11 @@ export default class TransactionSpec extends CommonBase {
   /**
    * Gets an iterator for the operations of the indicated category.
    *
+   * **Note:** We return an iterator and not (say) a `Set` because the latter
+   * can't be made immutable, and so returning them would force us to make a
+   * duplicate. Iterators, on the other hand, by their nature do not expose any
+   * ability to mutate the underlying collection.
+   *
    * @param {string} category The category to get.
    * @returns {Iterator<FileOp>} Iterator over all of the operations of the
    *   given category.
@@ -51,6 +56,6 @@ export default class TransactionSpec extends CommonBase {
     FileOp.validateCategory(category);
 
     const catSet = this._categorySets.get(category);
-    return ((catSet === undefined) ? [] : catSet).values();
+    return (catSet || []).values();
   }
 }

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -1,0 +1,56 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase } from 'util-common';
+
+import FileOp from './FileOp';
+
+/**
+ * Transaction specification. This is a set of operations (each an instance of
+ * `FileOp`) which are to be executed with regard to a file, as an atomic unit.
+ *
+ * When executed, the operations of a transaction are effectively performed in
+ * order by category; but within a category there is no effective ordering.
+ * Specifically, the category ordering is: revision restrictions, prerequisites,
+ * reads, and finally writes.
+ */
+export default class TransactionSpec extends CommonBase {
+  /**
+   * Constructs an instance consisting of all of the indicated operations.
+   *
+   * @param {...FileOp} ops The operations to perform.
+   */
+  constructor(...ops) {
+    super();
+
+    /** {Map<string,Set<FileOp>>} Per-category sets of operations. */
+    const catSets = this._categorySets = new Map();
+
+    for (const op of ops) {
+      FileOp.check(op);
+
+      let catSet = catSets.get(op.category);
+      if (catSet === null) {
+        catSet = new Set();
+        catSets.set(op.category, catSet);
+      }
+
+      catSet.add(op);
+    }
+  }
+
+  /**
+   * Gets an iterator for the operations of the indicated category.
+   *
+   * @param {string} category The category to get.
+   * @returns {Iterator<FileOp>} Iterator over all of the operations of the
+   *   given category.
+   */
+  opsFor(category) {
+    FileOp.validateCategory(category);
+
+    const catSet = this._categorySets.get(category);
+    return ((catSet === undefined) ? [] : catSet).values();
+  }
+}

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -31,7 +31,7 @@ export default class TransactionSpec extends CommonBase {
       FileOp.check(op);
 
       let catSet = catSets.get(op.category);
-      if (catSet === null) {
+      if (catSet === undefined) {
         catSet = new Set();
         catSets.set(op.category, catSet);
       }

--- a/local-modules/content-store/main.js
+++ b/local-modules/content-store/main.js
@@ -8,5 +8,14 @@ import Coder from './Coder';
 import FileId from './FileId';
 import FileOp from './FileOp';
 import StoragePath from './StoragePath';
+import TransactionSpec from './TransactionSpec';
 
-export { BaseContentStore, BaseFile, Coder, FileId, FileOp, StoragePath };
+export {
+  BaseContentStore,
+  BaseFile,
+  Coder,
+  FileId,
+  FileOp,
+  StoragePath,
+  TransactionSpec
+};

--- a/local-modules/typecheck/TMap.js
+++ b/local-modules/typecheck/TMap.js
@@ -1,0 +1,44 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from 'util-common-base';
+
+import TypeError from './TypeError';
+
+/**
+ * Type checker for type `Map`.
+ */
+export default class TMap extends UtilityClass {
+  /**
+   * Checks a value of type `Map`. Optionally checks the types of keys and
+   *  values.
+   *
+   * @param {*} value The (alleged) `Map`.
+   * @param {Function} [keyCheck = null] Key type checker. If passed as
+   *   non-`null`, must be a function that behaves like a standard
+   *   `<type>.check()` method.
+   * @param {Function} [valueCheck = null] Key type checker. If passed as,
+   *   non-`null`, must be a function that behaves like a standard
+   *   `<type>.check()` method.
+   * @returns {Map} `value`.
+   */
+  static check(value, keyCheck = null, valueCheck = null) {
+    if (!(value instanceof Map)) {
+      return TypeError.badValue(value, 'Map');
+    }
+
+    if ((keyCheck !== null) || (valueCheck !== null)) {
+      for (const [k, v] of value) {
+        if (keyCheck !== null) {
+          keyCheck(k);
+        }
+        if (valueCheck !== null) {
+          valueCheck(v);
+        }
+      }
+    }
+
+    return value;
+  }
+}

--- a/local-modules/typecheck/main.js
+++ b/local-modules/typecheck/main.js
@@ -6,8 +6,9 @@ import TArray from './TArray';
 import TBoolean from './TBoolean';
 import TFunction from './TFunction';
 import TInt from './TInt';
+import TMap from './TMap';
 import TObject from './TObject';
 import TString from './TString';
 import TypeError from './TypeError';
 
-export { TArray, TBoolean, TFunction, TInt, TObject, TString, TypeError };
+export { TArray, TBoolean, TFunction, TInt, TMap, TObject, TString, TypeError };


### PR DESCRIPTION
This PR implements `transact()` as a `content-store` API, but only stubs out the underlying implementation in `content-store-local`. More to come, soon!