### PR TITLE
Stub out most of the caret relay.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -10,6 +10,7 @@ import { EditorComplex, QuillEvent } from 'quill-util';
 import { Logger } from 'see-all';
 import { TFunction, TObject } from 'typecheck';
 import { DomUtil } from 'util-client';
+import { PromDelay } from 'util-common';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('top');
@@ -167,7 +168,11 @@ export default class TopControl {
       const range    = selEvent.range;
 
       sessionProxy.caretUpdate(range.index, range.length);
-      currentEvent = selEvent;
+
+      // Avoid spamming the server with tons of updates. To see every event,
+      // this should just be `currentEvent = selEvent`.
+      currentEvent = this._editorComplex.quill.currentEvent;
+      await PromDelay.resolve(5000);
     }
   }
 

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -155,7 +155,8 @@ export default class TopControl {
   /**
    * Skeletal code for updating the caret / selection.
    *
-   * **TODO:** This code should almost certainly live elsewhere.
+   * **TODO:** This code should almost certainly live elsewhere. Also, it needs
+   * to actually do something more useful.
    */
   async _watchSelection() {
     const sessionProxy =

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -166,7 +166,7 @@ export default class TopControl {
       const selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
       const range    = selEvent.range;
 
-      sessionProxy.updateCaret(range.index, range.length);
+      sessionProxy.caretUpdate(range.index, range.length);
       currentEvent = selEvent;
     }
   }

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -23,7 +23,7 @@ export default class Caret extends CommonBase {
     Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
+  /** {string} Name of this class in the API. */
   static get API_NAME() {
     return 'Caret';
   }

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -1,0 +1,48 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase } from 'util-common';
+
+/**
+ * Information about the state of a single document editing session. Instances
+ * of this class are always frozen (immutable).
+ *
+ * **Note:** The use of the term "caret" in this and other classes, method
+ * names, and the like, is meant to be a synecdochal metaphor for all
+ * information about a session, including the human driving it. The caret per
+ * se is merely the most blatant aspect of it.
+ */
+export default class Caret extends CommonBase {
+  /**
+   * Constructs an instance. **TODO:** Fill this in!
+   */
+  constructor() {
+    super();
+
+    Object.freeze(this);
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'Caret';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @returns {Caret} The constructed instance.
+   */
+  static fromApi() {
+    return new Caret();
+  }
+}

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -1,0 +1,75 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+import RevisionNumber from './RevisionNumber';
+
+/**
+ * Delta for caret information. Instances of this class can be applied to
+ * instances of `CaretSnapshot` to produce updated snapshots.
+ *
+ * Instances of this class are immutable.
+ */
+export default class CaretDelta extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} revNum Revision number of the caret information produced by
+   *   this instance.
+   * @param {array<object>} ops Array of individual caret information
+   *   modification operations.
+   */
+  constructor(revNum, ops) {
+    super();
+
+    /** {Int} The produced revision number. */
+    this._revNum = RevisionNumber.check(revNum);
+
+    /**
+     * {array<object>} Array of operations to perform on the (implied) base
+     * `CaretSnapshot` to produce the new revision.
+     */
+    this._ops = Object.freeze(TArray.check(ops));
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'CaretDelta';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._revNum, this._ops];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {Int} revNum Same as with the regular constructor.
+   * @param {array<object>} ops Same as with the regular constructor.
+   * @returns {CaretDelta} The constructed instance.
+   */
+  static fromApi(revNum, ops) {
+    return new CaretDelta(revNum, ops);
+  }
+
+  /** {Int} The produced revision number. */
+  get revNum() {
+    return this._revNum;
+  }
+
+  /**
+   * {array<object>} Array of operations to be applied. This is guaranteed to
+   * be a frozen (immutable) value.
+   */
+  get ops() {
+    return this._ops;
+  }
+}

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -35,7 +35,7 @@ export default class CaretDelta extends CommonBase {
     this._ops = Object.freeze(TArray.check(ops));
   }
 
-  /** Name of this class in the API. */
+  /** {string} Name of this class in the API. */
   static get API_NAME() {
     return 'CaretDelta';
   }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -1,0 +1,72 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+import Caret from './Caret';
