### PR TITLE
Timeout-related tweaks.

### DIFF
--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -260,6 +260,9 @@ export default class FileOp extends CommonBase {
    * before it is aborted. Timeouts are performed on a "best effort" basis as
    * well as silently clamped to implementation-specific limits (if any).
    *
+   * **Note:** It is an error for a transaction to contain more than one
+   * `timeout` operation.
+   *
    * @param {Int} durMsec Duration of the timeout, in milliseconds.
    * @returns {FileOp} An appropriately-constructed instance.
    */

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -24,6 +24,11 @@ export default class TransactionSpec extends CommonBase {
 
     /** {array<FileOp>} Category-sorted array of operations. */
     this._ops = FileOp.sortByCategory(ops);
+
+    // Validate the restriction on timeouts.
+    if (this.opsWithName('timeout').length > 1) {
+      throw new Error('Too many `timeout` operations.');
+    }
   }
 
   /**
@@ -36,6 +41,15 @@ export default class TransactionSpec extends CommonBase {
    */
   get ops() {
     return this._ops[Symbol.iterator];
+  }
+
+  /**
+   * {Int|null} The timeout duration in milliseconds, or `null` if this
+   * transaction specifies no timeout.
+   */
+  get timeoutMsec() {
+    const result = this.opsWithName('timeout')[0];
+    return (result === undefined) ? null : result;
   }
 
   /**

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -44,12 +44,12 @@ export default class TransactionSpec extends CommonBase {
   }
 
   /**
-   * {Int|null} The timeout duration in milliseconds, or `null` if this
-   * transaction specifies no timeout.
+   * {Int|'never'} The timeout duration in milliseconds, or the string `'never'`
+   * if this transaction specifies no timeout.
    */
   get timeoutMsec() {
     const result = this.opsWithName('timeout')[0];
-    return (result === undefined) ? null : result;
+    return (result === undefined) ? 'never' : result;
   }
 
   /**

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import FileOp from './FileOp';
@@ -35,5 +36,27 @@ export default class TransactionSpec extends CommonBase {
    */
   get ops() {
     return this._ops[Symbol.iterator];
+  }
+
+  /**
+   * Gets all of the operations with the given category.
+   *
+   * @param {string} category Category of the operations.
+   * @returns {array<FileOp>} Array of all such operations.
+   */
+  opsWithCategory(category) {
+    FileOp.validateCategory(category);
+    return this._ops.filter(op => (op.category === category));
+  }
+
+  /**
+   * Gets all of the operations with the given Name.
+   *
+   * @param {string} name Name of the operations.
+   * @returns {array<FileOp>} Array of all such operations.
+   */
+  opsWithName(name) {
+    TString.nonempty(name);
+    return this._ops.filter(op => (op.name === name));
   }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -276,7 +276,7 @@ export default class DocControl extends CommonBase {
       // Wait for the file to change (or for the storage layer to timeout), and
       // then iterate to see if in fact the change updated the document revision
       // number.
-      await this._file.whenChange(-1, fileRevNum, Paths.REVISION_NUMBER);
+      await this._file.whenChange('never', fileRevNum, Paths.REVISION_NUMBER);
     }
   }
 


### PR DESCRIPTION
This PR tweaks a bunch of stuff related to transaction timeouts, and actually implements the `timeout` transaction op in `content-store-local`, though it's kinda vacuous right now as there's no other ops that are implemented.