### PR TITLE
Session reaping again.

### DIFF
--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -113,7 +113,7 @@ export default class DocServer extends Singleton {
     const resultPromise = (async () => {
       const file      = await Hooks.theOne.contentStore.getFile(docId);
       const result    = new FileComplex(this._codec, file);
-      const resultRef = weak(result, this._reapFileComplex.bind(this, docId));
+      const resultRef = weak(result, this._complexReaper(docId));
 
       // Replace the promise in the cache with a weak reference to the actaul
       // result.
@@ -164,20 +164,23 @@ export default class DocServer extends Singleton {
   }
 
   /**
-   * Weak reference callback that removes a collected file complex from the
-   * map of same.
+   * Returns a weak reference callback function for the indicated document ID,
+   * that removes a collected file complex from the map of same.
    *
    * @param {string} docId Document ID of the file complex to remove.
+   * @returns {function} An appropriately-constructed function.
    */
-  _reapFileComplex(docId) {
-    this._complexes.delete(docId);
-    log.info(`Reaped idle file complex: ${docId}`);
+  _complexReaper(docId) {
+    return () => {
+      this._complexes.delete(docId);
+      log.info(`Reaped idle file complex: ${docId}`);
+    };
   }
 
   /**
-   * Returns a weak reference callback function for the indicated complex/session
-   * pair, that removes a collected session object from the session map and
-   * informs the associated file complex.
+   * Returns a weak reference callback function for the indicated complex /
+   * session pair, that removes a collected session object from the session map
+   * and informs the associated file complex.
    *
    * @param {FileComplex} fileComplex File complex the session was used with.
    * @param {string} sessionId ID of the session to remove.

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -174,4 +174,18 @@ export default class FileComplex extends CommonBase {
   makeNewSession(authorId, makeSessionId) {
     return DocServer.theOne._makeNewSession(this, authorId, makeSessionId);
   }
+
+  /**
+   * Indicates that a particular session was reaped (GC'ed). This is a "friend"
+   * method which gets called by `DocServer`.
+   *
+   * @param {string} sessionId ID of the session that got reaped.
+   */
+  _sessionReaped(sessionId) {
+    // Pass through to the caret controller (if present), since it might have a
+    // record of the session.
+    if (this._caretControl) {
+      this._caretControl._sessionReaped(sessionId);
+    }
+  }
 }


### PR DESCRIPTION
This PR hooks up the code that notices a session going away to the caret controller for the session in question. As it currently stands, it takes a while for dead sessions to get noticed and it's not super-reliable, because we rely on GC; as we all should know, GC's job isn't to promptly notify your system about dead objects, so anything it does in this regard has to be considered "gravy" (weak gravy, in this case, but better than nothing).

That's all to say, in the long run we need to do more than just this to clean up dead/idle sessions.