### PR TITLE
Pass a DOM node into `boot-from-key` instead of a selector.

### DIFF
--- a/client/assets/boot-for-debug.js
+++ b/client/assets/boot-for-debug.js
@@ -48,11 +48,21 @@ function BAYOU_RECOVER(key) {
   })
 }
 
-// We wrap everything else in an immediately-executed function so as to avoid
-// polluting the global namespace.
-(function () {
+// Once the rest of the page is loaded, find the `#editor` node and arrange for
+// the main boot script to load and run.
+window.addEventListener('load', () => {
+  // This is the node that is IDed specifically in `DebugTools._handle_edit`.
+  var editorNode = document.querySelector('#debugEditor');
+  if (!editorNode) {
+    // Indicates a bug either here or in `DebugTools`.
+    throw new Error('Could not find editor node!');
+  }
+
+  // This gets used by `boot-from-key`.
+  window.BAYOU_NODE = editorNode;
+
   // Add the standard bootstrap code to the page.
   var elem = document.createElement('script');
   elem.src = '/boot-from-key.js';
   document.head.appendChild(elem);
-}());
+})

--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -8,8 +8,7 @@
 //
 // * `BAYOU_KEY` -- The JSON-encoded form of an instance of `SplitKey`, to be
 //   used to authenticate access to a particular documemt.
-// * `BAYOU_NODE` -- The selector for the DOM node into which the editor should
-//   be embedded.
+// * `BAYOU_NODE` -- The DOM node into which the editor should be embedded.
 // * `BAYOU_RECOVER` (optional) -- Function to use when attempting to recover
 //   from connection trouble.
 //

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -43,7 +43,7 @@ export default class TopControl {
 
     // Validate it.
     if (this._editorNode.nodeName !== 'DIV') {
-      throw new Error('Expected `BAYOU_NODE` to refer to a \`div\`.');
+      throw new Error('Expected `BAYOU_NODE` to refer to a `div`.');
     }
 
     /**

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -8,7 +8,7 @@ import { DocClient } from 'doc-client';
 import { Hooks } from 'hooks-client';
 import { QuillMaker } from 'quill-util';
 import { Logger } from 'see-all';
-import { TFunction, TString } from 'typecheck';
+import { TFunction, TObject } from 'typecheck';
 import { DomUtil } from 'util-client';
 
 /** {Logger} Logger for this module. */
@@ -38,11 +38,13 @@ export default class TopControl {
      */
     this._key = SplitKey.check(Codec.theOne.decodeJson(window.BAYOU_KEY));
 
-    /**
-     * {string} DOM Selector string that indicates which node in the DOM should
-     * become the editor.
-     */
-    this._node = TString.nonempty(window.BAYOU_NODE);
+    /** {Element} DOM node to use for the editor. */
+    this._editorNode = TObject.check(window.BAYOU_NODE, Element);
+
+    // Validate it.
+    if (this._editorNode.nodeName !== 'DIV') {
+      throw new Error('Expected `BAYOU_NODE` to refer to a \`div\`.');
+    }
 
     /**
      * {function} Function to call when the editor finds itself in an
@@ -86,31 +88,31 @@ export default class TopControl {
     this._makeApiClient();
 
     // Arrange for the rest of initialization to happen once the initial page
-    // contents are fully loaded.
-    this._window.addEventListener('load', (event_unused) => {
-      log.detail('Initial page load complete.');
-      this._onLoad();
-    });
+    // contents are ready (from the browser's perspective).
+    const document = this._window.document;
+    if (document.readyState === 'complete') {
+      log.detail('Page already ready. No waiting needed!');
+      this._onReady();
+    } else {
+      log.detail('Waiting for page to be ready.');
+      const listener = (event_unused) => {
+        if (document.readyState === 'complete') {
+          log.detail('Page now ready.');
+          this._onReady();
+          document.removeEventListener('readystatechange', listener);
+        }
+      };
+      document.addEventListener('readystatechange', listener);
+    }
   }
 
   /**
-   * Callback for page load. This is set up in `start()`.
+   * Callback for page content readiness. This is set up in `start()`.
    */
-  async _onLoad() {
-    const document = this._window.document;
-    const baseUrl = this._apiClient.baseUrl;
-    const editorNode = document.querySelector(this._node);
-
-    if (editorNode === null) {
-      // The indicated node (incoming `BAYOU_NODE` value) does not exist. If
-      // we land here, no further init can possibly be done, so we just
-      // `throw` out of it.
-      const extra = (this._node[0] === '#') ? '' : ' (maybe need a `#` prefix?)';
-      throw new Error(`No such selector${extra}: \`${this._node}\``);
-    } else if (editorNode.nodeName !== 'DIV') {
-      // Similar to above.
-      throw new Error(`Expected selector \`${this._node}\` to refer to a \`div\`.`);
-    }
+  async _onReady() {
+    const document   = this._window.document;
+    const baseUrl    = this._apiClient.baseUrl;
+    const editorNode = this._editorNode;
 
     // Do our basic page setup. Specifically, we add the CSS we need to the
     // page, set the expected classes on the `html` and editor nodes, and build

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -226,14 +226,13 @@ export default class DebugTools {
       '<title>Editor</title>\n' +
       '<script>\n' +
       `  BAYOU_KEY         = ${quotedKey};\n` +
-      '  BAYOU_NODE        = "#editor";\n' +
       `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
       `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
       '</script>\n' +
       '<script src="/boot-for-debug.js"></script>\n';
     const body =
       '<h1>Editor</h1>\n' +
-      '<div id="editor"><p>Loading&hellip;</p></div>\n';
+      '<div id="debugEditor"><p>Loading&hellip;</p></div>\n';
 
     this._htmlResponse(res, head, body);
   }


### PR DESCRIPTION
The idea here is that we avoid doing any kind of global DOM-y stuff inside the main system, keeping it just at the edge where absolutely needed.