### PR TITLE
Tweak caret upload.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -153,14 +153,26 @@ export default class TopControl {
     let currentEvent   = this._editorComplex.quill.currentEvent;
 
     for (;;) {
-      const selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
-      const range    = selEvent.range;
+      let selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
+
+      // This, along with the explicit delay at the bottom of the loop, is how
+      // we avoid spamming the server with tons of caret updates.
+      for (;;) {
+        const event = selEvent.nextOfNow(QuillEvent.SELECTION_CHANGE);
+        if (event === null) {
+          break;
+        }
+        selEvent = event;
+      }
+
+      const range = selEvent.range;
+      currentEvent = selEvent;
 
       // Only update when given a non-`null` range. `null` gets sent when the
       // editor UI loses focus.
       if (range !== null) {
         try {
-          await sessionProxy.caretUpdate(range.index, range.length);
+          await sessionProxy.caretUpdate(0, range.index, range.length);
         } catch (e) {
           // This happens when the server gets restarted. As currently written,
           // the caret updater doesn't track session recovery. (See TODO above.)
@@ -168,9 +180,7 @@ export default class TopControl {
         }
       }
 
-      // Avoid spamming the server with tons of updates. To see every event,
-      // this should just be `currentEvent = selEvent`.
-      currentEvent = this._editorComplex.quill.currentEvent;
+      //
       await PromDelay.resolve(5000);
     }
   }

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -153,20 +153,13 @@ export default class TopControl {
     let currentEvent   = this._editorComplex.quill.currentEvent;
 
     for (;;) {
-      let selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
+      // Using `lastestOfNow()`, along with the explicit delay at the bottom of
+      // the loop, is how we avoid spamming the server with tons of caret
+      // updates.
+      currentEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
+      currentEvent = currentEvent.latestOfNow(QuillEvent.SELECTION_CHANGE);
 
-      // This, along with the explicit delay at the bottom of the loop, is how
-      // we avoid spamming the server with tons of caret updates.
-      for (;;) {
-        const event = selEvent.nextOfNow(QuillEvent.SELECTION_CHANGE);
-        if (event === null) {
-          break;
-        }
-        selEvent = event;
-      }
-
-      const range = selEvent.range;
-      currentEvent = selEvent;
+      const range = currentEvent.range;
 
       // Only update when given a non-`null` range. `null` gets sent when the
       // editor UI loses focus.
@@ -180,7 +173,7 @@ export default class TopControl {
         }
       }
 
-      //
+      // See comment at top of loop.
       await PromDelay.resolve(5000);
     }
   }

--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CaretDelta, CaretSnapshot } from 'doc-common';
+import { CaretDelta, CaretSnapshot, RevisionNumber } from 'doc-common';
 import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 
@@ -38,6 +38,9 @@ export default class AuthorSession {
 
     /** {string} Author ID. */
     this._authorId = TString.nonempty(authorId);
+
+    /** {Logger} Logger for this session. */
+    this._log = log.withPrefix(`[${sessionId}]`);
   }
 
   /**
@@ -166,18 +169,25 @@ export default class AuthorSession {
    * Informs the system of the client's current caret or text selection extent.
    * This should be called by clients when they notice user activity that
    * changes the selection. More specifically, Quill's `SELECTION_CHANGED`
-   * events are expected to drive calls to this method. Arguments to this method
-   * have the semantics of offset and length within a Quill `Delta`.
+   * events are expected to drive calls to this method. The `index` and `length
+   * arguments to this method have the same semantics as they have in Quill,
+   * that is, they ultimately refer to an extent within a Quill `Delta`.
    *
+   * @param {Int} docRevNum The _document_ revision number that this information
+   *   is with respect to.
    * @param {Int} index Caret position (if no selection per se) or starting
    *   caret position of the selection.
    * @param {Int} [length = 0] If non-zero, length of the selection.
    */
