### PR TITLE
Fix the authorship node construction

### DIFF
--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -68,7 +68,7 @@ div.bayou-top .ql-editor {
  * The <svg> layer on top of the Quill editor that is used to show things
  * like remote author highlights.
  */
-#author-overlay {
+.bayou-author-overlay {
   /*
    * This positions the author overlay with respect to the outer node being
    * managed here, sizing it to exactly match it, which means (by construction)

--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -34,7 +34,7 @@ html.bayou-page {
 }
 
 /* Top-level editor container. */
-div.bayou-top {
+div.bayou-editor {
   margin: 0;
 
   padding-top: 0.5em;
@@ -51,7 +51,7 @@ div.bayou-top {
 }
 
 /* Basic font and layout characteristics. */
-div.bayou-top .ql-editor {
+div.bayou-editor .ql-editor {
   line-height: 1.7rem;
   font-size: 1rem; /* This thwacks it back from Quill's smaller default. */
 
@@ -90,9 +90,9 @@ div.bayou-top .ql-editor {
  * (hence `rem` units) and the spacing below is based on the actual header font
  * size (hence `em` units).
  */
-div.bayou-top .ql-editor h1,
-div.bayou-top .ql-editor h2,
-div.bayou-top .ql-editor h3 {
+div.bayou-editor .ql-editor h1,
+div.bayou-editor .ql-editor h2,
+div.bayou-editor .ql-editor h3 {
   padding-top: 2rem;
   padding-bottom: 0.5em;
 }
@@ -100,14 +100,14 @@ div.bayou-top .ql-editor h3 {
 /*
  * Smaller header spacing. Similar above/below setup as for the bigger headers.
  */
-div.bayou-top .ql-editor h4,
-div.bayou-top .ql-editor h5,
-div.bayou-top .ql-editor h6 {
+div.bayou-editor .ql-editor h4,
+div.bayou-editor .ql-editor h5,
+div.bayou-editor .ql-editor h6 {
   padding-top: 1rem;
   padding-bottom: 0.25em;
 }
 
 /* Colorful markup for code. */
-.bayou-top code, .bayou-top pre {
+.bayou-editor code, .bayou-editor pre {
   color: #c25;
 }

--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -21,7 +21,7 @@ html.bayou-page {
   font-size: 18px;
 }
 
-#content-wrapper {
+.bayou-content-wrapper {
   /*
    * When not given any offset, specifying `position: relative` is equivalent to
    * not saying `position` at all, with one exception: Enclosed nodes that have

--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -21,7 +21,8 @@ html.bayou-page {
   font-size: 18px;
 }
 
-.bayou-content-wrapper {
+/* Top-level container for all the nodes for a single editor "complex." */
+.bayou-top {
   /*
    * When not given any offset, specifying `position: relative` is equivalent to
    * not saying `position` at all, with one exception: Enclosed nodes that have
@@ -33,7 +34,7 @@ html.bayou-page {
   position: relative;
 }
 
-/* Top-level editor container. */
+/* Container for the Quill editor. */
 div.bayou-editor {
   margin: 0;
 

--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -22,9 +22,15 @@ html.bayou-page {
 }
 
 #content-wrapper {
-  position: absolute;
-  height: 100%;
-  width: 100%;
+  /*
+   * When not given any offset, specifying `position: relative` is equivalent to
+   * not saying `position` at all, with one exception: Enclosed nodes that have
+   * `position: absolute` are defined to actually mean "relative with respect to
+   * the closest enclosing explicitly positioned node." So, by doing this, we
+   * are arranging for the enclosed author overlay to find this node and not
+   * walk all the way up to the root node.
+   */
+  position: relative;
 }
 
 /* Top-level editor container. */
@@ -45,13 +51,7 @@ div.bayou-top {
 }
 
 /* Basic font and layout characteristics. */
-/* TODO: Need to do some work on the position: field here and in
-         #author-overlay below so that things don't individually scroll. */
 div.bayou-top .ql-editor {
-  position: absolute;
-  left: 0px;
-  top: 0px;
-
   line-height: 1.7rem;
   font-size: 1rem; /* This thwacks it back from Quill's smaller default. */
 
@@ -68,15 +68,21 @@ div.bayou-top .ql-editor {
  * The <svg> layer on top of the Quill editor that is used to show things
  * like remote author highlights.
  */
-#content-wrapper #author-overlay {
+#author-overlay {
+  /*
+   * This positions the author overlay with respect to the outer node being
+   * managed here, sizing it to exactly match it, which means (by construction)
+   * that it exactly overlays the actual editor.
+   */
+  position: absolute;
   width: 100%;
   height: 100%;
-  position: absolute;
   left: 0px;
   top: 0px;
   z-index: 2;
+
+  /* The editor, not this node, is what listens to pointer events. */
   pointer-events: none;
-  overflow: hidden;
 }
 
 /*

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -113,7 +113,8 @@ export default class TopControl {
     }
 
     // Do our basic page setup. Specifically, we add the CSS we need to the
-    // page and set the expected classes on the `html` and editor nodes.
+    // page, set the expected classes on the `html` and editor nodes, and build
+    // the required node structure within the editor node.
 
     const styleDone =
       DomUtil.addStylesheet(document, `${baseUrl}/static/index.css`);
@@ -124,11 +125,24 @@ export default class TopControl {
     }
     htmlNode.classList.add('bayou-page');
 
-    // Expect the editor node to have one child, namely the inner editor
-    // container.
-    const editorChildren = editorNode.children;
-    const quillNode = editorChildren[0];
+    editorNode.classList.add('bayou-top');
+
+    // The "editor" node that gets passed in actually ends up being a container
+    // for both the editor per se as well as other bits. The node we make here
+    // is the one that actually ends up getting controlled by Quill. The loop
+    // re-parents all the default content under the original editor to instead
+    // be under the Quill node.
+    const quillNode = document.createElement('div');
     quillNode.classList.add('bayou-editor');
+    for (;;) {
+      const node = editorNode.firstChild;
+      if (!node) {
+        break;
+      }
+      editorNode.removeChild(node);
+      quillNode.appendChild(node);
+    }
+    editorNode.appendChild(quillNode);
 
     // Make the author overlay node. **Note:** The wacky namespace URL is
     // required. Without it, the "SVG" element is actually left uninterpreted.

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -124,13 +124,17 @@ export default class TopControl {
     }
     htmlNode.classList.add('bayou-page');
 
-    // Expect the editor node to have two children, namely the author overlay
-    // and the inner editor containor.
+    // Expect the editor node to have one child, namely the inner editor
+    // container.
     const editorChildren = editorNode.children;
-    const authorOverlayNode = editorChildren[0];
-    const quillNode = editorChildren[1];
-    authorOverlayNode.classList.add('bayou-author-overlay');
+    const quillNode = editorChildren[0];
     quillNode.classList.add('bayou-editor');
+
+    // Make the author overlay node. **Note:** The wacky namespace URL is
+    // required. Without it, the "SVG" element is actually left uninterpreted.
+    const authorOverlayNode = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    authorOverlayNode.classList.add('bayou-author-overlay');
+    editorNode.insertBefore(authorOverlayNode, quillNode);
 
     // Give the overlay a chance to do any initialization.
     const hookDone = Hooks.theOne.run(this._window, baseUrl);

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -148,7 +148,7 @@ export default class TopControl {
     // required. Without it, the "SVG" element is actually left uninterpreted.
     const authorOverlayNode = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     authorOverlayNode.classList.add('bayou-author-overlay');
-    editorNode.insertBefore(authorOverlayNode, quillNode);
+    editorNode.appendChild(authorOverlayNode);
 
     // Give the overlay a chance to do any initialization.
     const hookDone = Hooks.theOne.run(this._window, baseUrl);

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -100,6 +100,7 @@ export default class TopControl {
     const document = this._window.document;
     const baseUrl = this._apiClient.baseUrl;
     const editorNode = document.querySelector(this._node);
+    const quillNode = editorNode; // TEMP!!! FIXME! REMOVE BEFORE PR!
 
     if (editorNode === null) {
       // The indicated node (incoming `BAYOU_NODE` value) does not exist. If
@@ -137,7 +138,7 @@ export default class TopControl {
     await styleDone;
     await hookDone;
 
-    this._quill = QuillMaker.theOne.make(this._node);
+    this._quill = QuillMaker.theOne.make(quillNode);
     log.detail('Made editor instance.');
 
     // Hook up the `DocClient` (which intermediates between the server and

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -100,7 +100,6 @@ export default class TopControl {
     const document = this._window.document;
     const baseUrl = this._apiClient.baseUrl;
     const editorNode = document.querySelector(this._node);
-    const quillNode = editorNode; // TEMP!!! FIXME! REMOVE BEFORE PR!
 
     if (editorNode === null) {
       // The indicated node (incoming `BAYOU_NODE` value) does not exist. If
@@ -125,7 +124,13 @@ export default class TopControl {
     }
     htmlNode.classList.add('bayou-page');
 
-    editorNode.classList.add('bayou-editor');
+    // Expect the editor node to have two children, namely the author overlay
+    // and the inner editor containor.
+    const editorChildren = editorNode.children;
+    const authorOverlayNode = editorChildren[0];
+    const quillNode = editorChildren[1];
+    authorOverlayNode.classList.add('bayou-author-overlay');
+    quillNode.classList.add('bayou-editor');
 
     // Give the overlay a chance to do any initialization.
     const hookDone = Hooks.theOne.run(this._window, baseUrl);

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -125,7 +125,7 @@ export default class TopControl {
     }
     htmlNode.classList.add('bayou-page');
 
-    editorNode.classList.add('bayou-top');
+    editorNode.classList.add('bayou-editor');
 
     // Give the overlay a chance to do any initialization.
     const hookDone = Hooks.theOne.run(this._window, baseUrl);

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -233,7 +233,7 @@ export default class DebugTools {
       '<script src="/boot-for-debug.js"></script>\n';
     const body =
       '<h1>Editor</h1>\n' +
-      '<div class="bayou-content-wrapper">\n' +
+      '<div class="bayou-top">\n' +
         '<svg class="bayou-author-overlay"></svg>' +
         '<div id="editor"><p>Loading&hellip;</p></div>\n' +
       '</div>';

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -234,7 +234,6 @@ export default class DebugTools {
     const body =
       '<h1>Editor</h1>\n' +
       '<div id="editor" class="bayou-top">\n' +
-        '<svg></svg>' +
         '<div><p>Loading&hellip;</p></div>\n' +
       '</div>';
 

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -233,9 +233,7 @@ export default class DebugTools {
       '<script src="/boot-for-debug.js"></script>\n';
     const body =
       '<h1>Editor</h1>\n' +
-      '<div id="editor" class="bayou-top">\n' +
-        '<div><p>Loading&hellip;</p></div>\n' +
-      '</div>';
+      '<div id="editor"><p>Loading&hellip;</p></div>\n';
 
     this._htmlResponse(res, head, body);
   }

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -233,9 +233,9 @@ export default class DebugTools {
       '<script src="/boot-for-debug.js"></script>\n';
     const body =
       '<h1>Editor</h1>\n' +
-      '<div class="bayou-top">\n' +
-        '<svg class="bayou-author-overlay"></svg>' +
-        '<div id="editor"><p>Loading&hellip;</p></div>\n' +
+      '<div id="editor" class="bayou-top">\n' +
+        '<svg></svg>' +
+        '<div><p>Loading&hellip;</p></div>\n' +
       '</div>';
 
     this._htmlResponse(res, head, body);

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -234,7 +234,7 @@ export default class DebugTools {
     const body =
       '<h1>Editor</h1>\n' +
       '<div class="bayou-content-wrapper">\n' +
-        '<svg id="author-overlay"></svg>' +
+        '<svg class="bayou-author-overlay"></svg>' +
         '<div id="editor"><p>Loading&hellip;</p></div>\n' +
       '</div>';
 

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -233,7 +233,7 @@ export default class DebugTools {
       '<script src="/boot-for-debug.js"></script>\n';
     const body =
       '<h1>Editor</h1>\n' +
-      '<div id="content-wrapper">\n' +
+      '<div class="bayou-content-wrapper">\n' +
         '<svg id="author-overlay"></svg>' +
         '<div id="editor"><p>Loading&hellip;</p></div>\n' +
       '</div>';

--- a/local-modules/quill-util/QuillMaker.js
+++ b/local-modules/quill-util/QuillMaker.js
@@ -37,16 +37,16 @@ export default class QuillMaker extends Singleton {
    * a promise chain to get at the edit events, this makes an instance of our
    * custom subclass `QuillProm`.
    *
-   * @param {string} id DOM id of the element to attach to.
+   * @param {Element} node DOM element to attach to.
    * @returns {QuillProm} instance of `Quill`.
    */
-  make(id) {
+  make(node) {
     if (toolbarConfig === null) {
       toolbarConfig = Object.freeze(
         Hooks.theOne.quillToolbarConfig(DEFAULT_TOOLBAR_CONFIG));
     }
 
-    const result = new QuillProm(id, {
+    const result = new QuillProm(node, {
       readOnly: true,
       strict: true,
       theme: 'bubble',

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -43,7 +43,7 @@ export default class QuillProm extends Quill {
     this._currentChange = new DeltaEvent(
       accessKey, FrozenDelta.EMPTY, FrozenDelta.EMPTY, API);
 
-    this._authorOverlay = new AuthorOverlay(this, '#author-overlay');
+    this._authorOverlay = new AuthorOverlay(this, '.bayou-author-overlay');
 
     // We override `emitter.emit()` to _synchronously_ add an event to the
     // promise chain. We do it this way instead of relying on an event callback

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -43,7 +43,7 @@ export default class QuillProm extends Quill {
     this._currentChange = new DeltaEvent(
       accessKey, FrozenDelta.EMPTY, FrozenDelta.EMPTY, API);
 
-    this._authorOverlay = new AuthorOverlay(this, 'author-overlay');
+    this._authorOverlay = new AuthorOverlay(this, '#author-overlay');
 
     // We override `emitter.emit()` to _synchronously_ add an event to the
     // promise chain. We do it this way instead of relying on an event callback

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -43,6 +43,8 @@ export default class QuillProm extends Quill {
     this._currentChange = new DeltaEvent(
       accessKey, FrozenDelta.EMPTY, FrozenDelta.EMPTY, API);
 
+    // **TODO:** The constructor should accept the node to use directly and not
+    // assume that there's a unique node for the selector.
     this._authorOverlay = new AuthorOverlay(this, '.bayou-author-overlay');
 
     // We override `emitter.emit()` to _synchronously_ add an event to the

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -84,11 +84,11 @@ export default class QuillProm extends Quill {
       } else if ((type === EDITOR_CHANGE) && (arg0 === SELECTION_CHANGE)) {
         // TODO: Do something with the local author's selection range. Somehow this needs to
         // go to the server and other clients.
-        // const selectionRange = this.getSelection();
+        const selectionRange = this.getSelection();
 
         // This line is handy for debugging. It will use the remote author highlight
         // system to highlight the local author's selection.
-        // this._authorOverlay.setAuthorSelection('local-author', selectionRange);
+        this._authorOverlay.setAuthorSelection('local-author', selectionRange);
       }
 
       // This is the moral equivalent of `super.emit(...)`.

--- a/local-modules/remote-authors/AuthorOverlay.js
+++ b/local-modules/remote-authors/AuthorOverlay.js
@@ -20,7 +20,7 @@ const REFRESH_DELAY_MSEC = 2000;
  * into an SVG element that overlays the Quill editor.
  */
 export default class AuthorOverlay {
-  constructor(quillInstance, svgElementId) {
+  constructor(quillInstance, svgElementSelector) {
     /**
      * {Map<AuthorId, Map<string, object>>} _Ad hoc_ storage for arbitrary data
      * associated with remote authors (highlights, color, avatar, etc).
@@ -35,7 +35,7 @@ export default class AuthorOverlay {
      * The SVG should be the same dimensions as `this._quillInstance.scrollingContainer`
      * and on top of it in z-index order (closer to the viewer).
      */
-    this._authorOverlay = document.getElementById(svgElementId);
+    this._authorOverlay = document.querySelector(svgElementSelector);
 
     this._quill.scrollingContainer.addEventListener('scroll', function () {
       this._updateScrollPosition();

--- a/local-modules/remote-authors/AuthorOverlay.js
+++ b/local-modules/remote-authors/AuthorOverlay.js
@@ -163,7 +163,7 @@ export default class AuthorOverlay {
     }
 
     this._authorOverlay.innerHTML = paths.join('\n');
-    this.updateScrollPosition();
+    this._updateScrollPosition();
   }
 
   /**


### PR DESCRIPTION
This PR fixes the bulk of the TODOs (expressed and implied) on the recent authorship work:

* Stop using node IDs for the inner bits. Use CSS classes instead, which is more resilient with respect to multiple instantiations of an editor in a single page (which I _think_ ultimately we will want).
* Revert the expanded HTML in `DebugTools`, so we're back to just having a single `div` with a node ID (which in this case is okay, because that ID is referenced locally to explicitly hook Quill up to _that element specifically_).
* Rename a couple of the CSS classes to reflect their new positions in the world. In particular, `bayou-top` had stopped being the top element because the authorship stuff required one more outer layer. So, the old `bayou-top` is now `bayou-editor`.