+import RevisionNumber from './RevisionNumber';
+
+/**
+ * Snapshot of information about all active sessions on a particular document.
+ * Instances of this class are always frozen (immutable).
+ */
+export default class CaretSnapshot extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} revNum Revision number of the document for which this snapshot
+   *   is valid.
+   * @param {array<Caret>} carets Array of all the active carets.
+   */
+  constructor(revNum, carets) {
+    super();
+
+    /** {Int} The associated revision number. */
+    this._revNum = RevisionNumber.check(revNum);
+
+    /** {array<Caret>} Array of all the active carets. */
+    this._carets = Object.freeze(TArray.check(carets, Caret.check));
+
+    Object.freeze(this);
+  }
+
+  /** Name of this class in the API. */
+  static get API_NAME() {
+    return 'CaretSnapshot';
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._revNum, this._carets];
+  }
+
+  /**
+   * Constructs an instance from API arguments.
+   *
+   * @param {Int} revNum Same as with the regular constructor.
+   * @param {array<Caret>} carets Same as with the regular constructor.
+   * @returns {CaretSnapshot} The constructed instance.
+   */
+  static fromApi(revNum, carets) {
+    return new CaretSnapshot(revNum, carets);
+  }
+
+  /** {Int} The produced revision number. */
+  get revNum() {
+    return this._revNum;
+  }
+
+  /**
+   * {array<Caret>} Array of active carets. It is guaranteed to be a frozen
+   * (immutable) value.
+   */
+  get carets() {
+    return this._carets;
+  }
+}

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -16,15 +16,19 @@ export default class CaretSnapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} revNum Revision number of the document for which this snapshot
-   *   is valid.
+   * @param {Int} revNum Revision number of the caret information.
+   * @param {Int} docRevNum Revision number of the document to which the caret
+   *   information applies.
    * @param {array<Caret>} carets Array of all the active carets.
    */
-  constructor(revNum, carets) {
+  constructor(revNum, docRevNum, carets) {
     super();
 
-    /** {Int} The associated revision number. */
+    /** {Int} The associated caret information revision number. */
     this._revNum = RevisionNumber.check(revNum);
+
+    /** {Int} The associated document information revision number. */
+    this._docRevNum = RevisionNumber.check(docRevNum);
 
     /** {array<Caret>} Array of all the active carets. */
     this._carets = Object.freeze(TArray.check(carets, Caret.check));
@@ -43,21 +47,29 @@ export default class CaretSnapshot extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this._revNum, this._carets];
+    return [this._revNum, this._docRevNum, this._carets];
   }
 
   /**
    * Constructs an instance from API arguments.
    *
    * @param {Int} revNum Same as with the regular constructor.
+   * @param {Int} docRevNum Same as with the regular constructor.
    * @param {array<Caret>} carets Same as with the regular constructor.
    * @returns {CaretSnapshot} The constructed instance.
    */
