### PR TITLE
Only compile new/updated files.

### DIFF
--- a/compiler/main.js
+++ b/compiler/main.js
@@ -47,8 +47,11 @@ function compileFile(inputFile, outputFile) {
   try {
     inputStat = fs.statSync(inputFile);
     outputStat = fs.statSync(outputFile);
-    if (inputStat.mtime > outputStat.mtime) {
+    // **TODO:** Newer versions of Node have a numeric `mtimeMs` field on stats
+    // objects. Would be great to use it instead of `valueOf()`.
+    if (inputStat.mtime.valueOf() <= outputStat.mtime.valueOf()) {
       console.log('Unchanged', inputFile);
+      return;
     }
   } catch (e) {
     if (inputStat === null) {

--- a/compiler/main.js
+++ b/compiler/main.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const fs = require('fs');
+const fs_extra = require('fs-extra');
 const path = require('path');
 
 const babel = require('babel-core');
@@ -72,6 +73,7 @@ function compileFile(inputFile, outputFile) {
   }
 
   if (output !== null) {
+    fs_extra.ensureDirSync(path.dirname(outputFile));
     fs.writeFileSync(outputFile, output.code);
     console.log('Compiled', inputFile);
   }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "babel-core": "^6.22.0",
     "babel-polyfill": "^6.22.0",
-    "babel-preset-env": "^1.4.0"
+    "babel-preset-env": "^1.4.0",
+    "fs-extra": "^3.0.1"
   }
 }

--- a/local-modules/dev-mode/package.json
+++ b/local-modules/dev-mode/package.json
@@ -5,7 +5,7 @@
 
   "dependencies": {
     "chokidar": "^1.6.1",
-    "fs-extra": "^0.30.0",
+    "fs-extra": "^3.0.1",
 
     "see-all": "local",
     "server-env": "local",

--- a/scripts/build
+++ b/scripts/build
@@ -111,6 +111,9 @@ fi
 # The name for source mapping files.
 sourceMapName='source-map.txt'
 
+# List of all mapping files.
+mappingFiles=()
+
 # Helper for `check-environment-dependencies` which validates one dependency.
 function check-dependency {
     local name="$1"
@@ -192,6 +195,8 @@ function add-directory-mapping {
             echo "${overlayDir}/${fromDir}"
         fi
     ) > "${dirInfoFile}"
+
+    mappingFiles+=("${dirInfoFile}")
 }
 
 # Adds new directory mappings to the build info file for each subdirectory of
@@ -240,16 +245,11 @@ function set-up-dir-mapping {
 # Copies the server and client source directories into `out`, including the
 # overlay contents (if any).
 function copy-sources {
-    local mappings=($(
-        cd "${outDir}"
-        find . -name "${sourceMapName}" | cut -c 3-
-    ))
-
     # For each mapping file, copy all of the specified source files, but don't
     # include directories that themselves have separately-specified maps; those
     # get handled in their own iterations of this loop.
     local mapFile dir excludes sources s delArg
-    for mapFile in "${mappings[@]}"; do
+    for mapFile in "${mappingFiles[@]}"; do
         dir="$(dirname "${mapFile}")"
 
         excludes=($(
@@ -260,9 +260,13 @@ function copy-sources {
             # during the build, and we don't want to trample them.
             echo '--exclude=node_modules'
 
-            # Exclude subdirectories that have maps.
-            cd "${outDir}/${dir}"
-            find . -mindepth 2 -name "${sourceMapName}" \
+            # Exclude subdirectories that have maps. We don't have to bother
+            # mentioning `node_modules` subdirectories here because of the
+            # earlier blanket exclusion.
+            cd "${dir}"
+            find . -mindepth 2 \
+                '(' '!' -path '*/node_modules/*' ')' \
+                -name "${sourceMapName}" \
                 -exec dirname '{}' ';' \
                 | awk '{ printf("--exclude=/%s\n", substr($1, 3)); }'
         ))
@@ -274,11 +278,10 @@ function copy-sources {
         # also knows how to create directories as needed. Note that trailing
         # slashes on source directory names are significant to `rsync`
         # semantics.
-        sources=($(cat "${outDir}/${mapFile}"))
+        sources=($(cat "${mapFile}"))
         delArg=(--delete)
         for s in "${sources[@]}"; do
-            rsync --archive "${delArg[@]}" \
-                "${excludes[@]}" "${s}/" "${outDir}/${dir}"
+            rsync --archive "${delArg[@]}" "${excludes[@]}" "${s}/" "${dir}"
             delArg=()
         done
     done

--- a/scripts/build
+++ b/scripts/build
@@ -362,12 +362,17 @@ function build-server {
         return 1
     fi
 
-    # Do the initial npm(ish) installation.
-    do-install server-src || return 1
+    # Do the initial npm(ish) installation. We have to remove any pre-existing
+    # versions of the local modules first, because otherwise `npm` won't notice
+    # when they get updated.
 
-    # Copy everything over to the final `server` directory. See above about
-    # why we use `rsync`.
-    rsync --archive --delete "${fromDir}/" "${toDir}"
+    # We determine what's a "local module" by the presence of a source map file.
+    local f
+    for f in $(find "${fromDir}/node_modules" -name "${sourceMapName}"); do
+        rm -rf "$(dirname "${f}")"
+    done
+
+    do-install server-src || return 1
 
     # Run Babel on all of the local source files, storing them next to the
     # imported and patched modules.
@@ -384,6 +389,12 @@ function build-server {
                 || return 1
         fi
     done
+
+    # Copy everything else over to the final `server` directory as-is. See above
+    # about why we use `rsync` in general; in addition, in this case we also get
+    # to use the `--update` option to avoid clobbering those Babel-compiled
+    # files we just went through all the trouble to make.
+    rsync --archive --delete --update "${fromDir}/" "${toDir}" || return 1
 }
 
 # Builds the client code.

--- a/scripts/build
+++ b/scripts/build
@@ -108,6 +108,9 @@ fi
 # Helper functions
 #
 
+# The name for source mapping files.
+sourceMapName='source-map.txt'
+
 # Helper for `check-environment-dependencies` which validates one dependency.
 function check-dependency {
     local name="$1"
@@ -437,9 +440,6 @@ function build-product-info {
 #
 # Main script
 #
-
-# The name for source mapping files.
-sourceMapName='source-map.txt'
 
 set-up-out || exit 1
 


### PR DESCRIPTION
The build system was always intended to only do compilation as necessary, but a series of bugs prevented that from happening (while also causing lots of extra unnecessary copying of files from place to place). This PR sorts it all out.

**Bonus:** Updated the `fs-extra` dependency in the `dev-mode` module.