### PR TITLE
Better change composition

### DIFF
--- a/local-modules/doc-common/RevisionNumber.js
+++ b/local-modules/doc-common/RevisionNumber.js
@@ -20,6 +20,7 @@ export default class RevisionNumber extends UtilityClass {
     try {
       return TInt.min(value, 0);
     } catch (e) {
+      // More appropriate error.
       return TypeError.badValue(value, 'RevisionNumber');
     }
   }
@@ -34,8 +35,9 @@ export default class RevisionNumber extends UtilityClass {
    */
   static maxExc(value, maxExc) {
     try {
-      return TInt.range(value, 0, maxExc);
+      return TInt.maxExc(value, maxExc);
     } catch (e) {
+      // More appropriate error.
       return TypeError.badValue(value, 'RevisionNumber', `value < ${maxExc}`);
     }
   }
@@ -50,9 +52,27 @@ export default class RevisionNumber extends UtilityClass {
    */
   static maxInc(value, maxInc) {
     try {
-      return TInt.rangeInc(value, 0, maxInc);
+      return TInt.maxInc(value, maxInc);
     } catch (e) {
+      // More appropriate error.
       return TypeError.badValue(value, 'RevisionNumber', `value <= ${maxInc}`);
+    }
+  }
+
+  /**
+   * Checks a value of type `RevisionNumber`, which must furthermore be at least
+   * an indicated value (inclusive).
+   *
+   * @param {*} value Value to check.
+   * @param {Int} minInc Minimum acceptable value (inclusive).
+   * @returns {Int} `value`.
+   */
+  static min(value, minInc) {
+    try {
+      return TInt.min(value, minInc);
+    } catch (e) {
+      // More appropriate error.
+      return TypeError.badValue(value, 'RevisionNumber', `value >= ${minInc}`);
     }
   }
 

--- a/local-modules/doc-common/RevisionNumber.js
+++ b/local-modules/doc-common/RevisionNumber.js
@@ -110,20 +110,4 @@ export default class RevisionNumber extends UtilityClass {
       return TypeError.badValue(value, 'RevisionNumber', `${minInc} <= value <= ${maxInc}`);
     }
   }
-
-  /**
-   * Returns the revision number after the given one. This is the same as
-   * `revNum + 1` _except_ that `null` (the revision "number" for an empty
-   * document) is a valid input for which `0` is the return value.
-   *
-   * **Note:** Unlike the rest of the methods in this class, this one isn't a
-   * simple data validator. (TODO: This arrangement is error prone and should
-   * be reconsidered.)
-   *
-   * @param {Int|null} revNum Starting revision number.
-   * @returns {Int} The revision number immediately after `revNum`
-   */
-  static after(revNum) {
-    return (revNum === null) ? 0 : (RevisionNumber.check(revNum) + 1);
-  }
 }

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -644,21 +644,22 @@ export default class DocControl extends CommonBase {
   }
 
   /**
-   * Gets the current document revision number.
+   * Gets the current document revision number. It is an error to call this on
+   * an empty or uninitialized document.
    *
-   * @returns {RevisionNumber|null} The revision number, or `null` if it is not
-   *   set.
+   * @returns {RevisionNumber} The revision number.
    */
   async _currentRevNum() {
     const storagePath = Paths.REVISION_NUMBER;
     const spec = new TransactionSpec(
+      FileOp.op_checkPathExists(storagePath),
       FileOp.op_readPath(storagePath)
     );
 
     const transactionResult = await this._fileCodec.transact(spec);
     const result = transactionResult.data.get(storagePath);
 
-    return (result === undefined) ? null : TInt.min(result, 0);
+    return RevisionNumber.check(result);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -349,7 +349,7 @@ export default class DocControl extends CommonBase {
         // form and return a result. Compose all the deltas from the revision
         // after the base through and including the current revision.
         const delta = await this._composeRevisions(
-          FrozenDelta.EMPTY, baseRevNum + 1, RevisionNumber.after(docRevNum));
+          FrozenDelta.EMPTY, baseRevNum + 1, docRevNum + 1);
         return new DeltaResult(docRevNum, delta);
       }
 
