### PR TITLE
Introduce `FileComplex` (by parallel with `EditorComplex`).

### DIFF
--- a/local-modules/doc-server/AuthorSession.js
+++ b/local-modules/doc-server/AuthorSession.js
@@ -8,7 +8,7 @@ import { TInt, TString } from 'typecheck';
 
 import DocControl from './DocControl';
 
-/** Logger. */
+/** {Logger} Logger to use for this module. */
 const log = new Logger('author-session');
 
 /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -1,0 +1,38 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase } from 'util-common';
+
+import FileComplex from './FileComplex';
+
+/**
+ * Controller for the active caret info for a given document.
+ *
+ * There is only ever exactly one instance of this class per document, no matter
+ * how many active editors there are on that document. (This guarantee is
+ * provided by virtue of the fact that `DocServer` only ever creates one
+ * `FileComplex` per document, and each `FileComplex` instance only ever makes
+ * one instance of this class.
+ *
+ * **TODO:** Fill in this class!
+ */
+export default class CaretControl extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileComplex} fileComplex File complex that this instance is part
+   *   of.
+   */
+  constructor(fileComplex) {
+    super();
+
+    /** {FileComplex} File complex that this instance is part of. */
+    this._fileComplex = FileComplex.check(fileComplex);
+
+    /** {Logger} Logger specific to this document's ID. */
+    this._log = fileComplex.log;
+
+    this._log.detail('Constructed.');
+  }
+}

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -34,9 +34,13 @@ const MAX_APPEND_TIME_MSEC = 20 * 1000; // 20 seconds.
 const MAX_CHANGE_READS_PER_TRANSACTION = 20;
 
 /**
- * Controller for a given document. There is only ever exactly one instance of
- * this class per document, no matter how many active editors there are on that
- * document. (This guarantee is provided by `DocServer`.)
+ * Controller for a given document's content.
+ *
+ * There is only ever exactly one instance of this class per document, no matter
+ * how many active editors there are on that document. (This guarantee is
+ * provided by virtue of the fact that `DocServer` only ever creates one
+ * `FileComplex` per document, and each `FileComplex` instance only ever makes
+ * one instance of this class.
  */
 export default class DocControl extends CommonBase {
   /** {string} Return value from `validationStatus()`, see which for details. */

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -2,17 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codec } from 'api-common';
-import { BaseFile, FileCodec, TransactionSpec } from 'content-store';
+import { FileCodec, TransactionSpec } from 'content-store';
 import { DocumentDelta, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber, Timestamp } from 'doc-common';
-import { Logger } from 'see-all';
 import { TInt, TString } from 'typecheck';
 import { CommonBase, InfoError, PromDelay } from 'util-common';
 
+import FileComplex from './FileComplex';
 import Paths from './Paths';
-
-/** {Logger} Logger for this module. */
-const log = new Logger('doc-control');
 
 /** {number} Initial amount of time (in msec) between append retries. */
 const INITIAL_APPEND_RETRY_MSEC = 50;
@@ -66,24 +62,20 @@ export default class DocControl extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Codec} codec Codec instance to use.
-   * @param {BaseFile} file The underlying document storage.
-   * @param {string} formatVersion Format version to expect and use.
+   * @param {FileComplex} fileComplex File complex that this instance is part
+   *   of.
    */