-  caretUpdate(index, length = 0) {
+  caretUpdate(docRevNum, index, length = 0) {
+    RevisionNumber.check(docRevNum);
     TInt.min(index, 0);
     TInt.min(length, 0);
 
     // **TODO:** Something interesting should go here.
-    log.info(`Got caret update for ${this._sessionId}: ${index}, ${length}`);
+    const caretStr = (length === 0)
+      ? `@${index}`
+      : `[${index}..${index + length - 1}]`;
+    this._log.info(`Caret update: r${docRevNum}, ${caretStr}`);
   }
 }

--- a/local-modules/quill-util/BaseEvent.js
+++ b/local-modules/quill-util/BaseEvent.js
@@ -58,7 +58,7 @@ export default class BaseEvent extends CommonBase {
    * matching event is available.
    *
    * @param {string} eventName Event name of interest.
-   * @returns {QuillEvent} The earliest event with the indidated name, starting
+   * @returns {BaseEvent} The earliest event with the indidated name, starting
    *   at this instance.
    */
   async earliestOf(eventName) {
@@ -75,9 +75,9 @@ export default class BaseEvent extends CommonBase {
    * matching event is immediately available, this method returns `null`.
    *
    * @param {string} eventName Event name of interest.
-   * @returns {QuillEvent|null} The earliest immediately-available event with
+   * @returns {BaseEvent|null} The earliest immediately-available event with
    *   the indidated name, starting at this instance; or `null` if there is no
-   * such event.
+   *   such event.
    */
   earliestOfNow(eventName) {
     for (let e = this; e !== null; e = e.nextNow) {
@@ -90,11 +90,57 @@ export default class BaseEvent extends CommonBase {
   }
 
   /**
+   * Gets the latest (most recent) event of the indicated name in the event
+   * chain, starting at (and possibly including) this instance. This method only
+   * returns once a matching event is available.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {BaseEvent|null} The latest immediately-available event with the
+   *   indidated name, starting at this instance; or `null` if there is no
+   *   such event.
+   */
+  async latestOf(eventName) {
+    const resultNow = this.latestOfNow(eventName);
+
+    if (resultNow !== null) {
+      return resultNow;
+    } else {
+      // Wait for at least one matching event, and then get the instantaneously-
+      // latest (because there could have been more than one).
+      const next = await this.nextOf(eventName);
+      return next.latestOfNow(eventName);
+    }
+  }
+
+  /**
+   * Gets the latest (most recent) immediately-available event of the indicated
+   * name in the event chain, starting at (and possibly including) this
+   * instance. If no matching event is immediately available, this method
+   * returns `null`.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {BaseEvent|null} The latest immediately-available event with the
+   *   indidated name, starting at this instance; or `null` if there is no
+   *   such event.
+   */
+  latestOfNow(eventName) {
+    let result = null;
+
+    for (let e = this; e !== null; e = e.nextNow) {
+      if (e.eventName === eventName) {
+        result = e;
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Gets the next event of the indicated name after this instance, whenever it
    * becomes resolved.
    *
    * @param {string} eventName Event name of interest.
-   * @returns {QuillEvent} The next event with the indidated name, once it has
+   * @returns {BaseEvent} The next event with the indidated name, once it has
    *   become resolved.
    */
   async nextOf(eventName) {
@@ -106,7 +152,7 @@ export default class BaseEvent extends CommonBase {
    * immediately available.
    *
    * @param {string} eventName Event name of interest.
-   * @returns {QuillEvent|null} The next event with the indidated name that has
+   * @returns {BaseEvent|null} The next event with the indidated name that has
    *   already been resolved, or `null` if there is no such event.
    */
   nextOfNow(eventName) {

--- a/local-modules/quill-util/BaseEvent.js
+++ b/local-modules/quill-util/BaseEvent.js
@@ -63,8 +63,9 @@ export default class BaseEvent extends CommonBase {
    */
   async earliestOf(eventName) {
     for (let e = this; /*e*/; e = await e.next) {
-      if (e.eventName === eventName) {
-        return e;
+      const resultNow = e.earliestOfNow(eventName);
+      if (resultNow !== null) {
+        return resultNow;
       }
     }
   }


### PR DESCRIPTION
This PR adds one necessary bit of info to the caret upload method, and cleans up the code a bit. This is in preparation for moving the client code to a more permanent home and hooking up the server side so that it does something useful.