-  static fromApi(revNum, carets) {
-    return new CaretSnapshot(revNum, carets);
+  static fromApi(revNum, docRevNum, carets) {
+    return new CaretSnapshot(revNum, docRevNum, carets);
   }
 
-  /** {Int} The produced revision number. */
+  /**
+   * {Int} The document revision number to which the caret information applies.
+   */
+  get docRevNum() {
+    return this._docRevNum;
+  }
+
+  /** {Int} The caret information revision number. */
   get revNum() {
     return this._revNum;
   }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -36,7 +36,7 @@ export default class CaretSnapshot extends CommonBase {
     Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
+  /** {string} Name of this class in the API. */
   static get API_NAME() {
     return 'CaretSnapshot';
   }

--- a/local-modules/doc-common/DeltaResult.js
+++ b/local-modules/doc-common/DeltaResult.js
@@ -30,14 +30,16 @@ export default class DeltaResult extends CommonBase {
   constructor(revNum, delta) {
     super();
 
-    /** The produced revision number. */
+    /** {Int} The produced revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** The actual change, as a delta. */
+    /** {FrozenDelta} The actual change, as a delta. */
     this._delta = FrozenDelta.check(delta);
+
+    Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
+  /** {string} Name of this class in the API. */
   static get API_NAME() {
     return 'DeltaResult';
   }

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -46,20 +46,24 @@ export default class DocumentChange extends CommonBase {
   constructor(revNum, timestamp, delta, authorId) {
     super();
 
-    /** The produced revision number. */
+    /** {Int} The produced revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** The time of the change. */
+    /** {Timestamp} The time of the change. */
     this._timestamp = Timestamp.check(timestamp);
 
-    /** The actual change, as a delta. */
+    /** {FrozenDelta} The actual change, as a delta. */
     this._delta = FrozenDelta.coerce(delta);
 
-    /** Author ID string. */
+    /**
+     * {string|null} Author ID string, or `null` if the change is authorless.
+     */
     this._authorId = TString.orNull(authorId);
+
+    Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
+  /** {string} Name of this class in the API. */
   static get API_NAME() {
     return 'DocumentChange';
   }
@@ -101,7 +105,9 @@ export default class DocumentChange extends CommonBase {
     return this._delta;
   }
 
-  /** {string|null} The author ID string. */
+  /**
+   * {string|null} The author ID string, or `null` if the change is authorless.
+   */
   get authorId() {
     return this._authorId;
   }

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -6,6 +6,7 @@ import { Codec } from 'api-common';
 
 import AuthorId from './AuthorId';
 import Caret from './Caret';
+import CaretDelta from './CaretDelta';
 import CaretSnapshot from './CaretSnapshot';
 import DeltaResult from './DeltaResult';
 import DocumentChange from './DocumentChange';
@@ -17,6 +18,7 @@ import RevisionNumber from './RevisionNumber';
 
 // Register classes with the API.
 Codec.theOne.registerClass(Caret);
+Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretSnapshot);
 Codec.theOne.registerClass(DeltaResult);
 Codec.theOne.registerClass(DocumentChange);
@@ -27,6 +29,7 @@ Codec.theOne.registerClass(Timestamp);
 export {
   AuthorId,
   Caret,
+  CaretDelta,
   CaretSnapshot,
   DeltaResult,
   DocumentChange,

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -5,6 +5,8 @@
 import { Codec } from 'api-common';
 
 import AuthorId from './AuthorId';
+import Caret from './Caret';
+import CaretSnapshot from './CaretSnapshot';
 import DeltaResult from './DeltaResult';
 import DocumentChange from './DocumentChange';
 import DocumentId from './DocumentId';
@@ -14,6 +16,8 @@ import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
 // Register classes with the API.
+Codec.theOne.registerClass(Caret);
+Codec.theOne.registerClass(CaretSnapshot);
 Codec.theOne.registerClass(DeltaResult);
 Codec.theOne.registerClass(DocumentChange);
 Codec.theOne.registerClass(FrozenDelta);
@@ -22,6 +26,8 @@ Codec.theOne.registerClass(Timestamp);
 
 export {
   AuthorId,
+  Caret,
+  CaretSnapshot,
   DeltaResult,
   DocumentChange,
   DocumentId,

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CaretSnapshot } from 'doc-common';
+import { CaretDelta, CaretSnapshot } from 'doc-common';
 import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 
@@ -113,21 +113,53 @@ export default class AuthorSession {
   }
 
   /**
+   * Gets a delta of caret information from the indicated base caret revision.
+   * This will throw an error if the indicated revision doesn't have caret
+   * information available, in which case the client will likely want to use
+   * `caretSnapshot()` to get back in synch.
+   *
+   * **Note:** Caret information and the main document have _separate_ revision
+   * numbers. `CaretSnapshot` instances have information about both revision
+   * numbers.
+   *
+   * **Note:** Caret information is only maintained ephemerally, so it is
+   * common for it not to be available for other than just a few recent
+   * revisions.
+   *
+   * @param {Int} baseRevNum Revision number for the caret information which
+   *   will form the basis for the result. If `baseRevNum` is the current
+   *   revision number, this method will block until a new revision is
+   *   available.
+   * @returns {Promise<CaretDelta>} Promise for a delta from the base caret
+   *   revision to a newer one. Applying this result to a `CaretSnapshot` for
+   *   `baseRevNum` will produce an up-to-date snapshot.
+   */
+  caretDeltaAfter(baseRevNum) {
+    // TODO: Something more interesting.
+    const docRevNum = 0;
+    return new CaretDelta(baseRevNum, baseRevNum + 1, docRevNum, []);
+  }
+
+  /**
    * Gets a snapshot of all active session caret information. This will throw
-   * an error if the indicated revision doesn't have caret information
+   * an error if the indicated caret revision doesn't have caret information
    * available.
    *
    * **Note:** Caret information is only maintained ephemerally, so it is
-   * common for it not to be available for revisions other than the most
-   * recent one.
+   * common for it not to be available for other than just a few recent
+   * revisions.
    *
-   * @param {Int|null} [revNum = null] Which revision to get. If passed as
+   * @param {Int|null} [revNum = null] Which caret revision to get. If passed as
    *   `null`, indicates the latest (most recent) revision.
    * @returns {CaretSnapshot} Snapshot of all the active carets.
    */
   caretSnapshot(revNum = null) {
     // TODO: Something more interesting.
-    return new CaretSnapshot(revNum, []);
+    if (revNum === null) {
+      revNum = 0;
+    }
+    const docRevNum = 0;
+    return new CaretSnapshot(revNum, docRevNum, []);
   }
 
   /**

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CaretSnapshot } from 'doc-common';
 import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 
@@ -109,6 +110,24 @@ export default class AuthorSession {
    */
   snapshot(revNum = null) {
     return this._doc.snapshot(revNum);
+  }
+
+  /**
+   * Gets a snapshot of all active session caret information. This will throw
+   * an error if the indicated revision doesn't have caret information
+   * available.
+   *
+   * **Note:** Caret information is only maintained ephemerally, so it is
+   * common for it not to be available for revisions other than the most
+   * recent one.
+   *
+   * @param {Int|null} [revNum = null] Which revision to get. If passed as
+   *   `null`, indicates the latest (most recent) revision.
+   * @returns {CaretSnapshot} Snapshot of all the active carets.
+   */
+  caretSnapshot(revNum = null) {
+    // TODO: Something more interesting.
+    return new CaretSnapshot(revNum, []);
   }
 
   /**

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -122,7 +122,7 @@ export default class AuthorSession {
    *   caret position of the selection.
    * @param {Int} [length = 0] If non-zero, length of the selection.
    */
-  updateCaret(index, length = 0) {
+  caretUpdate(index, length = 0) {
     TInt.min(index, 0);
     TInt.min(length, 0);
 


### PR DESCRIPTION
This PR finishes up the stubbing-out work of the previous day. With this, we now have a set of methods and classes which can be used on the client side to effect caret relay in both directions. That said, they are all well and truly stubby, so no real information is yet being conveyed.