### PR TITLE
Stub out caret / selection handling on the server side. Demo usage on the client.

### DIFF
--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -4,7 +4,7 @@
 
 import { SplitKey } from 'api-common';
 import { Connection, Context } from 'api-server';
-import { DocForAuthor, DocServer } from 'doc-server';
+import { AuthorSession, DocServer } from 'doc-server';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 
@@ -55,7 +55,7 @@ export default class RootAccess {
       : '*';
 
     const docControl = await DocServer.theOne.getDoc(docId);
-    const doc        = new DocForAuthor(docControl, authorId);
+    const doc        = new AuthorSession(docControl, authorId);
 
     let key = null;
     for (;;) {

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -43,6 +43,8 @@ export default class RootAccess {
     TString.nonempty(authorId);
     TString.nonempty(docId);
 
+    const docControl = await DocServer.theOne.getDoc(docId);
+
     // Under normal circumstances, this method is called in the context of an
     // active API connection, but it can also be called when debugging, and in
     // that case we just fall back on the catchall `*` for the associated URL.
@@ -54,9 +56,9 @@ export default class RootAccess {
       ? `${Connection.activeNow.baseUrl}/api`
       : '*';
 
-    const docControl = await DocServer.theOne.getDoc(docId);
-    const doc        = new AuthorSession(docControl, authorId);
-
+    // Make a new random key, with a guaranteed unique ID. **Note:** There
+    // cannot be any `await`s between here and when the resulting key gets added
+    // to the context, as otherwise we could end up generating a duplicate key.
     let key = null;
     for (;;) {
       key = SplitKey.randomInstance(url);
@@ -68,6 +70,7 @@ export default class RootAccess {
       // just iterate and try again.
     }
 
+    const doc = new AuthorSession(key.id, docControl, authorId);
     this._context.add(key, doc);
 
     log.info(`Newly-authorized access.`);

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -8,6 +8,8 @@ import DocControl from './DocControl';
 
 /**
  * Server side representative for a session for a specific author and document.
+ * Instances of this class are exposed across the API boundary, and as such
+ * all public methods are available for client use.
  *
  * For document access methods, this passes non-mutating methods through to the
  * underlying `DocControl` while implicitly adding an author argument to methods
@@ -17,10 +19,15 @@ export default class AuthorSession {
   /**
    * Constructs an instance.
    *
+   * @param {string} sessionId Session ID for this instance, which is expected
+   *   to be guaranteed unique by whatever service it is that generates it.
    * @param {DocControl} doc The underlying document controller.
    * @param {string} authorId The author this instance acts on behalf of.
    */
-  constructor(doc, authorId) {
+  constructor(sessionId, doc, authorId) {
+    /** {string} Author ID. */
+    this._sessionId = TString.nonempty(sessionId);
+
     /** {DocControl} The underlying document controller. */
     this._doc = DocControl.check(doc);
 
@@ -47,7 +54,16 @@ export default class AuthorSession {
    * @returns {string} A succinct identification string
    */
   getLogInfo() {
-    return `doc ${this._doc.id}; author ${this._authorId}`;
+    return `session ${this._sessionId}; doc ${this._doc.id}; author ${this._authorId}`;
+  }
+
+  /**
+   * Returns the session ID of this instance.
+   *
+   * @returns {string} The session ID.
+   */
+  getSessionId() {
+    return this._sessionId;
   }
 
   /**

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -7,11 +7,13 @@ import { TString } from 'typecheck';
 import DocControl from './DocControl';
 
 /**
- * Controller for a given document, which acts on behalf of one specific author.
- * This passes non-mutating methods through to the underlying `DocControl` while
- * implicitly adding an author argument to methods that modify the document.
+ * Server side representative for a session for a specific author and document.
+ *
+ * For document access methods, this passes non-mutating methods through to the
+ * underlying `DocControl` while implicitly adding an author argument to methods
+ * that modify the document.
  */
-export default class DocForAuthor {
+export default class AuthorSession {
   /**
    * Constructs an instance.
    *

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -2,9 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 
 import DocControl from './DocControl';
+
+/** Logger. */
+const log = new Logger('author-session');
 
 /**
  * Server side representative for a session for a specific author and document.
@@ -105,5 +109,21 @@ export default class AuthorSession {
    */
   snapshot(revNum = null) {
     return this._doc.snapshot(revNum);
+  }
+
+  /**
+   * Informs the system of the client's current caret or text selection extent.
+   * This should be called by clients when they notice user activity that
+   * changes the selection. More specifically, Quill's `SELECTION_CHANGED`
+   * events are expected to drive calls to this method. Arguments to this method
+   * have the semantics of offset and length within a Quill `Delta`.
+   *
+   * @param {Int} index Caret position (if no selection per se) or starting
+   *   caret position of the selection.
+   * @param {Int|null} [length = null] If non-`null`, length of the selection.
+   */
+  updateCaret(index, length = null) {
+    // **TODO:** Something interesting should go here.
+    log.info(`Got caret update for ${this._sessionId}: ${index}, ${length}`);
   }
 }

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Logger } from 'see-all';
-import { TString } from 'typecheck';
+import { TInt, TString } from 'typecheck';
 
 import DocControl from './DocControl';
 
@@ -120,9 +120,12 @@ export default class AuthorSession {
    *
    * @param {Int} index Caret position (if no selection per se) or starting
    *   caret position of the selection.
-   * @param {Int|null} [length = null] If non-`null`, length of the selection.
+   * @param {Int} [length = 0] If non-zero, length of the selection.
    */
-  updateCaret(index, length = null) {
+  updateCaret(index, length = 0) {
+    TInt.min(index, 0);
+    TInt.min(length, 0);
+
     // **TODO:** Something interesting should go here.
     log.info(`Got caret update for ${this._sessionId}: ${index}, ${length}`);
   }

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -36,6 +36,22 @@ export default class AuthorSession {
   }
 
   /**
+   * Applies a delta, assigning authorship of the change to the author
+   * represented by this instance. See the equivalent `DocControl` method for
+   * details.
+   *
+   * @param {number} baseRevNum Revision number which `delta` is with respect
+   *   to.
+   * @param {FrozenDelta} delta Delta indicating what has changed with respect
+   *   to `baseRevNum`.
+   * @returns {Promise<DeltaResult>} Promise for the correction from the
+   *   implied expected result to get the actual result.
+   */
+  applyDelta(baseRevNum, delta) {
+    return this._doc.applyDelta(baseRevNum, delta, this._authorId);
+  }
+
+  /**
    * Returns a particular change to the document. See the equivalent
    * `DocControl` method for details.
    *
@@ -47,11 +63,24 @@ export default class AuthorSession {
   }
 
   /**
+   * Returns a promise for a snapshot of any revision after the given
+   * `baseRevNum`. See the equivalent `DocControl` method for details.
+   *
+   * @param {Int} baseRevNum Revision number for the document.
+   * @returns {Promise<DeltaResult>} Promise for a delta and associated revision
+   *   number. The result's `delta` can be applied to revision `baseRevNum` to
+   *   produce revision `revNum` of the document.
+   */
+  deltaAfter(baseRevNum) {
+    return this._doc.deltaAfter(baseRevNum);
+  }
+
+  /**
    * Returns a bit of identifying info about this instance, for the purposes of
    * logging. Specifically, the client side will call this method and log the
    * results during session initiation.
    *
-   * @returns {string} A succinct identification string
+   * @returns {string} A succinct identification string.
    */
   getLogInfo() {
     return `session ${this._sessionId}; doc ${this._doc.id}; author ${this._authorId}`;
@@ -76,34 +105,5 @@ export default class AuthorSession {
    */
   snapshot(revNum = null) {
     return this._doc.snapshot(revNum);
-  }
-
-  /**
-   * Returns a promise for a snapshot of any revision after the given
-   * `baseRevNum`. See the equivalent `DocControl` method for details.
-   *
-   * @param {Int} baseRevNum Revision number for the document.
-   * @returns {Promise<DeltaResult>} Promise for a delta and associated revision
-   *   number. The result's `delta` can be applied to revision `baseRevNum` to
-   *   produce revision `revNum` of the document.
-   */
-  deltaAfter(baseRevNum) {
-    return this._doc.deltaAfter(baseRevNum);
-  }
-
-  /**
-   * Applies a delta, assigning authorship of the change to the author
-   * represented by this instance. See the equivalent `DocControl` method for
-   * details.
-   *
-   * @param {number} baseRevNum Revision number which `delta` is with respect
-   *   to.
-   * @param {FrozenDelta} delta Delta indicating what has changed with respect
-   *   to `baseRevNum`.
-   * @returns {Promise<DeltaResult>} Promise for the correction from the
-   *   implied expected result to get the actual result.
-   */
-  applyDelta(baseRevNum, delta) {
-    return this._doc.applyDelta(baseRevNum, delta, this._authorId);
   }
 }

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import AuthorSession from './AuthorSession';
 import DocControl from './DocControl';
-import DocForAuthor from './DocForAuthor';
 import DocServer from './DocServer';
 
-export { DocControl, DocForAuthor, DocServer };
+export { AuthorSession, DocControl, DocServer };

--- a/local-modules/remote-authors/AuthorOverlay.js
+++ b/local-modules/remote-authors/AuthorOverlay.js
@@ -5,7 +5,7 @@
 import { AuthorId } from 'doc-common';
 import { QuillEvent, QuillGeometry } from 'quill-util';
 import { TObject } from 'typecheck';
-import { ColorSelector, PromDelay } from 'util-common';
+import { PromDelay } from 'util-common';
 
 /**
  * Time span to wait between refreshes of remote author annotations.

--- a/local-modules/remote-authors/AuthorOverlay.js
+++ b/local-modules/remote-authors/AuthorOverlay.js
@@ -45,9 +45,6 @@ export default class AuthorOverlay {
      */
     this._displayIsDirty = false;
 
-    /** {ColorSelector} Used to select the highlight color for each author as they're added. */
-    this._colorSelector = new ColorSelector();
-
     this._watchSelection();
   }
 


### PR DESCRIPTION
This PR adds just barely enough infrastructure for us to succeed in getting Quill's selection info onto the server side, associated with a specific session. We don't yet do anything with it other than log it, and furthermore the client side is doing redundant API authorization, which we will need to stop doing (but it's more refactoring than is worth it to roll into this PR).