### PR TITLE
Two caret-related improvements.

### DIFF
--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -135,12 +135,21 @@ export default class CaretOverlay {
 
     for (;;) {
       const snapshot = await sessionProxy.caretSnapshot();
+      const oldSessions = new Set(this._sessions.keys());
 
       docSession.log.info(`Got snapshot! ${snapshot.carets.length} caret(s).`);
 
       for (const c of snapshot.carets) {
         docSession.log.info(`Caret: ${c.sessionId}, ${c.index}, ${c.length}, ${c.color}`);
         this._updateCaret(c.sessionId, c.index, c.length, c.color);
+        oldSessions.delete(c.sessionId);
+      }
+
+      // The remaining elements of `oldSessions` are sessions which have gone
+      // away.
+      for (const s of oldSessions) {
+        docSession.log.info(`Session ended: ${s}`);
+        this._endSession(s);
       }
 
       // TODO: Make this properly wait for and integrate changes.

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -33,9 +33,9 @@ export default class Caret extends CommonBase {
     super();
 
     this._sessionId = TString.check(sessionId);
-    this._index = TInt.min(index, 0);
-    this._length = TInt.min(length, 0);
-    this._color = ColorSelector.checkHexColor(color);
+    this._index     = TInt.min(index, 0);
+    this._length    = TInt.min(length, 0);
+    this._color     = ColorSelector.checkHexColor(color);
 
     Object.freeze(this);
   }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TString } from 'typecheck';
-import { ColorSelector } from 'util-common';
+import { TString } from 'typecheck';
 
+import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
 
 const KEY = Symbol('CaretOp constructor key');
@@ -50,27 +50,17 @@ export default class CaretOp {
   /**
    * Constructs a new "update caret" operation.
    *
-   * @param {string} sessionId The session id for the author whose selection is changing.
-   * @param {Int} index The starting point of the new selection.
-   * @param {Int} length The length o the selection, or zero if the update represents
-   *   a mere insertion point movement rather than a selection.
-   * @param {string} color The color to use for the background of the referenced author's selection.
-   *   It must be in three-byte CSS hex for (e.g. `'#fa9cb3'`).
+   * @param {Caret} caret The caret to update. `Caret` objects notably know what
+   *   session they are associated with.
    * @returns {CaretOp} An operation representing new caret information for a
    *   particular session.
    */
-  static op_updateCaret(sessionId, index, length, color) {
-    TString.check(sessionId);
-    TInt.min(index, 0);
-    TInt.min(length, 0);
-    ColorSelector.checkHexColor(color);
+  static op_updateCaret(caret) {
+    Caret.check(caret);
 
     const args = new Map();
 
-    args.set('sessionId', sessionId);
-    args.set('index', index);
-    args.set('length', length);
-    args.set('color', color);
+    args.set('caret', caret);
 
     return new CaretOp(KEY, CaretOp.UPDATE_CARET, args);
   }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -111,13 +111,8 @@ export default class CaretSnapshot extends CommonBase {
         }
 
         case CaretOp.UPDATE_CARET: {
-          const sessionId = op.arg('sessionId');
-          sessions.set(sessionId, new Caret(
-            sessionId,
-            op.arg('index'),
-            op.arg('length'),
-            op.arg('color')
-          ));
+          const caret = op.arg('caret');
+          sessions.set(caret.sessionId, caret);
           break;
         }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -2,7 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CaretDelta, CaretOp, CaretSnapshot, RevisionNumber } from 'doc-common';
+import { Caret, CaretDelta, CaretOp, CaretSnapshot, RevisionNumber }
+  from 'doc-common';
 import { TInt, TString } from 'typecheck';
 import { ColorSelector, CommonBase, PromCondition } from 'util-common';
 
@@ -139,7 +140,8 @@ export default class CaretControl extends CommonBase {
       color = oldCaret.color;
     }
 
-    ops.push(CaretOp.op_updateCaret(sessionId, index, length, color));
+    const caret = new Caret(sessionId, index, length, color);
+    ops.push(CaretOp.op_updateCaret(caret));
 
     // **TODO:** Handle `docRevNum` sensibly instead of just blithely thwacking
     // it into the new snapshot.


### PR DESCRIPTION
* Simplify the `CaretOp` code by putting an actual `Caret` instance in `updateCaret` ops.
* Get the (still janky) client-side caret tracker to notice when sessions go away.