### PR TITLE
Another transactional step.

### DIFF
--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -1,0 +1,84 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { FileOp } from 'content-store';
+import { CommonBase } from 'util-common';
+
+/**
+ * Handler for `LocalFile.transact()`. An instance of this class is constructed
+ * for each call to that method. Its `run()` method is what does most of the
+ * work of performing the transaction.
+ */
+export default class Transactor extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {TransactionSpec} spec The transaction specification.
+   * @param {object} fileFriend "Friend" access to the `LocalFile` which spawned
+   *   this instance. See below for more info.
+   */
+  constructor(spec, fileFriend) {
+    super();
+
+    /** {TransactionSpec} spec The transaction specification. */
+    this._spec = spec;
+
+    /**
+     * {object} "Friend" access to the `LocalFile` that spawned this instance.
+     * Properties and methods on this are defined in an ad-hoc
+     * manner intended to provide just enough access for this class to do its
+     * work. See `FileOp` where the friend is constructed for documentation on
+     * its makeup.
+     */
+    this._fileFriend = fileFriend;
+
+    /** {Logger} Logger to use. */
+    this._log = fileFriend.log;
+
+    this._log.detail('Transactor constructed.');
+  }
+
+  /**
+   * Runs the transaction.
+   *
+   * @returns {object} `_impl_transact()` result as defined by `BaseFile`.
+   */
+  run() {
+    this._log.detail('Transactor running.');
+
+    // Handle the operation categories in the prescribed order.
+
+    const spec      = this._spec;
+    const revNum    = this._fileFriend.revNum;
+    const newRevNum = null;
+    const data      = null;
+
+    for (const op of spec.opsFor(FileOp.CAT_REVISION)) {
+      this._log.detail('Op:', op);
+      // TODO: Should actually do stuff.
+      throw new Error('TODO');
+    }
+
+    for (const op of spec.opsFor(FileOp.CAT_PREREQUISITE)) {
+      this._log.detail('Op:', op);
+      // TODO: Should actually do stuff.
+      throw new Error('TODO');
+    }
+
+    for (const op of spec.opsFor(FileOp.CAT_READ)) {
+      this._log.detail('Op:', op);
+      // TODO: Should actually do stuff.
+      throw new Error('TODO');
+    }
+
+    for (const op of spec.opsFor(FileOp.CAT_WRITE)) {
+      this._log.detail('Op:', op);
+      // TODO: Should actually do stuff.
+      throw new Error('TODO');
+    }
+
+    this._log.detail('Transactor complete.');
+    return { revNum, newRevNum, data };
+  }
+}

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -9,6 +9,10 @@ import { CommonBase } from 'util-common';
  * Handler for `LocalFile.transact()`. An instance of this class is constructed
  * for each call to that method. Its `run()` method is what does most of the
  * work of performing the transaction.
