### PR TITLE
Rework `ApiError`.

### DIFF
--- a/local-modules/api-client/ApiError.js
+++ b/local-modules/api-client/ApiError.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
+import { InfoError } from 'util-common';
 
 /**
  * Error class for reporting errors coming from `ApiClient`. Differentiates
@@ -14,89 +15,28 @@ import { TString } from 'typecheck';
  * stack trace associated with these instances will almost never be useful, as
  * they will almost always get thrown most directly from API handler code.
  */
-export default class ApiError extends Error {
-  /** Constant indicating an application logic error. */
-  static get APP() { return 'app'; }
-
-  /** Constant indicating a connection / transport error. */
-  static get CONN() { return 'conn'; }
-
+export default class ApiError extends InfoError {
   /**
    * Constructs an instance.
    *
-   * @param {string} layer Which layer is the source of the problem. One of
-   *   `CONN` (connection / transport) or `APP` (application, that is, the code
-   *   on the far side of the connection).
-   * @param {string} code Short error code, meant to be human-readable and
-   *   machine-friendly. Must consist only of lowercase alphanumerics and the
-   *   underscore, and be at least 5 and at most 40 characters total.
-   * @param {string} [desc = 'API Error'] Longer-form human-readable
-   *   error description.
+   * @param {...*} args Constructor arguments, as described by `InfoError`.
    */
-  constructor(layer, code, desc = 'API Error') {
-    TString.check(layer);
-    TString.check(code);
-    TString.check(desc);
-
-    if ((layer !== ApiError.APP) && (layer !== ApiError.CONN)) {
-      throw new Error('Invalid value for `layer`.');
-    }
-
-    if (!/[a-z0-9_]{5,40}/.test(code)) {
-      throw new Error('Invalid value for `code`.');
-    }
-
-    super(ApiError._fullMessage(layer, code, desc));
-
-    /** The error layer. */
-    this._layer = layer;
-
-    /** The short error code. */
-    this._code = code;
-
-    /** The long-form error description. */
-    this._desc = desc;
+  constructor(...args) {
+    super(...args);
   }
 
   /**
-   * Convenient wrapper for `new ApiError(ApiError.APP, ...)`.
+   * Convenient wrapper for `new ApiError('connection_error', ...)`.
    *
-   * @param {...string} args Constructor arguments.
+   * @param {ApiError} cause Cause of the connection error.
+   * @param {string} connectionId Connection ID string.
    * @returns {ApiError} The constructed error.
    */
-  static appError(...args) {
-    return new ApiError(ApiError.APP, ...args);
-  }
+  static connError(cause, connectionId) {
+    ApiError.check(cause);
+    TString.check(connectionId);
 
-  /**
-   * Convenient wrapper for `new ApiError(ApiError.CONN, ...)`.
-   *
-   * @param {...string} args Constructor arguments.
-   * @returns {ApiError} The constructed error.
-   */
-  static connError(...args) {
-    return new ApiError(ApiError.CONN, ...args);
-  }
-
-  /**
-   * The error layer. One of `ApiError.APP` or `ApiError.CONN`.
-   */
-  get layer() {
-    return this._layer;
-  }
-
-  /**
-   * The short human-readable and machine-friendly error code.
-   */
-  get code() {
-    return this._code;
-  }
-
-  /**
-   * The long-form human-readable description.
-   */
-  get desc() {
-    return this._desc;
+    return new ApiError(cause, 'connection_error', connectionId);
   }
 
   /**
@@ -106,18 +46,6 @@ export default class ApiError extends Error {
    * @returns {boolean} `true` iff this instance is a connection-related error.
    */
   isConnectionError() {
-    return this._layer === 'CONN';
-  }
-
-  /**
-   * Makes a full message string from the given parts.
-   *
-   * @param {string} layer String as defined by the constructor.
-   * @param {string} code String as defined by the constructor.
-   * @param {string} desc String as defined by the constructor.
-   * @returns {string} Full message.
-   */
-  static _fullMessage(layer, code, desc) {
-    return `[${layer} ${code}] ${desc}`;
+    return this.name === 'connection_error';
   }
 }

--- a/local-modules/api-client/ApiError.js
+++ b/local-modules/api-client/ApiError.js
@@ -17,6 +17,14 @@ import { InfoError } from 'util-common';
  */
 export default class ApiError extends InfoError {
   /**
+   * {string} Error name which indicates trouble with the connection (as opposed
+   * to, say, an application logic error).
+   */
+  static get CONNECTION_ERROR() {
+    return 'connection_error';
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {...*} args Constructor arguments, as described by `InfoError`.
@@ -36,7 +44,7 @@ export default class ApiError extends InfoError {
     ApiError.check(cause);
     TString.check(connectionId);
 
-    return new ApiError(cause, 'connection_error', connectionId);
+    return new ApiError(cause, ApiError.CONNECTION_ERROR, connectionId);
   }
 
   /**
@@ -46,6 +54,6 @@ export default class ApiError extends InfoError {
    * @returns {boolean} `true` iff this instance is a connection-related error.
    */
   isConnectionError() {
-    return this.name === 'connection_error';
+    return this.name === ApiError.CONNECTION_ERROR;
   }
 }

--- a/local-modules/api-client/ApiError.js
+++ b/local-modules/api-client/ApiError.js
@@ -100,6 +100,16 @@ export default class ApiError extends Error {
   }
 
   /**
+   * Returns an indication of whether or not this instance is a
+   * connection-related error.
+   *
+   * @returns {boolean} `true` iff this instance is a connection-related error.
+   */
+  isConnectionError() {
+    return this._layer === 'CONN';
+  }
+
+  /**
    * Makes a full message string from the given parts.
    *
    * @param {string} layer String as defined by the constructor.

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -117,12 +117,12 @@ const webpackOptions = {
                   targets: {
                     browsers: [
                       // See <https://github.com/ai/browserslist> for syntax.
-                      'Chrome >= 55',
-                      'ChromeAndroid >= 55',
-                      'Electron >= 1',
-                      'Firefox >= 50',
-                      'iOS > 9',
-                      'Safari >= 9'
+                      'Chrome >= 59',
+                      'ChromeAndroid >= 59',
+                      'Electron >= 1.7',
+                      'Firefox >= 54',
+                      'iOS >= 10',
+                      'Safari >= 10.1'
                     ]
                   }
                 }

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -5,7 +5,7 @@
 import { ApiError } from 'api-client';
 import { DocumentDelta, DocumentSnapshot, FrozenDelta } from 'doc-common';
 import { QuillEvent } from 'quill-util';
-import { TObject, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { StateMachine } from 'state-machine';
 import { PromDelay } from 'util-common';
 
@@ -163,11 +163,11 @@ export default class DocClient extends StateMachine {
    * back from an API call.
    *
    * @param {string} method Name of the method that was called.
-   * @param {object} reason Error reason.
+   * @param {ApiError} reason Error reason.
    */
   _check_apiError(method, reason) {
     TString.nonempty(method);
-    TObject.check(reason);
+    ApiError.check(reason);
   }
 
   /**
@@ -244,7 +244,7 @@ export default class DocClient extends StateMachine {
    * reason.
    *
    * @param {string} method Name of the method that was called.
-   * @param {object} reason Error reason.
+   * @param {ApiError} reason Error reason.
    */
   _handle_any_apiError(method, reason) {
     // Stop the user from trying to do more edits, as they'd get lost.
@@ -252,14 +252,10 @@ export default class DocClient extends StateMachine {
 
     if (reason.isConnectionError()) {
       // It's connection-related and probably no big deal.
-      this._log.info(`${reason.code}, ${reason.desc}`);
+      this._log.info(reason.message);
     } else {
       // It's something more dire; could be a bug on either side, for example.
-      if (reason instanceof Error) {
-        this._log.error(`Severe synch issue in \`${method}\``, reason);
-      } else {
-        this._log.error(`Severe synch issue in \`${method}\`: ${reason.code}, ${reason.desc}`);
-      }
+      this._log.error(`Severe synch issue in \`${method}\``, reason);
     }
 
     // Note the time of the error, and determine if we've hit the point of

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -250,7 +250,7 @@ export default class DocClient extends StateMachine {
     // Stop the user from trying to do more edits, as they'd get lost.
     this._quill.disable();
 
-    if (reason.layer === ApiError.CONN) {
+    if (reason.isConnectionError()) {
       // It's connection-related and probably no big deal.
       this._log.info(`${reason.code}, ${reason.desc}`);
     } else {

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -22,7 +22,7 @@ export default class CommonBase {
     clazz.check         = this.check;
     clazz.coerce        = this.coerce;
     clazz.coerceOrNull  = this.coerceOrNull;
-    clazz._mustOverride = this.mustOverride;
+    clazz._mustOverride = this._mustOverride;
 
     const thisProto  = this.prototype;
     const clazzProto = clazz.prototype;

--- a/local-modules/util-common/InfoError.js
+++ b/local-modules/util-common/InfoError.js
@@ -4,6 +4,7 @@
 
 import { TString } from 'typecheck';
 
+import CommonBase from './CommonBase';
 import DataUtil from './DataUtil';
 
 /**
@@ -108,3 +109,7 @@ export default class InfoError extends Error {
     }
   }
 }
+
+// Add `CommonBase` as a mixin, because the main inheritence is the `Error`
+// class.
+CommonBase.mixInto(InfoError);


### PR DESCRIPTION
This PR cleans up how errors get reported on the client side. This is probably not the end of this particular development arc; notably, `ApiError` is now an almost-useless class and may ultimately want to be replaced by `InfoError` (which it now derives from).

As a quick note, during reconnection (e.g. when you restart the server), the client console gets a lot of spew about unhandled promise rejections. This is something we'll probably want to address sooner rather than later.

**Bonus:** Updated the Babel configuration, such that we now require a browser JS that supports the modern ES6 `class` syntax. This needed to happen so that we could succeed in subclassing `Error`. See <https://stackoverflow.com/questions/33870684/why-doesnt-instanceof-work-on-instances-of-error-subclasses-under-babel-node> for details.