### PR TITLE
`IterableUtil` and some cleanup.

### DIFF
--- a/local-modules/api-server/Schema.js
+++ b/local-modules/api-server/Schema.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from 'typecheck';
-import { PropertyIter } from 'util-common';
+import { PropertyIterable } from 'util-common';
 
 /**
  * Schema for an object. Represents what actions are available. More
@@ -49,7 +49,7 @@ export default class Schema {
   static _makeSchemaFor(target) {
     const result = new Map();
 
-    for (const desc of new PropertyIter(target).skipObject().onlyMethods()) {
+    for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
       const name = desc.name;
 
       if (name.match(/^_/) || (name === 'constructor')) {

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -21,7 +21,8 @@ export default class CaretSnapshot extends CommonBase {
    * @param {Int} revNum Revision number of the caret information.
    * @param {Int} docRevNum Revision number of the document to which the caret
    *   information applies.
-   * @param {Iterable<Caret>} carets Iterable of all the active carets.
+   * @param {Iterable<Caret>} carets Iterable of all the active carets. This
+   *   constructor will iterate with it exactly once.
    */
   constructor(revNum, docRevNum, carets) {
     RevisionNumber.check(revNum);

--- a/local-modules/state-machine/StateMachine.js
+++ b/local-modules/state-machine/StateMachine.js
@@ -4,7 +4,7 @@
 
 import { Logger } from 'see-all';
 import { TObject } from 'typecheck';
-import { PromCondition, PropertyIter } from 'util-common';
+import { PromCondition, PropertyIterable } from 'util-common';
 
 /**
  * Lightweight state machine framework. This allows a subclass to define
@@ -205,7 +205,7 @@ export default class StateMachine {
   _makeValidatorMap() {
     const result = {}; // Built-up result.
 
-    for (const desc of new PropertyIter(this).onlyMethods()) {
+    for (const desc of new PropertyIterable(this).onlyMethods()) {
       const match = desc.name.match(/^_check_([a-zA-Z0-9]+)$/);
       if (!match) {
         // Not the right name format.
@@ -231,7 +231,7 @@ export default class StateMachine {
 
     // First pass: Find all methods with the right name form, including those
     // with `any` (wildcard) names.
-    for (const desc of new PropertyIter(this).onlyMethods()) {
+    for (const desc of new PropertyIterable(this).onlyMethods()) {
       const match = desc.name.match(/^_handle_([a-zA-Z0-9]+)_([a-zA-Z0-9]+)$/);
       if (!match) {
         // Not the right name format.

--- a/local-modules/typecheck/TBuffer.js
+++ b/local-modules/typecheck/TBuffer.js
@@ -2,8 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TypeError } from 'typecheck';
-import { UtilityClass } from 'util-common';
+import { UtilityClass } from 'util-common-base';
+
+import TypeError from './TypeError';
 
 /**
  * Type checker for type `Buffer`.

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -4,9 +4,9 @@
 
 import { TString } from 'typecheck';
 
-/*
- * A regular expression that can be used to validate colors
- *    that are expected to be in CSS three-byte hex format (e.g. `'#fe8ef1'`)
+/**
+ * {RegExp} Regular expression that can be used to validate colors that are
+ * expected to be in CSS three-byte hex format (e.g. `'#fe8ef1'`).
  */
 const HEX_COLOR_REGEXP = /^#[a-fA-F0-9]{6}$/;
 

--- a/local-modules/util-common/IterableUtil.js
+++ b/local-modules/util-common/IterableUtil.js
@@ -1,0 +1,84 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TIterable } from 'typecheck';
+import { UtilityClass } from 'util-common-base';
+
+/**
+ * Utility methods for dealing with iterables.
+ */
+export default class IterableUtil extends UtilityClass {
+  /**
+   * Coerces an iterable-which-might-be-an-iterator into an iterable that is
+   * presumed safe to use more than once. Specifically:
+   *
+   * * Normal iterables are returned as-is.
+   * * If given an iterable which also appears to support the `Iterator`
+   *   protocol, returns a new iterable which is guaranteed to only iterate
+   *   using the originally-passed value once. The new iterable will only call
+   *   through to the original on an as-needed basis; that is, it doesn't just
+   *   collect the full iteration results up-front.
+   *
+   * **Context:** The values returned from built-in iteration methods such as
+   * `Map.values()` and `Object.entries()` are both `Iterator`s and `Iterable`s,
+   * but when used as an iterable, they are _not_ safe to use more than once.
+   * So, code that generically accepts an iterable-in-general and expects to
+   * iterate using it more than once needs to do _something_ to ensure that it
+   * doesn't get undermined by this oddball behavior. This method is one way to
+   * get the necessary protection.
+   *
+   * @param {Iterable} iterable The iterable to ensure safe multiple-use of.
+   * @returns {Iterable} `iterable` itself, if safe, or a new instance if not.
+   */
+  static multiUseSafe(iterable) {
+    TIterable.check(iterable);
+
+    if ((typeof iterable.next) !== 'function') {
+      // It does not appear to be an `Iterator`.
+      return iterable;
+    }
+
+    // It looks like an `Iterator`. Provide a safe replacement.
+
+    const iterator = iterable; // Rename to indicate what it really is.
+    const elements = [];
+    let   done     = false;
+
+    function* makeIterator() {
+      // Yield any elements already collected from the original iterator.
+      yield* elements;
+
+      // Continue to iterate over the original iterator, until it's exhausted.
+
+      let at = elements.length;
+      for (;;) {
+        // Yield elements that got appended by other simultaneously-active
+        // iterators or by our own handling of `next()` below.
+        while (at < elements.length) {
+          yield elements[at];
+          at++;
+        }
+
+        if (done) {
+          break;
+        }
+
+        // Append one more element to `elements`, or note that the iterator is
+        // done if that turns out to be the case.
+
+        const next = iterator.next();
+        if (next.done) {
+          done = true;
+          break;
+        } else {
+          elements.push(next.value);
+        }
+      }
+    }
+
+    return {
+      [Symbol.iterator]: () => { return makeIterator(); }
+    };
+  }
+}

