### PR TITLE
Add and use OT methods on `DocumentSnapshot`.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -168,7 +168,11 @@ export default class TopControl {
       const selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
       const range    = selEvent.range;
 
-      sessionProxy.caretUpdate(range.index, range.length);
+      // Only update when given a non-`null` range. `null` gets sent when the
+      // editor UI loses focus.
+      if (range !== null) {
+        sessionProxy.caretUpdate(range.index, range.length);
+      }
 
       // Avoid spamming the server with tons of updates. To see every event,
       // this should just be `currentEvent = selEvent`.

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -31,7 +31,7 @@ export default class DocumentChange extends DocumentDelta {
    * @returns {FrozenDelta} An appropriate initial change.
    */
   static firstChange() {
-    return new DocumentChange(0, Timestamp.now(), FrozenDelta.EMPTY, null);
+    return new DocumentChange(0, FrozenDelta.EMPTY, Timestamp.now(), null);
   }
 
   /**
@@ -40,15 +40,15 @@ export default class DocumentChange extends DocumentDelta {
    * @param {Int} revNum The revision number of the document produced by this
    *   change. If this instance represents the first change to a document,
    *   then this value will be `0`.
-   * @param {Timestamp} timestamp The time of the change, as msec since the Unix
-   *   Epoch.
    * @param {Delta|array|object} delta The document change per se, compared to
    *   the immediately-previous revision. Must be a value which can be coerced
    *   to a `FrozenDelta`.
+   * @param {Timestamp} timestamp The time of the change, as msec since the Unix
+   *   Epoch.
    * @param {string|null} authorId Stable identifier string representing the
    *   author of the change. Allowed to be `null` if the change is authorless.
    */
-  constructor(revNum, timestamp, delta, authorId) {
+  constructor(revNum, delta, timestamp, authorId) {
     super(revNum, FrozenDelta.coerce(delta),
       function init() {
         /** {Timestamp} The time of the change. */
@@ -73,20 +73,20 @@ export default class DocumentChange extends DocumentDelta {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this._revNum, this._timestamp, this._delta, this.authorId];
+    return [this._revNum, this._delta, this._timestamp, this.authorId];
   }
 
   /**
    * Constructs an instance from API arguments.
    *
    * @param {Int} revNum Same as with the regular constructor.
-   * @param {Timestamp} timestamp Same as with the regular constructor.
    * @param {Delta|array|object} delta Same as with the regular constructor.
+   * @param {Timestamp} timestamp Same as with the regular constructor.
    * @param {string|null} authorId Same as with the regular constructor.
    * @returns {DocumentChange} The constructed instance.
    */
-  static fromApi(revNum, timestamp, delta, authorId) {
-    return new DocumentChange(revNum, timestamp, delta, authorId);
+  static fromApi(revNum, delta, timestamp, authorId) {
+    return new DocumentChange(revNum, delta, timestamp, authorId);
   }
 
   /**

--- a/local-modules/doc-common/DocumentDelta.js
+++ b/local-modules/doc-common/DocumentDelta.js
@@ -24,7 +24,8 @@ export default class DocumentDelta extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} revNum Revision number of the document.
+   * @param {Int} revNum Revision number of the document which is produced by
+   *   this instance.
    * @param {FrozenDelta} delta Delta which can be applied in context to
    *   produce the document with the indicated revision number.
    */

--- a/local-modules/doc-common/DocumentDelta.js
+++ b/local-modules/doc-common/DocumentDelta.js
@@ -24,12 +24,18 @@ export default class DocumentDelta extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} revNum Revision number of the document which is produced by
-   *   this instance.
+   * @param {Int} revNum The revision number of the document produced by this
+   *   instance. If this instance represents the first change to a document,
+   *   then this value will be `0`.
    * @param {FrozenDelta} delta Delta which can be applied in context to
    *   produce the document with the indicated revision number.
+   * @param {function} [subclassInit = null] Optional function to call (bound as
+   *   method) in order to complete instance initialization. (This arrangement
+   *   is a hack which compensates for JavaScript's lack of expressiveness
+   *   around construction within a class hierarchy where every level aims to
+   *   create frozen instances.)
    */
-  constructor(revNum, delta) {
+  constructor(revNum, delta, subclassInit = null) {
     super();
 
     /** {Int} The produced revision number. */
@@ -37,6 +43,10 @@ export default class DocumentDelta extends CommonBase {
 
     /** {FrozenDelta} The actual change, as a delta. */
     this._delta = FrozenDelta.check(delta);
+
+    if (subclassInit !== null) {
+      subclassInit.call(this);
+    }
 
     Object.freeze(this);
   }

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -158,7 +158,10 @@ export default class DocumentSnapshot extends CommonBase {
   diff(newerSnapshot) {
     DocumentSnapshot.check(newerSnapshot);
 
-    const delta = FrozenDelta.coerce(this._contents.diff(newerSnapshot));
+    const oldContents = this.contents;
+    const newContents = newerSnapshot.contents;
+    const delta       = FrozenDelta.coerce(oldContents.diff(newContents));
+
     return new DocumentDelta(newerSnapshot.revNum, delta);
   }
 }

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -129,7 +129,7 @@ export default class DocumentSnapshot extends CommonBase {
    *   this instance with all of the `deltas`.
    */
   composeAll(deltas) {
-    TArray.check(deltas, DocumentDelta);
+    TArray.check(deltas, DocumentDelta.check);
 
     if (deltas.length === 0) {
       return this;

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -107,8 +107,9 @@ export default class DocumentSnapshot extends CommonBase {
    * snapshot passed in here as an argument. That is, `newerSnapshot ==
    * this.compose(this.diff(newerSnapshot))`.
    *
-   * @param {CaretSnapshot} newerSnapshot Snapshot to take the difference from.
-   * @returns {CaretDelta} Delta which represents the difference between
+   * @param {DocumentSnapshot} newerSnapshot Snapshot to take the difference
+   *   from.
+   * @returns {DocumentDelta} Delta which represents the difference between
    *   `newerSnapshot` and this instance.
    */
   diff(newerSnapshot) {

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -4,6 +4,7 @@
 
 import { CommonBase } from 'util-common';
 
+import DocumentDelta from './FrozenDelta';
 import FrozenDelta from './FrozenDelta';
 import RevisionNumber from './RevisionNumber';
 
@@ -80,5 +81,44 @@ export default class DocumentSnapshot extends CommonBase {
   /** {FrozenDelta} The document contents. */
   get contents() {
     return this._contents;
+  }
+
+  /**
+   * Composes a delta on top of this instance, to produce a new instance.
+   *
+   * @param {DocumentDelta} delta Delta to compose on top of this instance.
+   * @returns {DocumentSnapshot} New instance consisting of the composition of
+   *   this instance with `delta`.
+   */
+  compose(delta) {
+    DocumentDelta.check(delta);
+
+    // **TODO:** Implement this!
+    if (delta === delta) {
+      throw new Error('TODO');
+    }
+
+    return null;
+  }
+
+  /**
+   * Calculates the difference from a given snapshot to this one. The return
+   * value is a delta which can be composed with this instance to produce the
+   * snapshot passed in here as an argument. That is, `newerSnapshot ==
+   * this.compose(this.diff(newerSnapshot))`.
+   *
+   * @param {CaretSnapshot} newerSnapshot Snapshot to take the difference from.
+   * @returns {CaretDelta} Delta which represents the difference between
+   *   `newerSnapshot` and this instance.
+   */
+  diff(newerSnapshot) {
+    DocumentSnapshot.check(newerSnapshot);
+
+    // **TODO:** Implement this!
+    if (newerSnapshot === newerSnapshot) {
+      throw new Error('TODO');
+    }
+
+    return null;
   }
 }

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -4,7 +4,7 @@
 
 import { CommonBase } from 'util-common';
 
-import DocumentDelta from './FrozenDelta';
+import DocumentDelta from './DocumentDelta';
 import FrozenDelta from './FrozenDelta';
 import RevisionNumber from './RevisionNumber';
 

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -93,12 +93,8 @@ export default class DocumentSnapshot extends CommonBase {
   compose(delta) {
     DocumentDelta.check(delta);
 
-    // **TODO:** Implement this!
-    if (delta === delta) {
-      throw new Error('TODO');
-    }
-
-    return null;
+    const contents = FrozenDelta.coerce(this._contents.compose(delta.delta));
+    return new DocumentSnapshot(delta.revNum, contents);
   }
 
   /**
@@ -115,11 +111,7 @@ export default class DocumentSnapshot extends CommonBase {
   diff(newerSnapshot) {
     DocumentSnapshot.check(newerSnapshot);
 
-    // **TODO:** Implement this!
-    if (newerSnapshot === newerSnapshot) {
-      throw new Error('TODO');
-    }
-
-    return null;
+    const delta = FrozenDelta.coerce(this._contents.diff(newerSnapshot));
+    return new DocumentDelta(newerSnapshot.revNum, delta);
   }
 }

--- a/local-modules/doc-common/FrozenDelta.js
+++ b/local-modules/doc-common/FrozenDelta.js
@@ -8,10 +8,10 @@ import { TArray, TypeError } from 'typecheck';
 import { CommonBase, DataUtil, ObjectUtil } from 'util-common';
 
 /**
- * {FrozenDelta|null} Empty `Delta` instance. Initialized in the `EMPTY`
- * property accessor.
+ * {FrozenDelta|null} Empty instance. Initialized in the `EMPTY` property
+ * accessor.
  */
-let emptyDelta = null;
+let emptyInstance = null;
 
 /**
  * Always-frozen `Delta`. This is a subclass of `Delta` and mixes in
@@ -22,11 +22,11 @@ let emptyDelta = null;
 export default class FrozenDelta extends Delta {
   /** {FrozenDelta} Empty instance of this class. */
   static get EMPTY() {
-    if (emptyDelta === null) {
-      emptyDelta = new FrozenDelta([]);
+    if (emptyInstance === null) {
+      emptyInstance = new FrozenDelta([]);
     }
 
-    return emptyDelta;
+    return emptyInstance;
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -498,19 +498,19 @@ export default class DocControl extends CommonBase {
     // 3. Apply `dNext` to `rCurrent`, producing `rNext` as the new current
     //    server revision.
     // 4. Construct a delta from `rExpected` to `rNext` (that is, the diff).
-    //    This is `dCorrection`. This is what we return to the client; they will
-    //    compose `rExpected` with `dCorrection` to arrive at `rNext`.
-    // 5. Return the revision number of `rNext` along with the delta
-    //    `dCorrection`.
+    //    This is `dCorrection`. Return this to the client; they will compose
+    //    `rExpected` with `dCorrection` to arrive at `rNext`.
 
     // (0) Assign incoming arguments to variables that correspond to the
     //     description immediately above.
+
     const dClient   = delta;
     const rBase     = base;
     const rExpected = expected;
     const rCurrent  = current;
 
     // (1)
+
     const dServer = await this._composeRevisions(
       FrozenDelta.EMPTY, rBase.revNum + 1, rCurrent.revNum + 1);
 
@@ -528,6 +528,7 @@ export default class DocControl extends CommonBase {
     }
 
     // (3)
+
     const vNextNum = await this._appendDelta(rCurrent.revNum, dNext, authorId);
 
     if (vNextNum === null) {
@@ -538,11 +539,11 @@ export default class DocControl extends CommonBase {
     const rNext = await this.snapshot(vNextNum);
 
     // (4)
-    const dCorrection =
-      FrozenDelta.coerce(rExpected.contents.diff(rNext.contents));
 
-    // (5)
-    return new DocumentDelta(vNextNum, dCorrection);
+    // **Note:** The result's revision number is the same as `rNext`'s, which
+    // is exactly what we want.
+    const dCorrection = rExpected.diff(rNext);
+    return dCorrection;
   }
 
   /**

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -400,8 +400,7 @@ export default class DocControl extends CommonBase {
 
     // Compose the implied expected result. This has the effect of validating
     // the contents of `delta`.
-    const expected =
-      new DocumentSnapshot(baseRevNum + 1, base.contents.compose(delta));
+    const expected = base.compose(new DocumentDelta(baseRevNum + 1, delta));
 
     // We try performing the apply, and then we iterate if it failed _and_ the
     // reason is simply that there were any changes that got made while we were

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -123,7 +123,7 @@ export default class DocControl extends CommonBase {
     // constructing the transaction spec.
     const maybeChange1 = [];
     if (contents !== null) {
-      const change = new DocumentChange(1, Timestamp.now(), contents, null);
+      const change = new DocumentChange(1, contents, Timestamp.now(), null);
       const op     = fc.op_writePath(Paths.forRevNum(1), change);
       maybeChange1.push(op);
     }
@@ -572,7 +572,7 @@ export default class DocControl extends CommonBase {
     const fc = this._fileCodec; // Avoids boilerplate immediately below.
     const revNum = baseRevNum + 1;
     const changePath = Paths.forRevNum(revNum);
-    const change = new DocumentChange(revNum, Timestamp.now(), delta, authorId);
+    const change = new DocumentChange(revNum, delta, Timestamp.now(), authorId);
     const spec = new TransactionSpec(
       fc.op_checkPathEmpty(changePath),
       fc.op_checkPathBufferHash(Paths.REVISION_NUMBER, baseRevNum),

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.17.1
+version = 0.17.2


### PR DESCRIPTION
This PR aims to hew the `Document*` classes with the nascent `Caret*` classes, in terms of having consistent methods and usage style. Specifically, a handful of OT methods got added to `DocumentSnapshot`, and these are now being using in preference to "hand rolling" the equivalent functionality at use sites. In a couple of cases, things got a little more verbose, but I think that this change will eventually pay some good dividends in terms of maintainability. Ultimately I think we'll be able to simplify the code a bit, by continuing along this line.