-  constructor(codec, file, formatVersion) {
+  constructor(fileComplex) {
     super();
 
-    /** {Codec} Codec instance to use. */
-    this._codec = Codec.check(codec);
+    /** {FileComplex} File complex that this instance is part of. */
+    this._fileComplex = FileComplex.check(fileComplex);
 
     /** {BaseFile} The underlying document storage. */
-    this._file = BaseFile.check(file);
+    this._file = fileComplex.file;
 
     /** {FileCodec} File-codec wrapper to use. */
-    this._fileCodec = new FileCodec(this._file, this._codec);
-
-    /** {string} The document format version to expect and use. */
-    this._formatVersion = TString.nonempty(formatVersion);
+    this._fileCodec = new FileCodec(fileComplex.file, fileComplex.codec);
 
     /**
      * {Map<RevisionNumber,DocumentSnapshot>} Mapping from revision numbers to
@@ -92,7 +84,7 @@ export default class DocControl extends CommonBase {
     this._snapshots = new Map();
 
     /** {Logger} Logger specific to this document's ID. */
-    this._log = log.withPrefix(`[${this._file.id}]`);
+    this._log = fileComplex.log;
 
     this._log.detail('Constructed.');
   }
@@ -142,7 +134,7 @@ export default class DocControl extends CommonBase {
       fc.op_checkPathEmpty(Paths.REVISION_NUMBER),
 
       // Version for the file format.
-      fc.op_writePath(Paths.FORMAT_VERSION, this._formatVersion),
+      fc.op_writePath(Paths.FORMAT_VERSION, this._fileComplex.formatVersion),
 
       // Initial revision number.
       fc.op_writePath(Paths.REVISION_NUMBER, revNum),
@@ -269,10 +261,10 @@ export default class DocControl extends CommonBase {
       return DocControl.STATUS_ERROR;
     }
 
-    if (formatVersion !== this._formatVersion) {
+    const expectFormatVersion = this._fileComplex.formatVersion;
+    if (formatVersion !== expectFormatVersion) {
       const got = formatVersion;
-      const expected = this._formatVersion;
-      this._log.info(`Mismatched format version: got ${got}; expected ${expected}`);
+      this._log.info(`Mismatched format version: got ${got}; expected ${expectFormatVersion}`);
       return DocControl.STATUS_MIGRATE;
     }
 

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -35,6 +35,10 @@ const MIGRATION_NOTE = FrozenDelta.coerce(
  * Manager for the "complex" of objects which in aggregate allow access and
  * update to a file, for the purpose of managing it as an actively-edited
  * document.
+ *
+ * There is only ever exactly one instance of this class per document, no matter
+ * how many active editors there are on that document. (This guarantee is
+ * provided by `DocServer`.)
  */
 export default class FileComplex extends CommonBase {
   /**

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -11,6 +11,7 @@ import { ProductInfo } from 'server-env';
 import { TString } from 'typecheck';
 import { CommonBase, PromMutex } from 'util-common';
 
+import CaretControl from './DocControl';
 import DocControl from './DocControl';
 
 /** {Logger} Logger to use for this module. */
@@ -63,7 +64,13 @@ export default class FileComplex extends CommonBase {
     this._formatVersion = TString.nonempty(ProductInfo.theOne.INFO.version);
 
     /**
-     * {DocControl|null} Document controller. Set to non-`null` in the
+     * {CaretControl|null} Caret info controller. Set to non-`null` in the
+     * corresponding getter.
+     */
+    this._caretControl = null;
+
+    /**
+     * {DocControl|null} Document content controller. Set to non-`null` in the
      * corresponding getter.
      */
     this._docControl = null;
@@ -72,19 +79,29 @@ export default class FileComplex extends CommonBase {
     this._initMutex = new PromMutex();
   }
 
-  /** {DocControl} The document controller to use with this instance. */
-  get docControl() {
-    if (this._docControl === null) {
-      this._log.info('Contructing document controller.');
-      this._docControl = new DocControl(this.codec, this.file, this.formatVersion);
+  /** {CaretControl} The caret info controller to use with this instance. */
+  get caretControl() {
+    if (this._caretControl === null) {
+      this._caretControl = new CaretControl(this);
+      this._log.info('Constructed caret controller.');
     }
 
-    return this._docControl;
+    return this._caretControl;
   }
 
   /** {Codec} Codec instance to use with the underlying file. */
   get codec() {
     return this._codec;
+  }
+
+  /** {DocControl} The document controller to use with this instance. */
+  get docControl() {
+    if (this._docControl === null) {
+      this._docControl = new DocControl(this.codec, this.file, this.formatVersion);
+      this._log.info('Constructed document controller.');
+    }
+
+    return this._docControl;
   }
 
   /** {BaseFile} The underlying document storage. */
@@ -93,19 +110,19 @@ export default class FileComplex extends CommonBase {
   }
 
   /**
-   * {Logger} Logger to use with this instance. It prefixes logged items with
-   * the file's ID.
-   */
-  get log() {
-    return this._log;
-  }
-
-  /**
    * {string} The document format version to use for new documents and to expect
    * in existing documents.
    */
   get formatVersion() {
     return this._formatVersion;
+  }
+
+  /**
+   * {Logger} Logger to use with this instance. It prefixes logged items with
+   * the file's ID.
+   */
+  get log() {
+    return this._log;
   }
 
   /**

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -97,7 +97,7 @@ export default class FileComplex extends CommonBase {
   /** {DocControl} The document controller to use with this instance. */
   get docControl() {
     if (this._docControl === null) {
-      this._docControl = new DocControl(this.codec, this.file, this.formatVersion);
+      this._docControl = new DocControl(this);
       this._log.info('Constructed document controller.');
     }
 

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -1,0 +1,85 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Codec } from 'api-common';
+import { BaseFile } from 'content-store';
+import { Logger } from 'see-all';
+import { ProductInfo } from 'server-env';
+import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+import DocControl from './DocControl';
+
+/** {Logger} Logger to use for this module. */
+const log = new Logger('doc');
+
+/**
+ * Manager for the "complex" of objects which in aggregate allow access and
+ * update to a file, for the purpose of managing it as an actively-edited
+ * document.
+ */
+export default class FileComplex extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Codec} codec Codec instance to use.
+   * @param {BaseFile} file The underlying document storage.
+   */
+  constructor(codec, file) {
+    super();
+
+    /** {Codec} Codec instance to use. */
+    this._codec = Codec.check(codec);
+
+    /** {BaseFile} The underlying document storage. */
+    this._file = BaseFile.check(file);
+
+    /** {Logger} Logger for this instance. */
+    this._log = log.withPrefix(`[${file.id}]`);
+
+    /** {string} The document format version to use and expect. */
+    this._formatVersion = TString.nonempty(ProductInfo.theOne.INFO.version);
+
+    /**
+     * {DocControl|null} Document controller. Set to non-`null` in the
+     * corresponding getter.
+     */
+    this._docControl = null;
+  }
+
+  /** {DocControl} The document controller to use with this instance. */
+  get docControl() {
+    if (this._docControl === null) {
+      this._docControl = new DocControl(this.codec, this.file, this.formatVersion);
+    }
+
+    return this._docControl;
+  }
+
+  /** {Codec} Codec instance to use with the underlying file. */
+  get codec() {
+    return this._codec;
+  }
+
+  /** {BaseFile} The underlying document storage. */
+  get file() {
+    return this._file;
+  }
+
+  /**
+   * {Logger} Logger to use with this instance. It prefixes logged items with
+   * the file's ID.
+   */
+  get log() {
+    return this._log;
+  }
+
+  /**
+   * {string} The document format version to use for new documents and to expect
+   * in existing documents.
+   */
+  get formatVersion() {
+    return this._formatVersion;
+  }
+}

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -3,8 +3,9 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import AuthorSession from './AuthorSession';
+import CaretControl from './CaretControl';
 import DocControl from './DocControl';
 import DocServer from './DocServer';
 import FileComplex from './FileComplex';
 
-export { AuthorSession, DocControl, DocServer, FileComplex };
+export { AuthorSession, CaretControl, DocControl, DocServer, FileComplex };

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -5,5 +5,6 @@
 import AuthorSession from './AuthorSession';
 import DocControl from './DocControl';
 import DocServer from './DocServer';
+import FileComplex from './FileComplex';
 
-export { AuthorSession, DocControl, DocServer };
+export { AuthorSession, DocControl, DocServer, FileComplex };


### PR DESCRIPTION
This PR introduces the idea of an "object complex" on the server side, which collectively manages the relationship between an underlying file (storage) and all of the editors of a particular document. The new class `FileComplex` took a few duties from `DocServer` but mostly just sits in the middle of things, handing references from one object-of-the-complex to another.

The motivation for this PR was to have a place to put a `CaretControl` class, such that it gets managed along side the corresponding `DocControl` class. That now happens, though `CaretControl` is currently a near-pure stub.

**Bonus:** Way simplified the code for managing parallel requests for the same document. I had been overthinking it… or maybe underthinking it… or… something.