### PR TITLE
Miscellanea

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -20,6 +20,7 @@
     "babel-core": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-preset-env": "^1.4.0",
+    "chalk": "^1.1.1",
     "fs-extra": "^3.0.1"
   }
 }

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -124,7 +124,7 @@ export default class CommonBase {
       return value;
     } else {
       const result = this._impl_coerceOrNull(value);
-      if (!(result instanceof this)) {
+      if ((result !== null) && !(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
         throw new Error('Invalid `_impl_coerceOrNull()` implementation.');
@@ -135,7 +135,9 @@ export default class CommonBase {
 
   /**
    * Subclass-specific implementation of `coerceOrNull()`. Subclasses can
-   * override this as needed.
+   * override this as needed. The default implementation here simply calls
+   * through to `_impl_coerce()` and converts any thrown exception into a `null`
+   * return value.
    *
    * @param {*} value Value to coerce. This is guaranteed _not_ to be an
    *   instance of this class.


### PR DESCRIPTION
* Moved `DocumentChange` construction up a layer. This simplifies the newly-renamed `_appendChange()` a bit, and gets us more ready for timestamps to get minted at a higher layer (which I suspect we'll want to do).
* Fixed the default implementation of `CommonBase.coerceOrNull()`.
* Added a splash of color and some string trimming to make compiler output nicer.