### PR TITLE
Name changes to increase uniqueness.

### DIFF
--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -58,24 +58,24 @@ export default class Codec extends Singleton {
    * @param {*} value Value to convert.
    * @returns {*} The converted value.
    */
-  decode(value) {
-    return new Decoder(this._reg).decode(value);
+  decodeData(value) {
+    return new Decoder(this._reg).decodeData(value);
   }
 
   /**
-   * Converts JSON-encoded text to a usable value. See `decode()` for
+   * Converts JSON-encoded text to a usable value. See `decodeData()` for
    * details.
    *
    * @param {string} json Text to convert.
    * @returns {*} The converted value.
    */
   decodeJson(json) {
-    return this.decode(JSON.parse(json));
+    return this.decodeData(JSON.parse(json));
   }
 
   /**
    * Converts JSON-encoded text in a `FrozenBuffer` to a usable value. See
-   * `decode()` for details.
+   * `decodeData()` for details.
    *
    * @param {FrozenBuffer} encoded Value to decode.
    * @returns {*} Decoded value.

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -32,8 +32,9 @@ export default class Codec extends Singleton {
   }
 
   /**
-   * Converts a value that was previously converted with `encode()` (or the
-   * equivalent) back into fully useful objects. Specifically:
+   * Converts a "pure data" value that was previously converted with
+   * `encodeData()` (or the equivalent) back into fully useful objects.
+   * Specifically:
    *
    * * Non-object / non-function values are passed through as-is.
    * * `null` is passed through as-is.
@@ -85,9 +86,9 @@ export default class Codec extends Singleton {
   }
 
   /**
-   * Converts an arbitrary value to a form suitable for JSON-encoding and
-   * subsequent transfer over the API. In some cases, it rejects values.
-   * Specifically:
+   * Converts an arbitrary value to a "pure data" form suitable for
+   * JSON-encoding and/or transfer over an API boundary. In some cases, it
+   * rejects values. Specifically:
    *
    * * Functions are rejected.
    * * Symbols are rejected.
@@ -117,12 +118,12 @@ export default class Codec extends Singleton {
    * @param {*} value Value to convert.
    * @returns {*} The converted value.
    */
-  encode(value) {
-    return new Encoder(this._reg).encode(value);
+  encodeData(value) {
+    return new Encoder(this._reg).encodeData(value);
   }
 
   /**
-   * Converts an arbitrary value to JSON-encoded text. See `encode()` for
+   * Converts an arbitrary value to JSON-encoded text. See `encodeData()` for
    * details.
    *
    * @param {*} value Value to convert.
@@ -131,12 +132,12 @@ export default class Codec extends Singleton {
    * @returns {string} The converted value.
    */
   encodeJson(value, pretty = false) {
-    return JSON.stringify(this.encode(value), null, pretty ? 2 : 0);
+    return JSON.stringify(this.encodeData(value), null, pretty ? 2 : 0);
   }
 
   /**
    * Converts an arbitrary value to JSON-encoded text, which is furthermore
-   * converted to a `FrozenBuffer`. See `encode()` for details.
+   * converted to a `FrozenBuffer`. See `encodeData()` for details.
    *
    * @param {*} value Value to encode.
    * @returns {FrozenBuffer} Encoded and bufferized value.

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -5,7 +5,7 @@
 import { CommonBase } from 'util-common';
 
 /**
- * Main implementation of `Codec.decode()`.
+ * Main implementation of `Codec.decodeData()`.
  */
 export default class Decoder extends CommonBase {
   /**
@@ -24,12 +24,12 @@ export default class Decoder extends CommonBase {
   }
 
   /**
-   * Main implementation of `Codec.decode()`, see which for details.
+   * Main implementation of `Codec.decodeData()`, see which for details.
    *
    * @param {*} value Value to convert.
    * @returns {*} The converted value.
    */
-  decode(value) {
+  decodeData(value) {
     const type = typeof value;
 
     if (type === 'function') {
@@ -64,7 +64,7 @@ export default class Decoder extends CommonBase {
   }
 
   /**
-   * Helper for `decode()` which validates and converts a simple object.
+   * Helper for `decodeData()` which validates and converts a simple object.
    *
    * @param {object} value Value to convert.
    * @returns {object} The converted value.
@@ -73,26 +73,26 @@ export default class Decoder extends CommonBase {
     const result = {};
 
     for (const k in value) {
-      result[k] = this.decode(value[k]);
+      result[k] = this.decodeData(value[k]);
     }
 
     return Object.freeze(result);
   }
 
   /**
-   * Helper for `decode()` which validates and converts a regular array
+   * Helper for `decodeData()` which validates and converts a regular array
    * (which was originally tagged with `array`).
    *
    * @param {array} payload Value to convert.
    * @returns {array} The converted value.
    */
   _decodeArray(payload) {
-    const result = payload.map(this.decode.bind(this));
+    const result = payload.map(this.decodeData.bind(this));
     return Object.freeze(result);
   }
 
   /**
-   * Helper for `decode()` which validates and converts a tagged
+   * Helper for `decodeData()` which validates and converts a tagged
    * constructor array.
    *
    * @param {string} tag Name tag.

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -5,7 +5,7 @@
 import { CommonBase, ObjectUtil } from 'util-common';
 
 /**
- * Main implementation of `Codec.encode()`.
+ * Main implementation of `Codec.encodeData()`.
  */
 export default class Encoder extends CommonBase {
   /**
@@ -24,12 +24,12 @@ export default class Encoder extends CommonBase {
   }
 
   /**
-   * Main implementation of `Codec.encode()`, see which for details.
+   * Main implementation of `Codec.encodeData()`, see which for details.
    *
    * @param {*} value Value to convert.
    * @returns {*} The converted value.
    */
-  encode(value) {
+  encodeData(value) {
     switch (typeof value) {
       case 'boolean':
       case 'number':
@@ -69,7 +69,7 @@ export default class Encoder extends CommonBase {
   }
 
   /**
-   * Helper for `encode()` which validates and converts a simple object.
+   * Helper for `encodeData()` which validates and converts a simple object.
    *
    * @param {object} value Value to convert.
    * @returns {object} The converted value.
@@ -92,14 +92,14 @@ export default class Encoder extends CommonBase {
         }
       }
 
-      result[k] = this.encode(origValue);
+      result[k] = this.encodeData(origValue);
     }
 
     return Object.freeze(result);
   }
 
   /**
-   * Helper for `encode()` which validates and converts an array.
+   * Helper for `encodeData()` which validates and converts an array.
    *
    * @param {array} value Value to convert.
    * @param {string} [tag = Registry.arrayTag] "Header" tag for the result.
@@ -110,7 +110,7 @@ export default class Encoder extends CommonBase {
     let count = 0;
     const result = value.map((elem) => {
       count++;
-      return this.encode(elem);
+      return this.encodeData(elem);
     });
 
     if (value.length !== count) {
@@ -129,7 +129,7 @@ export default class Encoder extends CommonBase {
   }
 
   /**
-   * Helper for `encode()` which validates and converts an object which is
+   * Helper for `encodeData()` which validates and converts an object which is
    * expected (and verified) to have API metainfo properties.
    *
    * @param {object} value Value to convert.

--- a/local-modules/api-common/tests/test_Codec_decode.js
+++ b/local-modules/api-common/tests/test_Codec_decode.js
@@ -14,7 +14,7 @@ describe('api-common/Decoder', () => {
   // Convenient bindings for `decode*()` and `encodeData()` to avoid a lot of
   // boilerplate.
   const codec            = Codec.theOne;
-  const decode           = (value) => { return codec.decode(value);           };
+  const decodeData       = (value) => { return codec.decodeData(value);       };
   const decodeJson       = (value) => { return codec.decodeJson(value);       };
   const decodeJsonBuffer = (value) => { return codec.decodeJsonBuffer(value); };
   const encodeData       = (value) => { return codec.encodeData(value);       };
@@ -28,39 +28,39 @@ describe('api-common/Decoder', () => {
     }
   });
 
-  describe('decode', () => {
+  describe('decodeData', () => {
     it('should pass non-object values through as-is', () => {
-      assert.strictEqual(decode(37), 37);
-      assert.strictEqual(decode(true), true);
-      assert.strictEqual(decode(false), false);
-      assert.strictEqual(decode('Happy string'), 'Happy string');
-      assert.isNull(decode(null));
+      assert.strictEqual(decodeData(37), 37);
+      assert.strictEqual(decodeData(true), true);
+      assert.strictEqual(decodeData(false), false);
+      assert.strictEqual(decodeData('Happy string'), 'Happy string');
+      assert.isNull(decodeData(null));
     });
 
     it('should accept simple objects', () => {
       // The tests here are of objects whose values all decode to themselves.
-      assert.deepEqual(decode({}), {});
-      assert.deepEqual(decode({ a: true, b: 'yo' }), { a: true, b: 'yo' });
+      assert.deepEqual(decodeData({}), {});
+      assert.deepEqual(decodeData({ a: true, b: 'yo' }), { a: true, b: 'yo' });
     });
 
     it('should reject arrays whose first value is not a string', () => {
-      assert.throws(() => decode([]));
-      assert.throws(() => decode([1, 2, 3, '4 5 6']));
-      assert.throws(() => decode([true, 2, 3, '4 5 6']));
-      assert.throws(() => decode([null, 2, 3, '4 5 6']));
-      assert.throws(() => decode([[], 2, 3, '4 5 6']));
-      assert.throws(() => decode([() => true, 2, 3, '4 5 6']));
+      assert.throws(() => decodeData([]));
+      assert.throws(() => decodeData([1, 2, 3, '4 5 6']));
+      assert.throws(() => decodeData([true, 2, 3, '4 5 6']));
+      assert.throws(() => decodeData([null, 2, 3, '4 5 6']));
+      assert.throws(() => decodeData([[], 2, 3, '4 5 6']));
+      assert.throws(() => decodeData([() => true, 2, 3, '4 5 6']));
     });
 
     it('should reject functions', () => {
-      assert.throws(() => decode(function () { return true; }));
-      assert.throws(() => decode(() => 123));
+      assert.throws(() => decodeData(function () { return true; }));
+      assert.throws(() => decodeData(() => 123));
     });
 
     it('should decode an encoded array back to the original array', () => {
       const orig = [1, 2, 'buckle my shoe'];
       const encoded = encodeData(orig);
-      assert.deepEqual(decode(encoded), orig);
+      assert.deepEqual(decodeData(encoded), orig);
     });
 
     it('should convert propertly formatted values to an API object', () => {
@@ -68,8 +68,8 @@ describe('api-common/Decoder', () => {
       const encoding = encodeData(apiObject);
       let decodedObject = null;
 
-      assert.doesNotThrow(function () {
-        decodedObject = decode(encoding);
+      assert.doesNotThrow(() => {
+        decodedObject = decodeData(encoding);
       });
 
       assert.instanceOf(decodedObject, apiObject.constructor);

--- a/local-modules/api-common/tests/test_Codec_decode.js
+++ b/local-modules/api-common/tests/test_Codec_decode.js
@@ -11,13 +11,13 @@ import { Codec } from 'api-common';
 import MockApiObject from './MockApiObject';
 
 describe('api-common/Decoder', () => {
-  // Convenient bindings for `decode*()` and `encode()` to avoid a lot of
+  // Convenient bindings for `decode*()` and `encodeData()` to avoid a lot of
   // boilerplate.
   const codec            = Codec.theOne;
   const decode           = (value) => { return codec.decode(value);           };
   const decodeJson       = (value) => { return codec.decodeJson(value);       };
   const decodeJsonBuffer = (value) => { return codec.decodeJsonBuffer(value); };
-  const encode           = (value) => { return codec.encode(value);           };
+  const encodeData       = (value) => { return codec.encodeData(value);       };
 
   before(() => {
     try {
@@ -59,13 +59,13 @@ describe('api-common/Decoder', () => {
 
     it('should decode an encoded array back to the original array', () => {
       const orig = [1, 2, 'buckle my shoe'];
-      const encoded = encode(orig);
+      const encoded = encodeData(orig);
       assert.deepEqual(decode(encoded), orig);
     });
 
     it('should convert propertly formatted values to an API object', () => {
       const apiObject = new MockApiObject();
-      const encoding = encode(apiObject);
+      const encoding = encodeData(apiObject);
       let decodedObject = null;
 
       assert.doesNotThrow(function () {

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -23,38 +23,38 @@ class NoToApi {
 }
 
 describe('api-common/Encoder', () => {
-  // Convenient bindings for `encode()*` to avoid a lot of boilerplate.
+  // Convenient bindings for `encode*()` to avoid a lot of boilerplate.
   const codec            = Codec.theOne;
-  const encode           = (value) => { return codec.encode(value);           };
+  const encodeData       = (value) => { return codec.encodeData(value);       };
   const encodeJson       = (value) => { return codec.encodeJson(value);       };
   const encodeJsonBuffer = (value) => { return codec.encodeJsonBuffer(value); };
 
-  describe('encode', () => {
+  describe('encodeData', () => {
     it('should reject function values', () => {
-      assert.throws(() => encode(function () { true; }));
+      assert.throws(() => encodeData(function () { true; }));
     });
 
     it('should reject Symbols', () => {
-      assert.throws(() => encode(Symbol('this better not work!')));
+      assert.throws(() => encodeData(Symbol('this better not work!')));
     });
 
     it('should reject undefined', () => {
-      assert.throws(() => encode(undefined));
+      assert.throws(() => encodeData(undefined));
     });
 
     it('should pass through non-object values and null as-is', () => {
-      assert.strictEqual(encode(37), 37);
-      assert.strictEqual(encode(true), true);
-      assert.strictEqual(encode(false), false);
-      assert.strictEqual(encode('blort'), 'blort');
-      assert.strictEqual(encode(null), null);
+      assert.strictEqual(encodeData(37), 37);
+      assert.strictEqual(encodeData(true), true);
+      assert.strictEqual(encodeData(false), false);
+      assert.strictEqual(encodeData('blort'), 'blort');
+      assert.strictEqual(encodeData(null), null);
     });
 
     it('should pass through simple objects whose values are self-encoding as-is', () => {
-      assert.deepEqual(encode({}), {});
-      assert.deepEqual(encode({ a: 10 }), { a: 10 });
-      assert.deepEqual(encode({ b: false }), { b: false });
-      assert.deepEqual(encode({ c: 'yay', d: {} }), { c: 'yay', d: {} });
+      assert.deepEqual(encodeData({}), {});
+      assert.deepEqual(encodeData({ a: 10 }), { a: 10 });
+      assert.deepEqual(encodeData({ b: false }), { b: false });
+      assert.deepEqual(encodeData({ c: 'yay', d: {} }), { c: 'yay', d: {} });
     });
 
     it('should reject arrays with index holes', () => {
@@ -63,7 +63,7 @@ describe('api-common/Encoder', () => {
       value[1] = true;
       value[37] = true;
 
-      assert.throws(() => encode(value));
+      assert.throws(() => encodeData(value));
     });
 
     it('should reject arrays with non-numeric properties', () => {
@@ -72,25 +72,25 @@ describe('api-common/Encoder', () => {
       value['foo'] = 'bar';
       value['baz'] = 'floopty';
 
-      assert.throws(() => encode(value));
+      assert.throws(() => encodeData(value));
     });
 
     it('should reject API objects with no API_NAME property', () => {
       const noApiName = new NoApiName();
 
-      assert.throws(() => encode(noApiName));
+      assert.throws(() => encodeData(noApiName));
     });
 
     it('should reject API objects with no toApi() method', () => {
       const noToApi = new NoToApi();
 
-      assert.throws(() => encode(noToApi));
+      assert.throws(() => encodeData(noToApi));
     });
 
     it('should accept objects with an API_NAME property and toApi() method', () => {
       const fakeObject = new MockApiObject();
 
-      assert.doesNotThrow(() => encode(fakeObject));
+      assert.doesNotThrow(() => encodeData(fakeObject));
     });
   });
 

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -31,7 +31,7 @@ describe('api-common/Encoder', () => {
 
   describe('encodeData', () => {
     it('should reject function values', () => {
-      assert.throws(() => encodeData(function () { true; }));
+      assert.throws(() => encodeData(() => 1));
     });
 
     it('should reject Symbols', () => {


### PR DESCRIPTION
The methods called `encode()` and `decode()` aren't actually the ones in the system that warrant such unadorned names. Ultimately, I expect we'll define (something like) an interface that can be used with `content-store` to provide coding into and out of files; the methods defined by that interface will probably be the things named `encode` and `decode` (and will likely bottom out in the `*JsonBuffer()` variants in the near term).

So, to help keep things more obvious going forward, this PR renames the old `{en,de}code()` to be suffixed as `{en,de}codeData()`. I also clarified the docs around them a little.