### PR TITLE
First cut of full caret snapshotting.

### DIFF
--- a/local-modules/doc-client/CaretTracker.js
+++ b/local-modules/doc-client/CaretTracker.js
@@ -13,7 +13,7 @@ import DocSession from './DocSession';
 const UPDATE_DELAY_MSEC = 1000;
 
 /**
- * Manager of the API connection(s) needed to maintain a server session.
+ * Handler for the upload of caret info from this client.
  */
 export default class CaretTracker extends CommonBase {
   /**
@@ -48,7 +48,7 @@ export default class CaretTracker extends CommonBase {
     (async () => {
       this._sessionProxy = await docSession.makeSessionProxy();
       this._suppress = false;
-      this._log.detail('Caret updater got session proxy.');
+      this._log.detail('Caret tracker got session proxy.');
     })();
   }
 

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -18,16 +18,16 @@ export default class Caret extends CommonBase {
   /**
    * Constructs an instance.
    *
-   *  @param {string} sessionId An opaque token that can be used with other
-   *    APIs to get information about the author whose caret this is (e.g. author
-   *    name, avatar, user id, etc). No assumptions should be made about the
-   *    format of `sessionId`.
-   * @param {Int} index The zero-based location of the caret (or beginning of a selection)
-   *    within the document.
+   * @param {string} sessionId An opaque token that can be used with other
+   *   APIs to get information about the author whose caret this is (e.g. author
+   *   name, avatar, user id, etc). No assumptions should be made about the
+   *   format of `sessionId`.
+   * @param {Int} index The zero-based location of the caret (or beginning of a
+   *   selection) within the document.
    * @param {Int} length The number of characters within a selection, or zero if
-   *    this caret merely represents the insertion point and not a selection.
-   *  @param {string} color The color to be used when annotating this caret. The
-   *    color must be in the CSS three-byte hex form (e.g. `'#b8ff2e'`).
+   *   this caret merely represents the insertion point and not a selection.
+   * @param {string} color The color to be used when annotating this caret. The
+   *   color must be in the CSS three-byte hex form (e.g. `'#b8ff2e'`).
    */
   constructor(sessionId, index, length, color) {
     super();
@@ -35,14 +35,14 @@ export default class Caret extends CommonBase {
     this._sessionId = TString.check(sessionId);
     this._index = TInt.min(index, 0);
     this._length = TInt.min(length, 0);
-    this.color = ColorSelector.checkHexColor(color);
+    this._color = ColorSelector.checkHexColor(color);
 
     Object.freeze(this);
   }
 
   /**
-   * {string} Opaque reference to be used with other APIs to get information about
-   *   the author whose caret this is.
+   * {string} Opaque reference to be used with other APIs to get information
+   * about the author whose caret this is.
    */
   get sessionId() {
     return this._sessionId;
@@ -64,7 +64,7 @@ export default class Caret extends CommonBase {
 
   /**
    * {string} The color to be used when annotating this selection. It is in CSS
-   *   three-byte hex format (e.g. `'#ffeab9'`).
+   * three-byte hex format (e.g. `'#ffeab9'`).
    */
   get color() {
     return this._color;

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -87,8 +87,8 @@ export default class CaretOp {
   */
   static op_updateAuthorSelection(sessionId, index, length, color) {
     TString.check(sessionId);
-    TInt.min(0, index);
-    TInt.min(0, length);
+    TInt.min(index, 0);
+    TInt.min(length, 0);
     ColorSelector.checkHexColor(color);
 
     const args = new Map();

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -89,7 +89,7 @@ export default class CaretOp {
    *   a mere insertion point movement rather than a selection.
    * @param {string} color The color to use for the background of the referenced author's selection.
    *   It must be in three-byte CSS hex for (e.g. `'#fa9cb3'`).
-   * @returns {CaretOp} The operation representing the additoin of the referenced author.
+   * @returns {CaretOp} The operation representing the addition of the referenced author.
    */
   static op_updateAuthorSelection(sessionId, index, length, color) {
     TString.check(sessionId);

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -5,6 +5,8 @@
 import { TInt, TString } from 'typecheck';
 import { ColorSelector } from 'util-common';
 
+import RevisionNumber from './RevisionNumber';
+
 const KEY = Symbol('CaretOp constructor key');
 
 export default class CaretOp {
@@ -20,15 +22,19 @@ export default class CaretOp {
     return 'end-author-session-op';
   }
 
+  static get UPDATE_DOC_REV_NUM_OP() {
+    return 'update-doc-rev-num-op';
+  }
+
   /**
-  * Constructs an instance. This should not be used directly. Instead, used
-  * the static constructor methods defined by this class.
-  *
-  * @param {object} constructorKey The private-to-this-module key that
-  *   enforces the exhortation in the method documentation above.
-  * @param {string} name The operation name.
-  * @param {Map<string,*>} args Arguments to the operation.
-  */
+   * Constructs an instance. This should not be used directly. Instead, used
+   * the static constructor methods defined by this class.
+   *
+   * @param {object} constructorKey The private-to-this-module key that
+   *   enforces the exhortation in the method documentation above.
+   * @param {string} name The operation name.
+   * @param {Map<string,*>} args Arguments to the operation.
+   */
   constructor(constructorKey, name, args) {
     if (constructorKey !== KEY) {
       throw new Error('Constructor is private');
@@ -44,26 +50,26 @@ export default class CaretOp {
   }
 
   /**
-  * @returns {string} The name of this operation.
-  */
+   * @returns {string} The name of this operation.
+   */
   get name() {
     return this._name;
   }
 
   /**
-  * @returns {Map<string, *>} The arguments needed for this operation.
-  */
+   * @returns {Map<string, *>} The arguments needed for this operation.
+   */
   get args() {
     /* TODO: _args is at risk for mutation */
     return this._args;
   }
 
   /**
-  * Constructs a new instance of an add-author operation.
-  *
-  * @param {string} sessionId An author-editing session id.
-  * @returns {CaretOp} The operation representing the addition of the referenced author.
-  */
+   * Constructs a new instance of an add-author operation.
+   *
+   * @param {string} sessionId An author-editing session id.
+   * @returns {CaretOp} The operation representing the addition of the referenced author.
+   */
   static op_addAuthor(sessionId) {
     TString.check(sessionId);
 
@@ -75,16 +81,16 @@ export default class CaretOp {
   }
 
   /**
-  * Constructs a new instance of an update-selection operation.
-  *
-  * @param {string} sessionId The session id for the author whose selection is changing.
-  * @param {Int} index The starting point of the new selection.
-  * @param {Int} length The length o the selection, or zero if the update represents
-  *   a mere insertion point movement rather than a selection.
-  * @param {string} color The color to use for the background of the referenced author's selection.
-  *   It must be in three-byte CSS hex for (e.g. `'#fa9cb3'`).
-  * @returns {CaretOp} The operation representing the additoin of the referenced author.
-  */
+   * Constructs a new instance of an update-selection operation.
+   *
+   * @param {string} sessionId The session id for the author whose selection is changing.
+   * @param {Int} index The starting point of the new selection.
+   * @param {Int} length The length o the selection, or zero if the update represents
+   *   a mere insertion point movement rather than a selection.
+   * @param {string} color The color to use for the background of the referenced author's selection.
+   *   It must be in three-byte CSS hex for (e.g. `'#fa9cb3'`).
+   * @returns {CaretOp} The operation representing the additoin of the referenced author.
+   */
   static op_updateAuthorSelection(sessionId, index, length, color) {
     TString.check(sessionId);
     TInt.min(index, 0);
@@ -102,11 +108,11 @@ export default class CaretOp {
   }
 
   /**
-  * Constructs a new instance of a remove-author operation.
-  *
-  * @param {string} sessionId An author-editing session id.
-  * @returns {CaretOp} The operation representing the removal of the referenced author.
-  */
+   * Constructs a new instance of a remove-author operation.
+   *
+   * @param {string} sessionId An author-editing session id.
+   * @returns {CaretOp} The operation representing the removal of the referenced author.
+   */
   static op_removeAuthor(sessionId) {
     TString.check(sessionId);
 
@@ -115,6 +121,22 @@ export default class CaretOp {
     args.set('sessionId', sessionId);
 
     return new CaretOp(KEY, CaretOp.END_AUTHOR_SESSION_OP, args);
+  }
+
+  /**
+   * Constructs a new instance of an update-doc-rev-num operation.
+   *
+   * @param {Int} docRevNum The new revision number.
+   * @returns {CaretOp} The corresponding operation.
+   */
+  static op_updateDocRevNum(docRevNum) {
+    RevisionNumber.check(docRevNum);
+
+    const args = new Map();
+
+    args.set('docRevNum', docRevNum);
+
+    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM_OP, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -68,6 +68,25 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
+   * Gets the caret info for the given session, if any.
+   *
+   * @param {string} sessionId Session in question.
+   * @returns {Caret|null} Corresponding caret, or `null` if there is none.
+   */
+  caretForSession(sessionId) {
+    // **TODO:** This implementation strongly suggests that `_carets` ought to
+    // be a map.
+
+    for (const c of this.carets) {
+      if (c.sessionId === sessionId) {
+        return c;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Composes a delta on top of this instance, to produce a new instance.
    *
    * @param {CaretDelta} delta Delta to compose on top of this instance.

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -104,6 +104,8 @@ export default class CaretSnapshot extends CommonBase {
     }
 
     for (const op of delta.ops) {
+      const args = op.args;
+
       switch (op.name) {
         case CaretOp.BEGIN_AUTHOR_SESSION_OP: {
           // Nothing to do here.
@@ -111,29 +113,29 @@ export default class CaretSnapshot extends CommonBase {
         }
 
         case CaretOp.UPDATE_AUTHOR_SELECTION_OP: {
-          const sessionId = op.args.get('sessionId');
+          const sessionId = args.get('sessionId');
           sessions.set(sessionId, new Caret(
             sessionId,
-            op.get('index'),
-            op.get('length'),
-            op.get('color')
+            args.get('index'),
+            args.get('length'),
+            args.get('color')
           ));
           break;
         }
 
         case CaretOp.END_AUTHOR_SESSION_OP: {
-          const sessionId = op.args.get('sessionId');
+          const sessionId = args.get('sessionId');
           sessions.delete(sessionId);
           break;
         }
 
         case CaretOp.UPDATE_DOC_REV_NUM_OP: {
-          docRevNum = op.get('docRevNum');
+          docRevNum = args.get('docRevNum');
         }
       }
     }
 
-    return new CaretSnapshot(docRevNum, delta.revNum, sessions.values());
+    return new CaretSnapshot(docRevNum, delta.revNum, Array.from(sessions.values()));
   }
 
   /**
@@ -167,7 +169,7 @@ export default class CaretSnapshot extends CommonBase {
       }
     }
 
-    // Finally, find carets removed from `this` when going to `newerSnapshot`
+    // Finally, find carets removed from `this` when going to `newerSnapshot`.
     for (const oldCaret of this.carets) {
       const sessionId = oldCaret.sessionId;
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -18,7 +18,8 @@ import FileComplex from './FileComplex';
  * one instance of this class.
  *
  * **TODO:** This class needs to store caret info via the `content-store`,
- * instead of being purely ephemeral.
+ * instead of being purely ephemeral. It also needs to know how to remove
+ * sessions that go idle for too long.
  */
 export default class CaretControl extends CommonBase {
   /**


### PR DESCRIPTION
This PR unstubs all the caret-handling methods in `CaretControl`. There is still a lot left to do, but it _might_ be high-enough fidelity such that we can actually do useful caret relay. The main missing piece is the client side code to ask for and receive `CaretDelta`s.

**Bonus:** Cleaned up a bunch of incidental stuff in `doc-common/Caret*`, while I was in the area.