### PR TITLE
Extract `ItemCodec` class; enable future API-coding simplification and fancification.

### DIFF
--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -104,12 +104,13 @@ export default class Codec extends Singleton {
    * * Other arrays are allowed, with their values processed recursively using
    *   (the equivalent of) this method. The encoded form is also an array but
    *   with an additional first element of the value `Registry.arrayTag`.
-   * * Objects which bind a method `toApi()` and whose constructor binds a
-   *   property `API_NAME` are allowed. Such objects will have `toApi()` called
-   *   on them, which is expected to result in an array which is suitable for
-   *   processing using (the equivalent of) this method. The encoded form is an
-   *   array with the first element the value of `API_NAME` and the rest of the
-   *   elements whatever was returned by `toApi()`.
+   * * Objects that are instances of classes (that is, have constructor
+   *   functions) are allowed, as long as they at least bind a method `toApi()`.
+   *   In addition, if they have a static `API_NAME` property and/or a static
+   *   `fromApi()` method, those are used. See `ItemCodec` for how these are all
+   *   used to effect encoding and decoding. The encoded form is an array with
+   *   the first element being the value tag (typically the class name) and the
+   *   rest of the elements whatever was returned by `toApi()`.
    * * All other objects are rejected.
    *
    * In addition, if the result is an object (including an array), it is

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -156,4 +156,14 @@ export default class Codec extends Singleton {
   registerClass(clazz) {
     this._reg.registerClass(clazz);
   }
+
+  /**
+   * Registers an item codec to be accepted for API use. This is a pass-through
+   * to the method of the same name on the instance's `Registry`.
+   *
+   * @param {ItemCodec} codec The codec to register.
+   */
+  registerCodec(codec) {
+    this._reg.registerCodec(codec);
+  }
 }

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -44,12 +44,12 @@ export default class Codec extends Singleton {
    * * Arrays whose first element is not a string (including empty arrays) are
    *   rejected.
    * * Other arrays are processed recursively using (the equivalent of) this
-   *   method, without the first element. If the first element is the value
-   *   `Registry.arrayTag` then the processed form is used as-is. Otherwise,
-   *   the first element is used to look up a class that has been registered
-   *   under that name. Its `fromApi()` method is called, passing the converted
+   *   method, without the first element. The first element is taken to be a
+   *   string tag and is used to look up an item codec that was registered
+   *   under that tag. Its `decode()` method is called, passing the converted
    *   array as arguments. The result of that call becomes the result of
-   *   conversion.
+   *   conversion. **Note:** Decoding to an array result per se is a special
+   *   case of this, using the item codec `SpecialCodecs.ARRAY`.
    * * All other objects (including functions) are rejected.
    *
    * In addition, if the result is an object (including an array), it is
@@ -103,7 +103,7 @@ export default class Codec extends Singleton {
    * * Arrays with non-numeric properties are rejected.
    * * Other arrays are allowed, with their values processed recursively using
    *   (the equivalent of) this method. The encoded form is also an array but
-   *   with an additional first element of the value `Registry.arrayTag`.
+   *   with an additional first element of the value `SpecialCodec.ARRAY.tag`.
    * * Objects that are instances of classes (that is, have constructor
    *   functions) are allowed, as long as they at least bind a method `toApi()`.
    *   In addition, if they have a static `API_NAME` property and/or a static

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -100,13 +100,9 @@ export default class Decoder extends CommonBase {
    * @returns {object} The converted value.
    */
   _decodeInstance(tag, payload) {
-    const clazz = this._reg.classForName(tag);
+    const itemCodec = this._reg.codecForTag(tag);
     const args = this._decodeArray(payload);
 
-    if (!clazz) {
-      throw new Error(`API cannot decode object of class \`${tag}\`.`);
-    }
-
-    return clazz.fromApi(...args);
+    return itemCodec.decode(...args);
   }
 }

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -48,8 +48,8 @@ export default class Decoder extends CommonBase {
     const tag = value[0];
     const payload = value.slice(1);
 
-    // ...except that it's an error if the array doesn't start with a string
-    // tag, so check for that.
+    // It's an error if the array doesn't start with a string tag (even for
+    // a value that decodes to an array per se), so check for that.
     if (typeof tag !== 'string') {
       if (value.length === 0) {
         throw new Error('API cannot decode empty arrays.');

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -18,9 +18,6 @@ export default class Decoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
-
-    /** {static} Conveniently cached value of `reg.arrayTag`. */
-    this._arrayTag = reg.arrayTag;
   }
 
   /**

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -101,8 +101,9 @@ export default class Decoder extends CommonBase {
    */
   _decodeInstance(tag, payload) {
     const itemCodec = this._reg.codecForTag(tag);
-    const args = this._decodeArray(payload);
 
-    return itemCodec.decode(...args);
+    payload = this._decodeArray(payload);
+
+    return itemCodec.decode(payload);
   }
 }

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -136,18 +136,9 @@ export default class Encoder extends CommonBase {
    * @returns {object} The converted value.
    */
   _encodeInstance(value) {
-    const apiName = value.constructor && value.constructor.API_NAME;
-    const toApi = value.toApi;
+    const itemCodec = this._reg.codecForValue(value);
+    const encoded = itemCodec.encode(value);
 
-    if ((typeof apiName !== 'string') || (typeof toApi !== 'function')) {
-      throw new Error(`API cannot encode object of class \`${value.constructor.name}\`.`);
-    }
-
-    const payload = value.toApi();
-    if (!Array.isArray(payload)) {
-      throw new Error(`Non-array result from \`toApi()\` on class \`${value.constructor.name}\`.`);
-    }
-
-    return this._encodeArray(payload, apiName);
+    return this._encodeArray(encoded, itemCodec.tag);
   }
 }

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -18,9 +18,6 @@ export default class Encoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
-
-    /** {static} Conveniently cached value of `reg.arrayTag`. */
-    this._arrayTag = reg.arrayTag;
   }
 
   /**
@@ -48,16 +45,9 @@ export default class Encoder extends CommonBase {
 
         if (proto === Object.prototype) {
           return this._encodeSimpleObject(value);
-        } else if (proto === Array.prototype) {
-          // Note: We don't use `Array.isArray()` because that will return
-          // `true` for subclasses of Array. We want to instead treat Array
-          // subclass instances as regular object instances (in the next
-          // clause), so as not to miss out on their API metadata (or so as to
-          // fail to encode them if they aren't in fact API-ready).
-          return this._encodeArray(value);
         } else {
-          // It had better define the API metainfo properties, but if not, then
-          // this call will throw.
+          // It had better be a value whose class/type is registered, but if
+          // not, then this call will throw.
           return this._encodeInstance(value);
         }
       }
@@ -99,46 +89,21 @@ export default class Encoder extends CommonBase {
   }
 
   /**
-   * Helper for `encodeData()` which validates and converts an array.
-   *
-   * @param {array} value Value to convert.
-   * @param {string} [tag = Registry.arrayTag] "Header" tag for the result.
-   * @returns {array} The converted value.
-   */
-  _encodeArray(value, tag = this._arrayTag) {
-    // Convert elements and keep a count of how many elements we encounter.
-    let count = 0;
-    const result = value.map((elem) => {
-      count++;
-      return this.encodeData(elem);
-    });
-
-    if (value.length !== count) {
-      // `Array.map()` skips holes, so a `length` / `count` mismatch
-      // occurs iff there is a hole.
-      throw new Error('API cannot encode arrays with holes.');
-    } else if (value.length !== Object.keys(value).length) {
-      // Since we know there are no holes (per above), the only way we
-      // could have a different number of keys than the array `length` is
-      // if there are additional named properties.
-      throw new Error('API cannot encode arrays with named properties.');
-    }
-
-    result.unshift(tag); // The specified "header" tag value.
-    return Object.freeze(result);
-  }
-
-  /**
    * Helper for `encodeData()` which validates and converts an object which is
-   * expected (and verified) to have API metainfo properties.
+   * expected (and verified) to be API-encodable.
    *
    * @param {object} value Value to convert.
    * @returns {object} The converted value.
    */
   _encodeInstance(value) {
-    const itemCodec = this._reg.codecForValue(value);
-    const encoded = itemCodec.encode(value);
+    const itemCodec      = this._reg.codecForValue(value);
+    const payload        = itemCodec.encode(value);
+    const encodedPayload = payload.map(this.encodeData.bind(this));
 
-    return this._encodeArray(encoded, itemCodec.tag);
+    // "Unshift" the item tag onto the encoded payload; that is, push on the
+    // front.
+    encodedPayload.unshift(itemCodec.tag);
+
+    return Object.freeze(encodedPayload);
   }
 }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -169,6 +169,12 @@ export default class ItemCodec extends CommonBase {
     }
 
     const result = this._encode(value);
-    return TArray.check(result);
+
+    try {
+      return TArray.check(result);
+    } catch (e) {
+      // Throw a higher-fidelity error.
+      throw new Error('Invalid encoding result (not an array).');
+    }
   }
 }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray, TClass, TFunction, TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 /**
  * Handler for API-codable items of a particular class, type, or (in general)
@@ -11,7 +12,7 @@ import { TArray, TClass, TFunction, TString } from 'typecheck';
  * constructing instances of them from (presumably) previously-derived
  * parameters.
  */
