### PR TITLE
Clean up and fix a few problems in the caret code.

### DIFF
--- a/local-modules/doc-client/AuthorOverlay.js
+++ b/local-modules/doc-client/AuthorOverlay.js
@@ -61,23 +61,23 @@ export default class AuthorOverlay {
   /**
    * Begin tracking a new author's selections.
    *
-   * @param {string} authorSessionId The author to track.
+   * @param {string} sessionId The session to track.
    */
-  beginSession(authorSessionId) {
-    TString.check(authorSessionId);
+  _beginSession(sessionId) {
+    TString.check(sessionId);
 
-    this._authors.set(authorSessionId, new Map());
+    this._authors.set(sessionId, new Map());
   }
 
   /**
-   * Stop tracking a new author's selections.
+   * Stop tracking a given session.
    *
-   * @param {string} authorSessionId The author to stop tracking.
+   * @param {string} sessionId The session to stop tracking.
    */
-  endSession(authorSessionId) {
-    TString.check(authorSessionId);
+  _endSession(sessionId) {
+    TString.check(sessionId);
 
-    this._authors.delete(authorSessionId);
+    this._authors.delete(sessionId);
     this._displayNeedsRedraw();
   }
 
@@ -90,14 +90,14 @@ export default class AuthorOverlay {
    * @param {string} color The color to use for the background of the remote author selection.
    *    It should be in hex format (e.g. `#ffb8b8`).
    */
-  updateCaret(authorSessionId, index, length, color) {
+  _updateCaret(authorSessionId, index, length, color) {
     TString.check(authorSessionId);
     TInt.min(index, 0);
     TInt.min(length, 0);
     TString.check(color);
 
     if (!this._authors.has(authorSessionId)) {
-      this.beginSession(authorSessionId);
+      this._beginSession(authorSessionId);
     }
 
     const authorInfo = this._authors.get(authorSessionId);
@@ -142,7 +142,7 @@ export default class AuthorOverlay {
         const selEvent = await currentEvent.nextOf(QuillEvent.SELECTION_CHANGE);
         const range    = selEvent.range;
 
-        this.updateCaret('local-author', range.index, range.length, '#ffb8b8');
+        this._updateCaret('local-author', range.index, range.length, '#ffb8b8');
         currentEvent = selEvent;
       }
     }
@@ -157,7 +157,7 @@ export default class AuthorOverlay {
 
       for (const c of snapshot.carets) {
         docSession.log.info(`Caret: ${c.sessionId}, ${c.index}, ${c.length}, ${c.color}`);
-        this.updateCaret(c.sessionId, c.index, c.length, c.color);
+        this._updateCaret(c.sessionId, c.index, c.length, c.color);
       }
 
       // TODO: Make this properly wait for and integrate changes.

--- a/local-modules/doc-client/AuthorOverlay.js
+++ b/local-modules/doc-client/AuthorOverlay.js
@@ -30,9 +30,9 @@ export default class AuthorOverlay {
   constructor(editorComplex, svgElement) {
     /**
      * {Map<string, Map<string, object>>} _Ad hoc_ storage for arbitrary data
-     * associated with remote authors (highlights, color, avatar, etc).
+     * associated with sessions (highlights, color, avatar, etc).
      */
-    this._authors = new Map();
+    this._sessions = new Map();
 
     /** {EditorComplex} Editor complex that this instance is a part of. */
     this._editorComplex = editorComplex;
@@ -66,7 +66,7 @@ export default class AuthorOverlay {
   _beginSession(sessionId) {
     TString.check(sessionId);
 
-    this._authors.set(sessionId, new Map());
+    this._sessions.set(sessionId, new Map());
   }
 
   /**
@@ -77,14 +77,15 @@ export default class AuthorOverlay {
   _endSession(sessionId) {
     TString.check(sessionId);
 
-    this._authors.delete(sessionId);
+    this._sessions.delete(sessionId);
     this._displayNeedsRedraw();
   }
 
   /**
-   * Updates annotation for a remote author's selection, and updates the display.
+   * Updates annotation for a remote session's selection, and updates the
+   * display.
    *
-   * @param {string} authorSessionId The author whose state we're updating.
+   * @param {string} authorSessionId The session whose state we're updating.
    * @param {Int} index The position of the remote author caret or start of teh selection.
    * @param {Int} length The extend of the remote author selection, or 0 for just the caret.
    * @param {string} color The color to use for the background of the remote author selection.
@@ -96,14 +97,14 @@ export default class AuthorOverlay {
     TInt.min(length, 0);
     TString.check(color);
 
-    if (!this._authors.has(authorSessionId)) {
+    if (!this._sessions.has(authorSessionId)) {
       this._beginSession(authorSessionId);
     }
 
-    const authorInfo = this._authors.get(authorSessionId);
+    const info = this._sessions.get(authorSessionId);
 
-    authorInfo.set('selection', { index, length });
-    authorInfo.set('color', color);
+    info.set('selection', { index, length });
+    info.set('color', color);
 
     this._displayNeedsRedraw();
   }
@@ -172,7 +173,7 @@ export default class AuthorOverlay {
     }
 
     // For each author…
-    for (const [authorSessionId_unused, authorInfo] of this._authors) {
+    for (const [authorSessionId_unused, authorInfo] of this._sessions) {
       // Generate a list of rectangles representing their selection…
       let rects = QuillGeometry.boundsForLinesInRange(
         this._editorComplex.quill, authorInfo.get('selection'));

--- a/local-modules/doc-client/AuthorOverlay.js
+++ b/local-modules/doc-client/AuthorOverlay.js
@@ -109,26 +109,6 @@ export default class AuthorOverlay {
   }
 
   /**
-   * Updates the local ledger of author selections in light
-   * of changes from an editor delta. For instance, if a remote author has a
-   * selection of `{ index:5, length:10 }` and a delta says that there was an
-   * insert of 2 characters at `index:6` then the selection will be adjusted
-   * to show `{ index:5, length:12 }`
-   *
-   * @param {Delta} delta_unused The edit that is to be applied to each of the
-   *  selections tracked by this module.
-   */
-  updateSelectionsWithDelta(delta_unused) {
-    //  TODO
-    //  for (op of delta.ops) {
-    //    for (authorInfo of this._authors.values()) {
-    //      update authorInfo['selection'] with op
-    //    }
-    //  }
-    this._displayNeedsRedraw();
-  }
-
-  /**
    * Watches for selection-related activity.
    */
   async _watchCarets() {

--- a/local-modules/doc-client/AuthorOverlay.js
+++ b/local-modules/doc-client/AuthorOverlay.js
@@ -59,7 +59,7 @@ export default class AuthorOverlay {
   }
 
   /**
-   * Begin tracking a new author's selections.
+   * Begin tracking a new session.
    *
    * @param {string} sessionId The session to track.
    */
@@ -85,23 +85,25 @@ export default class AuthorOverlay {
    * Updates annotation for a remote session's selection, and updates the
    * display.
    *
-   * @param {string} authorSessionId The session whose state we're updating.
-   * @param {Int} index The position of the remote author caret or start of teh selection.
-   * @param {Int} length The extend of the remote author selection, or 0 for just the caret.
-   * @param {string} color The color to use for the background of the remote author selection.
-   *    It should be in hex format (e.g. `#ffb8b8`).
+   * @param {string} sessionId The session whose state we're updating.
+   * @param {Int} index The position of the remote caret or start of the
+   *   selection.
+   * @param {Int} length The extent of the remote selection, or `0` for just the
+   *   caret.
+   * @param {string} color The color to use for the background of the remote
+   *    selection. It must be in hex format (e.g. `#ffb8b8`).
    */
-  _updateCaret(authorSessionId, index, length, color) {
-    TString.check(authorSessionId);
+  _updateCaret(sessionId, index, length, color) {
+    TString.check(sessionId);
     TInt.min(index, 0);
     TInt.min(length, 0);
     TString.check(color);
 
-    if (!this._sessions.has(authorSessionId)) {
-      this._beginSession(authorSessionId);
+    if (!this._sessions.has(sessionId)) {
+      this._beginSession(sessionId);
     }
 
-    const info = this._sessions.get(authorSessionId);
+    const info = this._sessions.get(sessionId);
 
     info.set('selection', { index, length });
     info.set('color', color);
@@ -160,7 +162,7 @@ export default class AuthorOverlay {
   }
 
   /**
-   * Waits a bit of time and then redraws remote author annotations.
+   * Waits a bit of time and then redraws our state.
    */
   async _waitThenUpdateDisplay() {
     await PromDelay.resolve(REFRESH_DELAY_MSEC);
@@ -172,8 +174,8 @@ export default class AuthorOverlay {
       this._authorOverlay.removeChild(this._authorOverlay.firstChild);
     }
 
-    // For each author…
-    for (const [authorSessionId_unused, authorInfo] of this._sessions) {
+    // For each session…
+    for (const [sessionId_unused, authorInfo] of this._sessions) {
       // Generate a list of rectangles representing their selection…
       let rects = QuillGeometry.boundsForLinesInRange(
         this._editorComplex.quill, authorInfo.get('selection'));

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -4,7 +4,7 @@
 
 import { QuillEvent, QuillGeometry } from 'quill-util';
 import { TObject, TInt, TString } from 'typecheck';
-import { PromDelay } from 'util-common';
+import { ColorSelector, PromDelay } from 'util-common';
 
 /**
  * Time span to wait between refreshes of remote session annotations.
@@ -96,7 +96,7 @@ export default class CaretOverlay {
     TString.check(sessionId);
     TInt.min(index, 0);
     TInt.min(length, 0);
-    TString.check(color);
+    ColorSelector.checkHexColor(color);
 
     if (!this._sessions.has(sessionId)) {
       this._beginSession(sessionId);

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -14,12 +14,12 @@ import { PromDelay } from 'util-common';
 const REFRESH_DELAY_MSEC = 2000;
 
 /**
- * The AuthorOverlay class manages the visual display of the
+ * The CaretOverlay class manages the visual display of the
  * selection and insertion caret of remote users editing the
  * same document as the local user. It renders the selections
  * into an SVG element that overlays the Quill editor.
  */
-export default class AuthorOverlay {
+export default class CaretOverlay {
   /**
    * Constructs an instance.
    *

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -14,9 +14,8 @@ import { PromDelay } from 'util-common';
 const REFRESH_DELAY_MSEC = 2000;
 
 /**
- * The CaretOverlay class manages the visual display of the
- * selection and insertion caret of remote users editing the
- * same document as the local user. It renders the selections
+ * Manager of the visual display of the selection and insertion caret of remote
+ * users editing the same document as the local user. It renders the selections
  * into an SVG element that overlays the Quill editor.
  */
 export default class CaretOverlay {

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -101,8 +101,8 @@ export default class EditorComplex extends CommonBase {
       // Let the overlay do extra initialization.
       Hooks.theOne.quillInstanceInit(this._quill);
 
-      /** {AuthorOverlay} The author overlay controller. */
-      this._authorOverlay = new AuthorOverlay(this, authorOverlayNode);
+      /** {AuthorOverlay} The remote caret overlay controller. */
+      this._caretOverlay = new AuthorOverlay(this, authorOverlayNode);
 
       // Do session setup using the initial key.
       this._initSession(sessionKey, true);
@@ -113,7 +113,7 @@ export default class EditorComplex extends CommonBase {
 
   /** {AuthorOverlay} The author overlay controller. */
   get authorOverlay() {
-    return this._authorOverlay;
+    return this._caretOverlay;
   }
 
   /** {DocClient} The document client instance. */

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -10,7 +10,7 @@ import { TObject } from 'typecheck';
 import { DomUtil } from 'util-client';
 import { CommonBase, PromCondition } from 'util-common';
 
-import AuthorOverlay from './AuthorOverlay';
+import CaretOverlay from './CaretOverlay';
 import DocClient from './DocClient';
 import DocSession from './DocSession';
 
@@ -101,8 +101,8 @@ export default class EditorComplex extends CommonBase {
       // Let the overlay do extra initialization.
       Hooks.theOne.quillInstanceInit(this._quill);
 
-      /** {AuthorOverlay} The remote caret overlay controller. */
-      this._caretOverlay = new AuthorOverlay(this, authorOverlayNode);
+      /** {CaretOverlay} The remote caret overlay controller. */
+      this._caretOverlay = new CaretOverlay(this, authorOverlayNode);
 
       // Do session setup using the initial key.
       this._initSession(sessionKey, true);
@@ -111,7 +111,7 @@ export default class EditorComplex extends CommonBase {
     })();
   }
 
-  /** {AuthorOverlay} The author overlay controller. */
+  /** {CaretOverlay} The author overlay controller. */
   get authorOverlay() {
     return this._caretOverlay;
   }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -10,16 +10,16 @@ import RevisionNumber from './RevisionNumber';
 const KEY = Symbol('CaretOp constructor key');
 
 export default class CaretOp {
-  static get BEGIN_AUTHOR_SESSION_OP() {
-    return 'begin-author-session-op';
+  static get BEGIN_SESSION_OP() {
+    return 'begin-session-op';
   }
 
   static get UPDATE_AUTHOR_SELECTION_OP() {
     return 'update-author-selection-op';
   }
 
-  static get END_AUTHOR_SESSION_OP() {
-    return 'end-author-session-op';
+  static get END_SESSION_OP() {
+    return 'end-session-op';
   }
 
   static get UPDATE_DOC_REV_NUM_OP() {
@@ -77,7 +77,7 @@ export default class CaretOp {
 
     args.set('sessionId', sessionId);
 
-    return new CaretOp(KEY, CaretOp.BEGIN_AUTHOR_SESSION_OP, args);
+    return new CaretOp(KEY, CaretOp.BEGIN_SESSION_OP, args);
   }
 
   /**
@@ -120,7 +120,7 @@ export default class CaretOp {
 
     args.set('sessionId', sessionId);
 
-    return new CaretOp(KEY, CaretOp.END_AUTHOR_SESSION_OP, args);
+    return new CaretOp(KEY, CaretOp.END_SESSION_OP, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -31,44 +31,6 @@ export default class CaretOp {
   }
 
   /**
-   * Constructs an instance. This should not be used directly. Instead, used
-   * the static constructor methods defined by this class.
-   *
-   * @param {object} constructorKey The private-to-this-module key that
-   *   enforces the exhortation in the method documentation above.
-   * @param {string} name The operation name.
-   * @param {Map<string,*>} args Arguments to the operation.
-   */
-  constructor(constructorKey, name, args) {
-    if (constructorKey !== KEY) {
-      throw new Error('Constructor is private');
-    }
-
-    /** {string} name The name of this operation. */
-    this._name = name;
-
-    /** {Map<string,*>} args The arguments needed for the operation. */
-    this._args = args;
-
-    Object.freeze(this);
-  }
-
-  /**
-   * @returns {string} The name of this operation.
-   */
-  get name() {
-    return this._name;
-  }
-
-  /**
-   * @returns {Map<string, *>} The arguments needed for this operation.
-   */
-  get args() {
-    /* TODO: _args is at risk for mutation */
-    return this._args;
-  }
-
-  /**
    * Constructs a new "begin session" operation.
    *
    * @param {string} sessionId The session ID.
@@ -144,6 +106,44 @@ export default class CaretOp {
     args.set('docRevNum', docRevNum);
 
     return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, args);
+  }
+
+  /**
+   * Constructs an instance. This should not be used directly. Instead, used
+   * the static constructor methods defined by this class.
+   *
+   * @param {object} constructorKey The private-to-this-module key that
+   *   enforces the exhortation in the method documentation above.
+   * @param {string} name The operation name.
+   * @param {Map<string,*>} args Arguments to the operation.
+   */
+  constructor(constructorKey, name, args) {
+    if (constructorKey !== KEY) {
+      throw new Error('Constructor is private');
+    }
+
+    /** {string} name The name of this operation. */
+    this._name = name;
+
+    /** {Map<string,*>} args The arguments needed for the operation. */
+    this._args = args;
+
+    Object.freeze(this);
+  }
+
+  /**
+   * @returns {string} The name of this operation.
+   */
+  get name() {
+    return this._name;
+  }
+
+  /**
+   * @returns {Map<string, *>} The arguments needed for this operation.
+   */
+  get args() {
+    /* TODO: _args is at risk for mutation */
+    return this._args;
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -139,11 +139,21 @@ export default class CaretOp {
   }
 
   /**
-   * @returns {Map<string, *>} The arguments needed for this operation.
+   * Gets the operation argument with the given name. It is an error to
+   * request an argument that is not bound. Return values are guaranteed to be
+   * deep frozen.
+   *
+   * @param {string} name The argument name.
+   * @returns {*} Corresponding argument value.
    */
-  get args() {
-    /* TODO: _args is at risk for mutation */
-    return this._args;
+  arg(name) {
+    const result = this._args.get(name);
+
+    if (result === undefined) {
+      throw new Error(`No such argument: ${name}`);
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -16,8 +16,8 @@ export default class CaretOp {
   }
 
   /** {string} Operation name for "update caret" operations. */
-  static get UPDATE_AUTHOR_SELECTION() {
-    return 'update-author-selection';
+  static get UPDATE_CARET() {
+    return 'update-caret';
   }
 
   /** {string} Operation name for "end session" operations. */
@@ -86,7 +86,7 @@ export default class CaretOp {
   }
 
   /**
-   * Constructs a new instance of an update-selection operation.
+   * Constructs a new "update caret" operation.
    *
    * @param {string} sessionId The session id for the author whose selection is changing.
    * @param {Int} index The starting point of the new selection.
@@ -94,9 +94,10 @@ export default class CaretOp {
    *   a mere insertion point movement rather than a selection.
    * @param {string} color The color to use for the background of the referenced author's selection.
    *   It must be in three-byte CSS hex for (e.g. `'#fa9cb3'`).
-   * @returns {CaretOp} The operation representing the addition of the referenced author.
+   * @returns {CaretOp} An operation representing new caret information for a
+   *   particular session.
    */
-  static op_updateAuthorSelection(sessionId, index, length, color) {
+  static op_updateCaret(sessionId, index, length, color) {
     TString.check(sessionId);
     TInt.min(index, 0);
     TInt.min(length, 0);
@@ -109,7 +110,7 @@ export default class CaretOp {
     args.set('length', length);
     args.set('color', color);
 
-    return new CaretOp(KEY, CaretOp.UPDATE_AUTHOR_SELECTION, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_CARET, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -10,18 +10,22 @@ import RevisionNumber from './RevisionNumber';
 const KEY = Symbol('CaretOp constructor key');
 
 export default class CaretOp {
+  /** {string} Operation name for "begin session" operations. */
   static get BEGIN_SESSION() {
     return 'begin-session';
   }
 
+  /** {string} Operation name for "update caret" operations. */
   static get UPDATE_AUTHOR_SELECTION() {
     return 'update-author-selection';
   }
 
+  /** {string} Operation name for "end session" operations. */
   static get END_SESSION() {
     return 'end-session';
   }
 
+  /** {string} Operation name for "update document rev-num" operations. */
   static get UPDATE_DOC_REV_NUM() {
     return 'update-doc-rev-num';
   }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -65,12 +65,13 @@ export default class CaretOp {
   }
 
   /**
-   * Constructs a new instance of an add-author operation.
+   * Constructs a new "begin session" operation.
    *
-   * @param {string} sessionId An author-editing session id.
-   * @returns {CaretOp} The operation representing the addition of the referenced author.
+   * @param {string} sessionId The session ID.
+   * @returns {CaretOp} An operation representing the start of the so-IDed
+   *   session.
    */
-  static op_addAuthor(sessionId) {
+  static op_beginSession(sessionId) {
     TString.check(sessionId);
 
     const args = new Map();
@@ -108,12 +109,13 @@ export default class CaretOp {
   }
 
   /**
-   * Constructs a new instance of a remove-author operation.
+   * Constructs a new "end session" operation.
    *
-   * @param {string} sessionId An author-editing session id.
-   * @returns {CaretOp} The operation representing the removal of the referenced author.
+   * @param {string} sessionId ID of the session.
+   * @returns {CaretOp} An operation representing the end of the so-IDed
+   *   session.
    */
-  static op_removeAuthor(sessionId) {
+  static op_endSession(sessionId) {
     TString.check(sessionId);
 
     const args = new Map();

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -11,19 +11,19 @@ const KEY = Symbol('CaretOp constructor key');
 
 export default class CaretOp {
   static get BEGIN_SESSION_OP() {
-    return 'begin-session-op';
+    return 'begin-session';
   }
 
   static get UPDATE_AUTHOR_SELECTION_OP() {
-    return 'update-author-selection-op';
+    return 'update-author-selection';
   }
 
   static get END_SESSION_OP() {
-    return 'end-session-op';
+    return 'end-session';
   }
 
   static get UPDATE_DOC_REV_NUM_OP() {
-    return 'update-doc-rev-num-op';
+    return 'update-doc-rev-num';
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -162,30 +162,24 @@ export default class CaretOp {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
+    // Convert the `_args` map to a simple object for the purpose of coding.
     const args = {};
+    for (const [k, v] of this._args) {
+      args[k] = v;
+    }
 
-    // TODO: We need a codec for `Map`s. Or, more particularly here, we need to
-    // not use JSON strings as part of the coding form.
-    this._args.forEach((k, v) => { args.set(k, v); });
-
-    return [this._name, JSON.stringify(args)];
+    return [this._name, args];
   }
 
   /**
    * Instaniate a new instance of this class from API arguments.
    *
    * @param {string} name The name of the operation.
-   * @param {string} argsJson The JSON-encoded arguments for this operation.
+   * @param {object} args The arguments for the operation, as a simple object
+   *   (not a map).
    * @returns {CaretOp} The new instance.
    */
-  static fromApi(name, argsJson) {
-    const argsObj = JSON.parse(argsJson);
-    const args = new Map();
-
-    for (const k of Object.keys(argsObj)) {
-      args.set(k, argsObj[k]);
-    }
-
-    return new CaretOp(KEY, name, args);
+  static fromApi(name, args) {
+    return new CaretOp(KEY, name, new Map(Object.entries(args)));
   }
 }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -10,19 +10,19 @@ import RevisionNumber from './RevisionNumber';
 const KEY = Symbol('CaretOp constructor key');
 
 export default class CaretOp {
-  static get BEGIN_SESSION_OP() {
+  static get BEGIN_SESSION() {
     return 'begin-session';
   }
 
-  static get UPDATE_AUTHOR_SELECTION_OP() {
+  static get UPDATE_AUTHOR_SELECTION() {
     return 'update-author-selection';
   }
 
-  static get END_SESSION_OP() {
+  static get END_SESSION() {
     return 'end-session';
   }
 
-  static get UPDATE_DOC_REV_NUM_OP() {
+  static get UPDATE_DOC_REV_NUM() {
     return 'update-doc-rev-num';
   }
 
@@ -77,7 +77,7 @@ export default class CaretOp {
 
     args.set('sessionId', sessionId);
 
-    return new CaretOp(KEY, CaretOp.BEGIN_SESSION_OP, args);
+    return new CaretOp(KEY, CaretOp.BEGIN_SESSION, args);
   }
 
   /**
@@ -104,7 +104,7 @@ export default class CaretOp {
     args.set('length', length);
     args.set('color', color);
 
-    return new CaretOp(KEY, CaretOp.UPDATE_AUTHOR_SELECTION_OP, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_AUTHOR_SELECTION, args);
   }
 
   /**
@@ -120,7 +120,7 @@ export default class CaretOp {
 
     args.set('sessionId', sessionId);
 
-    return new CaretOp(KEY, CaretOp.END_SESSION_OP, args);
+    return new CaretOp(KEY, CaretOp.END_SESSION, args);
   }
 
   /**
@@ -136,7 +136,7 @@ export default class CaretOp {
 
     args.set('docRevNum', docRevNum);
 
-    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM_OP, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -112,7 +112,7 @@ export default class CaretSnapshot extends CommonBase {
           break;
         }
 
-        case CaretOp.UPDATE_AUTHOR_SELECTION: {
+        case CaretOp.UPDATE_CARET: {
           const sessionId = args.get('sessionId');
           sessions.set(sessionId, new Caret(
             sessionId,

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -184,7 +184,7 @@ export default class CaretSnapshot extends CommonBase {
     const caretOps = [];
 
     for (const caret of caretsAdded) {
-      caretOps.push(CaretDelta.op_addAuthor(caret.sessionId));
+      caretOps.push(CaretDelta.op_beginSession(caret.sessionId));
     }
 
     for (const caret of caretsUpdated) {
@@ -192,7 +192,7 @@ export default class CaretSnapshot extends CommonBase {
     }
 
     for (const caret of caretsRemoved) {
-      caretOps.push(CaretDelta.op_removeAuthor(caret.sessionId));
+      caretOps.push(CaretDelta.op_endSession(caret.sessionId));
     }
 
     if (this.docRevNum !== newerSnapshot.docRevNum) {

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -107,12 +107,12 @@ export default class CaretSnapshot extends CommonBase {
       const args = op.args;
 
       switch (op.name) {
-        case CaretOp.BEGIN_SESSION_OP: {
+        case CaretOp.BEGIN_SESSION: {
           // Nothing to do here.
           break;
         }
 
-        case CaretOp.UPDATE_AUTHOR_SELECTION_OP: {
+        case CaretOp.UPDATE_AUTHOR_SELECTION: {
           const sessionId = args.get('sessionId');
           sessions.set(sessionId, new Caret(
             sessionId,
@@ -123,13 +123,13 @@ export default class CaretSnapshot extends CommonBase {
           break;
         }
 
-        case CaretOp.END_SESSION_OP: {
+        case CaretOp.END_SESSION: {
           const sessionId = args.get('sessionId');
           sessions.delete(sessionId);
           break;
         }
 
-        case CaretOp.UPDATE_DOC_REV_NUM_OP: {
+        case CaretOp.UPDATE_DOC_REV_NUM: {
           docRevNum = args.get('docRevNum');
         }
       }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -104,8 +104,6 @@ export default class CaretSnapshot extends CommonBase {
     }
 
     for (const op of delta.ops) {
-      const args = op.args;
-
       switch (op.name) {
         case CaretOp.BEGIN_SESSION: {
           // Nothing to do here.
@@ -113,24 +111,24 @@ export default class CaretSnapshot extends CommonBase {
         }
 
         case CaretOp.UPDATE_CARET: {
-          const sessionId = args.get('sessionId');
+          const sessionId = op.arg('sessionId');
           sessions.set(sessionId, new Caret(
             sessionId,
-            args.get('index'),
-            args.get('length'),
-            args.get('color')
+            op.arg('index'),
+            op.arg('length'),
+            op.arg('color')
           ));
           break;
         }
 
         case CaretOp.END_SESSION: {
-          const sessionId = args.get('sessionId');
+          const sessionId = op.arg('sessionId');
           sessions.delete(sessionId);
           break;
         }
 
         case CaretOp.UPDATE_DOC_REV_NUM: {
-          docRevNum = args.get('docRevNum');
+          docRevNum = op.arg('docRevNum');
         }
       }
     }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -107,7 +107,7 @@ export default class CaretSnapshot extends CommonBase {
       const args = op.args;
 
       switch (op.name) {
-        case CaretOp.BEGIN_AUTHOR_SESSION_OP: {
+        case CaretOp.BEGIN_SESSION_OP: {
           // Nothing to do here.
           break;
         }
@@ -123,7 +123,7 @@ export default class CaretSnapshot extends CommonBase {
           break;
         }
 
-        case CaretOp.END_AUTHOR_SESSION_OP: {
+        case CaretOp.END_SESSION_OP: {
           const sessionId = args.get('sessionId');
           sessions.delete(sessionId);
           break;

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -6,7 +6,7 @@ import { TInt } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 /**
- * Minimum (inclusive) acceptable timestamp `secs` value.
+ * {Int} Minimum (inclusive) acceptable timestamp `secs` value.
  *
  * ```
  * $ date -u -r 1010000000
@@ -16,7 +16,7 @@ import { CommonBase } from 'util-common';
 const MIN_SECS = 1010000000;
 
 /**
- * Maximum (exclusive) acceptable timestamp `secs` value.
+ * {Int} Maximum (exclusive) acceptable timestamp `secs` value.
  *
  * ```
  * $ date -u -r 2530000000
@@ -25,7 +25,7 @@ const MIN_SECS = 1010000000;
  */
 const MAX_SECS = 2530000000;
 
-/** Number of microseconds in a second. */
+/** {Int} Number of microseconds in a second. */
 const USECS_PER_SEC = 1000000;
 
 /**
@@ -90,12 +90,12 @@ export default class Timestamp extends CommonBase {
     return [this._secs, this._usecs];
   }
 
-  /** The number of seconds since the Unix Epoch. */
+  /** {Int} The number of seconds since the Unix Epoch. */
   get secs() {
     return this._secs;
   }
 
-  /** The additional microseconds. */
+  /** {Int} The additional microseconds. */
   get usecs() {
     return this._usecs;
   }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -133,7 +133,7 @@ export default class CaretControl extends CommonBase {
     let color;
 
     if (oldCaret === null) {
-      ops.push(CaretOp.op_addAuthor(sessionId));
+      ops.push(CaretOp.op_beginSession(sessionId));
       color = this._colorSelector.nextColorHex();
     } else {
       color = oldCaret.color;
@@ -182,7 +182,7 @@ export default class CaretControl extends CommonBase {
     const oldCaret = snapshot.caretForSession(sessionId);
 
     if (oldCaret !== null) {
-      const ops   = [CaretOp.op_removeAuthor(sessionId)];
+      const ops   = [CaretOp.op_endSession(sessionId)];
 
       this._log.info(`[${sessionId}] Caret removed.`);
       this._applyOps(ops);

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -139,7 +139,7 @@ export default class CaretControl extends CommonBase {
       color = oldCaret.color;
     }
 
-    ops.push(CaretOp.op_updateAuthorSelection(sessionId, index, length, color));
+    ops.push(CaretOp.op_updateCaret(sessionId, index, length, color));
 
     // **TODO:** Handle `docRevNum` sensibly instead of just blithely thwacking
     // it into the new snapshot.

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -10,7 +10,7 @@ import { Logger } from 'see-all';
 import { TFunction, TString } from 'typecheck';
 import { Singleton } from 'util-common';
 
-import AuthorSession from './AuthorSession';
+import DocSession from './DocSession';
 import FileComplex from './FileComplex';
 
 /** {Logger} Logger for this module. */
@@ -49,8 +49,8 @@ export default class DocServer extends Singleton {
     this._complexes = new Map();
 
     /**
-     * {Map<string,Weak<AuthorSession>>} Map from session IDs to corresponding
-     * weak-reference-wrapped `AuthorSession` instances. See `_complexes` for
+     * {Map<string,Weak<DocSession>>} Map from session IDs to corresponding
+     * weak-reference-wrapped `DocSession` instances. See `_complexes` for
      * rationale on weakness.
      */
     this._sessions = new Map();
@@ -60,7 +60,7 @@ export default class DocServer extends Singleton {
    * Gets the session with the given ID, if it exists.
    *
    * @param {string} sessionId The session ID in question.
-   * @returns {AuthorSession|null} Corresponding session instance, or `null` if
+   * @returns {DocSession|null} Corresponding session instance, or `null` if
    *   there is no such session.
    */
   getSessionOrNull(sessionId) {
@@ -137,7 +137,7 @@ export default class DocServer extends Singleton {
    * @param {FileComplex} fileComplex Main complex to attach to.
    * @param {string} authorId ID for the author.
    * @param {function} makeSessionId Function to generate a random session ID.
-   * @returns {AuthorSession} A newly-constructed session.
+   * @returns {DocSession} A newly-constructed session.
    */
   _makeNewSession(fileComplex, authorId, makeSessionId) {
     FileComplex.check(fileComplex);
@@ -156,8 +156,8 @@ export default class DocServer extends Singleton {
       // just iterate and try again.
     }
 
-    const result = new AuthorSession(fileComplex, sessionId, authorId);
-    const reaper = this._sessionreaper(fileComplex, sessionId);
+    const result = new DocSession(fileComplex, sessionId, authorId);
+    const reaper = this._sessionReaper(fileComplex, sessionId);
 
     this._sessions.set(sessionId, weak(result, reaper));
     return result;

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -15,7 +15,7 @@ import FileComplex from './FileComplex';
  * underlying `DocControl` while implicitly adding an author argument to methods
  * that modify the document.
  */
-export default class AuthorSession {
+export default class DocSession {
   /**
    * Constructs an instance.
    *

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -169,7 +169,7 @@ export default class FileComplex extends CommonBase {
    *   a randomly-generated string to use as a session ID. This will get called
    *   more than once if the string happens to be a duplicate in the namespace
    *   for session IDs.
-   * @returns {AuthorSession} A newly-constructed session.
+   * @returns {DocSession} A newly-constructed session.
    */
   makeNewSession(authorId, makeSessionId) {
     return DocServer.theOne._makeNewSession(this, authorId, makeSessionId);

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -2,10 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import AuthorSession from './AuthorSession';
 import CaretControl from './CaretControl';
 import DocControl from './DocControl';
 import DocServer from './DocServer';
+import DocSession from './DocSession';
 import FileComplex from './FileComplex';
 
-export { AuthorSession, CaretControl, DocControl, DocServer, FileComplex };
+export { CaretControl, DocControl, DocServer, DocSession, FileComplex };

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.17.2
+version = 0.18.0


### PR DESCRIPTION
* Consistently refer to sessions as "sessions" not "author sessions" or similar.
* Consistently refer to caret info as "caret" info and not "selection" info or similar.
* Remove redundant bits from names, especially the names of caret ops which end up as part of an API-encoded payload.
* Remove the (TODO-noted) mutation hazard from `CaretOp`.
* Stop using an explicit JSON string in the encoded form of `CaretOp`.
* Add a bit of documentation.