+ *
+ * The class defines a method named `_op_<name>` for each of the named `FileOp`s
+ * that this class knows how to handle (which is hopefully all of them, but
+ * perhaps at times there will be something missing...or extra).
  */
 export default class Transactor extends CommonBase {
   /**
@@ -80,5 +84,85 @@ export default class Transactor extends CommonBase {
 
     this._log.detail('Transactor complete.');
     return { revNum, newRevNum, data };
+  }
+
+  /**
+   * Handler for `checkPathEmpty` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkPathEmpty(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `checkPathExists` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkPathExists(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `checkPathHash` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkPathHash(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `deletePath` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_deletePath(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `maxRevNum` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_maxRevNum(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `minRevNum` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_minRevNum(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `readPath` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_readPath(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `writePath` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_writePath(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
   }
 }

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -58,6 +58,12 @@ export default class Transactor extends CommonBase {
     const newRevNum = null;
     const data      = null;
 
+    for (const op of spec.opsFor(FileOp.CAT_ENVIRONMENT)) {
+      this._log.detail('Op:', op);
+      // TODO: Should actually do stuff.
+      throw new Error('TODO');
+    }
+
     for (const op of spec.opsFor(FileOp.CAT_REVISION)) {
       this._log.detail('Op:', op);
       // TODO: Should actually do stuff.
@@ -152,6 +158,16 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_readPath(op) {
+    this._log.info('TODO', op);
+    throw new Error('TODO');
+  }
+
+  /**
+   * Handler for `timeout` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_timeout(op) {
     this._log.info('TODO', op);
     throw new Error('TODO');
   }

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { FileOp } from 'content-store';
 import { CommonBase } from 'util-common';
 
 /**
@@ -58,31 +57,7 @@ export default class Transactor extends CommonBase {
     const newRevNum = null;
     const data      = null;
 
-    for (const op of spec.opsFor(FileOp.CAT_ENVIRONMENT)) {
-      this._log.detail('Op:', op);
-      // TODO: Should actually do stuff.
-      throw new Error('TODO');
-    }
-
-    for (const op of spec.opsFor(FileOp.CAT_REVISION)) {
-      this._log.detail('Op:', op);
-      // TODO: Should actually do stuff.
-      throw new Error('TODO');
-    }
-
-    for (const op of spec.opsFor(FileOp.CAT_PREREQUISITE)) {
-      this._log.detail('Op:', op);
-      // TODO: Should actually do stuff.
-      throw new Error('TODO');
-    }
-
-    for (const op of spec.opsFor(FileOp.CAT_READ)) {
-      this._log.detail('Op:', op);
-      // TODO: Should actually do stuff.
-      throw new Error('TODO');
-    }
-
-    for (const op of spec.opsFor(FileOp.CAT_WRITE)) {
+    for (const op of spec.ops) {
       this._log.detail('Op:', op);
       // TODO: Should actually do stuff.
       throw new Error('TODO');

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -53,9 +53,10 @@ const CAT_WRITE = 'write';
  * order by category; but within a category there is no effective ordering.
  * Specifically, the category ordering is as listed above.
  *
- * There is a static method on this class to construct each named operation.
+ * There are static methods on this class to construct each named operation,
+ * named `op_<name>`, as well as some convenience methods to construct variants.
  * See documentation on those methods for details about the meaning and
- * arguments of these.
+ * arguments of each of these.
  */
 export default class FileOp extends CommonBase {
   /** {string} Operation category for environment ops. */
@@ -112,7 +113,7 @@ export default class FileOp extends CommonBase {
    * @param {string} storagePath The storage path to check.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static checkPathEmpty(storagePath) {
+  static op_checkPathEmpty(storagePath) {
     StoragePath.check(storagePath);
     return new FileOp(KEY, CAT_PREREQUISITE, 'checkPathEmpty',
       [['storagePath', storagePath]]);
@@ -127,7 +128,7 @@ export default class FileOp extends CommonBase {
    * @param {string} storagePath The storage path to check.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static checkPathExists(storagePath) {
+  static op_checkPathExists(storagePath) {
     StoragePath.check(storagePath);
     return new FileOp(KEY, CAT_PREREQUISITE, 'checkPathExists',
       [['storagePath', storagePath]]);
@@ -142,7 +143,7 @@ export default class FileOp extends CommonBase {
    * @param {string} hash The expected hash.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static checkPathHash(storagePath, hash) {
+  static op_checkPathHash(storagePath, hash) {
     StoragePath.check(storagePath);
     TString.nonempty(hash); // TODO: Better hash validation.
     return new FileOp(KEY, CAT_PREREQUISITE, 'checkPathHash',
@@ -157,7 +158,7 @@ export default class FileOp extends CommonBase {
    * @param {string} storagePath The storage path to delete.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static deletePath(storagePath) {
+  static op_deletePath(storagePath) {
     StoragePath.check(storagePath);
     return new FileOp(KEY, CAT_WRITE, 'deletePath',
       [['storagePath', storagePath]]);
@@ -175,7 +176,7 @@ export default class FileOp extends CommonBase {
    * @param {Int} revNum Maximum revision number (exclusive).
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static maxRevNum(revNum) {
+  static op_maxRevNum(revNum) {
     TInt.min(revNum, 1);
     return new FileOp(KEY, CAT_REVISION, 'maxRevNum',
       [['revNum', revNum]]);
@@ -188,7 +189,7 @@ export default class FileOp extends CommonBase {
    * @param {Int} revNum Maximum revision number (inclusive).
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static maxRevNumInc(revNum) {
+  static op_maxRevNumInc(revNum) {
     TInt.min(revNum, 0);
     return FileOp.maxRevNum(revNum + 1);
   }
@@ -202,7 +203,7 @@ export default class FileOp extends CommonBase {
    * @param {Int} revNum Minimum revision number (inclusive).
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static minRevNum(revNum) {
+  static op_minRevNum(revNum) {
     TInt.min(revNum, 0);
     return new FileOp(KEY, CAT_REVISION, 'minRevNum',
       [['revNum', revNum]]);
@@ -217,7 +218,7 @@ export default class FileOp extends CommonBase {
    * @param {string} storagePath The storage path to read from.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static readPath(storagePath) {
+  static op_readPath(storagePath) {
     StoragePath.check(storagePath);
     return new FileOp(KEY, CAT_READ, 'readPath',
       [['storagePath', storagePath]]);
@@ -232,7 +233,7 @@ export default class FileOp extends CommonBase {
    * @param {Int} durMsec Duration of the timeout, in milliseconds.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static timeout(durMsec) {
+  static op_timeout(durMsec) {
     TInt.min(durMsec, 0);
     return new FileOp(KEY, CAT_ENVIRONMENT, 'timeout',
       [['durMsec', durMsec]]);
@@ -247,7 +248,7 @@ export default class FileOp extends CommonBase {
    * @param {FrozenBuffer} value The value to store and bind to `storagePath`.
    * @returns {FileOp} An appropriately-constructed instance.
    */
-  static writePath(storagePath, value) {
+  static op_writePath(storagePath, value) {
     StoragePath.check(storagePath);
     FrozenBuffer.check(value);
     return new FileOp(KEY, CAT_WRITE, 'writePath',

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TString } from 'typecheck';
+import { TArray, TInt, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 import { FrozenBuffer } from 'util-server';
 
@@ -32,6 +32,11 @@ const CAT_REVISION = 'revision';
 /** {string} Operation category for data writes. */
 const CAT_WRITE = 'write';
 
+/** {array<string>} List of categories in defined execution order. */
+const CATEGORY_EXECUTION_ORDER = [
+  CAT_ENVIRONMENT, CAT_REVISION, CAT_PREREQUISITE, CAT_READ, CAT_WRITE
+];
+
 /**
  * Operation to perform on a file as part of a transaction. In terms of overall
  * structure, an operation consists of a string name and arbitrary additional
@@ -45,7 +50,7 @@ const CAT_WRITE = 'write';
  *   to being based only on certain revisions of the file.
  * * Prerequisite checks &mdash; A prerequisite check must pass in order for
  *   the remainder of a transaction to apply.
- * * Data reads &mdsah; A data read gets the value of a blob within a file.
+ * * Data reads &mdash; A data read gets the value of a blob within a file.
  * * Data writes &mdash; A data write stores new data in a file or erases
  *   previously-existing data within a file.
  *
@@ -82,6 +87,31 @@ export default class FileOp extends CommonBase {
   /** {string} Operation category for data writes. */
   static get CAT_WRITE() {
     return CAT_WRITE;
+  }
+
+  /**
+   * Sorts an `Iterable` (e.g. an array) of `FileOp`s by category, in the
+   * prescribed order of execution. Within a category, the result's ordering is
+   * arbitrary; that is, the sort is not guaranteed to be stable. The return
+   * value is a newly-constructed array; the original input is left unmodified.
+   *
+   * @param {Iterable<FileOp>} orig `Iterable` collection of `FileOp`s to sort.
+   * @returns {array<FileOp>} Array in the defined category-sorted order.
+   */
+  static sortByCategory(orig) {
+    TArray.check(orig, FileOp);
+
+    const result = [];
+
+    for (const cat of CATEGORY_EXECUTION_ORDER) {
+      for (const op of orig) {
+        if (op.category === cat) {
+          result.push(op);
+        }
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -149,18 +149,6 @@ export default class FileOp extends CommonBase {
   }
 
   /**
-   * Constructs an inclusive `maxRevNum` operation. This is a convenience
-   * method that is equivalent to calling `maxRevNum(revNum + 1)`.
-   *
-   * @param {Int} revNum Maximum revision number (inclusive).
-   * @returns {FileOp} An appropriately-constructed instance.
-   */
-  static maxRevNumInc(revNum) {
-    TInt.min(revNum, 0);
-    return FileOp.maxRevNum(revNum + 1);
-  }
-
-  /**
    * Constructs a `maxRevNum` operation. This is a revision restriction that
    * limits a transaction to only be performed with respect to an earlier
    * revision number of the file than the indicated revision. That is, it
@@ -176,6 +164,18 @@ export default class FileOp extends CommonBase {
     TInt.min(revNum, 1);
     return new FileOp(KEY, CAT_REVISION, 'maxRevNum',
       [['revNum', revNum]]);
+  }
+
+  /**
+   * Constructs an inclusive `maxRevNum` operation. This is a convenience
+   * method that is equivalent to calling `maxRevNum(revNum + 1)`.
+   *
+   * @param {Int} revNum Maximum revision number (inclusive).
+   * @returns {FileOp} An appropriately-constructed instance.
+   */
+  static maxRevNumInc(revNum) {
+    TInt.min(revNum, 0);
+    return FileOp.maxRevNum(revNum + 1);
   }
 
   /**

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -21,38 +21,19 @@ export default class TransactionSpec extends CommonBase {
   constructor(...ops) {
     super();
 
-    /** {Map<string,Set<FileOp>>} Per-category sets of operations. */
-    const catSets = this._categorySets = new Map();
-
-    for (const op of ops) {
-      FileOp.check(op);
-
-      let catSet = catSets.get(op.category);
-      if (catSet === undefined) {
-        catSet = new Set();
-        catSets.set(op.category, catSet);
-      }
-
-      catSet.add(op);
-    }
+    /** {array<FileOp>} Category-sorted array of operations. */
+    this._ops = FileOp.sortByCategory(ops);
   }
 
   /**
-   * Gets an iterator for the operations of the indicated category.
+   * {Iterator<FileOp>} An iterator for the operations to perform. The
+   * operations are yielded by the iterator in category-sorted order, as
+   * documented by `FileOp`.
    *
-   * **Note:** We return an iterator and not (say) a `Set` because the latter
-   * can't be made immutable, and so returning them would force us to make a
-   * duplicate. Iterators, on the other hand, by their nature do not expose any
-   * ability to mutate the underlying collection.
-   *
-   * @param {string} category The category to get.
-   * @returns {Iterator<FileOp>} Iterator over all of the operations of the
-   *   given category.
+   * **Note:** This is an iterator and not (say) an array so as to make it
+   * obvious that the contents are immutable.
    */
-  opsFor(category) {
-    FileOp.validateCategory(category);
-
-    const catSet = this._categorySets.get(category);
-    return (catSet || []).values();
+  get ops() {
+    return this._ops[Symbol.iterator];
   }
 }

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -9,11 +9,8 @@ import FileOp from './FileOp';
 /**
  * Transaction specification. This is a set of operations (each an instance of
  * `FileOp`) which are to be executed with regard to a file, as an atomic unit.
- *
- * When executed, the operations of a transaction are effectively performed in
- * order by category; but within a category there is no effective ordering.
- * Specifically, the category ordering is: revision restrictions, prerequisites,
- * reads, and finally writes.
+ * See `FileOp` for more information about the possible operations and how they
+ * get executed.
  */
 export default class TransactionSpec extends CommonBase {
   /**


### PR DESCRIPTION
This PR represents another chunk of work on implementing transactions at the `content-store` layer.

* Defined a new operation `timeout`, with the obvious semantics.
* Extracted out a new `Transactor` class from `LocalFile.transact()`. The latter was just a stub, and the former is also a stub, though somewhat less stubby.
* Cleaned up / consolidated how ops get sorted by category.