### PR TITLE
Start fleshing out `transact`.

### DIFF
--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -225,7 +225,7 @@ export default class LocalFile extends BaseFile {
    *   missing properties.
    */
   async _impl_transact(spec) {
-    this._log.info('Transaction:', spec);
+    this._log.detail('Transaction:', spec);
 
     // Arrange for timeout. **Note:** Needs to be done _before_ reading
     // storage, as that storage read can take significant time.
@@ -265,8 +265,10 @@ export default class LocalFile extends BaseFile {
 
       for (const [storagePath, value] of updatedStorage) {
         if (value === null) {
+          this._log.detail(`Transaction deleted path: ${storagePath}`);
           this._storage.delete(storagePath);
         } else {
+          this._log.detail(`Transaction wrote path: ${storagePath}`);
           this._storage.set(storagePath, value);
         }
 
@@ -277,6 +279,7 @@ export default class LocalFile extends BaseFile {
       this._storageNeedsWrite();
     }
 
+    this._log.detail('Transaction complete.');
     return { revNum, newRevNum, data };
   }
 

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -181,21 +181,6 @@ export default class LocalFile extends BaseFile {
    * Implementation as required by the superclass.
    *
    * @param {string} storagePath Path to write to.
-   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
-   *   at `path` is to be deleted.
-   * @returns {boolean} `true` once the write operation is complete.
-   */
-  async _impl_forceOp(storagePath, newValue) {
-    await this._readStorageIfNecessary();
-
-    this._storeOrDeleteValue(storagePath, newValue);
-    return true;
-  }
-
-  /**
-   * Implementation as required by the superclass.
-   *
-   * @param {string} storagePath Path to write to.
    * @param {FrozenBuffer|null} oldValue Value expected to be stored at `path`
    *   at the moment of writing, or `null` if `path` is expected to have nothing
    *   stored at it.

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -123,7 +123,7 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_deletePath(op) {
-    this._updatedStorage.set(op.arg('storagPath'), null);
+    this._updatedStorage.set(op.arg('storagePath'), null);
   }
 
   /**
@@ -172,6 +172,6 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_writePath(op) {
-    this._updatedStorage.set(op.arg('storagPath'), op.arg('value'));
+    this._updatedStorage.set(op.arg('storagePath'), op.arg('value'));
   }
 }

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -148,9 +148,9 @@ export default class BaseFile extends CommonBase {
    * @returns {boolean} `true` once the operation is complete.
    */
   async opForceDelete(storagePath) {
-    const spec = new TransactionSpec([
+    const spec = new TransactionSpec(
       FileOp.op_deletePath(storagePath)
-    ]);
+    );
 
     await this.transact(spec);
     return true;
@@ -165,9 +165,9 @@ export default class BaseFile extends CommonBase {
    * @returns {boolean} `true` once the operation is complete.
    */
   async opForceWrite(storagePath, newValue) {
-    const spec = new TransactionSpec([
+    const spec = new TransactionSpec(
       FileOp.op_writePath(storagePath, newValue)
-    ]);
+    );
 
     await this.transact(spec);
     return true;

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -379,7 +379,7 @@ export default class BaseFile extends CommonBase {
     if (result.data === null) {
       delete result.data;
     } else {
-      TMap.check(result.data, TString, FrozenBuffer);
+      TMap.check(result.data, TString.check, FrozenBuffer.check);
     }
 
     return result;

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TArray, TInt, TString } from 'typecheck';
+import { TInt, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 import { FrozenBuffer } from 'util-server';
 
@@ -99,7 +99,9 @@ export default class FileOp extends CommonBase {
    * @returns {array<FileOp>} Array in the defined category-sorted order.
    */
   static sortByCategory(orig) {
-    TArray.check(orig, FileOp.check);
+    for (const op of orig) {
+      FileOp.check(op);
+    }
 
     const result = [];
 

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -99,7 +99,7 @@ export default class FileOp extends CommonBase {
    * @returns {array<FileOp>} Array in the defined category-sorted order.
    */
   static sortByCategory(orig) {
-    TArray.check(orig, FileOp);
+    TArray.check(orig, FileOp.check);
 
     const result = [];
 

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -40,7 +40,12 @@ export default class TransactionSpec extends CommonBase {
    * obvious that the contents are immutable.
    */
   get ops() {
-    return { [Symbol.iterator]: this._ops[Symbol.iterator] };
+    const ops = this._ops;
+    function* generate() {
+      yield* ops;
+    }
+
+    return { [Symbol.iterator]: generate };
   }
 
   /**

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -40,7 +40,7 @@ export default class TransactionSpec extends CommonBase {
    * obvious that the contents are immutable.
    */
   get ops() {
-    return this._ops[Symbol.iterator];
+    return { [Symbol.iterator]: this._ops[Symbol.iterator] };
   }
 
   /**


### PR DESCRIPTION
This PR implements two of the transaction ops in `content-store-local`, and rewrites `BaseFile.opForceWrite()` in terms of transactions.

As of this PR, the `content-store*` code is working but in an intermediate state, in that ultimately all the `op*` methods on `BaseFile` should be written in terms of `transact()`… and once that's done, their call sites should be updated to more directly use transactions, ultimately getting rid of the `op*` methods entirely.