### PR TITLE
Transaction conversion part N of M.

### DIFF
--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -334,18 +334,6 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
-   * Implementation as required by the superclass.
-   *
-   * @param {string} storagePath Path to read from.
-   * @returns {FrozenBuffer|null} Value stored at the indicated path, or `null`
-   *   if there is none.
-   */
-  async _impl_pathReadOrNull(storagePath) {
-    await this._readStorageIfNecessary();
-    return this._storage.get(storagePath) || null;
-  }
-
-  /**
    * Reads the file storage if it has not yet been loaded.
    */
   async _readStorageIfNecessary() {

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -180,36 +180,6 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {string} storagePath Path to write to.
-   * @param {FrozenBuffer|null} oldValue Value expected to be stored at `path`
-   *   at the moment of writing, or `null` if `path` is expected to have nothing
-   *   stored at it.
-   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
-   *   at `path` is to be deleted.
-   * @returns {boolean} `true` if the write is successful, or `false` if it
-   *   failed due to value mismatch.
-   */
-  async _impl_op(storagePath, oldValue, newValue) {
-    await this._readStorageIfNecessary();
-
-    const existingValue = this._storage.get(storagePath) || null;
-
-    if (oldValue !== existingValue) {
-      if (   (oldValue === null)
-          || (existingValue === null)
-          || !oldValue.equals(existingValue)) {
-        // Mismatch between expected and actual pre-existing value.
-        return false;
-      }
-    }
-
-    this._storeOrDeleteValue(storagePath, newValue);
-    return true;
-  }
-
-  /**
-   * Implementation as required by the superclass.
-   *
    * @returns {Int} The instantaneously current revision number of the file.
    */
   async _impl_revNum() {
@@ -371,26 +341,6 @@ export default class LocalFile extends BaseFile {
     // The timeout expired.
     this._log.detail('Timed out.');
     return null;
-  }
-
-  /**
-   * Helper for the update methods, which performs the actual updating.
-   *
-   * @param {string} storagePath Path to write to.
-   * @param {FrozenBuffer|null} newValue Value to write, or `null` if the value
-   *   at `path` is to be deleted.
-   */
-  _storeOrDeleteValue(storagePath, newValue) {
-    if (newValue === null) {
-      this._storage.delete(storagePath);
-    } else {
-      this._storage.set(storagePath, newValue);
-    }
-
-    this._revNum++;
-    this._storageRevNums.set(storagePath, this._revNum);
-    this._storageToWrite.set(storagePath, newValue);
-    this._storageNeedsWrite();
   }
 
   /**

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -180,16 +180,6 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
-   * @returns {Int} The instantaneously current revision number of the file.
-   */
-  async _impl_revNum() {
-    await this._readStorageIfNecessary();
-    return this._revNum;
-  }
-
-  /**
-   * Implementation as required by the superclass.
-   *
    * @param {TransactionSpec} spec Same as with `transact()`.
    * @returns {object} Same as with `transact()`, except with `null`s instead of
    *   missing properties.

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -246,13 +246,25 @@ export default class LocalFile extends BaseFile {
     // state of this instance to the transactor (constructed immediately
     // hereafter) such that the latter can do its job.
 
-    const revNum = this._revNum;
+    const revNum     = this._revNum;
+    const storage    = this._storage;
     const fileFriend = {
       /** {Logger} Pass-through of this instance's logger. */
       log: this._log,
 
       /** {Int} Current revision number of the file. */
-      revNum
+      revNum,
+
+      /**
+       * Gets the value stored at the given path, if any.
+       *
+       * @param {string} storagePath The path.
+       * @returns {FrozenBuffer|null} The corresponding stored value, or `null`
+       *   if there is none.
+       */
+      readPathOrNull(storagePath) {
+        return storage.get(storagePath) || null;
+      }
     };
 
     // Run the transaction, gather the results, and queue up the writes.

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -180,13 +180,14 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `timeout` operations.
+   * Handler for `timeout` operations. In this case, there's nothing to do
+   * because the code in `LocalFile` that calls into here already takes care
+   * of timeouts.
    *
-   * @param {FileOp} op The operation.
+   * @param {FileOp} op_unused The operation.
    */
-  _op_timeout(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+  _op_timeout(op_unused) {
+    // This space intentionally left blank.
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -175,8 +175,14 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_readPath(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const storagePath = op.arg('storagePath');
+    const data        = this._fileFriend.readPathOrNull(storagePath);
+
+    if (data !== null) {
+      // Per the `FileOp` documentation, we are _not_ supposed to bind result
+      // data if the path isn't found.
+      this._data.set(storagePath, data);
+    }
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { FileOp } from 'content-store';
-import { CommonBase } from 'util-common';
+import { CommonBase, InfoError } from 'util-common';
 
 /**
  * Handler for `LocalFile.transact()`. An instance of this class is constructed
@@ -93,8 +93,10 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkPathEmpty(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const storagePath = op.arg('storagePath');
+    if (this._fileFriend.readPathOrNull(storagePath) !== null) {
+      throw new InfoError('path_not_empty', storagePath);
+    }
   }
 
   /**
@@ -103,8 +105,10 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkPathExists(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const storagePath = op.arg('storagePath');
+    if (this._fileFriend.readPathOrNull(storagePath) === null) {
+      throw new InfoError('path_not_found', storagePath);
+    }
   }
 
   /**
@@ -113,8 +117,15 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkPathHash(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const storagePath  = op.arg('storagePath');
+    const expectedHash = op.arg('hash');
+    const data         = this._fileFriend.readPathOrNull(storagePath);
+
+    if (data === null) {
+      throw new InfoError('path_not_found', storagePath);
+    } else if (data.hash !== expectedHash) {
+      throw new InfoError('path_hash_mismatch', storagePath, expectedHash);
+    }
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -138,23 +138,35 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `maxRevNum` operations.
+   * Handler for `maxRevNum` operations. In this implementation, we only ever
+   * have a single revision available, and we reject the transaction should it
+   * not be covered by the requested restriction.
    *
    * @param {FileOp} op The operation.
    */
   _op_maxRevNum(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const revNum = op.arg('revNum');
+
+    // **Note:** `>=` because the op is for an exclusive (not inclusive)
+    // maximum.
+    if (this._fileFriend.revNum >= revNum) {
+      throw new InfoError('revision_not_available', 'max', revNum);
+    }
   }
 
   /**
-   * Handler for `minRevNum` operations.
+   * Handler for `minRevNum` operations. In this implementation, we only ever
+   * have a single revision available, and we reject the transaction should it
+   * not be covered by the requested restriction.
    *
    * @param {FileOp} op The operation.
    */
   _op_minRevNum(op) {
-    this._log.info('TODO', op);
-    throw new Error('TODO');
+    const revNum = op.arg('revNum');
+
+    if (this._fileFriend.revNum < revNum) {
+      throw new InfoError('revision_not_available', 'min', revNum);
+    }
   }
 
   /**

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -244,20 +244,18 @@ export default class BaseFile extends CommonBase {
    * @returns {Int} The instantaneously current revision number of the file.
    */
   async revNum() {
-    const result = TInt.min(await this._impl_revNum(), this._lastRevNum);
+    // By definition executing an empty transaction spec will have a result that
+    // binds `revNum` to the instantaneously current revision number.
+    const spec = new TransactionSpec();
+    const transactionResult = await this.transact(spec);
+    const revNum = transactionResult.revNum;
 
-    this._lastRevNum = result;
-    return result;
-  }
+    // Validate that the subclass doesn't move the number in the wrong
+    // direction.
+    TInt.min(revNum, this._lastRevNum);
 
-  /**
-   * Main implementation of `revNum()`.
-   *
-   * @abstract
-   * @returns {Int} The instantaneously current revision number of the file.
-   */
-  async _impl_revNum() {
-    this._mustOverride();
+    this._lastRevNum = revNum;
+    return revNum;
   }
 
   /**

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -4,7 +4,7 @@
 
 import { TBoolean, TInt, TMap, TObject, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
-import { FrozenBuffer } from 'util-server';
+import { FrozenBuffer, InfoError } from 'util-server';
 
 import FileOp from './FileOp';
 import StoragePath from './StoragePath';
@@ -173,8 +173,16 @@ export default class BaseFile extends CommonBase {
       FileOp.op_writePath(storagePath, newValue)
     );
 
-    await this.transact(spec);
-    return true;
+    try {
+      await this.transact(spec);
+      return true;
+    } catch (e) {
+      if ((e instanceof InfoError) && (e.name === 'path_not_empty')) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
   }
 
   /**

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -334,6 +334,8 @@ export default class BaseFile extends CommonBase {
    * @param {TransactionSpec} spec Specification for the transaction, that is,
    *   the set of operations to perform.
    * @returns {object} Object with mappings as described above.
+   * @throws {InfoError} Thrown if the transaction failed. Errors so thrown
+   *   contain details sufficient for programmatic understanding of the issue.
    */
   async transact(spec) {
     TransactionSpec.check(spec);

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -263,7 +263,10 @@ export default class BaseFile extends CommonBase {
    * bindings:
    *
    * * `revNum` &mdash; The revision number of the file which was used to
-   *   satisfy the request.
+   *   satisfy the request. This is always the most recent revision possible
+   *   given the restrictions defined in the transaction spec (if any). If there
+   *   are no restrictions, then this is always the most recent revision at the
+   *   instant the transaction was run.
    * * `newRevNum` &mdash; If the transaction spec included any write
    *   operations, the revision number of the file that resulted from those
    *   writes.

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -35,7 +35,7 @@ export default class TString extends UtilityClass {
   }
 
   /**
-   * Checks a value of type `String`, which must further more be a valid string
+   * Checks a value of type `String`, which must furthermore be a valid string
    * of hexadecimal bytes (lower case). Optionally checks for a minimum and/or
    * maximum length.
    *
@@ -60,6 +60,24 @@ export default class TString extends UtilityClass {
     }
 
     return value;
+  }
+
+  /**
+   * Checks a value of type `String`, which must furthermore be a valid
+   * programming language identifier per the usual rules for same. That is, it
+   * must be a non-empty string consisting of characters from the set
+   * `[a-zA-Z_0-9]` and with a non-numeric first character.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static identifier(value) {
+    try {
+      return TString.check(value, /^[a-zA-Z_][a-zA-Z_0-9]*$/);
+    } catch (e) {
+      // More on-point error.
+      return TypeError.badValue(value, 'String', 'identifier');
+    }
   }
 
   /**

--- a/local-modules/util-common/InfoError.js
+++ b/local-modules/util-common/InfoError.js
@@ -1,0 +1,110 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+
+import DataUtil from './DataUtil';
+
+/**
+ * `Error` subclass that comes with additional structured information.
+ * Specifically, instances have mandatory "details" which take the form of a
+ * functor (in this case a string name and optional arguments) and optionally
+ * indicate a different error that was the "cause" of this one.
+ *
+ * The point of this is to be able to instantiate errors along the lines of
+ * `new InfoError('file_not_found', '/foo/bar/baz.txt')` where the error comes
+ * with a name and associated info in a well-defined form such that other code
+ * can succeed in doing something useful with it, should it be useful to do so.
+ */
+export default class InfoError extends Error {
+  /**
+   * Makes a message for passing to the superclass constructor.
+   *
+   * @param {string} detailsName The detail schema name.
+   * @param {array<*>} detailsArgs The detail arguments.
+   * @returns {string} An appropriately-constructed message string.
+   */
+  static _makeMessage(detailsName, detailsArgs) {
+    return `${detailsName}(${detailsArgs.join(', ')})`;
+  }
+
+  /**
+   * Constructs an instance. JSDoc doesn't have enough expressiveness to
+   * describe the arguments, so here is a more complete description:
+   *
+   * The constructor accepts an _optional_ cause `Error`, followed by a
+   * mandatory detail schema name, followed by any number of additional detail
+   * values, whose interpretation is defined by the name. All detail values must
+   * be simple data (e.g. JSON-codable).
+   *
+   * The name must conform to the usual syntax for a programming language
+   * "identifier," that is, a non-empty string with characters taken from the
+   * set `[a-zA-Z_0-9]` and a non-numeric first character.
+   *
+   * @param {Error|string} firstArg _Either_ the causal `Error` or the detail
+   *   schema name
+   * @param {...*} args Additional arguments, as described above.
+   */
+  constructor(firstArg, ...args) {
+    // "Parse" the constructor arguments first, so we can make an appropriate
+    // call to `super()` (which is required before setting instance variables.)
+    const hasCause    = (firstArg instanceof Error);
+    const cause       = hasCause ? firstArg : null;
+    const detailsName = TString.identifier(hasCause ? args[0] : firstArg);
+    const detailsArgs = DataUtil.deepFreeze(hasCause ? args.slice(1) : args);
+
+    super(InfoError._makeMessage(detailsName, detailsArgs));
+
+    /** {Error|null} The causal error, if any. */
+    this._cause = cause;
+
+    /** {string} The detail schema name. */
+    this._name = detailsName;
+
+    /** {array<*>} The detail arguments. */
+    this._args = detailsArgs;
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {Error|null} The error that "caused" this one, or `null` if there is no
+   * causative error.
+   */
+  get cause() {
+    return this._cause;
+  }
+
+  /**
+   * {string} The name of the detail schema. This can be thought of as the
+   * "type" or "kind" of error.
+   */
+  get name() {
+    return this._name;
+  }
+
+  /**
+   * {array<*>} Array of arguments that provide details corresponding to the
+   * schema name. Guaranteed to be deep-frozen.
+   */
+  get args() {
+    return this._args;
+  }
+
+  /**
+   * Gets the string form of this instance. This includes the `cause`, if any.
+   *
+   * @returns {string} The string form.
+   */
+  toString() {
+    const thisTrace = super.toString();
+    const cause = this._cause;
+
+    if (cause === null) {
+      return thisTrace;
+    } else {
+      return `${thisTrace}${cause.toString()}`;
+    }
+  }
+}

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -5,6 +5,7 @@
 import CommonBase from './CommonBase';
 import DataUtil from './DataUtil';
 import DeferredLoader from './DeferredLoader';
+import InfoError from './InfoError';
 import JsonUtil from './JsonUtil';
 import PromCondition from './PromCondition';
 import PromDelay from './PromDelay';
@@ -17,6 +18,7 @@ export {
   CommonBase,
   DataUtil,
   DeferredLoader,
+  InfoError,
   JsonUtil,
   PromCondition,
   PromDelay,


### PR DESCRIPTION
More work on getting the `content-store` layer to be all about transactions.

* Implemented all of the missing transaction ops in `content-store-local`.
* Reworked all methods in `content-store.BaseFile` that _could_ be defined in terms of transactions (as they currently stand) to in fact be so defined.
* Removed all sorts of support code that was no longer needed due to the previous bullet item.

**Note:** There's a new `Error` class defined here called `InfoError`, which is being used to convey more structured information in an exception than is provided by the standard `Error` class. The ultimate aim here is to standardize the "schemas" of errors, such that code can deal with the details of errors more programmatically than is generally possible with `Error` per se. (This is more or less a generalization of what `ApiError` is doing. Eventually `ApiError` will probably be retired in favor of using this class.) You can see the first hints of programmatic error detail handling in this PR (look at `BaseFile.opNew()`), but this is only just a start.