-export default class ItemCodec {
+export default class ItemCodec extends CommonBase {
   /**
    * Constructs an instance from a class that has the standard API-coding
    * methods.
@@ -53,6 +54,8 @@ export default class ItemCodec {
    *   equivalent to one that got encoded to produce the arguments it received.
    */
   constructor(tag, clazzOrType, predicate, encode, decode) {
+    super();
+
     /** {string} Tag (name) for the item's type. */
     this._tag = TString.nonempty(tag);
 

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -1,0 +1,171 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray, TClass, TFunction, TString } from 'typecheck';
+
+/**
+ * Handler for API-codable items of a particular class, type, or (in general)
+ * kind. This bundles the functionality of identifying codable values, naming
+ * them, deriving construction parameters from instances of them, and
+ * constructing instances of them from (presumably) previously-derived
+ * parameters.
+ */
+export default class ItemCodec {
+  /**
+   * Constructs an instance from a class that has the standard API-coding
+   * methods.
+   *
+   * @param {function} clazz Class (constructor function) to base the instance
+   *   on.
+   * @returns {ItemCodec} An appropriately-constructed instance.
+   */
+  static fromClass(clazz) {
+    TClass.check(clazz);
+    TFunction.check(clazz.prototype.toApi);
+
+    const tag = clazz.API_NAME || clazz.name;
+    const encode = (value) => { return value.toApi(); };
+    const decode = clazz.fromApi
+      ? TFunction.check(clazz.fromApi).bind(clazz)
+      : (...args) => { return new clazz(...args); };
+
+    return new ItemCodec(tag, clazz, null, encode, decode);
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} tag Tag (name) for the item's type. This must be unique
+   *   amongst all `ItemCodec`s using a given registry.
+   * @param {function|string} clazzOrType Either the class (constructor
+   *   function) which values must be exact instances of (not subclasses), or
+   *   the (string) name of the type (as in `typeof value`) which values must
+   *   be, in order to match this instance.
+   * @param {function|null} predicate Additional predicate that values must
+   *   satisfy in order to match this instance, or `null` if there are no
+   *   additional qualifications.
+   * @param {function} encode Encoder function, which accepts a single argument,
+   *   `value`, of a value to encode as this item type. It must return an array
+   *   of values which represent the construction parameters for the value.
+   * @param {function} decode Decoder function, which accepts the same arguments
+   *   that the `encode` function returned. It must return a value that is
+   *   equivalent to one that got encoded to produce the arguments it received.
+   */
+  constructor(tag, clazzOrType, predicate, encode, decode) {
+    /** {string} Tag (name) for the item's type. */
+    this._tag = TString.nonempty(tag);
+
+    /**
+     * {function|null} The class (constructor function) which identifies
+     * qualified values, or `null` if qualified values aren't objects.
+     */
+    this._clazz = ((typeof clazzOrType) === 'function')
+      ? TClass.check(clazzOrType)
+      : null;
+
+    /** {string} Name of the type which identifies qualified values. */
+    this._type = (this._clazz !== null) ? 'object' : TString.check(clazzOrType);
+
+    /**
+     * {function|null} Additional predicate that must be `true` of values for
+     * them to qualify, if any.
+     */
+    this._predicate = TFunction.orNull(predicate);
+
+    /** {function} Value encoder function. */
+    this._encode = TFunction.check(encode);
+
+    /** {function} Value decoder function. */
+    this._decode = TFunction.check(decode);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {function|null} The class (constructor function) which identifies
+   * qualified values, or `null` if qualified values aren't objects.
+   */
+  get clazz() {
+    return this._clazz;
+  }
+
+  /**
+   * {function|null} Additional predicate that must be `true` of values for them
+   * to qualify, if any.
+   */
+  get predicate() {
+    return this._predicate;
+  }
+
+  /** {string} Tag (name) for the item's type. */
+  get tag() {
+    return this._tag;
+  }
+
+  /** {string} Name of the type which identifies qualified values. */
+  get type() {
+    return this._type;
+  }
+
+  /**
+   * Determines whether or not this instance is applicable to the given value,
+   * that is, whether the value qualifies as being of this item's type/kind and
+   * so can be encoded by this instance.
+   *
+   * @param {*} value Value to check.
+   * @returns {boolean} `true` if this instance can be used to encode `value`,
+   *   or `false` if not.
+   */
+  canEncode(value) {
+    if ((typeof value) !== this.type) {
+      return false;
+    }
+
+    if (this.clazz !== null) {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== this.clazz.prototype) {
+        return false;
+      }
+    }
+
+    return (this.predicate === null) || this.predicate(value);
+  }
+
+  /**
+   * Decodes the given arguments into a value which is equivalent to one that
+   * was previously encoded into those arguments using this instance.
+   *
+   * @param {...*} args Arguments which resulted from an earlier call to
+   *   `encode()` on this instance, or the equivalent thereto.
+   * @returns {*} A value for which `canEncode()` on this instance would return
+   *   `true`.
+   */
+  decode(...args) {
+    const result = this._decode(...args);
+
+    if (!this.canEncode(result)) {
+      throw new Error('Invalid result from decoder.');
+    }
+
+    return result;
+  }
+
+  /**
+   * Encodes the given value into arguments suitable for later passing to
+   * `decode()` on this instance.
+   *
+   * @param {*} value Value to encode. It is only valid to pass a value for
+   *   which `canEncode()` would have returned `true`.
+   * @returns {array<*>} Array of arguments suitable for passing to `decode()`
+   *   on this instance.
+   */
+  encode(value) {
+    if (!this.canEncode(value)) {
+      throw new Error('Attempt to encode invalid value.');
+    }
+
+    const result = this._encode(value);
+    return TArray.check(result);
+  }
+}

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -2,22 +2,21 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TFunction, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
-/** {string} The "class" tag used for regular arrays. */
-const ARRAY_TAG = 'array';
+import ItemCodec from './ItemCodec';
+
+/** {ItemCodec} Item codec for arrays. */
+const ARRAY_CODEC = new ItemCodec('array', Array, null,
+  (value => value),
+  ((...args) => args)
+);
 
 /**
- * Methods for registering and looking up classes by name. The names are what
- * are how classes are identified when encoding and decoding instances on
+ * Methods for registering and looking up item codecs by name. The names are
+ * how classes/types are identified when encoding and decoding instances on
  * the wire (for API transmission and receipt, and for storage to disk or in
  * a database).
- *
- * Every class registered through this mechanism must define a property
- * `API_NAME` and a static method `fromApi()`. In addition, instances to be
- * encoded must define a method `toApi()`. These are all used as described
- * elsewhere in this module.
  */
 export default class Regsitry extends CommonBase {
   /**
@@ -27,47 +26,71 @@ export default class Regsitry extends CommonBase {
     super();
 
     /**
-     * Map of registered class names to their respective classes. **Note:** The
-     * constructor argument prevents the `array` tag from getting improperly
-     * registered (by client code).
+     * {Map<string,ItemCodec>} Map of registered names to their respective
+     * item codecs.
+     *
+     * **Note:** The constructor argument here initializes the registry with the
+     * handler for arrays, which both enables its usage and prevents it from
+     * getting improperly registered by client code.
      */
-    this._registry = new Map([[ARRAY_TAG, null]]);
+    this._registry = new Map([[ARRAY_CODEC.name, ARRAY_CODEC]]);
   }
 
-  /** {string} The "class" tag used for regular arrays. */
+  /** {string} The item tag used for regular arrays. */
   get arrayTag() {
-    return ARRAY_TAG;
+    return ARRAY_CODEC.tag;
   }
 
   /**
-   * Registers a class to be accepted for API use.
+   * Registers a class to be accepted for API use. To be valid, a class must
+   * define an instance method `toApi()`. In addition, it can optionally
+   * define a static property `API_NAME` as a replacement for its class name
+   * for use as the tag when encoding; and optionally define a static method
+   * `fromApi()` to override the default of using the class's constructor when
+   * decoding.
    *
    * @param {object} clazz The class to register.
    */
   registerClass(clazz) {
-    const apiName = TString.check(clazz.API_NAME);
-    TFunction.check(clazz.fromApi);
-    TFunction.check(clazz.prototype.toApi);
+    const itemCodec = ItemCodec.fromClass(clazz);
+    const tag       = itemCodec.tag;
 
-    if (this._registry.get(apiName)) {
-      throw new Error(`Cannot re-register class name \`${apiName}\`.`);
+    if (this._registry.get(tag)) {
+      throw new Error(`Cannot re-register tag \`${tag}\`.`);
     }
 
-    this._registry.set(apiName, clazz);
+    this._registry.set(tag, itemCodec);
   }
 
   /**
-   * Finds a previously-registered class by name. This throws an error if there
-   * is no registered class with the given name.
+   * Finds a previously-registered class by tag (name). This throws an error if
+   * there is no registered class with the given tag.
    *
-   * @param {string} name The class name.
+   * @param {string} tag The item codec tag (name).
    * @returns {class} The class that was registered under the given name.
    */
-  classForName(name) {
-    const result = this._registry.get(name);
+  classForName(tag) {
+    const result = this.codecForTag(tag);
+
+    if (!(result.clazz && !result.predicate)) {
+      throw new Error(`No class registered with tag \`${tag}\`.`);
+    }
+
+    return result.clazz;
+  }
+
+  /**
+   * Finds a previously-registered item codec by tag (name). This throws an
+   * error if there is no codec registered with the given tag.
+   *
+   * @param {string} tag The item codec tag (name).
+   * @returns {ItemCodec} The codec that was registered under the given name.
+   */
+  codecForTag(tag) {
+    const result = this._registry.get(tag);
 
     if (!result) {
-      throw new Error(`No class registered with name \`${name}\`.`);
+      throw new Error(`No codec registered with tag \`${tag}\`.`);
     }
 
     return result;

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -24,7 +24,7 @@ export default class Registry extends CommonBase {
      * {Map<string,ItemCodec>} Map of registered item tags to their respective
      * item codecs.
      */
-    this._registry = new Map();
+    this._tagToCodec = new Map();
 
     /**
      * {Map<class,array<ItemCodec>>} Map of classes that have `ItemCodec`s
@@ -32,7 +32,7 @@ export default class Registry extends CommonBase {
      * one is that some classes can be encoded multiple ways, with the multiple
      * `ItemCodec`'s `predicate`s determining which one applies.
      */
-    this._classes = new Map();
+    this._classToCodecs = new Map();
 
     // Register the array codec, which both enables its usage and prevents it
     // from getting improperly registered by client code.
@@ -68,19 +68,19 @@ export default class Registry extends CommonBase {
       // For now, we only allow registration of class/instance codecs.
       // **TODO:** Allow other types.
       throw new Error(`Cannot register non-object type \`${codec.type}\`.`);
-    } else if (this._registry.get(tag)) {
+    } else if (this._tagToCodec.get(tag)) {
       throw new Error(`Cannot re-register tag \`${tag}\`.`);
     }
 
-    this._registry.set(codec.tag, codec);
+    this._tagToCodec.set(codec.tag, codec);
 
-    let forClass = this._classes.get(clazz);
-    if (!forClass) {
-      forClass = [];
-      this._classes.set(clazz, forClass);
+    let codecs = this._classToCodecs.get(clazz);
+    if (!codecs) {
+      codecs = [];
+      this._classToCodecs.set(clazz, codecs);
     }
 
-    forClass.push(codec);
+    codecs.push(codec);
   }
 
   /**
@@ -101,7 +101,7 @@ export default class Registry extends CommonBase {
     }
 
     const clazz = value.constructor;
-    const codecs = this._classes.get(clazz);
+    const codecs = this._classToCodecs.get(clazz);
 
     if (!codecs) {
       throw new Error(`No codec registered for class \`${clazz.name}\`.`);
@@ -129,7 +129,7 @@ export default class Registry extends CommonBase {
    * @returns {ItemCodec} The codec that was registered under the given name.
    */
   codecForTag(tag) {
-    const result = this._registry.get(tag);
+    const result = this._tagToCodec.get(tag);
 
     if (!result) {
       throw new Error(`No codec registered with tag \`${tag}\`.`);

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -5,18 +5,7 @@
 import { CommonBase } from 'util-common';
 
 import ItemCodec from './ItemCodec';
-
-/**
- * {ItemCodec} Item codec for arrays.
- *
- * **TODO:** This is not yet complete, but it is also not hooked up for actual
- * usage yet (because both `Encoder` and `Decoder` have an explicit special
- * case for arrays). Both of these facts should be rectified.
- */
-const ARRAY_CODEC = new ItemCodec('array', Array, null,
-  (value => value),
-  ((...args) => args)
-);
+import SpecialCodecs from './SpecialCodecs';
 
 /**
  * Methods for registering and looking up item codecs by name. The names are
@@ -46,13 +35,14 @@ export default class Registry extends CommonBase {
     this._classes = new Map();
 
     // Register the array codec, which both enables its usage and prevents it
-    // from getting improperly registered by client code.
-    this.registerCodec(ARRAY_CODEC);
+    // from getting improperly registered by client code. **TODO:** It is not
+    // actually used for encoding and decoding yet, and it should be.
+    this.registerCodec(SpecialCodecs.ARRAY);
   }
 
   /** {string} The item tag used for regular arrays. */
   get arrayTag() {
-    return ARRAY_CODEC.tag;
+    return SpecialCodecs.ARRAY.tag;
   }
 
   /**

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -35,14 +35,8 @@ export default class Registry extends CommonBase {
     this._classes = new Map();
 
     // Register the array codec, which both enables its usage and prevents it
-    // from getting improperly registered by client code. **TODO:** It is not
-    // actually used for encoding and decoding yet, and it should be.
+    // from getting improperly registered by client code.
     this.registerCodec(SpecialCodecs.ARRAY);
-  }
-
-  /** {string} The item tag used for regular arrays. */
-  get arrayTag() {
-    return SpecialCodecs.ARRAY.tag;
   }
 
   /**

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -94,23 +94,6 @@ export default class Regsitry extends CommonBase {
   }
 
   /**
-   * Finds a previously-registered class by tag (name). This throws an error if
-   * there is no registered class with the given tag.
-   *
-   * @param {string} tag The item codec tag (name).
-   * @returns {class} The class that was registered under the given name.
-   */
-  classForName(tag) {
-    const result = this.codecForTag(tag);
-
-    if (!(result.clazz && !result.predicate)) {
-      throw new Error(`No class registered with tag \`${tag}\`.`);
-    }
-
-    return result.clazz;
-  }
-
-  /**
    * Finds a previously-registered item codec which is suitable for encoding the
    * given value. This throws an error if there is no suitable codec or if there
    * is more than one suitable codec.

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -24,7 +24,7 @@ const ARRAY_CODEC = new ItemCodec('array', Array, null,
  * the wire (for API transmission and receipt, and for storage to disk or in
  * a database).
  */
-export default class Regsitry extends CommonBase {
+export default class Registry extends CommonBase {
   /**
    * Constructs the instance.
    */

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -6,7 +6,13 @@ import { CommonBase } from 'util-common';
 
 import ItemCodec from './ItemCodec';
 
-/** {ItemCodec} Item codec for arrays. */
+/**
+ * {ItemCodec} Item codec for arrays.
+ *
+ * **TODO:** This is not yet complete, but it is also not hooked up for actual
+ * usage yet (because both `Encoder` and `Decoder` have an explicit special
+ * case for arrays). Both of these facts should be rectified.
+ */
 const ARRAY_CODEC = new ItemCodec('array', Array, null,
   (value => value),
   ((...args) => args)

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -20,12 +20,13 @@ export default class SpecialCodecs extends UtilityClass {
   /**
    * Decodes an array.
    *
-   * @param {array<*>} args Arguments as previously produced by `arrayEncode()`.
+   * @param {array<*>} payload Construction payload as previously produced by
+   *   `arrayEncode()`.
    * @returns {array<*>} Decoded array.
    */
-  static arrayDecode(args) {
+  static arrayDecode(payload) {
     // The array payload is self-representative. Easy!
-    return args;
+    return payload;
   }
 
   /**

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -13,8 +13,8 @@ import ItemCodec from './ItemCodec';
 export default class SpecialCodecs extends UtilityClass {
   /** {ItemCodec} Codec used for coding arrays. */
   static get ARRAY() {
-    return new ItemCodec('array', Array, this.arrayPredicate,
-      this.arrayEncode, this.arrayDecode);
+    return new ItemCodec('array', Array, this._arrayPredicate,
+      this._arrayEncode, this._arrayDecode);
   }
 
   /**
@@ -24,7 +24,7 @@ export default class SpecialCodecs extends UtilityClass {
    *   `arrayEncode()`.
    * @returns {array<*>} Decoded array.
    */
-  static arrayDecode(payload) {
+  static _arrayDecode(payload) {
     // The array payload is self-representative. Easy!
     return payload;
   }
@@ -35,7 +35,7 @@ export default class SpecialCodecs extends UtilityClass {
    * @param {array<*>} value Array to encode.
    * @returns {array<*>} Encoded form.
    */
-  static arrayEncode(value) {
+  static _arrayEncode(value) {
     // Because of how the calling code operates, we know that by the time we get
     // here, `value` has passed `arrayPredicate()`. This means that all we have
     // to do is return the `value` itself. The one twist is that the coding
@@ -50,7 +50,7 @@ export default class SpecialCodecs extends UtilityClass {
    * @param {array<*>} value Array to encode.
    * @returns {boolean} `true` iff `value` can be encoded.
    */
-  static arrayPredicate(value) {
+  static _arrayPredicate(value) {
     // Check for `undefined` in the indexed properties. If we find one, then
     // either it's an explicit `undefined` or it's a hole; in either case, the
     // array is not encodable.

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -1,0 +1,72 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from 'util-common';
+
+import ItemCodec from './ItemCodec';
+
+/**
+ * Utility class which holds special `ItemCodec`s (that is, ones that aren't
+ * straightforward coders for class instances).
+ */
+export default class SpecialCodecs extends UtilityClass {
+  /** {ItemCodec} Codec used for coding arrays. */
+  static get ARRAY() {
+    return new ItemCodec('array', Array, this.arrayPredicate,
+      this.arrayEncode, this.arrayDecode);
+  }
+
+  /**
+   * Decodes an array.
+   *
+   * @param {array<*>} args Arguments as previously produced by `arrayEncode()`.
+   * @returns {array<*>} Decoded array.
+   */
+  static arrayDecode(args) {
+    // The array payload is self-representative. Easy!
+    return args;
+  }
+
+  /**
+   * Encodes an array.
+   *
+   * @param {array<*>} value Array to encode.
+   * @returns {array<*>} Encoded form.
+   */
+  static arrayEncode(value) {
+    // Because of how the calling code operates, we know that by the time we get
+    // here, `value` has passed `arrayPredicate()`. This means that all we have
+    // to do is return the `value` itself. The one twist is that the coding
+    // logic may want to alter the return value, so we can't return the same
+    // exact object; but we _can_ just return a simple shallow copy.
+    return value.slice();
+  }
+
+  /**
+   * Checks an array for encodability.
+   *
+   * @param {array<*>} value Array to encode.
+   * @returns {boolean} `true` iff `value` can be encoded.
+   */
+  static arrayPredicate(value) {
+    // Check for `undefined` in the indexed properties. If we find one, then
+    // either it's an explicit `undefined` or it's a hole; in either case, the
+    // array is not encodable.
+    for (const e of value) {
+      if (e === undefined) {
+        return false;
+      }
+    }
+
+    // Since we know there are no holes (per above), the only way we could have
+    // a different number of keys than the array `length` is if there are
+    // additional named (non-indexed) properties. If this is the case, then the
+    // array is not encodable.
+    if (value.length !== Object.keys(value).length) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -4,6 +4,7 @@
 
 import BaseKey from './BaseKey';
 import Codec from './Codec';
+import ItemCodec from './ItemCodec';
 import Message from './Message';
 import SplitKey from './SplitKey';
 
@@ -11,4 +12,4 @@ import SplitKey from './SplitKey';
 Codec.theOne.registerClass(Message);
 Codec.theOne.registerClass(SplitKey);
 
-export { BaseKey, Codec, Message, SplitKey };
+export { BaseKey, Codec, ItemCodec, Message, SplitKey };

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -60,13 +60,6 @@ class NoFromApi {
 }
 
 describe('api-common/Registry', () => {
-  describe('.arrayTag', () => {
-    it("should return 'array'", () => {
-      const reg = new Registry();
-      assert.strictEqual(reg.arrayTag, 'array');
-    });
-  });
-
   describe('register(class)', () => {
     it('should accept a class with all salient properties', () => {
       const reg = new Registry();

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -68,7 +68,23 @@ describe('api-common/Registry', () => {
   });
 
   describe('register(class)', () => {
-    it('should require classes with an APP_NAME property, fromName() class method, and toApi() instance method', () => {
+    it('should accept a class with all salient properties', () => {
+      const reg = new Registry();
+      assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
+    });
+
+    it('should allow classes without `API_NAME` or `fromApi()`', () => {
+      const reg = new Registry();
+      assert.doesNotThrow(() => reg.registerClass(NoApiName));
+      assert.doesNotThrow(() => reg.registerClass(NoFromApi));
+    });
+
+    it('should reject a class without `toApi()`', () => {
+      const reg = new Registry();
+      assert.throws(() => reg.registerClass(NoToApi));
+    });
+
+    it('should reject non-classes', () => {
       const reg = new Registry();
       assert.throws(() => reg.registerClass(true));
       assert.throws(() => reg.registerClass(37));
@@ -77,11 +93,6 @@ describe('api-common/Registry', () => {
       assert.throws(() => reg.registerClass([]));
       assert.throws(() => reg.registerClass(null));
       assert.throws(() => reg.registerClass(undefined));
-      assert.throws(() => reg.registerClass(NoApiName));
-      assert.throws(() => reg.registerClass(NoToApi));
-      assert.throws(() => reg.registerClass(NoFromApi));
-
-      assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
     });
   });
 

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -4,7 +4,8 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
-import { Random } from 'util-common';
+
+import { ItemCodec } from 'api-common';
 
 // The class being tested here isn't exported from the module, so we import it
 // by path.
@@ -25,24 +26,6 @@ class RegistryTestApiObject {
 
   static fromApi(arguments_unused) {
     return new RegistryTestApiObject();
-  }
-}
-
-class FindTestApiObject {
-  constructor() {
-    this.initialized = true;
-  }
-
-  static get API_NAME() {
-    return 'FindTestApiObject';
-  }
-
-  toApi() {
-    return ['fake argument', 0, 1, 2];
-  }
-
-  static fromApi(arguments_unused) {
-    return new FindTestApiObject();
   }
 }
 
@@ -102,21 +85,20 @@ describe('api-common/Registry', () => {
     });
   });
 
-  describe('find(className)', () => {
-    it('should throw an error if an unregistered class is requested', () => {
+  describe('codecForTag(tag)', () => {
+    it('should throw an error if an unregistered tag is requested', () => {
       const reg = new Registry();
-      const randomName = Random.hexByteString(32);
-      assert.throws(() => reg.classForName(randomName));
+      assert.throws(() => reg.codecForTag('florp'));
     });
 
-    it('should return the named class if it is registered', () => {
+    it('should return the named codec if it is registered', () => {
       const reg = new Registry();
-      reg.registerClass(FindTestApiObject);
+      const itemCodec = new ItemCodec('florp', Boolean, null, () => 0, () => 0);
 
-      const testClass = reg.classForName(FindTestApiObject.API_NAME);
-      const testObject = new testClass();
+      reg.registerCodec(itemCodec);
 
-      assert.instanceOf(testObject, FindTestApiObject);
+      const testCodec = reg.codecForTag('florp');
+      assert.strictEqual(testCodec, itemCodec);
     });
   });
 });

--- a/local-modules/typecheck/TClass.js
+++ b/local-modules/typecheck/TClass.js
@@ -1,0 +1,28 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from 'util-common-base';
+
+import TypeError from './TypeError';
+
+/**
+ * Type checker for type `Class`. A "class" is simply a function that can be
+ * used as an object constructor.
+ */
+export default class TClass extends UtilityClass {
+  /**
+   * Checks a value of type `Class`.
+   *
+   * @param {*} value The (alleged) class.
+   * @returns {Class} `value`.
+   */
+  static check(value) {
+    if (   ((typeof value) !== 'function')
+        || ((typeof value.prototype) !== 'object')) {
+      return TypeError.badValue(value, 'Class');
+    }
+
+    return value;
+  }
+}

--- a/local-modules/typecheck/TFunction.js
+++ b/local-modules/typecheck/TFunction.js
@@ -7,18 +7,33 @@ import { UtilityClass } from 'util-common-base';
 import TypeError from './TypeError';
 
 /**
- * Type checker for type `Function`.
+ * Type checker for type `function`.
  */
 export default class TFunction extends UtilityClass {
   /**
    * Checks a value of type `Function`.
    *
    * @param {*} value The (alleged) function.
-   * @returns {Function} `value`.
+   * @returns {function} `value`.
    */
   static check(value) {
     if (typeof value !== 'function') {
-      return TypeError.badValue(value, 'Function');
+      return TypeError.badValue(value, 'function');
+    }
+
+    return value;
+  }
+
+  /**
+   * Checks a value which must either be of type `Function` or the exact value
+   * `null`.
+   *
+   * @param {*} value Value to check.
+   * @returns {function|null} `value`.
+   */
+  static orNull(value) {
+    if ((value !== null) && (typeof value !== 'function')) {
+      return TypeError.badValue(value, 'function|null');
     }
 
     return value;

--- a/local-modules/typecheck/main.js
+++ b/local-modules/typecheck/main.js
@@ -5,6 +5,7 @@
 import TArray from './TArray';
 import TBoolean from './TBoolean';
 import TBuffer from './TBuffer';
+import TClass from './TClass';
 import TFunction from './TFunction';
 import TInt from './TInt';
 import TMap from './TMap';
@@ -16,6 +17,7 @@ export {
   TArray,
   TBoolean,
   TBuffer,
+  TClass,
   TFunction,
   TInt,
   TMap,


### PR DESCRIPTION
This PR introduces a new class `ItemCodec` to be the bottleneck through which values get encoded and decoded. Each instance represents a different class (or slice of a class), and ultimately it will also be able to be used for the coding of non-object values.

There is a static constructor method, `ItemCodec.fromClass()`, which derives an instance from a class, taking into account the standard properties `toApi()`, `fromApi()`, and `API_NAME`, the latter two of which are now optional (defaulting to the constructor and the class name, respectively). This latter bit is the simplification enabler alluded to in the subject line above. This also avoids having to re-(re-)check classes for compatibility with each encode or decode.

As of this PR, `ItemCodec` is used, but not as deeply as it could be, and I also didn't do any simplification at the use sites; that will come with a later PR.