### PR TITLE
`FileCodec` and use.

### DIFF
--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -49,17 +49,28 @@ describe('content-store-local/LocalFile', () => {
       const value = FrozenBuffer.coerce('x');
 
       // Baseline assumption.
-      await file.create();
-      const spec = new TransactionSpec(
+
+      let spec = new TransactionSpec(
         FileOp.op_writePath(storagePath, value)
       );
+
+      await file.create();
       await file.transact(spec);
 
-      assert.strictEqual(await file.pathReadOrNull(storagePath), value);
+      spec = new TransactionSpec(
+        FileOp.op_readPath(storagePath)
+      );
+
+      let result = (await file.transact(spec)).data.get(storagePath);
+      assert.strictEqual(result.string, value.string);
 
       // The real test.
+
       await file.create();
-      assert.strictEqual(await file.pathReadOrNull(storagePath), null);
+
+      // Same transaction as above.
+      result = (await file.transact(spec)).data.get(storagePath);
+      assert.strictEqual(result, undefined);
     });
   });
 });

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -140,25 +140,6 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Reads the value stored at the given path. This returns `null` if there is
-   * no value stored at the given path.
-   *
-   * @param {string} storagePath Path to read from.
-   * @returns {FrozenBuffer|null} Value stored at the indicated path, or `null`
-   *   if there is none.
-   */
-  async pathReadOrNull(storagePath) {
-    const spec = new TransactionSpec(
-      FileOp.op_readPath(storagePath)
-    );
-
-    const transactionResult = await this.transact(spec);
-    const data              = transactionResult.data.get(storagePath);
-
-    return (data === undefined) ? null : data;
-  }
-
-  /**
    * Gets the instantaneously current revision number of the file. The revision
    * number starts at `0` for a newly-created file and increases monotonically
    * as changes are made to it.

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -140,23 +140,6 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Reads the value stored at the given path. This throws an error if there is
-   * no value stored at the given path.
-   *
-   * @param {string} storagePath Path to read from.
-   * @returns {FrozenBuffer} Value stored at the indicated path.
-   */
-  async pathRead(storagePath) {
-    const spec = new TransactionSpec(
-      FileOp.op_checkPathExists(storagePath),
-      FileOp.op_readPath(storagePath)
-    );
-
-    const transactionResult = await this.transact(spec);
-    return transactionResult.data.get(storagePath);
-  }
-
-  /**
    * Reads the value stored at the given path. This returns `null` if there is
    * no value stored at the given path.
    *

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -5,7 +5,6 @@
 import { TBoolean, TInt, TMap, TObject, TString } from 'typecheck';
 import { CommonBase, FrozenBuffer } from 'util-common';
 
-import FileOp from './FileOp';
 import StoragePath from './StoragePath';
 import TransactionSpec from './TransactionSpec';
 

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -14,6 +14,8 @@ import BaseFile from './BaseFile';
  *
  * **Note:** This class is _intentionally_ not a full wrapper over `BaseFile`.
  * It _just_ provides operations that benefit from the application of a `Codec`.
+ *
+ * **TODO:** Provide the above-promised help in building transactions.
  */
 export default class FileCodec extends CommonBase {
   /**

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -36,7 +36,8 @@ export default class FileCodec extends CommonBase {
 
   /**
    * Runs the specified transaction, automatically decoding any values returned
-   * in the `data`.
+   * in the `data`. This method passes through any errors thrown due to failure
+   * to decode a buffer.
    *
    * @param {TransactionSpec} spec Specification for the transaction, that is,
    *   the set of operations to perform.

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -1,0 +1,65 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Codec } from 'api-common';
+import { CommonBase } from 'util-common';
+
+import BaseFile from './BaseFile';
+
+/**
+ * Combination of a `BaseFile` with a `Codec`, with operations to make it easy
+ * to build transactions and interpret their results with respect to API-coded
+ * values.
+ *
+ * **Note:** This class is _intentionally_ not a full wrapper over `BaseFile`.
+ * It _just_ provides operations that benefit from the application of a `Codec`.
+ */
+export default class FileCodec extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseFile} file The file to use.
+   * @param {Codec} codec The codec to use.
+   */
+  constructor(file, codec) {
+    super();
+
+    /** {BaseFile} The file to use. */
+    this._file = BaseFile.check(file);
+
+    /** {Codec} The codec to use. */
+    this._codec = Codec.check(codec);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Runs the specified transaction, automatically decoding any values returned
+   * in the `data`.
+   *
+   * @param {TransactionSpec} spec Specification for the transaction, that is,
+   *   the set of operations to perform.
+   * @returns {object} Object with mappings as described in
+   *   `BaseFile.transact()`, except that mappings in `data` bind to decoded
+   *   values and not raw buffers.
+   * @throws {InfoError} Thrown if the transaction failed. Errors so thrown
+   *   contain details sufficient for programmatic understanding of the issue.
+   */
+  async transact(spec) {
+    const result  = await this._file.transact(spec);
+    const rawData = result.data;
+
+    if (rawData === undefined) {
+      return result;
+    }
+
+    const cookedData = new Map();
+    for (const [storagePath, value] of rawData) {
+      cookedData.set(storagePath, this._codec.decodeJsonBuffer(value));
+    }
+
+    result.data = cookedData;
+    return result;
+  }
+}

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -182,6 +182,19 @@ export default class FileOp extends CommonBase {
   }
 
   /**
+   * Constructs a `checkPathHash` operation based on a given buffer's data. This
+   * is a convenient shorthand for `op_checkPathHash(storagePath, buffer.hash)`.
+   *
+   * @param {string} storagePath The storage path to check.
+   * @param {FrozenBuffer} value Buffer whose hash should be taken.
+   * @returns {FileOp} An appropriately-constructed instance.
+   */
+  static op_checkPathBufferHash(storagePath, value) {
+    FrozenBuffer.check(value);
+    return FileOp.op_checkPathHash(storagePath, value.hash);
+  }
+
+  /**
    * Constructs a `deletePath` operation. This is a write operation that
    * deletes the binding for the given path, if any. If the path wasn't bound,
    * then this operation does nothing.

--- a/local-modules/content-store/main.js
+++ b/local-modules/content-store/main.js
@@ -4,6 +4,7 @@
 
 import BaseContentStore from './BaseContentStore';
 import BaseFile from './BaseFile';
+import FileCodec from './FileCodec';
 import FileId from './FileId';
 import FileOp from './FileOp';
 import StoragePath from './StoragePath';
@@ -12,6 +13,7 @@ import TransactionSpec from './TransactionSpec';
 export {
   BaseContentStore,
   BaseFile,
+  FileCodec,
   FileId,
   FileOp,
   StoragePath,

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Codec } from 'api-common';
 import { DeltaResult, DocumentChange, FrozenDelta, RevisionNumber, Snapshot, Timestamp }
   from 'doc-common';
 import { BaseFile, FileOp, TransactionSpec } from 'content-store';
@@ -63,7 +64,7 @@ export default class DocControl extends CommonBase {
     super();
 
     /** {Codec} Codec instance to use. */
