### PR TITLE
Make some more-involved transactions.

### DIFF
--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -7,6 +7,7 @@ import fs from 'fs';
 import { after, before, describe, it } from 'mocha';
 import path from 'path';
 
+import { FileOp, TransactionSpec } from 'content-store';
 import { LocalFile } from 'content-store-local';
 import { FrozenBuffer } from 'util-server';
 
@@ -49,7 +50,11 @@ describe('content-store-local/LocalFile', () => {
 
       // Baseline assumption.
       await file.create();
-      await file.opForceWrite(storagePath, value);
+      const spec = new TransactionSpec(
+        FileOp.op_writePath(storagePath, value)
+      );
+      await file.transact(spec);
+
       assert.strictEqual(await file.pathReadOrNull(storagePath), value);
 
       // The real test.

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -4,7 +4,7 @@
 
 import { TBoolean, TInt, TMap, TObject, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
-import { FrozenBuffer, InfoError } from 'util-server';
+import { FrozenBuffer } from 'util-server';
 
 import FileOp from './FileOp';
 import StoragePath from './StoragePath';
@@ -138,34 +138,6 @@ export default class BaseFile extends CommonBase {
    */
   async _impl_exists() {
     this._mustOverride();
-  }
-
-  /**
-   * Writes a value at the indicated path, failing if there is already any
-   * value stored at the path. If there is already a value, this method returns
-   * `false`. All other problems are indicated by throwing errors.
-   *
-   * @param {string} storagePath Path to write to.
-   * @param {FrozenBuffer} newValue Value to write.
-   * @returns {boolean} `true` if the write is successful, or `false` if it
-   *   failed due to `path` already having a value.
-   */
-  async opNew(storagePath, newValue) {
-    const spec = new TransactionSpec(
-      FileOp.op_checkPathEmpty(storagePath),
-      FileOp.op_writePath(storagePath, newValue)
-    );
-
-    try {
-      await this.transact(spec);
-      return true;
-    } catch (e) {
-      if ((e instanceof InfoError) && (e.name === 'path_not_empty')) {
-        return false;
-      } else {
-        throw e;
-      }
-    }
   }
 
   /**

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -141,23 +141,6 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Writes a value at the indicated path, without regard to whether there was
-   * a value already at the path, nor what value was already stored if any.
-   *
-   * @param {string} storagePath Path to write to.
-   * @param {FrozenBuffer} newValue Value to write.
-   * @returns {boolean} `true` once the operation is complete.
-   */
-  async opForceWrite(storagePath, newValue) {
-    const spec = new TransactionSpec(
-      FileOp.op_writePath(storagePath, newValue)
-    );
-
-    await this.transact(spec);
-    return true;
-  }
-
-  /**
    * Writes a value at the indicated path, failing if there is already any
    * value stored at the path. If there is already a value, this method returns
    * `false`. All other problems are indicated by throwing errors.

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -4,7 +4,7 @@
 
 import { DeltaResult, DocumentChange, FrozenDelta, RevisionNumber, Snapshot, Timestamp }
   from 'doc-common';
-import { BaseFile, Coder } from 'content-store';
+import { BaseFile, Coder, FileOp, TransactionSpec } from 'content-store';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, PromDelay } from 'util-common';
@@ -622,7 +622,11 @@ export default class DocControl extends CommonBase {
   async _writeRevNum(revNum) {
     RevisionNumber.check(revNum);
 
-    await this._file.opForceWrite(Paths.REVISION_NUMBER, Coder.encode(revNum));
+    const spec = new TransactionSpec(
+      FileOp.op_writePath(Paths.REVISION_NUMBER, Coder.encode(revNum))
+    );
+
+    await this._file.transact(spec);
     return true;
   }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -567,7 +567,10 @@ export default class DocControl extends CommonBase {
 
     // Update the revision number. **Note:** The `await` is to get errors to be
     // thrown via this method instead of being dropped on the floor.
-    await this._writeRevNum(revNum);
+    const spec = new TransactionSpec(
+      FileOp.op_writePath(Paths.REVISION_NUMBER, Coder.encode(revNum))
+    );
+    await this._file.transact(spec);
 
     return revNum;
   }
@@ -611,22 +614,5 @@ export default class DocControl extends CommonBase {
   async _currentRevNum() {
     const encoded = await this._file.pathReadOrNull(Paths.REVISION_NUMBER);
     return (encoded === null) ? null : Coder.decode(encoded);
-  }
-
-  /**
-   * Writes the given value as the current document revision number.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {boolean} `true` once the write is complete.
-   */
-  async _writeRevNum(revNum) {
-    RevisionNumber.check(revNum);
-
-    const spec = new TransactionSpec(
-      FileOp.op_writePath(Paths.REVISION_NUMBER, Coder.encode(revNum))
-    );
-
-    await this._file.transact(spec);
-    return true;
   }
 }


### PR DESCRIPTION
As of this PR, the system finally uses the `content-store` transaction facility in a reasonably nontrivial manner. Highlights:

* Replace most of the guts of `DocControl._appendDelta()` and `DocControl._create()` each with a single transaction.
* Remove `BaseFile.opForceWrite()` and `BaseFile.opNew()` which were no longer used.