### PR TITLE
A second "special" codec, and affordances for the future.

### DIFF
--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -18,6 +18,9 @@ export default class Decoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
+
+    /** {function} Handy pre-bound version of `decodeData()`. */
+    this._decodeData = this.decodeData.bind(this);
   }
 
   /**
@@ -85,9 +88,7 @@ export default class Decoder extends CommonBase {
     }
 
     const itemCodec = this._reg.codecForTag(tag);
-    const decodedPayload =
-      Object.freeze(payload.map(this.decodeData.bind(this)));
 
-    return itemCodec.decode(decodedPayload);
+    return itemCodec.decode(payload, this._decodeData);
   }
 }

--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -4,6 +4,8 @@
 
 import { CommonBase } from 'util-common';
 
+import ItemCodec from './ItemCodec';
+
 /**
  * Main implementation of `Codec.decodeData()`.
  */
@@ -37,12 +39,10 @@ export default class Decoder extends CommonBase {
     } else if ((type !== 'object') || (value === null)) {
       // Pass through as-is.
       return value;
-    } else if (Object.getPrototypeOf(value) === Object.prototype) {
-      return this._decodeSimpleObject(value);
-    } else if (!Array.isArray(value)) {
-      throw new Error(`API cannot decode object of class \`${value.constructor.name}\`.`);
-    } else {
+    } else if (Array.isArray(value)) {
       return this._decodeInstance(value);
+    } else {
+      return this._decodeNonInstance(value);
     }
   }
 
@@ -52,14 +52,11 @@ export default class Decoder extends CommonBase {
    * @param {object} encoded The encoded value.
    * @returns {object} The decoded value.
    */
-  _decodeSimpleObject(encoded) {
-    const result = {};
+  _decodeNonInstance(encoded) {
+    const itemCodec =
+      this._reg.codecForTag(ItemCodec.tagFromType(typeof encoded));
 
-    for (const k in encoded) {
-      result[k] = this.decodeData(encoded[k]);
-    }
-
-    return Object.freeze(result);
+    return itemCodec.decode(encoded, this._decodeData);
   }
 
   /**

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -39,50 +39,14 @@ export default class Encoder extends CommonBase {
       }
 
       case 'object': {
-        if (value === null) {
-          // Pass through as-is.
-          return value;
-        }
-
-        const proto = Object.getPrototypeOf(value);
-
-        if (proto === Object.prototype) {
-          return this._encodeSimpleObject(value);
-        } else {
-          // It had better be a value whose class/type is registered, but if
-          // not, then this call will throw.
-          return this._encodeInstance(value);
-        }
+        // Pass `null` through as-is, and attempt to encode anything else.
+        return (value === null) ? null : this._encodeInstance(value);
       }
 
       default: {
         throw new Error(`API cannot encode type \`${typeof value}\`.`);
       }
     }
-  }
-
-  /**
-   * Helper for `encodeData()` which validates and converts a simple object.
-   *
-   * @param {object} value Value to convert.
-   * @returns {object} The converted value.
-   */
-  _encodeSimpleObject(value) {
-    const result = {};
-
-    // Iterate over all the properties in `value`, encoding the values and
-    // noticing (and rejecting the value) if there are any synthetic properties.
-    for (const k of Object.getOwnPropertyNames(value)) {
-      const prop = Object.getOwnPropertyDescriptor(value, k);
-
-      if ((prop.get !== undefined) || (prop.set !== undefined)) {
-        throw new Error('API cannot encode plain object with synthetic property.');
-      }
-
-      result[k] = this.encodeData(prop.value);
-    }
-
-    return Object.freeze(result);
   }
 
   /**
@@ -96,9 +60,15 @@ export default class Encoder extends CommonBase {
     const itemCodec = this._reg.codecForValue(value);
     const payload   = itemCodec.encode(value, this._encodeData);
 
-    // "Unshift" the item tag onto the encoded payload; that is, push on the
-    // front.
-    payload.unshift(itemCodec.tag);
+    if (Array.isArray(payload)) {
+      // "Unshift" the item tag onto the encoded payload; that is, push on the
+      // front.
+      payload.unshift(itemCodec.tag);
+    }
+
+    // **Note:** If `payload` isn't an array, that means that its not in
+    // "construction arguments" form. In that case its "tag" is implicit in the
+    // type of the value.
 
     return Object.freeze(payload);
   }

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -18,6 +18,9 @@ export default class Encoder extends CommonBase {
 
     /** {Registry} Registry instance to use. */
     this._reg = reg;
+
+    /** {function} Handy pre-bound version of `encodeData()`. */
+    this._encodeData = this.encodeData.bind(this);
   }
 
   /**
@@ -90,14 +93,13 @@ export default class Encoder extends CommonBase {
    * @returns {object} The converted value.
    */
   _encodeInstance(value) {
-    const itemCodec      = this._reg.codecForValue(value);
-    const payload        = itemCodec.encode(value);
-    const encodedPayload = payload.map(this.encodeData.bind(this));
+    const itemCodec = this._reg.codecForValue(value);
+    const payload   = itemCodec.encode(value, this._encodeData);
 
     // "Unshift" the item tag onto the encoded payload; that is, push on the
     // front.
-    encodedPayload.unshift(itemCodec.tag);
+    payload.unshift(itemCodec.tag);
 
-    return Object.freeze(encodedPayload);
+    return Object.freeze(payload);
   }
 }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -11,6 +11,23 @@ import { CommonBase } from 'util-common';
  * them, deriving construction parameters from instances of them, and
  * constructing instances of them from (presumably) previously-derived
  * parameters.
