### PR TITLE
Rename document classes to be `Document*`.

### DIFF
--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiError } from 'api-client';
-import { DeltaResult, DocumentSnapshot, FrozenDelta } from 'doc-common';
+import { DocumentDelta, DocumentSnapshot, FrozenDelta } from 'doc-common';
 import { QuillEvent } from 'quill-util';
 import { Logger } from 'see-all';
 import { TObject, TString } from 'typecheck';
@@ -180,12 +180,12 @@ export default class DocClient extends StateMachine {
    * from the API call `applyDelta()`.
    *
    * @param {FrozenDelta} delta The delta that was originally applied.
-   * @param {DeltaResult} correctedChange The correction to the expected
+   * @param {DocumentDelta} correctedChange The correction to the expected
    *   result as returned from `applyDelta()`.
    */
   _check_gotApplyDelta(delta, correctedChange) {
     FrozenDelta.check(delta);
-    DeltaResult.check(correctedChange);
+    DocumentDelta.check(correctedChange);
   }
 
   /**
@@ -194,12 +194,12 @@ export default class DocClient extends StateMachine {
    *
    * @param {DocumentSnapshot} baseDoc The document at the time of the original
    *   request.
-   * @param {DeltaResult} result How to transform `baseDoc` to get a later
+   * @param {DocumentDelta} result How to transform `baseDoc` to get a later
    *   document revision.
    */
   _check_gotDeltaAfter(baseDoc, result) {
     DocumentSnapshot.check(baseDoc);
-    DeltaResult.check(result);
+    DocumentDelta.check(result);
   }
 
   /**
@@ -481,7 +481,7 @@ export default class DocClient extends StateMachine {
    *
    * @param {DocumentSnapshot} baseDoc The document at the time of the original
    *   request.
-   * @param {DeltaResult} result How to transform `baseDoc` to get a later
+   * @param {DocumentDelta} result How to transform `baseDoc` to get a later
    *   document revision.
    */
   _handle_idle_gotDeltaAfter(baseDoc, result) {
@@ -516,7 +516,7 @@ export default class DocClient extends StateMachine {
    *
    * @param {DocumentSnapshot} baseDoc_unused The document at the time of the
    *   original request.
-   * @param {DeltaResult} result_unused How to transform `baseDoc` to get a
+   * @param {DocumentDelta} result_unused How to transform `baseDoc` to get a
    *   later document revision.
    */
   _handle_any_gotDeltaAfter(baseDoc_unused, result_unused) {
@@ -624,7 +624,7 @@ export default class DocClient extends StateMachine {
    * change was successfully merged by the server.
    *
    * @param {FrozenDelta} delta The delta that was originally applied.
-   * @param {DeltaResult} correctedChange The correction to the expected
+   * @param {DocumentDelta} correctedChange The correction to the expected
    *   result as returned from `applyDelta()`.
    */
   _handle_merging_gotApplyDelta(delta, correctedChange) {

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiError } from 'api-client';
-import { DeltaResult, FrozenDelta, Snapshot } from 'doc-common';
+import { DeltaResult, DocumentSnapshot, FrozenDelta } from 'doc-common';
 import { QuillEvent } from 'quill-util';
 import { Logger } from 'see-all';
 import { TObject, TString } from 'typecheck';
@@ -111,8 +111,8 @@ export default class DocClient extends StateMachine {
     this._sessionProxy = null;
 
     /**
-     * {Snapshot|null} Current revision of the document as received from the
-     * server. Becomes non-null once the first snapshot is received from the
+     * {DocumentSnapshot|null} Current revision of the document as received from
+     * the server. Becomes non-null once the first snapshot is received from the
      * server.
      */
     this._doc = null;
@@ -192,12 +192,13 @@ export default class DocClient extends StateMachine {
    * Validates a `gotDeltaAfter` event. This represents a successful result
    * from the API call `deltaAfter()`.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    * @param {DeltaResult} result How to transform `baseDoc` to get a later
    *   document revision.
    */
   _check_gotDeltaAfter(baseDoc, result) {
-    Snapshot.check(baseDoc);
+    DocumentSnapshot.check(baseDoc);
     DeltaResult.check(result);
   }
 
@@ -207,10 +208,11 @@ export default class DocClient extends StateMachine {
    * reflected in the given base document. Put another way, this indicates that
    * `_currentEvent` has a resolved `next`.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    */
   _check_gotLocalDelta(baseDoc) {
-    Snapshot.check(baseDoc);
+    DocumentSnapshot.check(baseDoc);
   }
 
   /**
@@ -224,10 +226,11 @@ export default class DocClient extends StateMachine {
    * Validates a `wantApplyDelta` event. This indicates that it is time to
    * send collected local changes up to the server.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    */
   _check_wantApplyDelta(baseDoc) {
-    Snapshot.check(baseDoc);
+    DocumentSnapshot.check(baseDoc);
   }
 
   /**
@@ -476,7 +479,8 @@ export default class DocClient extends StateMachine {
   /**
    * In state `idle`, handles event `gotDeltaAfter`.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    * @param {DeltaResult} result How to transform `baseDoc` to get a later
    *   document revision.
    */
@@ -510,8 +514,8 @@ export default class DocClient extends StateMachine {
    * such, it is safe to ignore, because after the local change is integrated,
    * the system will fire off a new `deltaAfter()` request.
    *
-   * @param {Snapshot} baseDoc_unused The document at the time of the original
-   *   request.
+   * @param {DocumentSnapshot} baseDoc_unused The document at the time of the
+   *   original request.
    * @param {DeltaResult} result_unused How to transform `baseDoc` to get a
    *   later document revision.
    */
@@ -524,7 +528,8 @@ export default class DocClient extends StateMachine {
    * user has started making some changes. We prepare to collect the changes
    * for a short period of time before sending them up to the server.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    */
   _handle_idle_gotLocalDelta(baseDoc) {
     const change = this._currentEvent.nextOfNow(QuillEvent.TEXT_CHANGE);
@@ -562,8 +567,8 @@ export default class DocClient extends StateMachine {
    * chain of local changes. As such, it is safe to ignore, because whatever
    * the change was, it will get handled by that pre-existing process.
    *
-   * @param {Snapshot} baseDoc_unused The document at the time of the original
-   *   request.
+   * @param {DocumentSnapshot} baseDoc_unused The document at the time of the
+   *   original request.
    */
   _handle_any_gotLocalDelta(baseDoc_unused) {
     // Nothing to do. Stay in the same state.
@@ -574,7 +579,8 @@ export default class DocClient extends StateMachine {
    * is time for the collected local changes to be sent up to the server for
    * integration.
    *
-   * @param {Snapshot} baseDoc The document at the time of the original request.
+   * @param {DocumentSnapshot} baseDoc The document at the time of the original
+   *   request.
    */
   _handle_collecting_wantApplyDelta(baseDoc) {
     if (this._doc.revNum !== baseDoc.revNum) {
@@ -805,7 +811,7 @@ export default class DocClient extends StateMachine {
     // object even when the delta is empty, so that `_doc === x` won't cause
     // surprising results when `x` is an old revision of `_doc`.
     const oldContents = this._doc.contents;
-    this._doc = new Snapshot(revNum,
+    this._doc = new DocumentSnapshot(revNum,
       delta.isEmpty() ? oldContents : oldContents.compose(delta));
 
     // Tell Quill if necessary.
@@ -818,7 +824,7 @@ export default class DocClient extends StateMachine {
    * Updates `_doc` to be the given snapshot, and tells the attached Quill
    * instance to update itself accordingly.
    *
-   * @param {Snapshot} snapshot New snapshot.
+   * @param {DocumentSnapshot} snapshot New snapshot.
    */
   _updateDocWithSnapshot(snapshot) {
     this._doc = snapshot;

--- a/local-modules/doc-common/DocumentDelta.js
+++ b/local-modules/doc-common/DocumentDelta.js
@@ -8,18 +8,19 @@ import { CommonBase } from 'util-common';
 import RevisionNumber from './RevisionNumber';
 
 /**
- * Delta-bearing result of an API call, which also comes with a revision number.
+ * Delta which can be applied to a `DocumentSnapshot`, along with associated
+ * information, to produce an updated snapshot.
+ *
  * Instances of this class are returned from calls to `applyDelta()` and
  * `deltaAfter()` as defined by the various `doc-server` classes. See those for
- * more details.
- *
- * Note that the meaning of the `delta` value is different depending on which
- * method the result came from. In particular, there is an implied "expected"
- * result from `applyDelta()` which this instance's `delta` is with respect to.
+ * more details. Note that the meaning of the `delta` value is different
+ * depending on which method the result came from. In particular, there is an
+ * implied "expected" result from `applyDelta()` which this instance's `delta`
+ * is with respect to.
  *
  * Instances of this class are immutable.
  */
-export default class DeltaResult extends CommonBase {
+export default class DocumentDelta extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -41,7 +42,7 @@ export default class DeltaResult extends CommonBase {
 
   /** {string} Name of this class in the API. */
   static get API_NAME() {
-    return 'DeltaResult';
+    return 'DocumentDelta';
   }
 
   /**
@@ -58,10 +59,10 @@ export default class DeltaResult extends CommonBase {
    *
    * @param {Int} revNum Same as with the regular constructor.
    * @param {FrozenDelta} delta Same as with the regular constructor.
-   * @returns {DeltaResult} The constructed instance.
+   * @returns {DocumentDelta} The constructed instance.
    */
   static fromApi(revNum, delta) {
-    return new DeltaResult(revNum, delta);
+    return new DocumentDelta(revNum, delta);
   }
 
   /** {Int} The produced revision number. */

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -9,9 +9,9 @@ import RevisionNumber from './RevisionNumber';
 
 
 /**
- * Snapshot of a document, with other associated information.
+ * Snapshot of document contents, with other associated information.
  */
-export default class Snapshot extends CommonBase {
+export default class DocumentSnapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -49,7 +49,7 @@ export default class Snapshot extends CommonBase {
 
   /** {string} Name of this class in the API. */
   static get API_NAME() {
-    return 'Snapshot';
+    return 'DocumentSnapshot';
   }
 
   /**
@@ -66,10 +66,10 @@ export default class Snapshot extends CommonBase {
    *
    * @param {number} revNum Same as regular constructor.
    * @param {Delta|array|object} contents Same as regular constructor.
-   * @returns {Snapshot} The constructed instance.
+   * @returns {DocumentSnapshot} The constructed instance.
    */
   static fromApi(revNum, contents) {
-    return new Snapshot(revNum, contents);
+    return new DocumentSnapshot(revNum, contents);
   }
 
   /** {RevisionNumber} The revision number. */

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -11,8 +11,8 @@ import CaretSnapshot from './CaretSnapshot';
 import DeltaResult from './DeltaResult';
 import DocumentChange from './DocumentChange';
 import DocumentId from './DocumentId';
+import DocumentSnapshot from './DocumentSnapshot';
 import FrozenDelta from './FrozenDelta';
-import Snapshot from './Snapshot';
 import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
@@ -22,8 +22,8 @@ Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretSnapshot);
 Codec.theOne.registerClass(DeltaResult);
 Codec.theOne.registerClass(DocumentChange);
+Codec.theOne.registerClass(DocumentSnapshot);
 Codec.theOne.registerClass(FrozenDelta);
-Codec.theOne.registerClass(Snapshot);
 Codec.theOne.registerClass(Timestamp);
 
 export {
@@ -34,8 +34,8 @@ export {
   DeltaResult,
   DocumentChange,
   DocumentId,
+  DocumentSnapshot,
   FrozenDelta,
-  Snapshot,
   Timestamp,
   RevisionNumber
 };

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -8,7 +8,7 @@ import AuthorId from './AuthorId';
 import Caret from './Caret';
 import CaretDelta from './CaretDelta';
 import CaretSnapshot from './CaretSnapshot';
-import DeltaResult from './DeltaResult';
+import DocumentDelta from './DocumentDelta';
 import DocumentChange from './DocumentChange';
 import DocumentId from './DocumentId';
 import DocumentSnapshot from './DocumentSnapshot';
@@ -20,7 +20,7 @@ import RevisionNumber from './RevisionNumber';
 Codec.theOne.registerClass(Caret);
 Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretSnapshot);
-Codec.theOne.registerClass(DeltaResult);
+Codec.theOne.registerClass(DocumentDelta);
 Codec.theOne.registerClass(DocumentChange);
 Codec.theOne.registerClass(DocumentSnapshot);
 Codec.theOne.registerClass(FrozenDelta);
@@ -31,7 +31,7 @@ export {
   Caret,
   CaretDelta,
   CaretSnapshot,
-  DeltaResult,
+  DocumentDelta,
   DocumentChange,
   DocumentId,
   DocumentSnapshot,

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -106,7 +106,7 @@ export default class AuthorSession {
    *
    * @param {Int|null} [revNum = null] Which revision to get. If passed as
    *   `null`, indicates the latest (most recent) revision.
-   * @returns {Promise<Snapshot>} Promise for the requested snapshot.
+   * @returns {Promise<DocumentSnapshot>} Promise for the requested snapshot.
    */
   snapshot(revNum = null) {
     return this._doc.snapshot(revNum);

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -49,7 +49,7 @@ export default class AuthorSession {
    *   to.
    * @param {FrozenDelta} delta Delta indicating what has changed with respect
    *   to `baseRevNum`.
-   * @returns {Promise<DeltaResult>} Promise for the correction from the
+   * @returns {Promise<DocumentDelta>} Promise for the correction from the
    *   implied expected result to get the actual result.
    */
   applyDelta(baseRevNum, delta) {
@@ -72,9 +72,9 @@ export default class AuthorSession {
    * `baseRevNum`. See the equivalent `DocControl` method for details.
    *
    * @param {Int} baseRevNum Revision number for the document.
-   * @returns {Promise<DeltaResult>} Promise for a delta and associated revision
-   *   number. The result's `delta` can be applied to revision `baseRevNum` to
-   *   produce revision `revNum` of the document.
+   * @returns {Promise<DocumentDelta>} Promise for a delta and associated
+   *   revision number. The result's `delta` can be applied to revision
+   *   `baseRevNum` to produce revision `revNum` of the document.
    */
   deltaAfter(baseRevNum) {
     return this._doc.deltaAfter(baseRevNum);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -4,7 +4,7 @@
 
 import { Codec } from 'api-common';
 import { BaseFile, FileCodec, TransactionSpec } from 'content-store';
-import { DeltaResult, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber, Timestamp } from 'doc-common';
+import { DocumentDelta, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber, Timestamp } from 'doc-common';
 import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 import { CommonBase, InfoError, PromDelay } from 'util-common';
@@ -327,7 +327,7 @@ export default class DocControl extends CommonBase {
    * least one change has been made.
    *
    * @param {Int} baseRevNum Revision number for the document.
-   * @returns {DeltaResult} Delta and associated revision number. The result's
+   * @returns {DocumentDelta} Delta and associated revision number. The result's
    *   `revNum` is guaranteed to be at least one more than `baseRevNum` (and
    *   could possibly be even larger.) The result's `delta` can be applied to
    *   revision `baseRevNum` to produce revision `revNum` of the document.
@@ -349,7 +349,7 @@ export default class DocControl extends CommonBase {
         // after the base through and including the current revision.
         const delta = await this._composeRevisions(
           FrozenDelta.EMPTY, baseRevNum + 1, docRevNum + 1);
-        return new DeltaResult(docRevNum, delta);
+        return new DocumentDelta(docRevNum, delta);
       }
 
       // Wait for the file to change (or for the storage layer to reach its
@@ -378,7 +378,7 @@ export default class DocControl extends CommonBase {
    *   to `baseRevNum`.
    * @param {string|null} authorId Author of `delta`, or `null` if the change
    *   is to be considered authorless.
-   * @returns {DeltaResult} The correction to the implied expected result of
+   * @returns {DocumentDelta} The correction to the implied expected result of
    *   this operation. The `delta` of this result can be applied to the expected
    *   result to get the actual result. The promise resolves sometime after the
    *   delta has been applied to the document.
@@ -395,7 +395,7 @@ export default class DocControl extends CommonBase {
     // Check for an empty `delta`. If it is, we don't bother trying to apply it.
     // See method header comment for more info.
     if (delta.isEmpty()) {
-      return new DeltaResult(baseRevNum, FrozenDelta.EMPTY);
+      return new DocumentDelta(baseRevNum, FrozenDelta.EMPTY);
     }
 
     // Compose the implied expected result. This has the effect of validating
@@ -460,7 +460,7 @@ export default class DocControl extends CommonBase {
    *   of the document.
    * @param {DocumentSnapshot} expected The implied expected result as defined
    *   by `applyDelta()`.
-   * @returns {DeltaResult|null} Result for the outer call to `applyDelta()`,
+   * @returns {DocumentDelta|null} Result for the outer call to `applyDelta()`,
    *   or `null` if the application failed due to an out-of-date `snapshot`.
    */
   async _applyDeltaTo(base, delta, authorId, current, expected) {
@@ -477,7 +477,7 @@ export default class DocControl extends CommonBase {
         return null;
       }
 
-      return new DeltaResult(revNum, FrozenDelta.EMPTY);
+      return new DocumentDelta(revNum, FrozenDelta.EMPTY);
     }
 
     // The hard case: The client has requested an application of a delta
@@ -525,7 +525,7 @@ export default class DocControl extends CommonBase {
       // It turns out that nothing changed. **Note:** It is unclear whether this
       // can actually happen in practice, given that we already return early
       // (in `applyDelta()`) if we are asked to apply an empty delta.
-      return new DeltaResult(rCurrent.revNum, FrozenDelta.EMPTY);
+      return new DocumentDelta(rCurrent.revNum, FrozenDelta.EMPTY);
     }
 
     // (3)
@@ -543,7 +543,7 @@ export default class DocControl extends CommonBase {
       FrozenDelta.coerce(rExpected.contents.diff(rNext.contents));
 
     // (5)
-    return new DeltaResult(vNextNum, dCorrection);
+    return new DocumentDelta(vNextNum, dCorrection);
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -4,8 +4,7 @@
 
 import { Codec } from 'api-common';
 import { BaseFile, FileCodec, TransactionSpec } from 'content-store';
-import { DeltaResult, DocumentChange, FrozenDelta, RevisionNumber, Snapshot, Timestamp }
-  from 'doc-common';
+import { DeltaResult, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber, Timestamp } from 'doc-common';
 import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 import { CommonBase, InfoError, PromDelay } from 'util-common';
@@ -83,7 +82,7 @@ export default class DocControl extends CommonBase {
     this._formatVersion = TString.nonempty(formatVersion);
 
     /**
-     * {Map<RevisionNumber,Snapshot>} Mapping from revision numbers to
+     * {Map<RevisionNumber,DocumentSnapshot>} Mapping from revision numbers to
      * corresponding document snapshots. Sparse.
      */
     this._snapshots = new Map();
@@ -180,7 +179,7 @@ export default class DocControl extends CommonBase {
    *
    * @param {Int|null} revNum Which revision to get. If passed as `null`,
    *   indicates the latest (most recent) revision.
-   * @returns {Snapshot} The corresponding snapshot.
+   * @returns {DocumentSnapshot} The corresponding snapshot.
    */
   async snapshot(revNum = null) {
     const currentRevNum = (await this._currentRevNums()).docRevNum;
@@ -210,7 +209,7 @@ export default class DocControl extends CommonBase {
     const contents = (base === null)
       ? this._composeRevisions(FrozenDelta.EMPTY, 0,               revNum + 1)
       : this._composeRevisions(base.contents,     base.revNum + 1, revNum + 1);
-    const result = new Snapshot(revNum, await contents);
+    const result = new DocumentSnapshot(revNum, await contents);
 
     this._log.detail(`Made snapshot for revision ${revNum}.`);
 
@@ -401,7 +400,8 @@ export default class DocControl extends CommonBase {
 
     // Compose the implied expected result. This has the effect of validating
     // the contents of `delta`.
-    const expected = new Snapshot(baseRevNum + 1, base.contents.compose(delta));
+    const expected =
+      new DocumentSnapshot(baseRevNum + 1, base.contents.compose(delta));
 
     // We try performing the apply, and then we iterate if it failed _and_ the
     // reason is simply that there were any changes that got made while we were
@@ -451,15 +451,15 @@ export default class DocControl extends CommonBase {
    * the snapshot being out-of-date, then this method returns `null`. All other
    * problems are reported by throwing an exception.
    *
-   * @param {Snapshot} base Snapshot of the base from which the delta is
+   * @param {DocumentSnapshot} base Snapshot of the base from which the delta is
    *   defined. That is, this is the snapshot of `baseRevNum` as provided to
    *   `applyDelta()`.
    * @param {FrozenDelta} delta Same as for `applyDelta()`.
    * @param {string|null} authorId Same as for `applyDelta()`.
-   * @param {Snapshot} current Snapshot of the current (latest) revision of the
-   *   document.
-   * @param {Snapshot} expected The implied expected result as defined by
-   *   `applyDelta()`.
+   * @param {DocumentSnapshot} current Snapshot of the current (latest) revision
+   *   of the document.
+   * @param {DocumentSnapshot} expected The implied expected result as defined
+   *   by `applyDelta()`.
    * @returns {DeltaResult|null} Result for the outer call to `applyDelta()`,
    *   or `null` if the application failed due to an out-of-date `snapshot`.
    */

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.17.0
+version = 0.17.1


### PR DESCRIPTION
This PR renames two document-related classes to be of the form `Document*`, to be parallel with the newly-minted `Caret*` classes.