### PR TITLE
Perform earlier-promised boilerplate removal.

### DIFF
--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -133,7 +133,7 @@ export default class BaseKey extends CommonBase {
    * @returns {string} The redacted form.
    */
   toString() {
-    const name = this.constructor.API_TAG || this.constructor.name;
-    return `{${name} ${this._url} ${this._impl_printableId()}}`;
+    const tag = this.constructor.API_TAG || this.constructor.name;
+    return `{${tag} ${this._url} ${this._impl_printableId()}}`;
   }
 }

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -133,7 +133,7 @@ export default class BaseKey extends CommonBase {
    * @returns {string} The redacted form.
    */
   toString() {
-    const name = this.constructor.API_NAME || this.constructor.name;
+    const name = this.constructor.API_TAG || this.constructor.name;
     return `{${name} ${this._url} ${this._impl_printableId()}}`;
   }
 }

--- a/local-modules/api-common/Codec.js
+++ b/local-modules/api-common/Codec.js
@@ -106,7 +106,7 @@ export default class Codec extends Singleton {
    *   with an additional first element of the value `SpecialCodec.ARRAY.tag`.
    * * Objects that are instances of classes (that is, have constructor
    *   functions) are allowed, as long as they at least bind a method `toApi()`.
-   *   In addition, if they have a static `API_NAME` property and/or a static
+   *   In addition, if they have a static `API_TAG` property and/or a static
    *   `fromApi()` method, those are used. See `ItemCodec` for how these are all
    *   used to effect encoding and decoding. The encoded form is an array with
    *   the first element being the value tag (typically the class name) and the

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -29,7 +29,7 @@ export default class ItemCodec extends CommonBase {
       TFunction.check(clazz.fromApi);
     }
 
-    const tag = clazz.API_NAME || clazz.name;
+    const tag = clazz.API_TAG || clazz.name;
     const encode = (value) => { return value.toApi(); };
     const decode = clazz.fromApi
       ? (payload) => { return clazz.fromApi(...payload); }

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -72,11 +72,6 @@ export default class Message {
     Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
-  static get API_NAME() {
-    return 'Message';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -102,20 +102,6 @@ export default class Message {
   }
 
   /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} id Same as with the regular constructor.
-   * @param {string} target Same as with the regular constructor.
-   * @param {string} action Same as with the regular constructor.
-   * @param {string} name Same as with the regular constructor.
-   * @param {Array<*>} args Same as with the regular constructor.
-   * @returns {Message} The constructed instance.
-   */
-  static fromApi(id, target, action, name, args) {
-    return new Message(id, target, action, name, args);
-  }
-
-  /**
    * Indicates whether this instance represents an error.
    *
    * @returns {boolean} `true` iff this is an error instance.

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -42,7 +42,7 @@ export default class Registry extends CommonBase {
   /**
    * Registers a class to be accepted for API use. To be valid, a class must
    * define an instance method `toApi()`. In addition, it can optionally
-   * define a static property `API_NAME` as a replacement for its class name
+   * define a static property `API_TAG` as a replacement for its class name
    * for use as the tag when encoding; and optionally define a static method
    * `fromApi()` to override the default of using the class's constructor when
    * decoding.

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -49,11 +49,6 @@ export default class SplitKey extends BaseKey {
     Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
-  static get API_NAME() {
-    return 'SplitKey';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -64,18 +64,6 @@ export default class SplitKey extends BaseKey {
   }
 
   /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {string} url Same as with the regular constructor.
-   * @param {string} id Same as with the regular constructor.
-   * @param {string} secret Same as with the regular constructor.
-   * @returns {SplitKey} The constructed instance.
-   */
-  static fromApi(url, id, secret) {
-    return new SplitKey(url, id, secret);
-  }
-
-  /**
    * {string} Shared secret. **Note:** It is important to _never_ reveal this
    * value across an unencrypted API boundary or to log it.
    */

--- a/local-modules/api-common/tests/MockApiObject.js
+++ b/local-modules/api-common/tests/MockApiObject.js
@@ -10,7 +10,7 @@ export default class MockApiObject {
     this.initialized = true;
   }
 
-  static get API_NAME() {
+  static get API_TAG() {
     return 'MockApiObject';
   }
 

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -18,7 +18,7 @@ class NoApiName {
 
 class NoToApi {
   constructor() {
-    this.API_NAME = 'NoToApi';
+    this.API_TAG = 'NoToApi';
   }
 }
 
@@ -75,7 +75,7 @@ describe('api-common/Encoder', () => {
       assert.throws(() => encodeData(value));
     });
 
-    it('should reject API objects with no API_NAME property', () => {
+    it('should reject API objects with no API_TAG property', () => {
       const noApiName = new NoApiName();
 
       assert.throws(() => encodeData(noApiName));
@@ -87,7 +87,7 @@ describe('api-common/Encoder', () => {
       assert.throws(() => encodeData(noToApi));
     });
 
-    it('should accept objects with an API_NAME property and toApi() method', () => {
+    it('should accept objects with an API_TAG property and toApi() method', () => {
       const fakeObject = new MockApiObject();
 
       assert.doesNotThrow(() => encodeData(fakeObject));

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -10,9 +10,9 @@ import { Codec } from 'api-common';
 
 import MockApiObject from './MockApiObject';
 
-class NoApiName {
+class NoApiTag {
   toApi() {
-    return 'NoApiName!';
+    return 'NoApiTag!';
   }
 }
 
@@ -76,9 +76,9 @@ describe('api-common/Encoder', () => {
     });
 
     it('should reject API objects with no API_TAG property', () => {
-      const noApiName = new NoApiName();
+      const NoApiTag = new NoApiTag();
 
-      assert.throws(() => encodeData(noApiName));
+      assert.throws(() => encodeData(NoApiTag));
     });
 
     it('should reject API objects with no toApi() method', () => {

--- a/local-modules/api-common/tests/test_Codec_encode.js
+++ b/local-modules/api-common/tests/test_Codec_encode.js
@@ -76,9 +76,9 @@ describe('api-common/Encoder', () => {
     });
 
     it('should reject API objects with no API_TAG property', () => {
-      const NoApiTag = new NoApiTag();
+      const noApiTag = new NoApiTag();
 
-      assert.throws(() => encodeData(NoApiTag));
+      assert.throws(() => encodeData(noApiTag));
     });
 
     it('should reject API objects with no toApi() method', () => {

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -16,7 +16,7 @@ class RegistryTestApiObject {
     this.initialized = true;
   }
 
-  static get API_NAME() {
+  static get API_TAG() {
     return 'RegistryTestApiObject';
   }
 
@@ -41,7 +41,7 @@ class NoApiName {
 
 class NoToApi {
   constructor() {
-    this.API_NAME = 'NoToApi';
+    this.API_TAG = 'NoToApi';
   }
 
   static fromApi() {
@@ -51,7 +51,7 @@ class NoToApi {
 
 class NoFromApi {
   constructor() {
-    this.API_NAME = 'NoFromApi';
+    this.API_TAG = 'NoFromApi';
   }
 
   toApi() {
@@ -66,7 +66,7 @@ describe('api-common/Registry', () => {
       assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
     });
 
-    it('should allow classes without `API_NAME` or `fromApi()`', () => {
+    it('should allow classes without `API_TAG` or `fromApi()`', () => {
       const reg = new Registry();
       assert.doesNotThrow(() => reg.registerClass(NoApiName));
       assert.doesNotThrow(() => reg.registerClass(NoFromApi));

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -29,13 +29,13 @@ class RegistryTestApiObject {
   }
 }
 
-class NoApiName {
+class NoApiTag {
   toApi() {
-    return 'NoApiName!';
+    return 'NoApiTag!';
   }
 
   static fromApi() {
-    return new NoApiName();
+    return new NoApiTag();
   }
 }
 
@@ -68,7 +68,7 @@ describe('api-common/Registry', () => {
 
     it('should allow classes without `API_TAG` or `fromApi()`', () => {
       const reg = new Registry();
-      assert.doesNotThrow(() => reg.registerClass(NoApiName));
+      assert.doesNotThrow(() => reg.registerClass(NoApiTag));
       assert.doesNotThrow(() => reg.registerClass(NoFromApi));
     });
 

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -23,11 +23,6 @@ export default class Caret extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'Caret';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -36,13 +36,4 @@ export default class Caret extends CommonBase {
   toApi() {
     return [];
   }
-
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @returns {Caret} The constructed instance.
-   */
-  static fromApi() {
-    return new Caret();
-  }
 }

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -49,17 +49,6 @@ export default class CaretDelta extends CommonBase {
     return [this._revNum, this._ops];
   }
 
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} revNum Same as with the regular constructor.
-   * @param {array<object>} ops Same as with the regular constructor.
-   * @returns {CaretDelta} The constructed instance.
-   */
-  static fromApi(revNum, ops) {
-    return new CaretDelta(revNum, ops);
-  }
-
   /** {Int} The produced revision number. */
   get revNum() {
     return this._revNum;

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -35,11 +35,6 @@ export default class CaretDelta extends CommonBase {
     this._ops = Object.freeze(TArray.check(ops));
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'CaretDelta';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -37,11 +37,6 @@ export default class CaretSnapshot extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'CaretSnapshot';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -52,18 +52,6 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} revNum Same as with the regular constructor.
-   * @param {Int} docRevNum Same as with the regular constructor.
-   * @param {array<Caret>} carets Same as with the regular constructor.
-   * @returns {CaretSnapshot} The constructed instance.
-   */
-  static fromApi(revNum, docRevNum, carets) {
-    return new CaretSnapshot(revNum, docRevNum, carets);
-  }
-
-  /**
    * {Int} The document revision number to which the caret information applies.
    */
   get docRevNum() {

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -77,19 +77,6 @@ export default class DocumentChange extends DocumentDelta {
   }
 
   /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} revNum Same as with the regular constructor.
-   * @param {Delta|array|object} delta Same as with the regular constructor.
-   * @param {Timestamp} timestamp Same as with the regular constructor.
-   * @param {string|null} authorId Same as with the regular constructor.
-   * @returns {DocumentChange} The constructed instance.
-   */
-  static fromApi(revNum, delta, timestamp, authorId) {
-    return new DocumentChange(revNum, delta, timestamp, authorId);
-  }
-
-  /**
    * {string|null} The author ID string, or `null` if the change is authorless.
    */
   get authorId() {

--- a/local-modules/doc-common/DocumentChange.js
+++ b/local-modules/doc-common/DocumentChange.js
@@ -62,11 +62,6 @@ export default class DocumentChange extends DocumentDelta {
       });
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'DocumentChange';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/DocumentDelta.js
+++ b/local-modules/doc-common/DocumentDelta.js
@@ -65,17 +65,6 @@ export default class DocumentDelta extends CommonBase {
     return [this._revNum, this._delta];
   }
 
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} revNum Same as with the regular constructor.
-   * @param {FrozenDelta} delta Same as with the regular constructor.
-   * @returns {DocumentDelta} The constructed instance.
-   */
-  static fromApi(revNum, delta) {
-    return new DocumentDelta(revNum, delta);
-  }
-
   /** {Int} The produced revision number. */
   get revNum() {
     return this._revNum;

--- a/local-modules/doc-common/DocumentDelta.js
+++ b/local-modules/doc-common/DocumentDelta.js
@@ -51,11 +51,6 @@ export default class DocumentDelta extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'DocumentDelta';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -81,17 +81,6 @@ export default class DocumentSnapshot extends CommonBase {
     return [this._revNum, this._contents];
   }
 
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {number} revNum Same as regular constructor.
-   * @param {Delta|array|object} contents Same as regular constructor.
-   * @returns {DocumentSnapshot} The constructed instance.
-   */
-  static fromApi(revNum, contents) {
-    return new DocumentSnapshot(revNum, contents);
-  }
-
   /** {RevisionNumber} The revision number. */
   get revNum() {
     return this._revNum;

--- a/local-modules/doc-common/DocumentSnapshot.js
+++ b/local-modules/doc-common/DocumentSnapshot.js
@@ -67,11 +67,6 @@ export default class DocumentSnapshot extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {string} Name of this class in the API. */
-  static get API_NAME() {
-    return 'DocumentSnapshot';
-  }
-
   /**
    * Converts this instance for API transmission.
    *

--- a/local-modules/doc-common/FrozenDelta.js
+++ b/local-modules/doc-common/FrozenDelta.js
@@ -101,9 +101,9 @@ export default class FrozenDelta extends Delta {
   /**
    * Constructs an instance.
    *
-   * @param {Array} ops The transformation operations of this instance. If not
-   *   deeply frozen, the actual stored `ops` will be a deep-frozen clone of the
-   *   given value.
+   * @param {array<object>} ops The transformation operations of this instance.
+   *   If not deeply frozen, the actual stored `ops` will be a deep-frozen clone
+   *   of the given value.
    */
   constructor(ops) {
     // TODO: Should consider validating the contents of `ops`.
@@ -125,16 +125,6 @@ export default class FrozenDelta extends Delta {
    */
   toApi() {
     return [this.ops];
-  }
-
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {array} ops Same as with the regular constructor.
-   * @returns {FrozenDelta} The constructed instance.
-   */
-  static fromApi(ops) {
-    return new FrozenDelta(ops);
   }
 
   /**

--- a/local-modules/doc-common/FrozenDelta.js
+++ b/local-modules/doc-common/FrozenDelta.js
@@ -114,7 +114,7 @@ export default class FrozenDelta extends Delta {
   }
 
   /** Name of this class in the API. */
-  static get API_NAME() {
+  static get API_TAG() {
     return 'Delta';
   }
 

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -95,17 +95,6 @@ export default class Timestamp extends CommonBase {
     return [this._secs, this._usecs];
   }
 
-  /**
-   * Constructs an instance from API arguments.
-   *
-   * @param {Int} secs Same as regular constructor.
-   * @param {Int} usecs Same as regular constructor.
-   * @returns {Timestamp} The constructed instance.
-   */
-  static fromApi(secs, usecs) {
-    return new Timestamp(secs, usecs);
-  }
-
   /** The number of seconds since the Unix Epoch. */
   get secs() {
     return this._secs;

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -81,11 +81,6 @@ export default class Timestamp extends CommonBase {
     Object.freeze(this);
   }
 
-  /** Name of this class in the API. */
-  static get API_NAME() {
-    return 'Timestamp';
-  }
-
   /**
    * Converts this instance for API transmission.
    *


### PR DESCRIPTION
This PR removes `fromApi()` and `API_NAME` definitions in API-codable classes for which those definitions have become redundant. I also took the opportunity to rename `API_NAME` to `API_TAG`, as the latter is a closer match for the terminology used in the rest of the related code.