### PR TITLE
Fix overlapping writes in `LocalFile`.

### DIFF
--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -492,8 +492,8 @@ export default class LocalFile extends BaseFile {
     // Wait for the prescribed amount of time.
     await PromDelay.resolve(DIRTY_DELAY_MSEC);
 
-    // The `try..finally` here guarantees that we release the mutex in the face
-    // of errors.
+    // Call `_writeStorge()` with the writer mutex held. The `try..finally` here
+    // guarantees that we release the mutex in the face of errors.
     const unlock = await this._writeMutex.lock();
     try {
       // **TODO:** If we want to catch write errors (e.g. filesystem full), here

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -119,11 +119,10 @@ export default class LocalFile extends BaseFile {
     this._changeCondition = new PromCondition(true);
 
     /**
-     * {Codec} Codec to use for internal use. This is specifically used _just_
-     * to encode and decode the file revision number. Coding for file content is
-     * handled by the superclass.
+     * {Codec} Codec to use specifically _just_ to encode and decode the file
+     * revision number. (Coding for file content is handled by the superclass.)
      */
-    this._codec = Codec.theOne;
+    this._revNumCodec = Codec.theOne;
 
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withPrefix(`[${fileId}]`);
@@ -426,7 +425,7 @@ export default class LocalFile extends BaseFile {
     // things reasonably gracefully if it's missing or corrupt.
     try {
       const revNumBuffer = storage.get(REVISION_NUMBER_PATH);
-      revNum = this._codec.decodeJsonBuffer(revNumBuffer);
+      revNum = this._revNumCodec.decodeJsonBuffer(revNumBuffer);
       this._log.info(`Starting revision number: ${revNum}`);
     } catch (e) {
       // In case of failure, use the size of the storage map as a good enough
@@ -528,7 +527,7 @@ export default class LocalFile extends BaseFile {
 
     // Put the file revision number in the `dirtyValues` map. This way, it gets
     // written out without further special casing.
-    dirtyValues.set(REVISION_NUMBER_PATH, this._codec.encodeJsonBuffer(revNum));
+    dirtyValues.set(REVISION_NUMBER_PATH, this._revNumCodec.encodeJsonBuffer(revNum));
 
     this._log.info(`About to write ${dirtyValues.size} value(s).`);
 

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -112,6 +112,13 @@ export default class LocalFile extends BaseFile {
      */
     this._changeCondition = new PromCondition(true);
 
+    /**
+     * {Codec} Codec to use for internal use. This is specifically used _just_
+     * to encode and decode the file revision number. Coding for file content is
+     * handled by the superclass.
+     */
+    this._codec = Codec.theOne;
+
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withPrefix(`[${fileId}]`);
 
@@ -413,7 +420,7 @@ export default class LocalFile extends BaseFile {
     // things reasonably gracefully if it's missing or corrupt.
     try {
       const revNumBuffer = storage.get(REVISION_NUMBER_PATH);
-      revNum = Codec.theOne.decodeJsonBuffer(revNumBuffer);
+      revNum = this._codec.decodeJsonBuffer(revNumBuffer);
       this._log.info(`Starting revision number: ${revNum}`);
     } catch (e) {
       // In case of failure, use the size of the storage map as a good enough
@@ -506,8 +513,7 @@ export default class LocalFile extends BaseFile {
 
     // Put the file revision number in the `dirtyValues` map. This way, it gets
     // written out without further special casing.
-    dirtyValues.set(REVISION_NUMBER_PATH,
-      Codec.theOne.encodeJsonBuffer(revNum));
+    dirtyValues.set(REVISION_NUMBER_PATH, this._codec.encodeJsonBuffer(revNum));
 
     // Erase and/or create the storage directory as needed.
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -181,7 +181,7 @@ export default class DocControl extends CommonBase {
    * @returns {Snapshot} The corresponding snapshot.
    */
   async snapshot(revNum = null) {
-    const currentRevNum = (await this._currentRevNums()).docRevNum;
+    const currentRevNum = await this._currentRevNum();
     revNum = (revNum === null)
       ? currentRevNum
       : RevisionNumber.maxInc(revNum, currentRevNum);
@@ -330,14 +330,18 @@ export default class DocControl extends CommonBase {
    *   revision `baseRevNum` to produce revision `revNum` of the document.
    */
   async deltaAfter(baseRevNum) {
-    RevisionNumber.check(baseRevNum);
-
     for (;;) {
-      const { docRevNum, fileRevNum } = await this._currentRevNums();
+      // It's essential to get the file revision number before asking for the
+      // document revision number: Due to the asynch nature of the system, it's
+      // possible for the document revision to be taken with regard to a later
+      // file revision, and this ordering guarantees that the `whenChange()` we
+      // do will properly return promptly when that situation occurs.
+      const fileRevNum = await this._file.revNum();
+      const docRevNum  = await this._currentRevNum();
 
-      // We can only validate the upper limit of `baseRevNum` after we have
-      // determined the document revision number. If we end up iterating we'll
-      // do redundant checks, but that's a very minor inefficiency.
+      // We can only validate `baseRevNum` after we have resolved the document
+      // revision number. If we end up iterating we'll do redundant checks, but
+      // that's a very minor inefficiency.
       RevisionNumber.maxInc(baseRevNum, docRevNum);
 
       if (baseRevNum < docRevNum) {
@@ -349,9 +353,9 @@ export default class DocControl extends CommonBase {
         return new DeltaResult(docRevNum, delta);
       }
 
-      // Wait for the file to change (or for the storage layer to reach its
-      // timeout), and then iterate to see if in fact the change updated the
-      // document revision number.
+      // Wait for the file to change (or for the storage layer to timeout), and
+      // then iterate to see if in fact the change updated the document revision
+      // number.
       await this._file.whenChange('never', fileRevNum, Paths.REVISION_NUMBER);
     }
   }
@@ -595,11 +599,10 @@ export default class DocControl extends CommonBase {
    * Constructs a delta consisting of the composition of the deltas from the
    * given initial revision through but not including the indicated end
    * revision, and composed from a given base. It is valid to pass as either
-   * revision number parameter one revision beyond the current document revision
-   * number (that is, `(await this._currentRevNums()).docRevNum + 1`. It is
-   * invalid to specify a non-existent revision _other_ than one beyond the
-   * current revision. If `startInclusive === endExclusive`, then this method
-   * returns `baseDelta`.
+   * revision number parameter one revision beyond the current revision number
+   * (that is, `(await this._currentRevNum() + 1`. It is invalid to specify a
+   * non-existent revision _other_ than one beyond the current revision. If
+   * `startInclusive === endExclusive`, then this method returns `baseDelta`.
    *
    * @param {FrozenDelta} baseDelta Base delta onto which the indicated deltas
    *   get composed.
@@ -638,14 +641,12 @@ export default class DocControl extends CommonBase {
   }
 
   /**
-   * Gets the instantaneously current document and file revision numbers. It is
-   * an error to call this on an uninitialized document (that is, if the
-   * underlying file is empty).
+   * Gets the current document revision number. It is an error to call this on
+   * an empty or uninitialized document.
    *
-   * @returns {object} Object that maps `docRevNum` to the document revision
-   *   number and `fileRevNum` to the file revision number.
+   * @returns {RevisionNumber} The revision number.
    */
-  async _currentRevNums() {
+  async _currentRevNum() {
     const storagePath = Paths.REVISION_NUMBER;
     const spec = new TransactionSpec(
       FileOp.op_checkPathExists(storagePath),
@@ -653,10 +654,9 @@ export default class DocControl extends CommonBase {
     );
 
     const transactionResult = await this._fileCodec.transact(spec);
-    const docRevNum = transactionResult.data.get(storagePath);
-    const fileRevNum = transactionResult.revNum;
+    const result = transactionResult.data.get(storagePath);
 
-    return { docRevNum, fileRevNum };
+    return RevisionNumber.check(result);
   }
 
   /**
@@ -698,7 +698,7 @@ export default class DocControl extends CommonBase {
       // Per docs, just need to verify that the arguments don't name an invalid
       // change. `0` is always valid, so we don't actually need to check that.
       if (start !== 0) {
-        const revNum = (await this._currentRevNums()).docRevNum;
+        const revNum = await this._currentRevNum();
         RevisionNumber.maxInc(start, revNum + 1);
       }
       return [];

--- a/local-modules/util-common/PromMutex.js
+++ b/local-modules/util-common/PromMutex.js
@@ -1,0 +1,76 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import CommonBase from './CommonBase';
+
+/**
+ * Promise-based mutex implementation. This provides _non-reentrant_ mutual
+ * exclusion. This class can be used to serialize running of critical sections
+ * of code, among other things.
+ */
+export default class PromMutex extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {Symbol|null} Unique symbol representing the current lock holder, or
+     * `null` if the lock is not currently held.
+     */
+    this._lockedBy = null;
+
+    /**
+     * {Array<object>} Array of waiters for lock acquisition, in FIFO order.
+     * Each element binds `key` to the would-be holder key (see `_lockedBy`) and
+     * `release` to a function which indicates that the key's owner can now
+     * acquire the lock.
+     */
+    this._waiters = [];
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Acquires the mutual exclusion lock. This method returns only after the
+   * lock has been released by all previous lock requesters. The return value is
+   * a function which, when called, releases the lock and so allows other
+   * threads of control to get the lock.
+   *
+   * @returns {Function} Function of no arguments which releases the lock when
+   *   called.
+   */
+  async lock() {
+    const key = Symbol('mutex-key'); // Uninterned symbol and so unique.
+
+    if (this._lockedBy !== null) {
+      // There's contention, so we have to queue up. The `release` function
+      // queued up here gets called inside the returned unlock function below.
+      const released = new Promise((res, rej_unused) => {
+        const release = () => { res(true); };
+        this._waiters.push({ key, release });
+      });
+
+      await released;
+      this._waiters = this._waiters.shift();
+    }
+
+    this._lockedBy = key;
+
+    // The return value is the unlock function.
+    return () => {
+      if (this._lockedBy !== key) {
+        throw new Error('Attempt to unlock by non-owner.');
+      }
+
+      this._lockedBy = null;
+
+      if (this._waiters.length !== 0) {
+        // Release the next queued up waiter.
+        this._waiters[0].release();
+      }
+    };
+  }
+}

--- a/local-modules/util-common/PromMutex.js
+++ b/local-modules/util-common/PromMutex.js
@@ -56,7 +56,7 @@ export default class PromMutex extends CommonBase {
       });
 
       await released;
-      this._waiters = this._waiters.shift();
+      this._waiters.shift();
     }
 
     this._lockedBy = key;

--- a/local-modules/util-common/PromMutex.js
+++ b/local-modules/util-common/PromMutex.js
@@ -30,7 +30,7 @@ export default class PromMutex extends CommonBase {
      */
     this._waiters = [];
 
-    Object.freeze(this);
+    Object.seal(this);
   }
 
   /**

--- a/local-modules/util-common/PromMutex.js
+++ b/local-modules/util-common/PromMutex.js
@@ -18,7 +18,9 @@ export default class PromMutex extends CommonBase {
 
     /**
      * {Symbol|null} Unique symbol representing the current lock holder, or
-     * `null` if the lock is not currently held.
+     * `null` if the lock is not currently held. This symbol serves as the "key"
+     * for unlocking, such that only the current lock holder can unlock the
+     * instance.
      */
     this._lockedBy = null;
 

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -10,6 +10,7 @@ import InfoError from './InfoError';
 import JsonUtil from './JsonUtil';
 import PromCondition from './PromCondition';
 import PromDelay from './PromDelay';
+import PromMutex from './PromMutex';
 import PropertyIter from './PropertyIter';
 import Random from './Random';
 import Singleton from './Singleton';
@@ -24,6 +25,7 @@ export {
   JsonUtil,
   PromCondition,
   PromDelay,
+  PromMutex,
   PropertyIter,
   Random,
   Singleton,

--- a/local-modules/util-common/tests/test_PromMutex.js
+++ b/local-modules/util-common/tests/test_PromMutex.js
@@ -1,0 +1,57 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { PromMutex } from 'util-common';
+
+describe('util-common/PromMutex', () => {
+  describe('lock()', () => {
+    it('should work when there is blatantly no contention', async () => {
+      const mutex = new PromMutex();
+      const unlock = await mutex.lock();
+
+      assert.isFunction(unlock);
+      unlock();
+    });
+
+    it('should reject attempts to double-unlock with the same unlocker', async () => {
+      const mutex = new PromMutex();
+      const unlock = await mutex.lock();
+
+      unlock();
+      assert.throws(() => { unlock(); });
+    });
+
+    it('should provide the lock in request order', async () => {
+      const mutex       = new PromMutex();
+      const gotOrder    = [];
+      const expectOrder = [];
+      const innerProms  = [];
+
+      // Get the lock, so we know there is contention when we make the
+      // additional lock calls.
+      const outerUnlock = await mutex.lock();
+
+      // All of these `lock()`s will be queued up.
+      for (let i = 0; i < 10; i++) {
+        const unlockProm = mutex.lock();
+        expectOrder.push(i);
+        innerProms.push((async () => {
+          const unlock = await unlockProm;
+          gotOrder.push(i);
+          unlock();
+        })());
+      }
+
+      outerUnlock();
+
+      // Wait for all the inner lock/unlock blocks (above) to run to completion.
+      await Promise.all(innerProms);
+
+      assert.deepEqual(gotOrder, expectOrder);
+    });
+  });
+});


### PR DESCRIPTION
The main intent of this PR is to address an arguable bug where it was possible for two calls to `LocalFile._awaitTheWriteStorage()` to be overlapped. This was not supposed to be possible by design, but it became so when I changed the nuanced meaning of `_storageIsDirty` (in order to fix a different bug).

**Bonuses:**
* New class `PromMutex` which provides a handy promise-based mutual exclusion primitive.
* Got `LocalFile` more ready for a world where `Codec` isn't a singleton.