### PR TITLE
Get `Caret` ready to be fluffier.

### DIFF
--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -37,9 +37,12 @@ export default class WsConnection extends Connection {
    * @param {string} msg Incoming message, in JSON string form.
    */
   async _handleMessage(msg) {
-    const response = await this.handleJsonMessage(msg);
-
-    this._ws.send(response);
+    try {
+      const response = await this.handleJsonMessage(msg);
+      this._ws.send(response);
+    } catch (e) {
+      this._handleError(e);
+    }
   }
 
   /**

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -150,8 +150,24 @@ export default class Caret extends CommonBase {
       throw new Error('Cannot `diff` carets with mismatched `sessionId`.');
     }
 
-    const fields = this._fields;
-    const ops    = [];
+    return this.diffFields(newerCaret, sessionId);
+  }
+
+  /**
+   * Like `diff()`, except does _not_ check to see if the two instances'
+   * `sessionId`s match. That is, it only looks at the fields.
+   *
+   * @param {Caret} newerCaret Caret to take the difference from.
+   * @param {string} sessionId Session ID to use for the ops in the result.
+   * @returns {CaretDelta} Delta which represents the difference between
+   *   `newerCaret` and this instance, _not_ including any difference in
+   *   `sessionId`, if any.
+   */
+  diffFields(newerCaret, sessionId) {
+    Caret.check(newerCaret);
+
+    const fields    = this._fields;
+    const ops       = [];
 
     for (const [k, v] of newerCaret._fields) {
       if (v !== fields.get(k)) {

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -112,7 +112,7 @@ export default class Caret extends CommonBase {
     const fields = new Map(this._fields);
 
     for (const op of delta.ops) {
-      if (op.name !== CaretOp.UPDATE_CARET_FIELD) {
+      if (op.name !== CaretOp.UPDATE_FIELD) {
         throw new Error(`Invalid operation name: ${op.name}`);
       } else if (op.arg('sessionId') !== this.sessionId) {
         throw new Error('Mismatched session ID.');

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -165,6 +165,7 @@ export default class Caret extends CommonBase {
    */
   diffFields(newerCaret, sessionId) {
     Caret.check(newerCaret);
+    TString.nonempty(sessionId);
 
     const fields    = this._fields;
     const ops       = [];

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -114,7 +114,10 @@ export default class Caret extends CommonBase {
     for (const op of delta.ops) {
       if (op.name !== CaretOp.UPDATE_CARET_FIELD) {
         throw new Error(`Invalid operation name: ${op.name}`);
+      } else if (op.arg('sessionId') !== this.sessionId) {
+        throw new Error('Mismatched session ID.');
       }
+
       fields.set(op.arg('key'), op.arg('value'));
     }
 

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -99,7 +99,7 @@ export default class Caret extends CommonBase {
 
   /**
    * Composes the given `delta` on top of this instance, producing a new
-   * instance. The operations in `delta` must all be `updateCaretField` ops
+   * instance. The operations in `delta` must all be `updateField` ops
    * for the same `sessionId` as this instance.
    *
    * @param {CaretDelta} delta Delta to apply.
@@ -172,7 +172,7 @@ export default class Caret extends CommonBase {
 
     for (const [k, v] of newerCaret._fields) {
       if (v !== fields.get(k)) {
-        ops.push(CaretOp.op_updateCaretField(sessionId, k, v));
+        ops.push(CaretOp.op_updateField(sessionId, k, v));
       }
     }
 

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -7,9 +7,15 @@ import { TString } from 'typecheck';
 import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
 
+import { CommonBase } from 'util-common';
+
+/** {Symbol} Key which protects the constructor from being called improperly. */
 const KEY = Symbol('CaretOp constructor key');
 
-export default class CaretOp {
+/**
+ * Operation which can be applied to a `Caret` or `CaretSnapshot`.
+ */
+export default class CaretOp extends CommonBase {
   /** {string} Operation name for "begin session" operations. */
   static get BEGIN_SESSION() {
     return 'begin-session';
@@ -129,6 +135,8 @@ export default class CaretOp {
    * @param {Map<string,*>} args Arguments to the operation.
    */
   constructor(constructorKey, name, args) {
+    super();
+
     if (constructorKey !== KEY) {
       throw new Error('Constructor is private');
     }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -5,7 +5,6 @@
 import { TInt, TString } from 'typecheck';
 import { ColorSelector, CommonBase } from 'util-common';
 
-import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
 
 /** {Symbol} Key which protects the constructor from being called improperly. */
@@ -31,11 +30,6 @@ export default class CaretOp extends CommonBase {
   /** {string} Operation name for "begin session" operations. */
   static get BEGIN_SESSION() {
     return 'begin-session';
-  }
-
-  /** {string} Operation name for "update caret" operations. */
-  static get UPDATE_CARET() {
-    return 'update-caret';
   }
 
   /** {string} Operation name for "update caret field" operations. */
@@ -73,24 +67,6 @@ export default class CaretOp extends CommonBase {
     args.set('sessionId', sessionId);
 
     return new CaretOp(KEY, CaretOp.BEGIN_SESSION, args);
-  }
-
-  /**
-   * Constructs a new "update caret" operation.
-   *
-   * @param {Caret} caret The caret to update. `Caret` objects notably know what
-   *   session they are associated with.
-   * @returns {CaretOp} An operation representing new caret information for a
-   *   particular session.
-   */
-  static op_updateCaret(caret) {
-    Caret.check(caret);
-
-    const args = new Map();
-
-    args.set('caret', caret);
-
-    return new CaretOp(KEY, CaretOp.UPDATE_CARET, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -12,7 +12,7 @@ const KEY = Symbol('CaretOp constructor key');
 
 /**
  * {Map<string,function>} Map from each allowed caret field name to a type
- * checker predicate for same, for use in `updateCaretField` operations.
+ * checker predicate for same, for use in `updateField` operations.
  *
  * **Note:** `sessionId` is not included, because that can't be altered by those
  * operations.
@@ -32,9 +32,9 @@ export default class CaretOp extends CommonBase {
     return 'begin-session';
   }
 
-  /** {string} Operation name for "update caret field" operations. */
-  static get UPDATE_CARET_FIELD() {
-    return 'update-caret-field';
+  /** {string} Operation name for "update field" operations. */
+  static get UPDATE_FIELD() {
+    return 'update-field';
   }
 
   /** {string} Operation name for "end session" operations. */
@@ -79,7 +79,7 @@ export default class CaretOp extends CommonBase {
    * @returns {CaretOp} An operation representing the update of the indicated
    *   field on the indicated caret.
    */
-  static op_updateCaretField(sessionId, key, value) {
+  static op_updateField(sessionId, key, value) {
     TString.check(sessionId);
     TString.nonempty(key);
 

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -101,7 +101,7 @@ export default class CaretOp extends CommonBase {
     args.set('key',       key);
     args.set('value',     value);
 
-    return new CaretOp(KEY, CaretOp.UPDATE_CARET_FIELD, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_FIELD, args);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -89,7 +89,7 @@ export default class CaretSnapshot extends CommonBase {
   /**
    * Composes a delta on top of this instance, to produce a new instance.
    *
-   * **Note:** It is an error if `delta` contains an `op_updateCaret` to a caret
+   * **Note:** It is an error if `delta` contains an `op_updateField` to a caret
    * that either does not exist in `this` or was not first introduced with an
    * `op_beginSession`.
    *

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -112,19 +112,7 @@ export default class CaretSnapshot extends CommonBase {
           break;
         }
 
-        case CaretOp.UPDATE_CARET: {
-          const caret     = op.arg('caret');
-          const sessionId = caret.sessionId;
-
-          if (!newCarets.get(sessionId)) {
-            throw new Error(`Invalid delta; update to nonexistent caret: ${sessionId}`);
-          }
-
-          newCarets.set(sessionId, caret);
-          break;
-        }
-
-        case CaretOp.UPDATE_CARET_FIELD: {
+        case CaretOp.UPDATE_FIELD: {
           const sessionId = op.arg('sessionId');
           const caret     = newCarets.get(sessionId);
 

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -7,9 +7,22 @@ import { describe, it } from 'mocha';
 
 import { Caret, CaretDelta, CaretOp } from 'doc-common';
 
-const caret1 = new Caret('session-1', 1, 0,  '#111111');
-const caret2 = new Caret('session-2', 2, 6,  '#222222');
-const caret3 = new Caret('session-3', 3, 99, '#333333');
+/**
+ * Convenient caret constructor, which takes positional parameters.
+ *
+ * @param {string} sessionId Session ID.
+ * @param {Int} index Start caret position.
+ * @param {Int} length Selection length.
+ * @param {string} color Highlight color.
+ * @returns {Caret} Appropriately-constructed caret.
+ */
+function newCaret(sessionId, index, length, color) {
+  return new Caret(sessionId, Object.entries({ index, length, color }));
+}
+
+const caret1 = newCaret('session-1', 1, 0,  '#111111');
+const caret2 = newCaret('session-2', 2, 6,  '#222222');
+const caret3 = newCaret('session-3', 3, 99, '#333333');
 
 describe('doc-common/Caret', () => {
   describe('compose()', () => {
@@ -134,8 +147,8 @@ describe('doc-common/Caret', () => {
     });
 
     it('should return `false` when session IDs differ', () => {
-      const c1 = new Caret('x', 1, 2, '#000011');
-      const c2 = new Caret('y', 1, 2, '#000011');
+      const c1 = newCaret('x', 1, 2, '#000011');
+      const c2 = newCaret('y', 1, 2, '#000011');
       assert.isFalse(c1.equals(c2));
     });
 

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -1,0 +1,116 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Caret, CaretDelta, CaretOp } from 'doc-common';
+
+const caret1 = new Caret('session-1', 1, 0,  '#111111');
+const caret2 = new Caret('session-2', 2, 6,  '#222222');
+const caret3 = new Caret('session-3', 3, 99, '#333333');
+
+describe('doc-common/Caret', () => {
+  describe('compose()', () => {
+    it('should produce an equal instance when passed an empty delta', () => {
+      let which = 0;
+      function test(caret) {
+        which++;
+        const result = caret.compose(CaretDelta.EMPTY);
+        assert.isTrue(result.equals(caret), `#${which}`);
+      }
+
+      test(caret1);
+      test(caret2);
+      test(caret3);
+    });
+
+    it('should update `index` given the appropriate op', () => {
+      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'index', 99999);
+      const result = caret1.compose(new CaretDelta([op]));
+
+      assert.strictEqual(result.index, 99999);
+    });
+
+    it('should update `length` given the appropriate op', () => {
+      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'length', 99999);
+      const result = caret1.compose(new CaretDelta([op]));
+
+      assert.strictEqual(result.length, 99999);
+    });
+
+    it('should update `color` given the appropriate op', () => {
+      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'color', '#aabbcc');
+      const result = caret1.compose(new CaretDelta([op]));
+
+      assert.strictEqual(result.color, '#aabbcc');
+    });
+
+    it('should refuse to compose if given a non-matching session ID', () => {
+      const op = CaretOp.op_updateCaretField(caret2.sessionId, 'index', 55);
+
+      assert.throws(() => { caret1.compose(new CaretDelta([op])); });
+    });
+  });
+
+  describe('diff()', () => {
+    it('should produce an empty diff when passed itself', () => {
+      const result = caret1.diff(caret1);
+
+      assert.instanceOf(result, CaretDelta);
+      assert.deepEqual(result.ops, []);
+    });
+
+    it('should refuse to diff if given a non-matching session ID', () => {
+      assert.throws(() => { caret1.diff(caret2); });
+    });
+
+    it('should result in an `index` diff if that in fact changes', () => {
+      const older   = caret1;
+      const op      = CaretOp.op_updateCaretField(older.sessionId, 'index', 99999);
+      const newer   = older.compose(new CaretDelta([op]));
+      const diffOps = older.diff(newer).ops;
+
+      assert.strictEqual(diffOps.length, 1);
+      assert.deepEqual(diffOps[0], op);
+    });
+  });
+
+  describe('equals()', () => {
+    it('should return `true` when passed itself', () => {
+      assert.isTrue(caret1.equals(caret1));
+      assert.isTrue(caret2.equals(caret2));
+      assert.isTrue(caret3.equals(caret3));
+    });
+
+    it('should return `true` when passed an identically-constructed value', () => {
+      const same = caret1.compose(CaretDelta.EMPTY);
+      assert.notStrictEqual(caret1, same);
+      assert.isTrue(caret1.equals(same));
+    });
+
+    it('should return `false` when session IDs differ', () => {
+      const c1 = new Caret('x', 1, 2, '#000011');
+      const c2 = new Caret('y', 1, 2, '#000011');
+      assert.isFalse(c1.equals(c2));
+    });
+
+    it('should return `false` when any field differs', () => {
+      const c1 = caret1;
+      let   c2, op;
+
+      op = CaretOp.op_updateCaretField(c1.sessionId, 'index', 99999);
+      c2 = c1.compose(new CaretDelta([op]));
+      assert.isFalse(c1.equals(c2));
+
+      op = CaretOp.op_updateCaretField(c1.sessionId, 'length', 99999);
+      c2 = c1.compose(new CaretDelta([op]));
+      assert.isFalse(c1.equals(c2));
+
+      op = CaretOp.op_updateCaretField(c1.sessionId, 'color', '#999999');
+      c2 = c1.compose(new CaretDelta([op]));
+      assert.isFalse(c1.equals(c2));
+    });
+  });
+});

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -77,6 +77,49 @@ describe('doc-common/Caret', () => {
     });
   });
 
+  describe('diffFields()', () => {
+    it('should produce an empty diff when passed itself', () => {
+      const result = caret1.diffFields(caret1, 'florp');
+
+      assert.instanceOf(result, CaretDelta);
+      assert.deepEqual(result.ops, []);
+    });
+
+    it('should diff fields even if given a non-matching session ID', () => {
+      assert.doesNotThrow(() => { caret1.diffFields(caret2, 'florp'); });
+    });
+
+    it('should result in an `index` diff if that in fact changes', () => {
+      const older   = caret1;
+      const op      = CaretOp.op_updateField(older.sessionId, 'index', 99999);
+      const newer   = older.compose(new CaretDelta([op]));
+      const diffOps = older.diffFields(newer, older.sessionId).ops;
+
+      assert.strictEqual(diffOps.length, 1);
+      assert.deepEqual(diffOps[0], op);
+    });
+
+    it('should result in a `length` diff if that in fact changes', () => {
+      const older   = caret1;
+      const op      = CaretOp.op_updateField(older.sessionId, 'length', 99999);
+      const newer   = older.compose(new CaretDelta([op]));
+      const diffOps = older.diffFields(newer, older.sessionId).ops;
+
+      assert.strictEqual(diffOps.length, 1);
+      assert.deepEqual(diffOps[0], op);
+    });
+
+    it('should result in a `color` diff if that in fact changes', () => {
+      const older   = caret1;
+      const op      = CaretOp.op_updateField(older.sessionId, 'color', '#abcdef');
+      const newer   = older.compose(new CaretDelta([op]));
+      const diffOps = older.diffFields(newer, older.sessionId).ops;
+
+      assert.strictEqual(diffOps.length, 1);
+      assert.deepEqual(diffOps[0], op);
+    });
+  });
+
   describe('equals()', () => {
     it('should return `true` when passed itself', () => {
       assert.isTrue(caret1.equals(caret1));

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -27,28 +27,28 @@ describe('doc-common/Caret', () => {
     });
 
     it('should update `index` given the appropriate op', () => {
-      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'index', 99999);
+      const op     = CaretOp.op_updateField(caret1.sessionId, 'index', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.index, 99999);
     });
 
     it('should update `length` given the appropriate op', () => {
-      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'length', 99999);
+      const op     = CaretOp.op_updateField(caret1.sessionId, 'length', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.length, 99999);
     });
 
     it('should update `color` given the appropriate op', () => {
-      const op     = CaretOp.op_updateCaretField(caret1.sessionId, 'color', '#aabbcc');
+      const op     = CaretOp.op_updateField(caret1.sessionId, 'color', '#aabbcc');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.color, '#aabbcc');
     });
 
     it('should refuse to compose if given a non-matching session ID', () => {
-      const op = CaretOp.op_updateCaretField(caret2.sessionId, 'index', 55);
+      const op = CaretOp.op_updateField(caret2.sessionId, 'index', 55);
 
       assert.throws(() => { caret1.compose(new CaretDelta([op])); });
     });
@@ -68,7 +68,7 @@ describe('doc-common/Caret', () => {
 
     it('should result in an `index` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_updateCaretField(older.sessionId, 'index', 99999);
+      const op      = CaretOp.op_updateField(older.sessionId, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diff(newer).ops;
 
@@ -100,15 +100,15 @@ describe('doc-common/Caret', () => {
       const c1 = caret1;
       let   c2, op;
 
-      op = CaretOp.op_updateCaretField(c1.sessionId, 'index', 99999);
+      op = CaretOp.op_updateField(c1.sessionId, 'index', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_updateCaretField(c1.sessionId, 'length', 99999);
+      op = CaretOp.op_updateField(c1.sessionId, 'length', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_updateCaretField(c1.sessionId, 'color', '#999999');
+      op = CaretOp.op_updateField(c1.sessionId, 'color', '#999999');
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
     });

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -55,7 +55,7 @@ describe('doc-common/CaretSnapshot', () => {
       const snap  = new CaretSnapshot(1, 2, [caret1]);
       const delta = new CaretDelta([CaretOp.op_updateCaret(new Caret('florp'))]);
 
-      assert.throws(() => { snap.update(delta); });
+      assert.throws(() => { snap.compose(delta); });
     });
 
     it('should update a pre-existing caret given the appropriate op', () => {

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -7,9 +7,22 @@ import { describe, it } from 'mocha';
 
 import { Caret, CaretDelta, CaretOp, CaretSnapshot } from 'doc-common';
 
-const caret1 = new Caret('session-1', 1, 0,  '#111111');
-const caret2 = new Caret('session-2', 2, 6,  '#222222');
-const caret3 = new Caret('session-3', 3, 99, '#333333');
+/**
+ * Convenient caret constructor, which takes positional parameters.
+ *
+ * @param {string} sessionId Session ID.
+ * @param {Int} index Start caret position.
+ * @param {Int} length Selection length.
+ * @param {string} color Highlight color.
+ * @returns {Caret} Appropriately-constructed caret.
+ */
+function newCaret(sessionId, index, length, color) {
+  return new Caret(sessionId, Object.entries({ index, length, color }));
+}
+
+const caret1 = newCaret('session-1', 1, 0,  '#111111');
+const caret2 = newCaret('session-2', 2, 6,  '#222222');
+const caret3 = newCaret('session-3', 3, 99, '#333333');
 
 describe('doc-common/CaretSnapshot', () => {
   describe('compose()', () => {
@@ -59,8 +72,8 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should update a pre-existing caret given an appropriate op', () => {
-      const c1       = new Caret('foo', 1, 2, '#333333');
-      const c2       = new Caret('foo', 3, 2, '#333333');
+      const c1       = newCaret('foo', 1, 2, '#333333');
+      const c2       = newCaret('foo', 3, 2, '#333333');
       const snap     = new CaretSnapshot(1, 2, [caret1, c1]);
       const expected = new CaretSnapshot(1, 2, [caret1, c2]);
       const op       = CaretOp.op_updateField('foo', 'index', 3);
@@ -142,9 +155,9 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should result in a caret update if that in fact happens', () => {
-      const c1 = new Caret('florp', 1, 3, '#444444');
-      const c2 = new Caret('florp', 2, 4, '#555555');
-      const c3 = new Caret('florp', 3, 5, '#666666');
+      const c1 = newCaret('florp', 1, 3, '#444444');
+      const c2 = newCaret('florp', 2, 4, '#555555');
+      const c3 = newCaret('florp', 3, 5, '#666666');
       const snap1 = new CaretSnapshot(1, 2, [c1]);
       const snap2 = new CaretSnapshot(1, 2, [c2]);
       const result = snap1.diff(snap2);
@@ -192,10 +205,10 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should return `true` when equal carets are not also `===`', () => {
-      const c1a = new Caret('florp', 2, 3, '#444444');
-      const c1b = new Caret('florp', 2, 3, '#444444');
-      const c2a = new Caret('like',  3, 0, '#dbdbdb');
-      const c2b = new Caret('like',  3, 0, '#dbdbdb');
+      const c1a = newCaret('florp', 2, 3, '#444444');
+      const c1b = newCaret('florp', 2, 3, '#444444');
+      const c2a = newCaret('like',  3, 0, '#dbdbdb');
+      const c2b = newCaret('like',  3, 0, '#dbdbdb');
 
       const snap1 = new CaretSnapshot(1, 2, [c1a, c2a]);
       const snap2 = new CaretSnapshot(1, 2, [c1b, c2b]);

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -53,7 +53,7 @@ describe('doc-common/CaretSnapshot', () => {
 
     it('should refuse to update a nonexistent caret', () => {
       const snap  = new CaretSnapshot(1, 2, [caret1]);
-      const delta = new CaretDelta([CaretOp.op_updateCaretField('florp', 'index', 1)]);
+      const delta = new CaretDelta([CaretOp.op_updateField('florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(delta); });
     });
@@ -63,7 +63,7 @@ describe('doc-common/CaretSnapshot', () => {
       const c2       = new Caret('foo', 3, 2, '#333333');
       const snap     = new CaretSnapshot(1, 2, [caret1, c1]);
       const expected = new CaretSnapshot(1, 2, [caret1, c2]);
-      const op       = CaretOp.op_updateCaretField('foo', 'index', 3);
+      const op       = CaretOp.op_updateField('foo', 'index', 3);
       const result   = snap.compose(new CaretDelta([op]));
 
       assert.isTrue(result.equals(expected));

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -53,17 +53,18 @@ describe('doc-common/CaretSnapshot', () => {
 
     it('should refuse to update a nonexistent caret', () => {
       const snap  = new CaretSnapshot(1, 2, [caret1]);
-      const delta = new CaretDelta([CaretOp.op_updateCaret(new Caret('florp'))]);
+      const delta = new CaretDelta([CaretOp.op_updateCaretField('florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(delta); });
     });
 
-    it('should update a pre-existing caret given the appropriate op', () => {
+    it('should update a pre-existing caret given an appropriate op', () => {
       const c1       = new Caret('foo', 1, 2, '#333333');
-      const c2       = new Caret('foo', 3, 4, '#555555');
+      const c2       = new Caret('foo', 3, 2, '#333333');
       const snap     = new CaretSnapshot(1, 2, [caret1, c1]);
       const expected = new CaretSnapshot(1, 2, [caret1, c2]);
-      const result   = snap.compose(new CaretDelta([CaretOp.op_updateCaret(c2)]));
+      const op       = CaretOp.op_updateCaretField('foo', 'index', 3);
+      const result   = snap.compose(new CaretDelta([op]));
 
       assert.isTrue(result.equals(expected));
     });
@@ -74,7 +75,7 @@ describe('doc-common/CaretSnapshot', () => {
 
       const delta = new CaretDelta([
         CaretOp.op_beginSession(caret1.sessionId),
-        CaretOp.op_updateCaret(caret1)]);
+        ...(Caret.EMPTY.diffFields(caret1, caret1.sessionId).ops)]);
 
       const result = snap.compose(delta);
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -134,12 +134,13 @@ export default class CaretControl extends CommonBase {
 
     if (oldCaret === null) {
       const color    = this._colorSelector.nextColorHex();
-      const newCaret = new Caret(sessionId, index, length, color);
+      const newCaret = new Caret(sessionId, Object.entries({ index, length, color }));
       const diff     = Caret.EMPTY.diffFields(newCaret, sessionId);
 
       ops = [CaretOp.op_beginSession(sessionId), ...diff.ops];
     } else {
-      const newCaret = new Caret(sessionId, index, length, oldCaret.color);
+      const color    = oldCaret.color;
+      const newCaret = new Caret(sessionId, Object.entries({ index, length, color }));
       const diff     = oldCaret.diff(newCaret);
 
       ops = [...diff.ops]; // `[...x]` so as to be mutable for `push()` below.

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -139,8 +139,7 @@ export default class CaretControl extends CommonBase {
 
       ops = [CaretOp.op_beginSession(sessionId), ...diff.ops];
     } else {
-      const color    = oldCaret.color;
-      const newCaret = new Caret(sessionId, Object.entries({ index, length, color }));
+      const newCaret = new Caret(oldCaret, Object.entries({ index, length }));
       const diff     = oldCaret.diff(newCaret);
 
       ops = [...diff.ops]; // `[...x]` so as to be mutable for `push()` below.

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -83,6 +83,17 @@ export default class TInt extends UtilityClass {
   }
 
   /**
+   * Checks a value of type `Int`, which must furthermore be a non-negative
+   * number.
+   *
+   * @param {*} value Value to check.
+   * @returns {Int} `value`.
+   */
+  static nonNegative(value) {
+    return TInt.min(value, 0);
+  }
+
+  /**
    * Checks a value of type `Int`, which must furthermore be within an indicated
    * inclusive-exclusive range.
    *

--- a/local-modules/typecheck/TIterable.js
+++ b/local-modules/typecheck/TIterable.js
@@ -31,7 +31,7 @@ export default class TIterable extends UtilityClass {
   static check(value, entryCheck = null) {
     if (   ((typeof value) !== 'object')
         || ((typeof value[Symbol.iterator]) !== 'function')) {
-      return TypeError.badValue(value, 'Iterator');
+      return TypeError.badValue(value, 'Iterable');
     }
 
     if (entryCheck !== null) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.18.1
+version = 0.18.2


### PR DESCRIPTION
The main thing in this PR is a rework of `Caret`, so as to make it easy to add new fields to it, because we already know it's missing at least one field (author ID). This change worked its way through to `CaretOp` which now defines an `updateField` op to update individual caret fields instead of the former `updateCaret` op which took a whole caret (including fields which didn't change)… and further through to `CaretSnapshot` which now diffs and composes using the new op.

The version bump is because the encoded form of `Caret` changed.

**Bonus:** Improved top-level error handling on the server, and fixed a typo or two.