-    this._codec = codec;
+    this._codec = Codec.check(codec);
 
     /** {BaseFile} The underlying document storage. */
     this._file = BaseFile.check(file);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -644,9 +644,9 @@ export default class DocControl extends CommonBase {
       FileOp.op_readPath(storagePath)
     );
 
-    const transactionResult = await this._file.transact(spec);
-    const encoded = transactionResult.data.get(storagePath);
-    return DocumentChange.check(this._decode(encoded));
+    const transactionResult = await this._fileCodec.transact(spec);
+    const result = transactionResult.data.get(storagePath);
+    return DocumentChange.check(result);
   }
 
   /**
@@ -665,16 +665,6 @@ export default class DocControl extends CommonBase {
     const result = transactionResult.data.get(storagePath);
 
     return (result === undefined) ? null : TInt.min(result, 0);
-  }
-
-  /**
-   * Convenient pass-through to `_codec.decodeJsonBuffer()`.
-   *
-   * @param {FrozenBuffer} encoded Value to decode.
-   * @returns {*} The decoded version.
-   */
-  _decode(encoded) {
-    return this._codec.decodeJsonBuffer(encoded);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -656,8 +656,15 @@ export default class DocControl extends CommonBase {
    *   set.
    */
   async _currentRevNum() {
-    const encoded = await this._file.pathReadOrNull(Paths.REVISION_NUMBER);
-    return (encoded === null) ? null : this._decode(encoded);
+    const storagePath = Paths.REVISION_NUMBER;
+    const spec = new TransactionSpec(
+      FileOp.op_readPath(storagePath)
+    );
+
+    const transactionResult = await this._fileCodec.transact(spec);
+    const result = transactionResult.data.get(storagePath);
+
+    return (result === undefined) ? null : TInt.min(result, 0);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -633,7 +633,14 @@ export default class DocControl extends CommonBase {
    * @returns {DocumentChange} The corresponding change.
    */
   async _changeRead(revNum) {
-    const encoded = await this._file.pathRead(Paths.forRevNum(revNum));
+    const storagePath = Paths.forRevNum(revNum);
+    const spec = new TransactionSpec(
+      FileOp.op_checkPathExists(storagePath),
+      FileOp.op_readPath(storagePath)
+    );
+
+    const transactionResult = await this._file.transact(spec);
+    const encoded = transactionResult.data.get(storagePath);
     return DocumentChange.check(this._decode(encoded));
   }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -226,6 +226,8 @@ export default class DocControl extends CommonBase {
 
     let transactionResult;
 
+    // Check the required metainfo paths.
+
     try {
       const spec = new TransactionSpec(
         FileOp.op_readPath(Paths.FORMAT_VERSION),
@@ -264,6 +266,8 @@ export default class DocControl extends CommonBase {
       this._log.info('Corrupt document: Bogus revision number.');
       return DocControl.STATUS_ERROR;
     }
+
+    // Make sure all the changes can be read and decoded.
 
     for (let i = 0; i <= revNum; i++) {
       try {

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -69,11 +69,10 @@ export default class DocServer extends Singleton {
     this._pending = new Map();
 
     /**
-     * {FrozenBuffer} The document format version to use for new documents and
+     * {string} The document format version to use for new documents and
      * to expect in existing documents.
      */
-    this._formatVersion =
-      this._codec.encodeJsonBuffer(ProductInfo.theOne.INFO.version);
+    this._formatVersion = TString.nonempty(ProductInfo.theOne.INFO.version);
   }
 
   /**


### PR DESCRIPTION
This PR introduces a new class `content-store.FileCodec`. This is the long-promised helper class which understands both file transactions and API coding. Right now, it's only got smarts on the buffer-to-decoded-object side of things, but in a later PR it will grow the ability to encode values into `FileOp`s (to be fed into transactions).

This new class gets used extensively in `DocControl`, where it replaces earlier code which more "manually" performed decoding. In addition, I used the opportunity to use explicit transactions instead of individual path reads (which let me reduce the overall number of transactions required to perform many actions). This all resulted in the removal of all the uses of the old `pathRead*()` transaction wrapper functions, so I removed those entirely.