--- a/local-modules/util-common/IterableUtil.js
+++ b/local-modules/util-common/IterableUtil.js
@@ -55,6 +55,7 @@ export default class IterableUtil extends UtilityClass {
       for (;;) {
         // Yield elements that got appended by other simultaneously-active
         // iterators or by our own handling of `next()` below.
+
         while (at < elements.length) {
           yield elements[at];
           at++;

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -10,7 +10,7 @@
  * either a string or a symbol) and `target` to the target object (either the
  * top-level object or an element in its prototype chain).
  */
-export default class PropertyIter {
+export default class PropertyIterable {
   /**
    * Constructs an instance.
    *
@@ -34,7 +34,7 @@ export default class PropertyIter {
    * specified.
    *
    * @param {function} filter The additional filter.
-   * @returns {PropertyIter} The new iterator.
+   * @returns {PropertyIterable} The new iterator.
    */
   filter(filter) {
     const origFilter = this._filter;
@@ -42,14 +42,14 @@ export default class PropertyIter {
       ? (desc => (origFilter(desc) && filter(desc)))
       : filter;
 
-    return new PropertyIter(this._object, newFilter);
+    return new PropertyIterable(this._object, newFilter);
   }
 
   /**
    * Gets an instance that is like this one but with an addition filter that
    * only passes methods (non-synthetic function-valued properties).
    *
-   * @returns {PropertyIter} The new iterator.
+   * @returns {PropertyIterable} The new iterator.
    */
   onlyMethods() {
     // **Note:** If `value` is defined, the property is guaranteed not to be
@@ -61,7 +61,7 @@ export default class PropertyIter {
    * Gets an instance that is like this one but with an addition filter that
    * skips properties defined on the root `Object` prototype.
    *
-   * @returns {PropertyIter} The new iterator.
+   * @returns {PropertyIterable} The new iterator.
    */
   skipObject() {
     return this.filter(desc => (desc.target !== Object.prototype));
@@ -71,7 +71,7 @@ export default class PropertyIter {
    * Gets an instance that is like this one but with an addition filter that
    * only passes regular non-synthetic properties.
    *
-   * @returns {PropertyIter} The new iterator.
+   * @returns {PropertyIterable} The new iterator.
    */
   skipSynthetic() {
     return this.filter(desc => !(desc.get || desc.set));

--- a/local-modules/util-common/StringUtil.js
+++ b/local-modules/util-common/StringUtil.js
@@ -12,7 +12,7 @@ import { UtilityClass } from 'util-common-base';
  * of the finer points of dealing with Unicdode) a little nicer.
  */
 export default class StringUtil extends UtilityClass {
-  /*
+  /**
    * Splits a string into its distinct grapheme clusters. For instance, the letter
    * 'ñ' could be represented as the single Unicode code point `0x00F1`, or as the
    * the letter 'n' (`0x63`) plus the '~' combinding mark (`0x0303`). The built-in
@@ -21,7 +21,8 @@ export default class StringUtil extends UtilityClass {
    * surrogate pairs, etc.
    *
    * @param {string} string The string to split.
-   * @returns {array<string>} An array of strings, one for each grapheme cluster in the input.
+   * @returns {array<string>} An array of strings, one for each grapheme cluster
+   *   in the input.
    */
   static graphemesForString(string) {
     const splitter = new GraphemeSplitter();

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -12,7 +12,7 @@ import JsonUtil from './JsonUtil';
 import PromCondition from './PromCondition';
 import PromDelay from './PromDelay';
 import PromMutex from './PromMutex';
-import PropertyIter from './PropertyIter';
+import PropertyIterable from './PropertyIterable';
 import Random from './Random';
 import Singleton from './Singleton';
 import StringUtil from './StringUtil';
@@ -29,7 +29,7 @@ export {
   PromCondition,
   PromDelay,
   PromMutex,
-  PropertyIter,
+  PropertyIterable,
   Random,
   Singleton,
   StringUtil,

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -8,6 +8,7 @@ import DataUtil from './DataUtil';
 import DeferredLoader from './DeferredLoader';
 import FrozenBuffer from './FrozenBuffer';
 import InfoError from './InfoError';
+import IterableUtil from './IterableUtil';
 import JsonUtil from './JsonUtil';
 import PromCondition from './PromCondition';
 import PromDelay from './PromDelay';
@@ -25,6 +26,7 @@ export {
   DeferredLoader,
   FrozenBuffer,
   InfoError,
+  IterableUtil,
   JsonUtil,
   PromCondition,
   PromDelay,

--- a/local-modules/util-common/tests/test_IterableUtil.js
+++ b/local-modules/util-common/tests/test_IterableUtil.js
@@ -1,0 +1,138 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { IterableUtil } from 'util-common';
+
+describe('util-common/IterableUtil', () => {
+  describe('multiUseSafe()', () => {
+    it('should throw an error if not passed an `Iterable`', () => {
+      assert.throws(() => IterableUtil.multiUseSafe(123));
+      assert.throws(() => IterableUtil.multiUseSafe('blort'));
+      assert.throws(() => IterableUtil.multiUseSafe({}));
+      assert.throws(() => IterableUtil.multiUseSafe({
+        next: () => { return { done: true }; }
+      }));
+    });
+
+    it('should pass a non-`Iterator` through as-is', () => {
+      let which = 0;
+      function assertAsIs(iterable) {
+        which++;
+        assert.strictEqual(IterableUtil.multiUseSafe(iterable), iterable, `#${which}`);
+      }
+
+      assertAsIs([]);
+      assertAsIs([1, 2, 3]);
+      assertAsIs(new Map());
+      assertAsIs(new Set([1, 2, 3]));
+    });
+
+    it('should wrap the usual built-in suspeccts', () => {
+      let which = 0;
+      function assertWrapped(iterable, expectedContents) {
+        which++;
+        const result = IterableUtil.multiUseSafe(iterable);
+        assert.notStrictEqual(result, iterable, `#${which}`);
+
+        const gotContents = [...result];
+        assert.deepEqual(gotContents, expectedContents, `#${which}`);
+      }
+
+      assertWrapped(new Map().entries(), []);
+      assertWrapped(new Map().keys(),    []);
+      assertWrapped(new Map().values(),  []);
+
+      assertWrapped(new Map([['a', 10]]).entries(), [['a', 10]]);
+      assertWrapped(new Map([['a', 10]]).keys(),    ['a']);
+      assertWrapped(new Map([['a', 10]]).values(),  [10]);
+
+      assertWrapped(new Map([['a', 10], ['b', 20]]).entries(), [['a', 10], ['b', 20]]);
+      assertWrapped(new Map([['a', 10], ['b', 20]]).keys(),    ['a', 'b']);
+      assertWrapped(new Map([['a', 10], ['b', 20]]).values(),  [10, 20]);
+
+      assertWrapped(new Set().entries(), []);
+      assertWrapped(new Set().keys(),    []);
+      assertWrapped(new Set().values(),  []);
+
+      assertWrapped(new Set([1]).entries(), [[1, 1]]);
+      assertWrapped(new Set([1]).keys(),    [1]);
+      assertWrapped(new Set([1]).values(),  [1]);
+
+      assertWrapped(new Set([1, 2, 3]).entries(), [[1, 1], [2, 2], [3, 3]]);
+      assertWrapped(new Set([1, 2, 3]).keys(),    [1, 2, 3]);
+      assertWrapped(new Set([1, 2, 3]).values(),  [1, 2, 3]);
+    });
+
+    it('should only call through to an underlying iterator once', () => {
+      const iterator = new Set([1, 2, 'blort', 4, 5]).keys();
+      const wrapped  = IterableUtil.multiUseSafe(iterator);
+      const expected = [1, 2, 'blort', 4, 5];
+      const result1  = [...wrapped];
+      const result2  = [...wrapped];
+      const result3  = [...wrapped];
+
+      assert.deepEqual(result1, expected);
+      assert.deepEqual(result2, expected);
+      assert.deepEqual(result3, expected);
+    });
+
+    it('should work in the face of interleaved iteration', () => {
+      const iterator = new Set([1, 2, 3, 'florp', 5, 6.7]).keys();
+      const wrapped  = IterableUtil.multiUseSafe(iterator);
+      const expected = [1, 2, 3, 'florp', 5, 6.7];
+      const iter1    = wrapped[Symbol.iterator]();
+      const iter2    = wrapped[Symbol.iterator]();
+      const result1  = [];
+      const result2  = [];
+
+      for (;;) {
+        const next1 = iter1.next();
+        if (next1.done) {
+          break;
+        } else {
+          result1.push(next1.value);
+        }
+
+        const next2 = iter2.next();
+        assert.notStrictEqual(next2.done, true);
+        result2.push(next2.value);
+      }
+
+      const next2 = iter2.next();
+      assert.strictEqual(next2.done, true);
+
+      assert.deepEqual(result1, expected);
+      assert.deepEqual(result2, expected);
+    });
+  });
+
+  it('should only call through to the underlying iterator as needed', () => {
+    let count = 0;
+
+    function* rawIterator() {
+      for (let i = 0; i < 10; i++) {
+        count = i + 1;
+        yield i;
+      }
+    }
+
+    const rawIterable = {
+      [Symbol.iterator]: () => { return rawIterator(); }
+    };
+
+    const wrapped  = IterableUtil.multiUseSafe(rawIterable);
+    const iterator = wrapped[Symbol.iterator]();
+
+    for (let i = 0; i < 10; i++) {
+      assert.strictEqual(count, i);
+      const next = iterator.next();
+      assert.strictEqual(next.value, i);
+    }
+
+    assert.strictEqual(count, 10);
+  });
+});

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -6,20 +6,20 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { TObject } from 'typecheck';
-import { PropertyIter } from 'util-common';
+import { PropertyIterable } from 'util-common';
 
 const TEST_OBJECT = {
   a: 1,
   b: 2,
   functionItem: assert,
-  classItem: PropertyIter,
+  classItem: PropertyIterable,
   objectItem: {}
 };
 
-describe('util-common/PropertyIter', () => {
+describe('util-common/PropertyIterable', () => {
   describe('iterating over all properties', () => {
     it('should return all properties of the object', () => {
-      const iter = new PropertyIter(TEST_OBJECT);
+      const iter = new PropertyIterable(TEST_OBJECT);
       const expectedProperties = ['a', 'b', 'functionItem', 'classItem', 'objectItem'];
 
       assert.doesNotThrow(() => _testIterator(iter, expectedProperties));
@@ -28,7 +28,7 @@ describe('util-common/PropertyIter', () => {
 
   describe('iterating soley over methods', () => {
     it('should return just function elements of the object', () => {
-      const iter = new PropertyIter(TEST_OBJECT);
+      const iter = new PropertyIterable(TEST_OBJECT);
       const methodIter = iter.onlyMethods();
       const expectedProperties = ['functionItem', 'classItem'];
       const unexpectedProperties = ['a', 'b', 'objectItem'];
@@ -39,7 +39,7 @@ describe('util-common/PropertyIter', () => {
 
   describe('iterating over properties not defined on Object', () => {
     it('should return just properties that are not part of Object', () => {
-      const iter = new PropertyIter(TEST_OBJECT);
+      const iter = new PropertyIterable(TEST_OBJECT);
       const nonObjectIter = iter.skipObject();
       const expectedProperties = ['a', 'b', 'objectItem', 'functionItem', 'classItem'];
 
@@ -63,7 +63,7 @@ describe('util-common/PropertyIter', () => {
  * were not. There may be additional properties set in the results beyond what
  * was specifically checked.
  *
- * @param {PropertyIter} iter The iterator we are testing.
+ * @param {PropertyIterable} iter The iterator we are testing.
  * @param {Array<string>|null} [expectedProperties=[]] A list of property
  *   names. The iterator must return _at least_ all of the properties in this
  *   list.


### PR DESCRIPTION
I ran into a rough edge in JS yesterday, and the new utility method `IterableUtil.multiUseSafe()` is the result. It's not used yet, because I ended up writing yesterday's code a different way; but if I needed it once, there's a good chance I'll need it again.

**Bonus:** Tangentially-related cleanup.