### PR TITLE
Get more draconian with the linting. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "eslint:recommended",
   "env": {
     "es6": true,
-    "browser": true,
     "node": true
   },
   "ecmaFeatures": {
@@ -13,6 +12,12 @@
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": "2017"
+  },
+  "globals": {
+    "Element": false,
+    "FileReader": false,
+    "URL": false,
+    "WebSocket": false
   },
   "rules" : {
     "array-bracket-spacing": "error",

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "../.eslintrc",
+  "env": {
+    "es6": true,
+    "browser": true
+  }
+}

--- a/local-modules/quill-util/EditorComplex.js
+++ b/local-modules/quill-util/EditorComplex.js
@@ -104,6 +104,7 @@ export default class EditorComplex extends CommonBase {
    */
   static _doSetupForNode(topNode) {
     topNode.classList.add('bayou-top');
+    const document = topNode.ownerDocument;
 
     // The "top" node that gets passed in actually ends up being a container
     // for both the editor per se as well as other bits. The node we make here

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -5,6 +5,7 @@
 import Quill from 'quill';
 
 import { FrozenDelta } from 'doc-common';
+import { TObject } from 'typecheck';
 
 import QuillEvent from './QuillEvent';
 
@@ -16,9 +17,15 @@ export default class QuillProm extends Quill {
   /**
    * Constructs an instance. Parameters are identical to the normal `Quill`
    * constructor (see which).
+   *
+   * @param {Element} domNode The DOM node that the instance gets attached to.
+   * @param {...*} constructArgs The rest of the Quill constructor arguments.
    */
-  constructor(...constructArgs) {
-    super(...constructArgs);
+  constructor(domNode, ...constructArgs) {
+    super(domNode, ...constructArgs);
+
+    /** {Element} The DOM node that this instance is attached to. */
+    this._domNode = TObject.check(domNode, Element);
 
     // We can't safely `import Emitter`, as it's not an exposed class, so we
     // instead get at it via the instance of it made in the superclass
@@ -75,6 +82,11 @@ export default class QuillProm extends Quill {
       // This is the moral equivalent of `super.emit(...)`.
       origEmit.call(origEmitter, type, ...rest);
     };
+  }
+
+  /** {Element} The DOM node that this instance is attached to. */
+  get domNode() {
+    return this._domNode;
   }
 
   /**

--- a/local-modules/quill-util/QuillUtil.js
+++ b/local-modules/quill-util/QuillUtil.js
@@ -45,10 +45,10 @@ export default class QuillUtil extends UtilityClass {
    * If the pixel is not found in the Quill context then `POSITION_NOT_FOUND`
    * will be returned.
    *
-   * @param {Quill} quillInstance The Quill context in which to search for the
-   *   pixel position
-   * @param {number} x The horizontal pixel offset in local (DOM context) space
-   * @param {number} y The vertical pixel offset in local (DOM context) space
+   * @param {QuillProm} quillInstance The Quill context in which to search for
+   *   the pixel position.
+   * @param {number} x The horizontal pixel offset in local (DOM context) space.
+   * @param {number} y The vertical pixel offset in local (DOM context) space.
    * @returns {object} The Quill context where the pixel is located.
    */
   static quillContextForPixelPosition(quillInstance, x, y) {
@@ -56,6 +56,7 @@ export default class QuillUtil extends UtilityClass {
       return POSITION_NOT_FOUND;
     }
 
+    const document = quillInstance.domNode.ownerDocument;
     const domElement = document.elementFromPoint(x, y);
 
     if (domElement === null) {

--- a/local-modules/state-machine/StateMachine.js
+++ b/local-modules/state-machine/StateMachine.js
@@ -236,7 +236,7 @@ export default class StateMachine {
 
       if ((eventName !== 'any') && !this._eventValidators[eventName]) {
         // No associated validator.
-        throw new Error(`Unknown event name in method: ${name}`);
+        throw new Error(`Unknown event name in method: ${eventName}`);
       }
 
       if (!result[stateName]) {


### PR DESCRIPTION
It turns out that we have been a bit over-permissive with our lint settings, specifically in that we set it up to not ever reject browser-only global references. This actually masked a real (if pretty innocuous) bug. This PR tightens things up. More specifically:

* `browser` is only set as an available environment under the `client` directory.
* Instead of also adding `browser` as allowed for client-only local modules, I explicitly allow the browser classes we use by name, in all code. To be clear, this means that the linter won't catch (say) using `Element` in server code; however, that's not a change from the status quo behavior. That is, what we have here is strictly less permissive than what we used to have.
* We no longer allow `document` or `window` to be used in local modules. I did this so that we have a reasonable chance of being resilient to use cases where those can't be relied on as truly being global. I am confident that this will help with unit testing, if nothing else.
* I fixed all the places in the code where we now tripped over the tighter rules. To make it a bit easier, I added a new public property `domNode` on `QuillProm`. Quill already defined an equivalent `container` property, but it isn't documented and so I didn't think it was a good idea to rely on it.