### PR TITLE
"Codec" refactoring.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiClient } from 'api-client';
-import { Decoder, SplitKey } from 'api-common';
+import { Codec, SplitKey } from 'api-common';
 import { DocClient } from 'doc-client';
 import { Hooks } from 'hooks-client';
 import { QuillMaker } from 'quill-util';
@@ -36,7 +36,7 @@ export default class TopControl {
      * as a specific author. The `BAYOU_KEY` incoming parameter is expected to
      * be a `SplitKey` in JSON-encoded form.
      */
-    this._key = SplitKey.check(Decoder.decodeJson(window.BAYOU_KEY));
+    this._key = SplitKey.check(Codec.theOne.decodeJson(window.BAYOU_KEY));
 
     /**
      * {string} DOM Selector string that indicates which node in the DOM should
@@ -217,7 +217,7 @@ export default class TopControl {
     }
 
     log.info('Attempting recovery with new key...');
-    this._key = SplitKey.check(Decoder.decodeJson(newKey));
+    this._key = SplitKey.check(Codec.theOne.decodeJson(newKey));
     this._makeApiClient();
     this._makeDocClient();
   }

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseKey, Decoder, Encoder, Message } from 'api-common';
+import { BaseKey, Codec, Message } from 'api-common';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { WebsocketCodes } from 'util-common';
@@ -261,7 +261,7 @@ export default class ApiClient {
     this._nextId++;
 
     const payloadObj = new Message(id, target, action, name, args);
-    const payload = Encoder.encodeJson(payloadObj);
+    const payload = Codec.theOne.encodeJson(payloadObj);
 
     switch (wsState) {
       case WebSocket.CONNECTING: {
@@ -368,7 +368,7 @@ export default class ApiClient {
   _handleMessage(event) {
     this._log.detail('Received raw payload:', event.data);
 
-    const payload = Decoder.decodeJson(event.data);
+    const payload = Codec.theOne.decodeJson(event.data);
     const id = payload.id;
     let result = payload.result;
     const error = payload.error;

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -6,6 +6,7 @@ import { Singleton } from 'util-common';
 
 import Decoder from './Decoder';
 import Encoder from './Encoder';
+import Registry from './Registry';
 
 /**
  * Encoder and decoder of values for transport over the API (or for storage on
@@ -43,7 +44,7 @@ export default class Codec extends Singleton {
    * @returns {*} The converted value.
    */
   decode(value) {
-    return Decoder.decode(value);
+    return new Decoder(Registry.theOne).decode(value);
   }
 
   /**

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -120,4 +120,14 @@ export default class Codec extends Singleton {
   encodeJson(value, pretty = false) {
     return JSON.stringify(this.encode(value), null, pretty ? 2 : 0);
   }
+
+  /**
+   * Registers a class to be accepted for API use. This is a pass-through to
+   * the method of the same name on the instance's `Registry`.
+   *
+   * @param {object} clazz The class to register.
+   */
+  registerClass(clazz) {
+    this._reg.registerClass(clazz);
+  }
 }

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -92,7 +92,7 @@ export default class Codec extends Singleton {
    * @returns {*} The converted value.
    */
   encode(value) {
-    return Encoder.encode(value);
+    return new Encoder(Registry.theOne).encode(value);
   }
 
   /**

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -18,6 +18,19 @@ import Registry from './Registry';
  */
 export default class Codec extends Singleton {
   /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {Registry} The registry instance to use. **Note:** If and when this class
+     * stops being a singleton, this will get set from a constructor argument.
+     */
+    this._reg = Registry.theOne;
+  }
+
+  /**
    * Converts a value that was previously converted with `encode()` (or the
    * equivalent) back into fully useful objects. Specifically:
    *
@@ -44,7 +57,7 @@ export default class Codec extends Singleton {
    * @returns {*} The converted value.
    */
   decode(value) {
-    return new Decoder(Registry.theOne).decode(value);
+    return new Decoder(this._reg).decode(value);
   }
 
   /**
@@ -92,7 +105,7 @@ export default class Codec extends Singleton {
    * @returns {*} The converted value.
    */
   encode(value) {
-    return new Encoder(Registry.theOne).encode(value);
+    return new Encoder(this._reg).encode(value);
   }
 
   /**

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -30,7 +30,7 @@ export default class Codec extends Singleton {
    *   rejected.
    * * Other arrays are processed recursively using (the equivalent of) this
    *   method, without the first element. If the first element is the value
-   *   `Registry.ARRAY_TAG` then the processed form is used as-is. Otherwise,
+   *   `Registry.arrayTag` then the processed form is used as-is. Otherwise,
    *   the first element is used to look up a class that has been registered
    *   under that name. Its `fromApi()` method is called, passing the converted
    *   array as arguments. The result of that call becomes the result of
@@ -76,7 +76,7 @@ export default class Codec extends Singleton {
    * * Arrays with non-numeric properties are rejected.
    * * Other arrays are allowed, with their values processed recursively using
    *   (the equivalent of) this method. The encoded form is also an array but
-   *   with an additional first element of the value `Registry.ARRAY_TAG`.
+   *   with an additional first element of the value `Registry.arrayTag`.
    * * Objects which bind a method `toApi()` and whose constructor binds a
    *   property `API_NAME` are allowed. Such objects will have `toApi()` called
    *   on them, which is expected to result in an array which is suitable for

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -1,0 +1,109 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Singleton } from 'util-common';
+
+import Decoder from './Decoder';
+import Encoder from './Encoder';
+
+/**
+ * Encoder and decoder of values for transport over the API (or for storage on
+ * disk or in databases).
+ *
+ * **TODO:** If and when `Registry` stops being a singleton, this class should
+ * correspondingly stop being one too, since it will no longer be the case that
+ * there is a unique registry to query.
+ */
+export default class Codec extends Singleton {
+  /**
+   * Converts a value that was previously converted with `encode()` (or the
+   * equivalent) back into fully useful objects. Specifically:
+   *
+   * * Non-object / non-function values are passed through as-is.
+   * * `null` is passed through as-is.
+   * * Direct instances of `Object` (`x` such that `Object.getPrototypeOf(x) ===
+   *   Object.prototype`) are allowed, with their values processed recursively
+   *   using (the equivalent of) this method.
+   * * Arrays whose first element is not a string (including empty arrays) are
+   *   rejected.
+   * * Other arrays are processed recursively using (the equivalent of) this
+   *   method, without the first element. If the first element is the value
+   *   `Registry.ARRAY_TAG` then the processed form is used as-is. Otherwise,
+   *   the first element is used to look up a class that has been registered
+   *   under that name. Its `fromApi()` method is called, passing the converted
+   *   array as arguments. The result of that call becomes the result of
+   *   conversion.
+   * * All other objects (including functions) are rejected.
+   *
+   * In addition, if the result is an object (including an array), it is
+   * guaranteed to be recursively frozen.
+   *
+   * @param {*} value Value to convert.
+   * @returns {*} The converted value.
+   */
+  decode(value) {
+    return Decoder.decode(value);
+  }
+
+  /**
+   * Converts JSON-encoded text to a usable value. See `decode()` for
+   * details.
+   *
+   * @param {string} json Text to convert.
+   * @returns {*} The converted value.
+   */
+  decodeJson(json) {
+    return this.decode(JSON.parse(json));
+  }
+
+  /**
+   * Converts an arbitrary value to a form suitable for JSON-encoding and
+   * subsequent transfer over the API. In some cases, it rejects values.
+   * Specifically:
+   *
+   * * Functions are rejected.
+   * * Symbols are rejected.
+   * * `undefined` is rejected.
+   * * Other non-object values are passed through as-is.
+   * * `null` is passed through as-is.
+   * * Direct instances of `Object` (`x` such that `Object.getPrototypeOf(x) ===
+   *   Object.prototype`) are allowed, with their values processed recursively
+   *   using (the equivalent of) this method.
+   * * Arrays with holes (unset value of `x[n]` for `n < x.length`) are
+   *   rejected.
+   * * Arrays with non-numeric properties are rejected.
+   * * Other arrays are allowed, with their values processed recursively using
+   *   (the equivalent of) this method. The encoded form is also an array but
+   *   with an additional first element of the value `Registry.ARRAY_TAG`.
+   * * Objects which bind a method `toApi()` and whose constructor binds a
+   *   property `API_NAME` are allowed. Such objects will have `toApi()` called
+   *   on them, which is expected to result in an array which is suitable for
+   *   processing using (the equivalent of) this method. The encoded form is an
+   *   array with the first element the value of `API_NAME` and the rest of the
+   *   elements whatever was returned by `toApi()`.
+   * * All other objects are rejected.
+   *
+   * In addition, if the result is an object (including an array), it is
+   * guaranteed to be recursively frozen.
+   *
+   * @param {*} value Value to convert.
+   * @returns {*} The converted value.
+   */
+  encode(value) {
+    return Encoder.encode(value);
+  }
+
+  /**
+   * Converts an arbitrary value to JSON-encoded text. See `encode()` for
+   * details.
+   *
+   * @param {*} value Value to convert.
+   * @param {boolean} [pretty = false] Whether to "pretty-print" (indent and
+   *   space for human consumption) the result.
+   * @returns {string} The converted value.
+   */
+  encodeJson(value, pretty = false) {
+    return JSON.stringify(this.encode(value), null, pretty ? 2 : 0);
+  }
+}

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -10,11 +10,12 @@ import Registry from './Registry';
 
 /**
  * Encoder and decoder of values for transport over the API (or for storage on
- * disk or in databases).
+ * disk or in databases), with binding to a name-to-class registry.
  *
- * **TODO:** If and when `Registry` stops being a singleton, this class should
- * correspondingly stop being one too, since it will no longer be the case that
- * there is a unique registry to query.
+ * **TODO:** This class should probably _not_ be a singleton, in that there are
+ * legitimately multiple different API coding contexts which ultimately might
+ * want to have different sets of classes (or different name bindings even if
+ * the classes overlap).
  */
 export default class Codec extends Singleton {
   /**
@@ -27,7 +28,7 @@ export default class Codec extends Singleton {
      * {Registry} The registry instance to use. **Note:** If and when this class
      * stops being a singleton, this will get set from a constructor argument.
      */
-    this._reg = Registry.theOne;
+    this._reg = new Registry();
   }
 
   /**

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -91,7 +91,7 @@ export default class Decoder extends UtilityClass {
    * @returns {object} The converted value.
    */
   static _decodeInstance(tag, payload) {
-    const clazz = Registry.theOne.find(tag);
+    const clazz = Registry.theOne.classForName(tag);
     const args = Decoder._decodeArray(payload);
 
     if (!clazz) {

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -2,25 +2,33 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { UtilityClass } from 'util-common';
+import { CommonBase } from 'util-common';
 
 import Registry from './Registry';
 
 /**
  * Main implementation of `Codec.decode()`.
- *
- * **TODO:** If and when `Registry` stops being a singleton, this class should
- * correspondingly stop being a utility class, since it will no longer be the
- * case that there is a unique registry to query.
  */
-export default class Decoder extends UtilityClass {
+export default class Decoder extends CommonBase {
+  /**
+   * Construct an instance.
+   *
+   * @param {Registry} reg Registry instance to use.
+   */
+  constructor(reg) {
+    super();
+
+    /** {Registry} Registry instance to use. */
+    this._reg = reg;
+  }
+
   /**
    * Main implementation of `Codec.decode()`, see which for details.
    *
    * @param {*} value Value to convert.
    * @returns {*} The converted value.
    */
-  static decode(value) {
+  decode(value) {
     const type = typeof value;
 
     if (type === 'function') {
@@ -29,7 +37,7 @@ export default class Decoder extends UtilityClass {
       // Pass through as-is.
       return value;
     } else if (Object.getPrototypeOf(value) === Object.prototype) {
-      return Decoder._decodeSimpleObject(value);
+      return this._decodeSimpleObject(value);
     } else if (!Array.isArray(value)) {
       throw new Error(`API cannot decode object of class \`${value.constructor.name}\`.`);
     }
@@ -44,13 +52,13 @@ export default class Decoder extends UtilityClass {
     const payload = value.slice(1);
 
     if (tag === Registry.ARRAY_TAG) {
-      return Decoder._decodeArray(payload);
+      return this._decodeArray(payload);
     } else if (typeof tag !== 'string') {
       throw new Error('API cannot decode arrays without an initial string tag.');
     } else {
       // It had better be a registered tag, but if not, then this call will
       // throw.
-      return Decoder._decodeInstance(tag, payload);
+      return this._decodeInstance(tag, payload);
     }
   }
 
@@ -60,11 +68,11 @@ export default class Decoder extends UtilityClass {
    * @param {object} value Value to convert.
    * @returns {object} The converted value.
    */
-  static _decodeSimpleObject(value) {
+  _decodeSimpleObject(value) {
     const result = {};
 
     for (const k in value) {
-      result[k] = Decoder.decode(value[k]);
+      result[k] = this.decode(value[k]);
     }
 
     return Object.freeze(result);
@@ -77,8 +85,8 @@ export default class Decoder extends UtilityClass {
    * @param {array} payload Value to convert.
    * @returns {array} The converted value.
    */
-  static _decodeArray(payload) {
-    const result = payload.map(Decoder.decode);
+  _decodeArray(payload) {
+    const result = payload.map(this.decode.bind(this));
     return Object.freeze(result);
   }
 
@@ -90,9 +98,9 @@ export default class Decoder extends UtilityClass {
    * @param {array} payload Construction arguments.
    * @returns {object} The converted value.
    */
-  static _decodeInstance(tag, payload) {
-    const clazz = Registry.theOne.classForName(tag);
-    const args = Decoder._decodeArray(payload);
+  _decodeInstance(tag, payload) {
+    const clazz = this._reg.classForName(tag);
+    const args = this._decodeArray(payload);
 
     if (!clazz) {
       throw new Error(`API cannot decode object of class \`${tag}\`.`);

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -4,8 +4,6 @@
 
 import { CommonBase } from 'util-common';
 
-import Registry from './Registry';
-
 /**
  * Main implementation of `Codec.decode()`.
  */
@@ -20,6 +18,9 @@ export default class Decoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
+
+    /** {static} Conveniently cached value of `reg.arrayTag`. */
+    this._arrayTag = reg.arrayTag;
   }
 
   /**
@@ -51,7 +52,7 @@ export default class Decoder extends CommonBase {
     const tag = value[0];
     const payload = value.slice(1);
 
-    if (tag === Registry.ARRAY_TAG) {
+    if (tag === this._arrayTag) {
       return this._decodeArray(payload);
     } else if (typeof tag !== 'string') {
       throw new Error('API cannot decode arrays without an initial string tag.');

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -7,8 +7,7 @@ import { UtilityClass } from 'util-common';
 import Registry from './Registry';
 
 /**
- * Decoding of values that had been transpored over the API (or were read in
- * from disk or databases).
+ * Main implementation of `Codec.decode()`.
  *
  * **TODO:** If and when `Registry` stops being a singleton, this class should
  * correspondingly stop being a utility class, since it will no longer be the
@@ -16,38 +15,7 @@ import Registry from './Registry';
  */
 export default class Decoder extends UtilityClass {
   /**
-   * Converts JSON-encoded text to a usable value. See `decode()` for
-   * details.
-   *
-   * @param {string} json Text to convert.
-   * @returns {*} The converted value.
-   */
-  static decodeJson(json) {
-    return Decoder.decode(JSON.parse(json));
-  }
-
-  /**
-   * Converts a value that was previously converted with `Encoder.encode()` (or
-   * the equivalent) back into fully useful objects. Specifically:
-   *
-   * * Non-object / non-function values are passed through as-is.
-   * * `null` is passed through as-is.
-   * * Direct instances of `Object` (`x` such that `Object.getPrototypeOf(x) ===
-   *   Object.prototype`) are allowed, with their values processed recursively
-   *   using (the equivalent of) this method.
-   * * Arrays whose first element is not a string (including empty arrays) are
-   *   rejected.
-   * * Other arrays are processed recursively using (the equivalent of) this
-   *   method, without the first element. If the first element is the value
-   *   `Registry.ARRAY_TAG` then the processed form is used as-is. Otherwise,
-   *   the first element is used to look up a class that has been registered
-   *   under that name. Its `fromApi()` method is called, passing the converted
-   *   array as arguments. The result of that call becomes the result of
-   *   conversion.
-   * * All other objects (including functions) are rejected.
-   *
-   * In addition, if the result is an object (including an array), it is
-   * guaranteed to be recursively frozen.
+   * Main implementation of `Codec.decode()`, see which for details.
    *
    * @param {*} value Value to convert.
    * @returns {*} The converted value.

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -7,8 +7,7 @@ import { ObjectUtil, UtilityClass } from 'util-common';
 import Registry from './Registry';
 
 /**
- * Encoding of values for transport over the API (or for storage on disk or in
- * databases).
+* Main implementation of `Codec.decode()`.
  *
  * **TODO:** If and when `Registry` stops being a singleton, this class should
  * correspondingly stop being a utility class, since it will no longer be the
@@ -16,47 +15,7 @@ import Registry from './Registry';
  */
 export default class Encoder extends UtilityClass {
   /**
-   * Converts an arbitrary value to JSON-encoded text. See `encode()` for
-   * details.
-   *
-   * @param {*} value Value to convert.
-   * @param {boolean} [pretty = false] Whether to "pretty-print" (indent and
-   *   space for human consumption) the result.
-   * @returns {string} The converted value.
-   */
-  static encodeJson(value, pretty = false) {
-    return JSON.stringify(Encoder.encode(value), null, pretty ? 2 : 0);
-  }
-
-  /**
-   * Converts an arbitrary value to a form suitable for JSON-encoding and
-   * subsequent transfer over the API. In some cases, it rejects values.
-   * Specifically:
-   *
-   * * Functions are rejected.
-   * * Symbols are rejected.
-   * * `undefined` is rejected.
-   * * Other non-object values are passed through as-is.
-   * * `null` is passed through as-is.
-   * * Direct instances of `Object` (`x` such that `Object.getPrototypeOf(x) ===
-   *   Object.prototype`) are allowed, with their values processed recursively
-   *   using (the equivalent of) this method.
-   * * Arrays with holes (unset value of `x[n]` for `n < x.length`) are
-   *   rejected.
-   * * Arrays with non-numeric properties are rejected.
-   * * Other arrays are allowed, with their values processed recursively using
-   *   (the equivalent of) this method. The encoded form is also an array but
-   *   with an additional first element of the value `Registry.ARRAY_TAG`.
-   * * Objects which bind a method `toApi()` and whose constructor binds a
-   *   property `API_NAME` are allowed. Such objects will have `toApi()` called
-   *   on them, which is expected to result in an array which is suitable for
-   *   processing using (the equivalent of) this method. The encoded form is an
-   *   array with the first element the value of `API_NAME` and the rest of the
-   *   elements whatever was returned by `toApi()`.
-   * * All other objects are rejected.
-   *
-   * In addition, if the result is an object (including an array), it is
-   * guaranteed to be recursively frozen.
+   * Main implementation of `Codec.encode()`, see which for details.
    *
    * @param {*} value Value to convert.
    * @returns {*} The converted value.

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -4,8 +4,6 @@
 
 import { CommonBase, ObjectUtil } from 'util-common';
 
-import Registry from './Registry';
-
 /**
  * Main implementation of `Codec.encode()`.
  */
@@ -20,6 +18,9 @@ export default class Encoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
+
+    /** {static} Conveniently cached value of `reg.arrayTag`. */
+    this._arrayTag = reg.arrayTag;
   }
 
   /**
@@ -101,10 +102,10 @@ export default class Encoder extends CommonBase {
    * Helper for `encode()` which validates and converts an array.
    *
    * @param {array} value Value to convert.
-   * @param {string} [tag = Registry.ARRAY_TAG] "Header" tag for the result.
+   * @param {string} [tag = Registry.arrayTag] "Header" tag for the result.
    * @returns {array} The converted value.
    */
-  _encodeArray(value, tag = Registry.ARRAY_TAG) {
+  _encodeArray(value, tag = this._arrayTag) {
     // Convert elements and keep a count of how many elements we encounter.
     let count = 0;
     const result = value.map((elem) => {

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -49,7 +49,7 @@ export default class Regsitry extends Singleton {
    *
    * @param {object} clazz The class to register.
    */
-  register(clazz) {
+  registerClass(clazz) {
     const apiName = TString.check(clazz.API_NAME);
     TFunction.check(clazz.fromApi);
     TFunction.check(clazz.prototype.toApi);

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -68,7 +68,7 @@ export default class Regsitry extends Singleton {
    * @param {string} name The class name.
    * @returns {class} The class that was registered under the given name.
    */
-  find(name) {
+  classForName(name) {
     const result = this._registry.get(name);
 
     if (!result) {

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TFunction, TString } from 'typecheck';
-import { Singleton } from 'util-common';
+import { CommonBase } from 'util-common';
 
 /** {string} The "class" tag used for regular arrays. */
 const ARRAY_TAG = 'array';
@@ -18,13 +18,8 @@ const ARRAY_TAG = 'array';
  * `API_NAME` and a static method `fromApi()`. In addition, instances to be
  * encoded must define a method `toApi()`. These are all used as described
  * elsewhere in this module.
- *
- * **TODO:** This class should probably _not_ be a singleton, in that there are
- * legitimately multiple different API coding contexts which ultimately might
- * want to have different sets of classes (or different name bindings even if
- * the classes overlap).
  */
-export default class Regsitry extends Singleton {
+export default class Regsitry extends CommonBase {
   /**
    * Constructs the instance.
    */

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -25,11 +25,6 @@ const ARRAY_TAG = 'array';
  * the classes overlap).
  */
 export default class Regsitry extends Singleton {
-  /** The "class" tag used for regular arrays. */
-  static get ARRAY_TAG() {
-    return ARRAY_TAG;
-  }
-
   /**
    * Constructs the instance.
    */
@@ -42,6 +37,11 @@ export default class Regsitry extends Singleton {
      * registered (by client code).
      */
     this._registry = new Map([[ARRAY_TAG, null]]);
+  }
+
+  /** {string} The "class" tag used for regular arrays. */
+  get arrayTag() {
+    return ARRAY_TAG;
   }
 
   /**

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import BaseKey from './BaseKey';
+import Codec from './Codec';
 import Decoder from './Decoder';
 import Encoder from './Encoder';
 import Message from './Message';
@@ -13,4 +14,4 @@ import SplitKey from './SplitKey';
 Registry.theOne.register(Message);
 Registry.theOne.register(SplitKey);
 
-export { BaseKey, Decoder, Encoder, Message, Registry, SplitKey };
+export { BaseKey, Codec, Decoder, Encoder, Message, Registry, SplitKey };

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -9,7 +9,7 @@ import Registry from './Registry';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
-Registry.theOne.registerClass(Message);
-Registry.theOne.registerClass(SplitKey);
+Codec.theOne.registerClass(Message);
+Codec.theOne.registerClass(SplitKey);
 
 export { BaseKey, Codec, Message, Registry, SplitKey };

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -9,7 +9,7 @@ import Registry from './Registry';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
-Registry.theOne.register(Message);
-Registry.theOne.register(SplitKey);
+Registry.theOne.registerClass(Message);
+Registry.theOne.registerClass(SplitKey);
 
 export { BaseKey, Codec, Message, Registry, SplitKey };

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -5,11 +5,10 @@
 import BaseKey from './BaseKey';
 import Codec from './Codec';
 import Message from './Message';
-import Registry from './Registry';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
 Codec.theOne.registerClass(Message);
 Codec.theOne.registerClass(SplitKey);
 
-export { BaseKey, Codec, Message, Registry, SplitKey };
+export { BaseKey, Codec, Message, SplitKey };

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -4,8 +4,6 @@
 
 import BaseKey from './BaseKey';
 import Codec from './Codec';
-import Decoder from './Decoder';
-import Encoder from './Encoder';
 import Message from './Message';
 import Registry from './Registry';
 import SplitKey from './SplitKey';
@@ -14,4 +12,4 @@ import SplitKey from './SplitKey';
 Registry.theOne.register(Message);
 Registry.theOne.register(SplitKey);
 
-export { BaseKey, Codec, Decoder, Encoder, Message, Registry, SplitKey };
+export { BaseKey, Codec, Message, Registry, SplitKey };

--- a/local-modules/api-common/tests/test_Codec_decode.js
+++ b/local-modules/api-common/tests/test_Codec_decode.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { before, describe, it } from 'mocha';
 
-import { Codec, Registry } from 'api-common';
+import { Codec } from 'api-common';
 
 import MockApiObject from './MockApiObject';
 
@@ -17,7 +17,7 @@ describe('api-common/Decoder', () => {
 
   before(() => {
     try {
-      Registry.theOne.registerClass(MockApiObject);
+      Codec.theOne.registerClass(MockApiObject);
     } catch (e) {
       // nothing to do here, the try/catch is just in case some other test
       // file has already registered the mock API object.

--- a/local-modules/api-common/tests/test_Codec_decode.js
+++ b/local-modules/api-common/tests/test_Codec_decode.js
@@ -17,7 +17,7 @@ describe('api-common/Decoder', () => {
 
   before(() => {
     try {
-      Registry.theOne.register(MockApiObject);
+      Registry.theOne.registerClass(MockApiObject);
     } catch (e) {
       // nothing to do here, the try/catch is just in case some other test
       // file has already registered the mock API object.

--- a/local-modules/api-common/tests/test_Codec_decode.js
+++ b/local-modules/api-common/tests/test_Codec_decode.js
@@ -5,11 +5,16 @@
 import { assert } from 'chai';
 import { before, describe, it } from 'mocha';
 
-import { Decoder, Encoder, Registry } from 'api-common';
+import { Codec, Registry } from 'api-common';
 
 import MockApiObject from './MockApiObject';
 
 describe('api-common/Decoder', () => {
+  // Convenient bindings for `decode()` and `encode()` to avoid a lot of
+  // boilerplate.
+  const decode = (value) => { return Codec.theOne.decode(value); };
+  const encode = (value) => { return Codec.theOne.encode(value); };
+
   before(() => {
     try {
       Registry.theOne.register(MockApiObject);
@@ -21,46 +26,46 @@ describe('api-common/Decoder', () => {
 
   describe('decode(value)', () => {
     it('should pass non-object values through as-is', () => {
-      assert.strictEqual(Decoder.decode(37), 37);
-      assert.strictEqual(Decoder.decode(true), true);
-      assert.strictEqual(Decoder.decode(false), false);
-      assert.strictEqual(Decoder.decode('Happy string'), 'Happy string');
-      assert.isNull(Decoder.decode(null));
+      assert.strictEqual(decode(37), 37);
+      assert.strictEqual(decode(true), true);
+      assert.strictEqual(decode(false), false);
+      assert.strictEqual(decode('Happy string'), 'Happy string');
+      assert.isNull(decode(null));
     });
 
     it('should accept simple objects', () => {
       // The tests here are of objects whose values all decode to themselves.
-      assert.deepEqual(Decoder.decode({}), {});
-      assert.deepEqual(Decoder.decode({ a: true, b: 'yo' }), { a: true, b: 'yo' });
+      assert.deepEqual(decode({}), {});
+      assert.deepEqual(decode({ a: true, b: 'yo' }), { a: true, b: 'yo' });
     });
 
     it('should reject arrays whose first value is not a string', () => {
-      assert.throws(() => Decoder.decode([]));
-      assert.throws(() => Decoder.decode([1, 2, 3, '4 5 6']));
-      assert.throws(() => Decoder.decode([true, 2, 3, '4 5 6']));
-      assert.throws(() => Decoder.decode([null, 2, 3, '4 5 6']));
-      assert.throws(() => Decoder.decode([[], 2, 3, '4 5 6']));
-      assert.throws(() => Decoder.decode([() => true, 2, 3, '4 5 6']));
+      assert.throws(() => decode([]));
+      assert.throws(() => decode([1, 2, 3, '4 5 6']));
+      assert.throws(() => decode([true, 2, 3, '4 5 6']));
+      assert.throws(() => decode([null, 2, 3, '4 5 6']));
+      assert.throws(() => decode([[], 2, 3, '4 5 6']));
+      assert.throws(() => decode([() => true, 2, 3, '4 5 6']));
     });
 
     it('should reject functions', () => {
-      assert.throws(() => Decoder.decode(function () { return true; }));
-      assert.throws(() => Decoder.decode(() => 123));
+      assert.throws(() => decode(function () { return true; }));
+      assert.throws(() => decode(() => 123));
     });
 
     it('should decode an encoded array back to the original array', () => {
       const orig = [1, 2, 'buckle my shoe'];
-      const encoded = Encoder.encode(orig);
-      assert.deepEqual(Decoder.decode(encoded), orig);
+      const encoded = encode(orig);
+      assert.deepEqual(decode(encoded), orig);
     });
 
     it('should convert propertly formatted values to an API object', () => {
       const apiObject = new MockApiObject();
-      const encoding = Encoder.encode(apiObject);
+      const encoding = encode(apiObject);
       let decodedObject = null;
 
       assert.doesNotThrow(function () {
-        decodedObject = Decoder.decode(encoding);
+        decodedObject = decode(encoding);
       });
 
       assert.instanceOf(decodedObject, apiObject.constructor);

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Encoder } from 'api-common';
+import { Codec } from 'api-common';
 
 import MockApiObject from './MockApiObject';
 
@@ -22,32 +22,36 @@ class NoToApi {
 }
 
 describe('api-common/Encoder', () => {
+  // Convenient bindings for `decode()` and `encode()` to avoid a lot of
+  // boilerplate.
+  const encode = (value) => { return Codec.theOne.encode(value); };
+
   describe('encode(value)', () => {
     it('should reject function values', () => {
-      assert.throws(() => Encoder.encode(function () { true; }));
+      assert.throws(() => encode(function () { true; }));
     });
 
     it('should reject Symbols', () => {
-      assert.throws(() => Encoder.encode(Symbol('this better not work!')));
+      assert.throws(() => encode(Symbol('this better not work!')));
     });
 
     it('should reject undefined', () => {
-      assert.throws(() => Encoder.encode(undefined));
+      assert.throws(() => encode(undefined));
     });
 
     it('should pass through non-object values and null as-is', () => {
-      assert.strictEqual(Encoder.encode(37), 37);
-      assert.strictEqual(Encoder.encode(true), true);
-      assert.strictEqual(Encoder.encode(false), false);
-      assert.strictEqual(Encoder.encode('blort'), 'blort');
-      assert.strictEqual(Encoder.encode(null), null);
+      assert.strictEqual(encode(37), 37);
+      assert.strictEqual(encode(true), true);
+      assert.strictEqual(encode(false), false);
+      assert.strictEqual(encode('blort'), 'blort');
+      assert.strictEqual(encode(null), null);
     });
 
     it('should pass through simple objects whose values are self-encoding as-is', () => {
-      assert.deepEqual(Encoder.encode({}), {});
-      assert.deepEqual(Encoder.encode({ a: 10 }), { a: 10 });
-      assert.deepEqual(Encoder.encode({ b: false }), { b: false });
-      assert.deepEqual(Encoder.encode({ c: 'yay', d: {} }), { c: 'yay', d: {} });
+      assert.deepEqual(encode({}), {});
+      assert.deepEqual(encode({ a: 10 }), { a: 10 });
+      assert.deepEqual(encode({ b: false }), { b: false });
+      assert.deepEqual(encode({ c: 'yay', d: {} }), { c: 'yay', d: {} });
     });
 
     it('should reject arrays with index holes', () => {
@@ -56,7 +60,7 @@ describe('api-common/Encoder', () => {
       value[1] = true;
       value[37] = true;
 
-      assert.throws(() => Encoder.encode(value));
+      assert.throws(() => encode(value));
     });
 
     it('should reject arrays with non-numeric properties', () => {
@@ -65,25 +69,25 @@ describe('api-common/Encoder', () => {
       value['foo'] = 'bar';
       value['baz'] = 'floopty';
 
-      assert.throws(() => Encoder.encode(value));
+      assert.throws(() => encode(value));
     });
 
     it('should reject API objects with no API_NAME property', () => {
       const noApiName = new NoApiName();
 
-      assert.throws(() => Encoder.encode(noApiName));
+      assert.throws(() => encode(noApiName));
     });
 
     it('should reject API objects with no toApi() method', () => {
       const noToApi = new NoToApi();
 
-      assert.throws(() => Encoder.encode(noToApi));
+      assert.throws(() => encode(noToApi));
     });
 
     it('should accept objects with an API_NAME property and toApi() method', () => {
       const fakeObject = new MockApiObject();
 
-      assert.doesNotThrow(() => Encoder.encode(fakeObject));
+      assert.doesNotThrow(() => encode(fakeObject));
     });
   });
 });

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -4,9 +4,11 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
-
-import { Registry } from 'api-common';
 import { Random } from 'util-common';
+
+// The class being tested here isn't exported from the module, so we import it
+// by path.
+import Registry from 'api-common/Registry';
 
 class RegistryTestApiObject {
   constructor() {

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -83,18 +83,18 @@ describe('api-common/Registry', () => {
 
   describe('register(class)', () => {
     it('should require classes with an APP_NAME property, fromName() class method, and toApi() instance method', () => {
-      assert.throws(() => Registry.theOne.register(true));
-      assert.throws(() => Registry.theOne.register(37));
-      assert.throws(() => Registry.theOne.register('this better not work!'));
-      assert.throws(() => Registry.theOne.register({ }));
-      assert.throws(() => Registry.theOne.register([]));
-      assert.throws(() => Registry.theOne.register(null));
-      assert.throws(() => Registry.theOne.register(undefined));
-      assert.throws(() => Registry.theOne.register(NoApiName));
-      assert.throws(() => Registry.theOne.register(NoToApi));
-      assert.throws(() => Registry.theOne.register(NoFromApi));
+      assert.throws(() => Registry.theOne.registerClass(true));
+      assert.throws(() => Registry.theOne.registerClass(37));
+      assert.throws(() => Registry.theOne.registerClass('this better not work!'));
+      assert.throws(() => Registry.theOne.registerClass({ }));
+      assert.throws(() => Registry.theOne.registerClass([]));
+      assert.throws(() => Registry.theOne.registerClass(null));
+      assert.throws(() => Registry.theOne.registerClass(undefined));
+      assert.throws(() => Registry.theOne.registerClass(NoApiName));
+      assert.throws(() => Registry.theOne.registerClass(NoToApi));
+      assert.throws(() => Registry.theOne.registerClass(NoFromApi));
 
-      assert.doesNotThrow(() => Registry.theOne.register(RegistryTestApiObject));
+      assert.doesNotThrow(() => Registry.theOne.registerClass(RegistryTestApiObject));
     });
   });
 
@@ -105,7 +105,7 @@ describe('api-common/Registry', () => {
     });
 
     it('should return the named class if it is registered', () => {
-      Registry.theOne.register(FindTestApiObject);
+      Registry.theOne.registerClass(FindTestApiObject);
 
       const testClass = Registry.theOne.classForName(FindTestApiObject.API_NAME);
       const testObject = new testClass();

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -79,37 +79,41 @@ class NoFromApi {
 describe('api-common/Registry', () => {
   describe('.arrayTag', () => {
     it("should return 'array'", () => {
-      assert.strictEqual(Registry.theOne.arrayTag, 'array');
+      const reg = new Registry();
+      assert.strictEqual(reg.arrayTag, 'array');
     });
   });
 
   describe('register(class)', () => {
     it('should require classes with an APP_NAME property, fromName() class method, and toApi() instance method', () => {
-      assert.throws(() => Registry.theOne.registerClass(true));
-      assert.throws(() => Registry.theOne.registerClass(37));
-      assert.throws(() => Registry.theOne.registerClass('this better not work!'));
-      assert.throws(() => Registry.theOne.registerClass({ }));
-      assert.throws(() => Registry.theOne.registerClass([]));
-      assert.throws(() => Registry.theOne.registerClass(null));
-      assert.throws(() => Registry.theOne.registerClass(undefined));
-      assert.throws(() => Registry.theOne.registerClass(NoApiName));
-      assert.throws(() => Registry.theOne.registerClass(NoToApi));
-      assert.throws(() => Registry.theOne.registerClass(NoFromApi));
+      const reg = new Registry();
+      assert.throws(() => reg.registerClass(true));
+      assert.throws(() => reg.registerClass(37));
+      assert.throws(() => reg.registerClass('this better not work!'));
+      assert.throws(() => reg.registerClass({}));
+      assert.throws(() => reg.registerClass([]));
+      assert.throws(() => reg.registerClass(null));
+      assert.throws(() => reg.registerClass(undefined));
+      assert.throws(() => reg.registerClass(NoApiName));
+      assert.throws(() => reg.registerClass(NoToApi));
+      assert.throws(() => reg.registerClass(NoFromApi));
 
-      assert.doesNotThrow(() => Registry.theOne.registerClass(RegistryTestApiObject));
+      assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
     });
   });
 
   describe('find(className)', () => {
     it('should throw an error if an unregistered class is requested', () => {
+      const reg = new Registry();
       const randomName = Random.hexByteString(32);
-      assert.throws(() => Registry.theOne.classForName(randomName));
+      assert.throws(() => reg.classForName(randomName));
     });
 
     it('should return the named class if it is registered', () => {
-      Registry.theOne.registerClass(FindTestApiObject);
+      const reg = new Registry();
+      reg.registerClass(FindTestApiObject);
 
-      const testClass = Registry.theOne.classForName(FindTestApiObject.API_NAME);
+      const testClass = reg.classForName(FindTestApiObject.API_NAME);
       const testObject = new testClass();
 
       assert.instanceOf(testObject, FindTestApiObject);

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -75,9 +75,9 @@ class NoFromApi {
 }
 
 describe('api-common/Registry', () => {
-  describe('.ARRAY_TAG', () => {
+  describe('.arrayTag', () => {
     it("should return 'array'", () => {
-      assert.strictEqual(Registry.ARRAY_TAG, 'array');
+      assert.strictEqual(Registry.theOne.arrayTag, 'array');
     });
   });
 

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -101,13 +101,13 @@ describe('api-common/Registry', () => {
   describe('find(className)', () => {
     it('should throw an error if an unregistered class is requested', () => {
       const randomName = Random.hexByteString(32);
-      assert.throws(() => Registry.theOne.find(randomName));
+      assert.throws(() => Registry.theOne.classForName(randomName));
     });
 
     it('should return the named class if it is registered', () => {
       Registry.theOne.register(FindTestApiObject);
 
-      const testClass = Registry.theOne.find(FindTestApiObject.API_NAME);
+      const testClass = Registry.theOne.classForName(FindTestApiObject.API_NAME);
       const testObject = new testClass();
 
       assert.instanceOf(testObject, FindTestApiObject);

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Decoder, Encoder, Message } from 'api-common';
+import { Codec, Message } from 'api-common';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, Random } from 'util-common';
@@ -169,7 +169,7 @@ export default class Connection extends CommonBase {
       response.result = result;
     }
 
-    const encodedResponse = Encoder.encodeJson(response);
+    const encodedResponse = Codec.theOne.encodeJson(response);
 
     // Log the response. In the case of an error, we include the error's stack
     // trace. We intentionally _don't_ expose the stack trace as part of the
@@ -225,7 +225,7 @@ export default class Connection extends CommonBase {
    */
   _decodeMessage(msg) {
     try {
-      msg = Decoder.decodeJson(msg);
+      msg = Codec.theOne.decodeJson(msg);
     } catch (error) {
       // Hail-mary attempt to determine a reasonable `id`.
       let id = -1;

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -6,7 +6,7 @@ import camelCase from 'camel-case';
 import express from 'express';
 import util from 'util';
 
-import { Encoder } from 'api-common';
+import { Codec } from 'api-common';
 import { AuthorId, DocumentId } from 'doc-common';
 import { DocServer } from 'doc-server';
 import { Logger } from 'see-all';
@@ -179,7 +179,7 @@ export default class DebugTools {
     const revNum = req.params.revNum;
     const doc = this._getExistingDoc(req);
     const change = (await doc).change(revNum);
-    const result = Encoder.encodeJson(await change, true);
+    const result = Codec.theOne.encodeJson(await change, true);
 
     this._textResponse(res, result);
   }
@@ -277,7 +277,7 @@ export default class DebugTools {
     const doc = this._getExistingDoc(req);
     const args = (revNum === undefined) ? [] : [revNum];
     const snapshot = (await doc).snapshot(...args);
-    const result = Encoder.encodeJson(await snapshot, true);
+    const result = Codec.theOne.encodeJson(await snapshot, true);
 
     this._textResponse(res, result);
   }
@@ -359,7 +359,7 @@ export default class DebugTools {
    */
   async _makeEncodedKey(documentId, authorId) {
     const key = await this._rootAccess.makeAccessKey(authorId, documentId);
-    return Encoder.encodeJson(key);
+    return Codec.theOne.encodeJson(key);
   }
 
   /**

--- a/local-modules/content-store/Coder.js
+++ b/local-modules/content-store/Coder.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Decoder, Encoder } from 'api-common';
+import { Codec } from 'api-common';
 import { FrozenBuffer } from 'util-server';
 import { UtilityClass } from 'util-common';
 
@@ -19,7 +19,7 @@ export default class Coder extends UtilityClass {
    * @returns {FrozenBuffer} Encoded and bufferized value.
    */
   static encode(value) {
-    return FrozenBuffer.coerce(Encoder.encodeJson(value));
+    return FrozenBuffer.coerce(Codec.theOne.encodeJson(value));
   }
 
   /**
@@ -30,6 +30,6 @@ export default class Coder extends UtilityClass {
    */
   static decode(encoded) {
     FrozenBuffer.check(encoded);
-    return Decoder.decodeJson(encoded.string);
+    return Codec.theOne.decodeJson(encoded.string);
   }
 }

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Registry } from 'api-common';
+import { Codec } from 'api-common';
 
 import AuthorId from './AuthorId';
 import DeltaResult from './DeltaResult';
@@ -14,11 +14,11 @@ import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
 // Register classes with the API.
-Registry.theOne.registerClass(DeltaResult);
-Registry.theOne.registerClass(DocumentChange);
-Registry.theOne.registerClass(FrozenDelta);
-Registry.theOne.registerClass(Snapshot);
-Registry.theOne.registerClass(Timestamp);
+Codec.theOne.registerClass(DeltaResult);
+Codec.theOne.registerClass(DocumentChange);
+Codec.theOne.registerClass(FrozenDelta);
+Codec.theOne.registerClass(Snapshot);
+Codec.theOne.registerClass(Timestamp);
 
 export {
   AuthorId,

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -14,11 +14,11 @@ import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
 // Register classes with the API.
-Registry.theOne.register(DeltaResult);
-Registry.theOne.register(DocumentChange);
-Registry.theOne.register(FrozenDelta);
-Registry.theOne.register(Snapshot);
-Registry.theOne.register(Timestamp);
+Registry.theOne.registerClass(DeltaResult);
+Registry.theOne.registerClass(DocumentChange);
+Registry.theOne.registerClass(FrozenDelta);
+Registry.theOne.registerClass(Snapshot);
+Registry.theOne.registerClass(Timestamp);
 
 export {
   AuthorId,


### PR DESCRIPTION
This PR is a major refactor of how the encoding and decoding functionality is exposed from `api-common` to the rest of the system. In particular, it used to be that there were three separate exposed classes, all either singletons or utility classes (and so effectively singletons), namely `Decoder`, `Encoder`, and `Registry`. Ultimately, we don't want any of these to be "singleton-ish," and the functionality of all three is fairly intertwined. So, what I did was explicitly represent that intertwinedness by exposing the entire suite of functionality via a new class, `Codec` and un-exporting the original three.

`Codec` is still a singleton like the classes that preceded it, so as to minimally disturb all of the existing client code for this functionality. Under the covers, though, all of the original code is now in the form of normal multiply-instantiable classes. When the time comes to make `Codec` stop being a singleton, the follow-on change from this new status quo should be reasonably palatable.

**Aside: Why am I doing this now?** With the recent changes to `content-store` it is now possible and desirable to define complicated transactions to effect changes to files. However, at the `doc-server` layer, much of the data going into and coming out of transactions wants to go through the API coding layer. There's a half-baked utility class that helps with this now, but it's fairly limited. To fully bake this sort of help (that is, to make API coding easy and natural to do) the `content-store` layer needs to accept (something like) `Codec` instances as arguments to `transact()` (or something along those lines). But before this PR, there was no easy `Codec` instance to so use. Now there is!