+ *
+ * The `decode` and `encode` arguments to the constructor are the "workhorses"
+ * of any instance. Each of these takes two parameters, the second of which is
+ * a function to recursively code any sub-components of the value in question:
+ *
+ * * `decode(payload, subDecode)` &mdash; `payload` is the payload to decode
+ *   into a value, and `subDecode(subPayload)` is a function to call on any
+ *   sub-components of the payload; it returns the decoded form of `subPayload`.
+ *   The overall return value from `decode` is a value that is (or is equivalent
+ *   to) one that was encoded via `encode` on this instance to produce the
+ *   received `payload`.
+ *
+ * * `encode(value, subEncode)` &mdash; `value` is the value to encode, and
+ *   `subEncode(subValue)` is a function to call on any sub-components of the
+ *   value; it returns the encoded form of `subValue`. The overall return value
+ *   from `encode` is a payload which is suitable for passing into `decode()`
+ *   on the same (or equivalent) item codec.
  */
 export default class ItemCodec extends CommonBase {
   /**
@@ -59,13 +76,10 @@ export default class ItemCodec extends CommonBase {
    * @param {function|null} predicate Additional predicate that values must
    *   satisfy in order to match this instance, or `null` if there are no
    *   additional qualifications.
-   * @param {function} encode Encoder function, which accepts a single argument,
-   *   `value`, of a value to encode as this item type. It must return an array
-   *   of values which represent the construction parameters for the value.
-   * @param {function} decode Decoder function, which accepts the same kinds of
-   *   value that the `encode` function returns (that is, an array of
-   *   construction parameters) . It must return a value that is equivalent to
-   *   one that got encoded to produce the payload it received.
+   * @param {function} encode Encoder function, as described in this class's
+   *   header.
+   * @param {function} decode Decoder function, as described in this class's
+   *   header.
    */
   constructor(tag, clazzOrType, predicate, encode, decode) {
     super();

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -169,6 +169,15 @@ export default class ItemCodec extends CommonBase {
   }
 
   /**
+   * {string|null} Name of the type of encoded values, if they are _not_
+   * encoded in "construction arguments" form. This is `null` for a
+   * "construction arguments" form.
+   */
+  get encodedType() {
+    return this._encodedType;
+  }
+
+  /**
    * {function|null} Additional predicate that must be `true` of values for them
    * to qualify, if any.
    */
@@ -181,7 +190,9 @@ export default class ItemCodec extends CommonBase {
     return this._tag;
   }
 
-  /** {string} Name of the type which identifies qualified values. */
+  /**
+   * {string} Name of the type which identifies qualified values for encoding.
+   */
   get type() {
     return this._type;
   }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -13,20 +13,21 @@ import { CommonBase } from 'util-common';
  * parameters.
  *
  * The `decode` and `encode` arguments to the constructor are the "workhorses"
- * of any instance. Each of these takes two parameters, the second of which is
- * a function to recursively code any sub-components of the value in question:
+ * of an instance of this class. Each of these takes two parameters, the second
+ * of which is a function to recursively code any sub-components of the value in
+ * question:
  *
  * * `decode(payload, subDecode)` &mdash; `payload` is the payload to decode
  *   into a value, and `subDecode(subPayload)` is a function to call on any
  *   sub-components of the payload; it returns the decoded form of `subPayload`.
- *   The overall return value from `decode` is a value that is (or is equivalent
- *   to) one that was encoded via `encode` on this instance to produce the
- *   received `payload`.
+ *   The overall return value from `decode()` is a value that is (or is
+ *   equivalent to) one that was encoded via `encode()` on this instance to
+ *   produce the received `payload`.
  *
  * * `encode(value, subEncode)` &mdash; `value` is the value to encode, and
  *   `subEncode(subValue)` is a function to call on any sub-components of the
  *   value; it returns the encoded form of `subValue`. The overall return value
- *   from `encode` is a payload which is suitable for passing into `decode()`
+ *   from `encode()` is a payload which is suitable for passing into `decode()`
  *   on the same (or equivalent) item codec.
  */
 export default class ItemCodec extends CommonBase {

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -42,6 +42,7 @@ export default class Registry extends CommonBase {
 
     // Register all the special codecs.
     this.registerCodec(SpecialCodecs.ARRAY);
+    this.registerCodec(SpecialCodecs.SIMPLE_OBJECT);
   }
 
   /**

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -36,7 +36,9 @@ export default class Registry extends CommonBase {
 
     /**
      * {Map<string,array<ItemCodec>} Map of non-class types that have
-     * `ItemCodec`s registered to the set of such codecs.
+     * `ItemCodec`s registered to the set of such codecs. There can be more
+     * than one codec per type for the same reason as `_classToCodecs` can (see
+     * which).
      */
     this._typeToCodecs = new Map();
 

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -22,26 +22,27 @@ export default class SpecialCodecs extends UtilityClass {
    *
    * @param {array<*>} payload Construction payload as previously produced by
    *   `arrayEncode()`.
+   * @param {function} subDecode Function to call to decode component values
+   *   inside `payload`, as needed.
    * @returns {array<*>} Decoded array.
    */
-  static _arrayDecode(payload) {
-    // The array payload is self-representative. Easy!
-    return payload;
+  static _arrayDecode(payload, subDecode) {
+    return payload.map(subDecode);
   }
 
   /**
    * Encodes an array.
    *
    * @param {array<*>} value Array to encode.
+   * @param {function} subEncode Function to call to encode component values
+   *   inside `value`, as needed.
    * @returns {array<*>} Encoded form.
    */
-  static _arrayEncode(value) {
+  static _arrayEncode(value, subEncode) {
     // Because of how the calling code operates, we know that by the time we get
     // here, `value` has passed `arrayPredicate()`. This means that all we have
-    // to do is return the `value` itself. The one twist is that the coding
-    // logic may want to alter the return value, so we can't return the same
-    // exact object; but we _can_ just return a simple shallow copy.
-    return value.slice();
+    // to do is encode all the elements.
+    return value.map(subEncode);
   }
 
   /**

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -21,13 +21,13 @@ export default class SpecialCodecs extends UtilityClass {
    * Decodes an array.
    *
    * @param {array<*>} payload Construction payload as previously produced by
-   *   `arrayEncode()`.
+   *   `_arrayEncode()`.
    * @param {function} subDecode Function to call to decode component values
    *   inside `payload`, as needed.
    * @returns {array<*>} Decoded array.
    */
   static _arrayDecode(payload, subDecode) {
-    return payload.map(subDecode);
+    return Object.freeze(payload.map(subDecode));
   }
 
   /**
@@ -46,9 +46,9 @@ export default class SpecialCodecs extends UtilityClass {
   }
 
   /**
-   * Checks an array for encodability.
+   * Checks a value for encodability as an array.
    *
-   * @param {array<*>} value Array to encode.
+   * @param {array<*>} value Array to (potentially) encode.
    * @returns {boolean} `true` iff `value` can be encoded.
    */
   static _arrayPredicate(value) {
@@ -69,6 +69,69 @@ export default class SpecialCodecs extends UtilityClass {
     // array is not encodable.
     if (value.length !== Object.keys(value).length) {
       return false;
+    }
+
+    return true;
+  }
+
+  /** {ItemCodec} Codec used for coding simple objects. */
+  static get SIMPLE_OBJECT() {
+    return new ItemCodec(ItemCodec.tagFromType('object'), Object,
+      this._objectPredicate, this._objectEncode, this._objectDecode);
+  }
+
+  /**
+   * Decodes a simple object.
+   *
+   * @param {object} payload Construction payload as previously produced by
+   *   `_objectEncode()`.
+   * @param {function} subDecode Function to call to decode component values
+   *   inside `payload`, as needed.
+   * @returns {object} Decoded object.
+   */
+  static _objectDecode(payload, subDecode) {
+    // Iterate over all the properties in `payload`, decoding the bound values.
+    const result = {};
+    for (const [k, v] of Object.entries(payload)) {
+      result[k] = subDecode(v);
+    }
+
+    return Object.freeze(result);
+  }
+
+  /**
+   * Encodes a simple object.
+   *
+   * @param {object} value Object to encode.
+   * @param {function} subEncode Function to call to encode component values
+   *   inside `value`, as needed.
+   * @returns {object} Encoded form.
+   */
+  static _objectEncode(value, subEncode) {
+    // Iterate over all the properties in `value`, encoding the bound values.
+    const result = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = subEncode(v);
+    }
+
+    return Object.freeze(result);
+  }
+
+  /**
+   * Checks a value for encodability as a simple object.
+   *
+   * @param {array<*>} value Value to (potentially) encode.
+   * @returns {boolean} `true` iff `value` can be encoded.
+   */
+  static _objectPredicate(value) {
+    // Iterate over all the properties in `value` to see if there are any that
+    // are synthetic. If so, the object is not encodable.
+    for (const k of Object.getOwnPropertyNames(value)) {
+      const prop = Object.getOwnPropertyDescriptor(value, k);
+
+      if ((prop.get !== undefined) || (prop.set !== undefined)) {
+        return false;
+      }
     }
 
     return true;

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -76,7 +76,7 @@ export default class SpecialCodecs extends UtilityClass {
 
   /** {ItemCodec} Codec used for coding simple objects. */
   static get SIMPLE_OBJECT() {
-    return new ItemCodec(ItemCodec.tagFromType('object'), Object,
+    return new ItemCodec(ItemCodec.tagFromType('object'), 'object',
       this._objectPredicate, this._objectEncode, this._objectDecode);
   }
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -383,12 +383,13 @@ export default class DocClient extends StateMachine {
 
     // Save the result as the current (latest known) revision of the document,
     // and tell Quill about it.
+    const firstEvent = this._quill.currentEvent;
     this._updateDocWithSnapshot(snapshot);
 
     // The above action should have caused the Quill instance to make a change
-    // which shows up on its change chain. Grab it, and verify that indeed it's
+    // which shows up on its event chain. Grab it, and verify that indeed it's
     // the change we're expecting.
-    const firstChange = this._quill.currentEvent;
+    const firstChange = firstEvent.nextOfNow(QuillEvent.TEXT_CHANGE);
     if (firstChange.source !== CLIENT_SOURCE) {
       // We expected the change to be the one we generated from the doc
       // update (above), but the `source` we got speaks otherwise.


### PR DESCRIPTION
This PR gets the encoding and decoding of simple objects (ones which are just direct instances of `Object` and just have an arbitrary set of named properties) to be done via a new `ItemCodec` instance defined in `SpecialCodecs`, instead of being an ad-hoc arrangement in `Encoder` and `Decoder`. This meant expanding `ItemCodec` and `Registry` just a bit, specifically in a direction that ultimately will allow `ItemCodec` to be used on all values of all types.

In addition, recursive coding of value sub-components is now done by the codec-specific `encode()` and `decode()` functions. This arrangement was motivated by the fact that simple objects need to do something different in this regard than class instances.

**Bonus:** Small fix to "first event" verification in `DocClient`, which I inadvertently broke when adding selection events to the event promise chain. (The breakage would only show up during session restart, and then only if you attempted to select when the client wasn't connected.)