@@ -401,9 +401,7 @@ export default class DocControl extends CommonBase {
 
     // Compose the implied expected result. This has the effect of validating
     // the contents of `delta`.
-    const expected = new Snapshot(
-      RevisionNumber.after(baseRevNum),
-      base.contents.compose(delta));
+    const expected = new Snapshot(baseRevNum + 1, base.contents.compose(delta));
 
     // We try performing the apply, and then we iterate if it failed _and_ the
     // reason is simply that there were any changes that got made while we were
@@ -515,7 +513,7 @@ export default class DocControl extends CommonBase {
 
     // (1)
     const dServer = await this._composeRevisions(
-      FrozenDelta.EMPTY, rBase.revNum + 1, RevisionNumber.after(rCurrent.revNum));
+      FrozenDelta.EMPTY, rBase.revNum + 1, rCurrent.revNum + 1);
 
     // (2)
 
@@ -571,7 +569,7 @@ export default class DocControl extends CommonBase {
       throw new Error('Should not have been called with an empty delta.');
     }
 
-    const revNum = RevisionNumber.after(baseRevNum);
+    const revNum = baseRevNum + 1;
     const changePath = Paths.forRevNum(revNum);
     const change = new DocumentChange(revNum, Timestamp.now(), delta, authorId);
     const spec = new TransactionSpec(
@@ -602,10 +600,9 @@ export default class DocControl extends CommonBase {
    * given initial revision through but not including the indicated end
    * revision, and composed from a given base. It is valid to pass as either
    * revision number parameter one revision beyond the current revision number
-   * (that is, `RevisionNumber.after(await this._currentRevNum())`. It is
-   * invalid to specify a non-existent revision _other_ than one beyond the
-   * current revision. If `startInclusive === endExclusive`, then this method
-   * returns `baseDelta`.
+   * (that is, `(await this._currentRevNum() + 1`. It is invalid to specify a
+   * non-existent revision _other_ than one beyond the current revision. If
+   * `startInclusive === endExclusive`, then this method returns `baseDelta`.
    *
    * @param {FrozenDelta} baseDelta Base delta onto which the indicated deltas
    *   get composed.

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -167,7 +167,10 @@ export default class DocControl extends CommonBase {
    * @returns {DocumentChange} The requested change.
    */
   async change(revNum) {
-    return this._changeRead(revNum);
+    RevisionNumber.check(revNum);
+
+    const changes = await this._readChangeRange(revNum, revNum + 1);
+    return changes[0];
   }
 
   /**
@@ -697,26 +700,6 @@ export default class DocControl extends CommonBase {
     }
 
     return revNum;
-  }
-
-  /**
-   * Reads the change for the indicated revision number. It is an error to
-   * request a change that doesn't exist.
-   *
-   * @param {RevisionNumber} revNum Revision number of the change. This
-   *   indicates the change that produced that document revision.
-   * @returns {DocumentChange} The corresponding change.
-   */
-  async _changeRead(revNum) {
-    const storagePath = Paths.forRevNum(revNum);
-    const spec = new TransactionSpec(
-      FileOp.op_checkPathExists(storagePath),
-      FileOp.op_readPath(storagePath)
-    );
-
-    const transactionResult = await this._fileCodec.transact(spec);
-    const result = transactionResult.data.get(storagePath);
-    return DocumentChange.check(result);
   }
 
   /**

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -29,6 +29,24 @@ export default class TInt extends UtilityClass {
   }
 
   /**
+   * Checks a value of type `Int`, which must furthermore be less than an
+   * indicated value.
+   *
+   * @param {*} value Value to check.
+   * @param {Int} maxExc Maximum acceptable value (exclusive).
+   * @returns {Int} `value`.
+   */
+  static maxExc(value, maxExc) {
+    TInt.check(value);
+    TInt.check(maxExc);
+    if (value >= maxExc) {
+      return TypeError.badValue(value, 'Int', `value < ${maxExc}`);
+    }
+
+    return value;
+  }
+
+  /**
    * Checks a value of type `Int`, which must furthermore be no more than an
    * indicated value (inclusive).
    *


### PR DESCRIPTION
The main thing going on in this PR is that change composition is reworked to use multi-read transactions, but not _too_ multi. The rest of the PR is pretty much cleanup, including notably around the use of the method `_readChangeRange()` which got extracted from the document validation code.