### PR TITLE
More caret progress.

### DIFF
--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -132,12 +132,14 @@ export default class CaretOverlay {
 
     let docSession = null;
     let sessionProxy;
+    let sessionId;
 
     for (;;) {
       if (docSession === null) {
         // Init the session variables (on the first iteration), or re-init them
         // if we got a failure during a previous iteration.
-        docSession = this._editorComplex.docSession;
+        docSession   = this._editorComplex.docSession;
+        sessionId    = this._editorComplex.sessionId;
         sessionProxy = await docSession.getSessionProxy();
       }
 
@@ -160,6 +162,11 @@ export default class CaretOverlay {
       const oldSessions = new Set(this._sessions.keys());
 
       for (const c of snapshot.carets) {
+        if (c.sessionId === sessionId) {
+          // Don't render the caret for this client.
+          continue;
+        }
+
         docSession.log.info(`Caret: ${c.sessionId}, ${c.index}, ${c.length}, ${c.color}`);
         this._updateCaret(c.sessionId, c.index, c.length, c.color);
         oldSessions.delete(c.sessionId);

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -139,8 +139,11 @@ export default class CaretOverlay {
         // Init the session variables (on the first iteration), or re-init them
         // if we got a failure during a previous iteration.
         docSession   = this._editorComplex.docSession;
-        sessionId    = this._editorComplex.sessionId;
         sessionProxy = await docSession.getSessionProxy();
+
+        // Can only get the session ID after we have a proxy. (Before that, the
+        // ID might not be set, because the session might not even exist!)
+        sessionId = this._editorComplex.sessionId;
       }
 
       let snapshot;

--- a/local-modules/doc-client/CaretTracker.js
+++ b/local-modules/doc-client/CaretTracker.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { RevisionNumber } from 'doc-common';
-import { TInt } from 'typecheck';
+import { TInt, TObject } from 'typecheck';
 import { CommonBase, PromDelay } from 'util-common';
 
 import DocSession from './DocSession';
@@ -75,6 +75,7 @@ export default class CaretTracker extends CommonBase {
    */
   update(docRevNum, range) {
     RevisionNumber.check(docRevNum);
+    TObject.check(range);
     TInt.min(range.index, 0);
     TInt.min(range.length, 0);
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -559,7 +559,9 @@ export default class DocClient extends StateMachine {
       case QuillEvent.SELECTION_CHANGE: {
         // Consume the event, and send it onward to the caret tracker, which
         // might ultimately inform the server about it. Then go back to idling.
-        this._docSession.caretTracker.update(this._doc.revNum, event.range);
+        if (event.range) {
+          this._docSession.caretTracker.update(this._doc.revNum, event.range);
+        }
         this._currentEvent = event;
         this._becomeIdle();
         return;

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -132,6 +132,15 @@ export default class EditorComplex extends CommonBase {
   }
 
   /**
+   * {string|null} The session ID of the current server session, or `null` if
+   * no session is currently active.
+   */
+  get sessionId() {
+    const docSession = this.docSession;
+    return (docSession === null) ? null : docSession.key.id;
+  }
+
+  /**
    * Hook this instance up to a new session.
    *
    * @param {SplitKey} sessionKey New session key to use.

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -180,7 +180,7 @@ export default class CaretControl extends CommonBase {
    * @param {string} sessionId ID of the session that got reaped.
    */
   _sessionReaped(sessionId) {
-    const snapshot = this.snapshot;
+    const snapshot = this._snapshot;
     const oldCaret = snapshot.caretForSession(sessionId);
 
     if (oldCaret !== null) {


### PR DESCRIPTION
* Don't suppress the last caret update of a series of activity.
* Handle session restart in the code that tracks remote carets.
* Stop rendering the caret from an editor's own session as if it's remote.