### PR TITLE
Coding-aware transaction operation construction.

### DIFF
--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.15.1
+version = 0.16.0


### PR DESCRIPTION
The main thrust of this PR is to add coding-aware constructors for transaction operations. Details:

* Reworked `FileOp` so that it defines an explicit set of schemata, one per operation. These are used for its own setup and also exported.
* Used those schemata in `FileCodec` to drive its own setup of instance operation-construction instance methods, which use the instance's `_codec` as needed.
* Changed `DocControl` to use the `FileCodec` methods instead of the raw `FileOp` ones, thereby removing the need for it to explicitly encode arguments into buffers.