### PR TITLE
`null` is not an object. 

### DIFF
--- a/local-modules/api-common/Decoder.js
+++ b/local-modules/api-common/Decoder.js
@@ -33,8 +33,8 @@ export default class Decoder extends CommonBase {
     const type = typeof payload;
 
     if (type === 'function') {
-      throw new Error(`API cannot decode functions.`);
-    } else if ((type !== 'object') || (payload === null)) {
+      throw new Error('API cannot decode functions.');
+    } else if (type !== 'object') {
       // Pass through as-is.
       return payload;
     } else {

--- a/local-modules/api-common/Encoder.js
+++ b/local-modules/api-common/Encoder.js
@@ -39,13 +39,8 @@ export default class Encoder extends CommonBase {
       }
 
       case 'object': {
-        // Pass `null` through as-is, and attempt to encode anything else.
-        if (value === null) {
-          return null;
-        } else {
-          const itemCodec = this._reg.codecForValue(value);
-          return itemCodec.encode(value, this._encodeData);
-        }
+        const itemCodec = this._reg.codecForValue(value);
+        return itemCodec.encode(value, this._encodeData);
       }
 
       default: {

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -44,8 +44,8 @@ import { CommonBase } from 'util-common';
  *
  * In these cases, the codec instance needs to be tagged with the type of the
  * value and not a class-name-like string. For the purposes of this class, the
- * value `null` is considered a distinct type from non-null object values, with
- * the type name `'null'`.
+ * value `null` is considered a distinct type from non-null object values and
+ * has the type name `'null'`.
  */
 export default class ItemCodec extends CommonBase {
   /**

--- a/local-modules/api-common/ItemCodec.js
+++ b/local-modules/api-common/ItemCodec.js
@@ -95,7 +95,7 @@ export default class ItemCodec extends CommonBase {
    *
    * @param {*} value Value in question.
    * @returns {string} Name of value's type, with the type of `null` being
-   *   `null`.
+   *   `'null'`.
    */
   static typeOf(value) {
     return (value === null) ? 'null' : (typeof value);

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -45,6 +45,7 @@ export default class Registry extends CommonBase {
     // Register all the special codecs.
     this.registerCodec(SpecialCodecs.ARRAY);
     this.registerCodec(SpecialCodecs.SIMPLE_OBJECT);
+    this.registerCodec(SpecialCodecs.selfRepresentative('null'));
   }
 
   /**

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -127,19 +127,18 @@ export default class Registry extends CommonBase {
    * @returns {ItemCodec} A codec suitable for encoding `value`.
    */
   codecForValue(value) {
-    const valueType = typeof value;
+    const valueType = ItemCodec.typeOf(value);
     let clazz;
     let codecs;
 
     if (   (valueType === 'object')
-        && (value !== null)
         && (Object.getPrototypeOf(value) !== Object.prototype)) {
       // The value is an instance of a class.
       clazz = value.constructor;
       codecs = this._classToCodecs.get(clazz);
     } else {
       // The value is a non-class-instance, including possibly being a simple
-      // object (e.g., `{florps: 10}`).
+      // object (e.g., `{florps: 10}`) or `null`.
       clazz = null;
       codecs = this._typeToCodecs.get(valueType);
     }

--- a/local-modules/api-common/SpecialCodecs.js
+++ b/local-modules/api-common/SpecialCodecs.js
@@ -136,4 +136,30 @@ export default class SpecialCodecs extends UtilityClass {
 
     return true;
   }
+
+  /**
+   * Makes a self-representative codec which matches the given value type.
+   * The result encodes and decodes all values of the type to themselves.
+   *
+   * @param {string} type Name of the type.
+   * @returns {ItemCodec} Codec for `type` which passes values through unaltered
+   *   in both directions.
+   */
+  static selfRepresentative(type) {
+    return new ItemCodec(ItemCodec.tagFromType(type), type, null,
+      this._passThrough, this._passThrough);
+  }
+
+  /**
+   * Implementation of both `encode()` and `decode()` for any
+   * self-representative codec, which (per `selfRepresentative()`) passes
+   * through values unaltered.
+   *
+   * @param {*} valueOrPayload The value or payload.
+   * @param {function} subCoder_unused The sub-encoder or sub-decoder.
+   * @returns {*} `valueOrPayload`, always.
+   */
+  static _passThrough(valueOrPayload, subCoder_unused) {
+    return valueOrPayload;
+  }
 }

--- a/scripts/build
+++ b/scripts/build
@@ -321,6 +321,14 @@ function do-install {
 
     cd "${toDir}"
 
+    # We have to remove any pre-existing versions of the local modules first,
+    # because otherwise `npm` won't notice when they get updated. (We determine
+    # what's a "local module" by the presence of a source map file.)
+    local f
+    for f in $(find node_modules -name "${sourceMapName}" 2>/dev/null); do
+        rm -rf "$(dirname "${f}")"
+    done
+
     if [[ ${boxDir} == '' ]]; then
         # No boxed dependencies. Normal install.
         npm install --cache="${outDir}/npm-cache" || return 1
@@ -362,16 +370,7 @@ function build-server {
         return 1
     fi
 
-    # Do the initial npm(ish) installation. We have to remove any pre-existing
-    # versions of the local modules first, because otherwise `npm` won't notice
-    # when they get updated.
-
-    # We determine what's a "local module" by the presence of a source map file.
-    local f
-    for f in $(find "${fromDir}/node_modules" -name "${sourceMapName}"); do
-        rm -rf "$(dirname "${f}")"
-    done
-
+    # Do the initial npm(ish) installation.
     do-install server-src || return 1
 
     # Run Babel on all of the local source files, storing them next to the


### PR DESCRIPTION
…at least not as far as API-coding is concerned anymore. This PR makes it so that `null` is treated as a separate type, and starts handling it via a new "self-representative" codec. This same codec will ultimately be used for the other self-coded values (to be achieved in a later PR).

**Bonus:** Worked around the `npm` issue where it would fail to update local modules when their sources changed. Two Weeks Ago Dan had already fixed this, except he only made it work for `server` modules, not `client` modules. I don't know what Two Weeks Ago Dan was thinking. He's totally in the doghouse now.