### PR TITLE
Notice edits and idle sessions.

### DIFF
--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -160,7 +160,7 @@ export default class CaretOverlay {
           // to do that.
           const delta = await sessionProxy.caretDeltaAfter(snapshot.revNum);
           snapshot = snapshot.compose(delta);
-          docSession.log.info(`Got caret delta. ${snapshot.carets.length} caret(s).`);
+          docSession.log.detail(`Got caret delta. ${snapshot.carets.length} caret(s).`);
         }
       } catch (e) {
         // Assume that the error isn't truly fatal. Most likely, it's because
@@ -179,7 +179,7 @@ export default class CaretOverlay {
           // latter is why this section isn't just part of an `else` block to
           // the previous `if`).
           snapshot = await sessionProxy.caretSnapshot();
-          docSession.log.info(`Got ${snapshot.carets.length} new caret(s)!`);
+          docSession.log.detail(`Got ${snapshot.carets.length} new caret(s)!`);
         }
       } catch (e) {
         // Assume that the error is transient and most likely due to the session
@@ -200,7 +200,6 @@ export default class CaretOverlay {
           continue;
         }
 
-        docSession.log.info(`Caret: ${c.sessionId}, ${c.index}, ${c.length}, ${c.color}`);
         this._updateCaret(c.sessionId, c.index, c.length, c.color);
         oldSessions.delete(c.sessionId);
       }

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -126,6 +126,11 @@ export default class EditorComplex extends CommonBase {
     return this._docSession;
   }
 
+  /** {Logger} Logger to use when _not_ referring to the session. */
+  get log() {
+    return log;
+  }
+
   /** {QuillProm} The Quill editor object. */
   get quill() {
     return this._quill;

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -104,6 +104,13 @@ export default class Caret extends CommonBase {
   }
 
   /**
+   * {Timestamp} The moment in time when this session was last active.
+   */
+  get lastActive() {
+    return this._fields.get('lastActive');
+  }
+
+  /**
    * {Int} The length of the selection, or zero if it is just an insertion point.
    */
   get length() {

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -28,7 +28,11 @@ export default class Caret extends CommonBase {
   static get EMPTY() {
     if (EMPTY === null) {
       EMPTY = new Caret('no-session',
-        Object.entries({ index: 0, length: 0, color: '#000000' }));
+        Object.entries({
+          index:  0,
+          length: 0,
+          color:  '#000000'
+        }));
     }
 
     return EMPTY;

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -7,6 +7,7 @@ import { CommonBase } from 'util-common';
 
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
+import Timestamp from './Timestamp';
 
 /**
  * {Caret|null} An instance with all default values. Initialized in the static
@@ -29,9 +30,10 @@ export default class Caret extends CommonBase {
     if (EMPTY === null) {
       EMPTY = new Caret('no-session',
         Object.entries({
-          index:  0,
-          length: 0,
-          color:  '#000000'
+          lastActive: Timestamp.now(),
+          index:      0,
+          length:     0,
+          color:      '#000000'
         }));
     }
 

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -6,6 +6,7 @@ import { TInt, TString } from 'typecheck';
 import { ColorSelector, CommonBase } from 'util-common';
 
 import RevisionNumber from './RevisionNumber';
+import Timestamp from './Timestamp';
 
 /** {Symbol} Key which protects the constructor from being called improperly. */
 const KEY = Symbol('CaretOp constructor key');
@@ -18,9 +19,10 @@ const KEY = Symbol('CaretOp constructor key');
  * operations.
  */
 const CARET_FIELDS = new Map([
-  ['index',     TInt.nonNegative],
-  ['length',    TInt.nonNegative],
-  ['color',     ColorSelector.checkHexColor]
+  ['lastActive', Timestamp.check],
+  ['index',      TInt.nonNegative],
+  ['length',     TInt.nonNegative],
+  ['color',      ColorSelector.checkHexColor]
 ]);
 
 /**

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -115,7 +115,7 @@ export default class Timestamp extends CommonBase {
    * Adds the indicated number of msec to this instance's value, returning a new
    * instance.
    *
-   * @param {Int} addMsec Amount to add.
+   * @param {Int} addMsec Amount to add. It can be negative.
    * @returns {Timestamp} An appropriately-constructed instance.
    */
   addMsec(addMsec) {

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Caret, CaretDelta, CaretOp, CaretSnapshot, RevisionNumber }
+import { Caret, CaretDelta, CaretOp, CaretSnapshot, RevisionNumber, Timestamp }
   from 'doc-common';
 import { TInt, TString } from 'typecheck';
 import { ColorSelector, CommonBase, PromCondition } from 'util-common';
@@ -160,14 +160,18 @@ export default class CaretControl extends CommonBase {
     let ops;
 
     if (oldCaret === null) {
-      const color    = this._colorSelector.nextColorHex();
-      const newCaret = new Caret(sessionId, Object.entries({ index, length, color }));
-      const diff     = Caret.EMPTY.diffFields(newCaret, sessionId);
+      const lastActive = Timestamp.now();
+      const color      = this._colorSelector.nextColorHex();
+      const fields     = { lastActive, index, length, color };
+      const newCaret   = new Caret(sessionId, Object.entries(fields));
+      const diff       = Caret.EMPTY.diffFields(newCaret, sessionId);
 
       ops = [CaretOp.op_beginSession(sessionId), ...diff.ops];
     } else {
-      const newCaret = new Caret(oldCaret, Object.entries({ index, length }));
-      const diff     = oldCaret.diff(newCaret);
+      const lastActive = Timestamp.now();
+      const fields     = { lastActive, index, length };
+      const newCaret   = new Caret(oldCaret, Object.entries(fields));
+      const diff       = oldCaret.diff(newCaret);
 
       ops = [...diff.ops]; // `[...x]` so as to be mutable for `push()` below.
     }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -126,14 +126,16 @@ export default class CaretControl extends CommonBase {
   async snapshot(revNum = null) {
     this._removeInactiveSessions();
 
-    // For now, we only succeed if the latest revision is being requested.
-    // **TODO:** Handle past revisions, details to be driven by client
-    // requirements.
-    if ((revNum !== null) && (revNum !== this._snapshot.revNum)) {
+    const minRevNum     = this._oldSnapshots[0].revNum;
+    const currentRevNum = this._snapshot.revNum;
+
+    if (revNum === null) {
+      revNum = currentRevNum;
+    } else if ((revNum < minRevNum) || (revNum > currentRevNum)) {
       throw new Error(`Revision not available: ${revNum}`);
     }
 
-    return this._snapshot;
+    return this._oldSnapshots[revNum - minRevNum];
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -100,9 +100,6 @@ export default class CaretControl extends CommonBase {
     // `_snapshot` because `_snapshot` is always the last element of
     // `_oldSnapshots`.
     const oldSnapshot = this._oldSnapshots[baseRevNum - minRevNum];
-    if (oldSnapshot.revNum !== baseRevNum) {
-      this._log.wtf(`Snapshot rev-num inconsistency: ${baseRevNum}, ${oldSnapshot.revNum}`);
-    }
 
     if (baseRevNum === currentRevNum) {
       // We've been asked for a revision newer than the most recent one, so we


### PR DESCRIPTION
A couple improvements to caret tracking:

* On the client side, notice when the document is edited, and update the caret overlay. This is a "backstop" for when edits come in that don't affect caret positioning in terms of the underlying text but _might_ affect them in terms of rendering (e.g. because of a font or style change).

* On the server side, start tracking when sessions are active and idle, and remove idle sessions from the caret snapshots reported to clients.