### PR TITLE
Rearrange and untangle.

### DIFF
--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -40,36 +40,17 @@ export default class Encoder extends CommonBase {
 
       case 'object': {
         // Pass `null` through as-is, and attempt to encode anything else.
-        return (value === null) ? null : this._encodeInstance(value);
+        if (value === null) {
+          return null;
+        } else {
+          const itemCodec = this._reg.codecForValue(value);
+          return itemCodec.encode(value, this._encodeData);
+        }
       }
 
       default: {
         throw new Error(`API cannot encode type \`${typeof value}\`.`);
       }
     }
-  }
-
-  /**
-   * Helper for `encodeData()` which validates and converts an object which is
-   * expected (and verified) to be API-encodable.
-   *
-   * @param {object} value Value to convert.
-   * @returns {object} The converted value.
-   */
-  _encodeInstance(value) {
-    const itemCodec = this._reg.codecForValue(value);
-    const payload   = itemCodec.encode(value, this._encodeData);
-
-    if (Array.isArray(payload)) {
-      // "Unshift" the item tag onto the encoded payload; that is, push on the
-      // front.
-      payload.unshift(itemCodec.tag);
-    }
-
-    // **Note:** If `payload` isn't an array, that means that its not in
-    // "construction arguments" form. In that case its "tag" is implicit in the
-    // type of the value.
-
-    return Object.freeze(payload);
   }
 }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -307,19 +307,22 @@ export default class ItemCodec extends CommonBase {
     const encodedType = this._encodedType;
     const result      = this._encode(value, subEncode);
 
-    // Validate the result.
+    // Validate the result, and in the case of normal "construction arguments"
+    // arrays, add the tag as the first element of the payload.
     if (encodedType === null) {
       try {
-        return TArray.check(result);
+        TArray.check(result);
       } catch (e) {
         // Throw a higher-fidelity error.
         throw new Error('Invalid encoding result (not an array).');
       }
+
+      result.unshift(this._tag);
     } else if ((typeof result) !== encodedType) {
       throw new Error('Invalid encoding result: ' +
         `got type ${typeof result}; expected type ${encodedType}`);
     }
 
-    return result;
+    return Object.freeze(result);
   }
 }

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -226,12 +226,7 @@ export default class ItemCodec extends CommonBase {
    *   or `false` if not.
    */
   canDecode(payload) {
-    if (Array.isArray(payload)) {
-      const tag = payload[0];
-      return tag === this._tag;
-    } else {
-      return (typeof payload) === this._encodedType;
-    }
+    return ItemCodec.tagFromPayload(payload) === this._tag;
   }
 
   /**

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -166,23 +166,6 @@ export default class Registry extends CommonBase {
   }
 
   /**
-   * Finds a previously-registered item codec by tag (name). This throws an
-   * error if there is no codec registered with the given tag.
-   *
-   * @param {string} tag The item codec tag (name).
-   * @returns {ItemCodec} The codec that was registered under the given name.
-   */
-  codecForTag(tag) {
-    const result = this._tagToCodec.get(tag);
-
-    if (!result) {
-      throw new Error(`No codec registered with tag \`${tag}\`.`);
-    }
-
-    return result;
-  }
-
-  /**
    * Helper for `codecForValue()` which builds an appropriate "name" string for
    * use in error messages.
    *

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -94,6 +94,31 @@ export default class Registry extends CommonBase {
   }
 
   /**
+   * Finds a previously-registered item codec which is suitable for decoding the
+   * given payload. This throws an error if there is no codec registered for
+   * the payload's tag (either explicit or implicit tag) or if the payload is
+   * invalid.
+   *
+   * @param {payload} payload The payload to (potentially) decode.
+   * @returns {ItemCodec} The codec that was registered for the payload's tag.
+   */
+  codecForPayload(payload) {
+    const tag = ItemCodec.tagFromPayload(payload);
+
+    if (tag === null) {
+      throw new Error('Invalid payload (no tag).');
+    }
+
+    const result = this._tagToCodec.get(tag);
+
+    if (!result) {
+      throw new Error(`No codec registered with tag \`${tag}\`.`);
+    }
+
+    return result;
+  }
+
+  /**
    * Finds a previously-registered item codec which is suitable for encoding the
    * given value. This throws an error if there is no suitable codec or if there
    * is more than one suitable codec.

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -114,7 +114,7 @@ export default class SpecialCodecs extends UtilityClass {
       result[k] = subEncode(v);
     }
 
-    return Object.freeze(result);
+    return result;
   }
 
   /**

--- a/local-modules/api-common/tests/test_Registry.js
+++ b/local-modules/api-common/tests/test_Registry.js
@@ -89,10 +89,13 @@ describe('api-common/Registry', () => {
     });
   });
 
-  describe('codecForTag(tag)', () => {
+  describe('codecForPayload(payload)', () => {
     it('should throw an error if an unregistered tag is requested', () => {
       const reg = new Registry();
-      assert.throws(() => reg.codecForTag('florp'));
+      assert.throws(() => reg.codecForPayload(['florp']));
+
+      // Throws because `Symbol` wasn't a registered type.
+      assert.throws(() => reg.codecForPayload(Symbol('foo')));
     });
 
     it('should return the named codec if it is registered', () => {
@@ -101,7 +104,7 @@ describe('api-common/Registry', () => {
 
       reg.registerCodec(itemCodec);
 
-      const testCodec = reg.codecForTag('florp');
+      const testCodec = reg.codecForPayload(['florp']);
       assert.strictEqual(testCodec, itemCodec);
     });
   });


### PR DESCRIPTION
This PR moves the main encode and decode logic all into `ItemCodec`, instead of having it split half in there and the other half in `Encode` and `Decode`. You'll note that the latter two classes are getting pretty small at this point. With a bit more work, they'll end up fully disappearing, with their former duties landing amongst `ItemCodec`, `Registry`, and `SpecialCodecs`.