### PR TITLE
Factor API session setup out of `TopControl`.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -149,10 +149,8 @@ export default class TopControl {
    * to actually do something more useful.
    */
   async _watchSelection() {
-    const sessionProxy =
-      await this._docSession.apiClient.authorizeTarget(this._docSession.key);
-
-    let currentEvent = this._editorComplex.quill.currentEvent;
+    const sessionProxy = await this._docSession.makeSessionProxy();
+    let currentEvent   = this._editorComplex.quill.currentEvent;
 
     for (;;) {
       const selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -181,8 +181,7 @@ export default class TopControl {
   _makeDocClient() {
     const quill = this._editorComplex.quill;
 
-    this._docClient =
-      new DocClient(quill, this._docSession.apiClient, this._docSession.key);
+    this._docClient = new DocClient(quill, this._docSession);
     this._docClient.start();
 
     // Log a note once everything is all set up.

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -5,10 +5,11 @@
 import { ApiError } from 'api-client';
 import { DocumentDelta, DocumentSnapshot, FrozenDelta } from 'doc-common';
 import { QuillEvent } from 'quill-util';
-import { Logger } from 'see-all';
 import { TObject, TString } from 'typecheck';
 import { StateMachine } from 'state-machine';
 import { PromDelay } from 'util-common';
+
+import DocSession from './DocSession';
 
 /**
  * {Int} Amount of time in msec over which errors are counted, in order to
@@ -21,9 +22,6 @@ const ERROR_WINDOW_MSEC = 3 * 60 * 1000; // Three minutes.
  * sufficient evidence that the instance is in an "unrecoverable" error state.
  */
 const ERROR_MAX_PER_MINUTE = 2.25;
-
-/** Logger. */
-const log = new Logger('doc');
 
 /**
  * How long to wait (in msec) after receiving a local change (to allow time for
@@ -84,29 +82,26 @@ export default class DocClient extends StateMachine {
    * Quill instance it manages.
    *
    * @param {QuillProm} quill Quill editor instance.
-   * @param {ApiClient} api API Client instance.
-   * @param {BaseKey} sessionKey Key that identifies the session and grants
-   *   access to it. **Note:** A session is specifically tied to a single
-   *   author and a single document.
+   * @param {DocSession} docSession Server session control / manager.
    */
-  constructor(quill, api, sessionKey) {
-    super('detached', log);
+  constructor(quill, docSession) {
+    super('detached', docSession.log);
 
     /** {Quill} Editor object. */
     this._quill = quill;
 
+    /** {DocSession} Server session control / manager. */
+    this._docSession = DocSession.check(docSession);
+
     /** {ApiClient} API interface. */
-    this._apiClient = api;
+    this._apiClient = docSession.apiClient;
 
     /** {Logger} Logger specific to this document's ID. */
-    this._log = log.withPrefix(`[${sessionKey.id}]`);
-
-    /** {BaseKey} Key that identifies the session and grants access to it. */
-    this._sessionKey = sessionKey;
+    this._log = docSession.log;
 
     /**
-     * {Proxy} Local proxy for accessing the server session. Becomes non-null
-     * during the handling of the `start` event.
+     * {Proxy|null} Local proxy for accessing the server session. Becomes
+     * non-`null` during the handling of the `start` event.
      */
     this._sessionProxy = null;
 
@@ -350,10 +345,9 @@ export default class DocClient extends StateMachine {
 
     // Perform a challenge-response to authorize access to the document.
     try {
-      this._sessionProxy =
-        await this._apiClient.authorizeTarget(this._sessionKey);
+      this._sessionProxy = await this._docSession.makeSessionProxy();
     } catch (e) {
-      this.q_apiError('authorizeTarget', e);
+      this.q_apiError('makeSessionProxy', e);
       return;
     }
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -464,8 +464,6 @@ export default class DocClient extends StateMachine {
         }
       })();
     }
-
-    this.s_idle();
   }
 
   /**
@@ -503,8 +501,6 @@ export default class DocClient extends StateMachine {
       await PromDelay.resolve(PULL_DELAY_MSEC);
       this.q_wantChanges();
     })();
-
-    this.s_idle();
   }
 
   /**

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -38,6 +38,12 @@ export default class DocSession extends CommonBase {
      * `apiClient`.
      */
     this._apiClient = null;
+
+    /**
+     * {Promise<Proxy>|null} Promise for the API session proxy. Set to
+     * non-`null` in `makeSessionProxy()`.
+     */
+    this._sessionProxyPromise = null;
   }
 
   /**
@@ -79,5 +85,24 @@ export default class DocSession extends CommonBase {
   /** {BaseKey} The session key. */
   get key() {
     return this._key;
+  }
+
+  /**
+   * Returns a proxy for the the server-side session object. This will cause the
+   * API client connection to be established if it is not already established or
+   * opening. The return value from this method always resolves to the same
+   * proxy instance, and it will only ever perform authorization for the session
+   * the first time it is called.
+   *
+   * @returns {Proxy} A proxy for the server-side session.
+   */
+  async makeSessionProxy() {
+    if (this._sessionProxyPromise === null) {
+      this._sessionProxyPromise = this.apiClient.authorizeTarget(this._key);
+    }
+
+    // **Note:** Because this is an `async` method, it's okay to return a
+    // promise.
+    return this._sessionProxyPromise;
   }
 }

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -1,0 +1,83 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { ApiClient } from 'api-client';
+import { BaseKey } from 'api-common';
+import { Logger } from 'see-all';
+import { CommonBase } from 'util-common';
+
+/** Logger. */
+const log = new Logger('doc');
+
+/**
+ * Manager of the API connection(s) needed to maintain a server session.
+ */
+export default class DocSession extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseKey} key Key that identifies the session and grants access to
+   *   it. **Note:** A session is specifically tied to a single author and a
+   *   single document.
+   */
+  constructor(key) {
+    super();
+
+    /**
+     * {BaseKey} Key that identifies the server-side session and grants access
+     * to it.
+     */
+    this._key = BaseKey.check(key);
+
+    /** {Logger} Logger specific to this document's ID. */
+    this._log = log.withPrefix(`[${key.id}]`);
+
+    /**
+     * {ApiClient|null} API client instance. Set to non-`null` in the getter
+     * `apiClient`.
+     */
+    this._apiClient = null;
+  }
+
+  /**
+   * {Logger} Logger to use when handling operations related to this instance.
+   * Logged messages include a reference to the session ID.
+   */
+  get log() {
+    return this._log;
+  }
+
+  /**
+   * {ApiClient} API client instance to use. This is always the same instance
+   * for any given instance of this class. (That is, this value is never
+   * updated.) The client is not guaranteed to be open at the time it is
+   * returned; however, `open()` will have been called on it, which means that
+   * it will at least be in the _process_ of opening.
+   *
+   * @returns {ApiClient} API client interface.
+   */
+  get apiClient() {
+    if (this._apiClient === null) {
+      log.detail('Opening API client...');
+      this._apiClient = new ApiClient(this._key.url);
+
+      (async () => {
+        await this._apiClient.open();
+        log.detail('API client open.');
+      })();
+    }
+
+    return this._apiClient;
+  }
+
+  /** {string} The base URL for talking with the server. */
+  get baseUrl() {
+    return this.apiClient.baseUrl;
+  }
+
+  /** {BaseKey} The session key. */
+  get key() {
+    return this._key;
+  }
+}

--- a/local-modules/doc-client/main.js
+++ b/local-modules/doc-client/main.js
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import DocClient from './DocClient';
+import DocSession from './DocSession';
 
-export { DocClient };
+export { DocClient, DocSession };

--- a/local-modules/doc-client/package.json
+++ b/local-modules/doc-client/package.json
@@ -5,6 +5,7 @@
 
   "dependencies": {
     "api-client": "local",
+    "api-common": "local",
     "doc-common": "local",
     "see-all": "local",
     "state-machine": "local",


### PR DESCRIPTION
This PR extracts a new class `DocSession` to be the locus where an API connection is open and a session proxy gets set up. This let us stop redundantly authing the session (once in `DocClient` and once in the stub-ish handler for caret relay).

**Bonus:** Clarified the contract for `when_*` methods on `StateMachine`, and implemented the clarified contract. This is in advance of likely using the newly-clarified semantics.