### PR TITLE
OT carets for realsies.

### DIFF
--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -14,6 +14,20 @@ import { ColorSelector, PromDelay } from 'util-common';
 const REFRESH_DELAY_MSEC = 2000;
 
 /**
+ * {Int} Amount of time (in msec) to wait after receiving a caret update from
+ * the server before requesting another one. This is to prevent the client from
+ * inundating the server with requests when there is some particularly active
+ * editing going on.
+ */
+const REQUEST_DELAY_MSEC = 250;
+
+/**
+ * {Int} Amount of time (in msec) to wait after a failure to communicate with
+ * the server, before trying to reconnect.
+ */
+const ERROR_DELAY_MSEC = 5000;
+
+/**
  * Manager of the visual display of the selection and insertion caret of remote
  * users editing the same document as the local user. It renders the selections
  * into an SVG element that overlays the Quill editor.
@@ -181,7 +195,7 @@ export default class CaretOverlay {
         docSession.log.warn('Trouble with `caretSnapshot`:', e);
         docSession   = null;
         sessionProxy = null;
-        await PromDelay.resolve(5000);
+        await PromDelay.resolve(ERROR_DELAY_MSEC);
         continue;
       }
 
@@ -205,8 +219,7 @@ export default class CaretOverlay {
         this._endSession(s);
       }
 
-      // TODO: Make this properly wait for and integrate changes.
-      await PromDelay.resolve(5000);
+      await PromDelay.resolve(REQUEST_DELAY_MSEC);
     }
   }
 

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -210,7 +210,7 @@ export default class CaretOverlay {
   }
 
   /**
-   * Waits a bit of time and then redraws our state.
+   * Redraws the current state of the remote carets.
    */
   _updateDisplay() {
     // Remove extant annotations.

--- a/local-modules/doc-client/CaretTracker.js
+++ b/local-modules/doc-client/CaretTracker.js
@@ -12,7 +12,7 @@ import DocSession from './DocSession';
  * How long to wait (in msec) after sending a caret update before sending the
  * next one.
  */
-const UPDATE_DELAY_MSEC = 1000;
+const UPDATE_DELAY_MSEC = 250;
 
 /**
  * Handler for the upload of caret info from this client.

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -67,11 +67,16 @@ export default class Caret extends CommonBase {
 
     /** {Map<string,*>} Map of all of the caret fields, from name to value. */
     this._fields = newFields;
+
     for (const [k, v] of fields) {
       // Construct an `updateField` op, which forces `k` and `v` to be
       // validated.
       CaretOp.op_updateField(sessionId, k, v);
-      this._fields.set(k, v);
+      newFields.set(k, v);
+    }
+
+    if (EMPTY && (newFields.size !== EMPTY._fields.size)) {
+      throw new Error(`Missing field.`);
     }
 
     Object.freeze(this);

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -242,3 +242,6 @@ export default class Caret extends CommonBase {
     return new Caret(sessionId, Object.entries(fields));
   }
 }
+
+// Ensure that `EMPTY` is initialized.
+Caret.EMPTY;

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -172,7 +172,8 @@ export default class CaretControl extends CommonBase {
     this._snapshot = snapshot.compose(new CaretDelta(ops));
     this._updatedCondition.onOff();
 
-    this._log.detail(`New caret revision number: ${newRevNum}`);
+    this._log.info(`Updated carets: Caret revision ${newRevNum}; ` +
+      `document revision ${this._snapshot.docRevNum}`);
 
     return newRevNum;
   }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -10,6 +10,12 @@ import { ColorSelector, CommonBase, PromCondition } from 'util-common';
 import FileComplex from './FileComplex';
 
 /**
+ * {Int} How many older caret snapshots should be maintained for potential use
+ * as the base for `deltaAfter()`.
+ */
+const MAX_OLD_SNAPSHOTS = 20;
+
+/**
  * Controller for the active caret info for a given document.
  *
  * There is only ever exactly one instance of this class per document, no matter
@@ -42,6 +48,12 @@ export default class CaretControl extends CommonBase {
     this._snapshot = new CaretSnapshot(0, 0, []);
 
     /**
+     * {array<CaretSnapshot>} Array of older caret snapshots, available for use
+     * for `deltaAfter()`.
+     */
+    this._oldSnapshots = [this._snapshot];
+
+    /**
      * {PromCondition} Condition that gets triggered whenever the snapshot is
      * updated.
      */
@@ -52,6 +64,8 @@ export default class CaretControl extends CommonBase {
 
     /** {Logger} Logger specific to this document's ID. */
     this._log = fileComplex.log;
+
+    Object.seal(this);
   }
 
   /**
@@ -66,16 +80,29 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretDelta} Delta from the base caret revision to a newer one.
    */
   async deltaAfter(baseRevNum) {
-    const oldSnapshot = this._snapshot;
+    const minRevNum     = this._oldSnapshots[0].revNum;
+    const currentRevNum = this._snapshot.revNum;
 
-    // For now, we only succeed if the latest revision is being requested.
-    // **TODO:** Handle past revisions, details to be driven by client
-    // requirements.
-    if (baseRevNum !== oldSnapshot.revNum) {
+    if ((baseRevNum < minRevNum) || (baseRevNum > currentRevNum)) {
       throw new Error(`Revision not available: ${baseRevNum}`);
     }
 
-    await this._updatedCondition.whenTrue();
+    // Grab the snapshot to use as the base. **Note:** If `baseRevNum` is in
+    // fact the current revision number, this will turn out to be the same as
+    // `_snapshot` because `_snapshot` is always the last element of
+    // `_oldSnapshots`.
+    const oldSnapshot = this._oldSnapshots[baseRevNum - minRevNum];
+    if (oldSnapshot.revNum !== baseRevNum) {
+      this._log.wtf(`Snapshot rev-num inconsistency: ${baseRevNum}, ${oldSnapshot.revNum}`);
+    }
+
+    if (baseRevNum === currentRevNum) {
+      // We've been asked for a revision newer than the most recent one, so we
+      // have to wait for a change to be made. `_snapshot` will have been
+      // changed by the time this `await` returns.
+      await this._updatedCondition.whenTrue();
+    }
+
     return oldSnapshot.diff(this._snapshot);
   }
 
@@ -169,8 +196,15 @@ export default class CaretControl extends CommonBase {
     ops.push(CaretOp.op_updateRevNum(newRevNum));
 
     // Update the snapshot, and wake up any waiters.
-    this._snapshot = snapshot.compose(new CaretDelta(ops));
+    const newSnapshot = snapshot.compose(new CaretDelta(ops));
+    this._snapshot = newSnapshot;
+    this._oldSnapshots.push(newSnapshot);
     this._updatedCondition.onOff();
+
+    while (this._oldSnapshots.length > MAX_OLD_SNAPSHOTS) {
+      // Trim `_oldSnapshots` down to its allowed length.
+      this._oldSnapshots.shift();
+    }
 
     this._log.info(`Updated carets: Caret revision ${newRevNum}; ` +
       `document revision ${this._snapshot.docRevNum}`);


### PR DESCRIPTION
This PR reworks the caret overlay code to actually ask for deltas, the same way that the document editor code does. This makes it possible to more promptly update the display as remote carets move around, instead of always lagging by N seconds (where N in our case had been ~5, because of conservative choices). There is still a bit of a delay between updates, just to keep network traffic from becoming the All Caret Show when edits are coming fast and furious.