### PR TITLE
Caret-related tweakage.

### DIFF
--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -83,7 +83,7 @@ export default class BaseFile extends CommonBase {
         : value;
     }
 
-    TInt.min(value, 0);
+    TInt.nonNegative(value);
 
     const minTimeoutMsec = this.minTimeoutMsec;
     if (minTimeoutMsec !== null) {
@@ -202,7 +202,7 @@ export default class BaseFile extends CommonBase {
 
     // Validate and convert the result to be as documented.
 
-    TInt.min(result.revNum, 0);
+    TInt.nonNegative(result.revNum);
 
     if (result.newRevNum === null) {
       delete result.newRevNum;
@@ -265,7 +265,7 @@ export default class BaseFile extends CommonBase {
    */
   async whenChange(timeoutMsec, baseRevNum, storagePath = null) {
     timeoutMsec = this.clampTimeoutMsec(timeoutMsec);
-    TInt.min(baseRevNum, 0);
+    TInt.nonNegative(baseRevNum);
     StoragePath.orNull(storagePath);
 
     const result =

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -401,7 +401,7 @@ export default class FileOp extends CommonBase {
               break;
             }
             case TYPE_DUR_MSEC: {
-              TInt.min(arg, 0);
+              TInt.nonNegative(arg);
               break;
             }
             case TYPE_HASH: {
@@ -414,7 +414,7 @@ export default class FileOp extends CommonBase {
               break;
             }
             case TYPE_REV_NUM: {
-              TInt.min(arg, 0);
+              TInt.nonNegative(arg);
               break;
             }
             case TYPE_REV_NUM_1: {

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -217,9 +217,10 @@ export default class CaretOverlay {
    * Watches the local editor for edits. When noticed, causes the display to
    * update. Much of the time, this will be a no-op because the caret activity
    * will have already caused an update. However, some edits won't actually
-   * affect carets (notably, style-only changes), and this method effectively
-   * provides a backstop that prevents those edits from causing lingering
-   * inaccuracy in the overlay.
+   * affect caret data even though the rendered coordinates for carets would
+   * change (notably, style-only changes), and this method effectively provides
+   * a backstop that prevents those edits from causing lingering inaccuracy in
+   * the rendered overlay.
    */
   async _watchLocalEdits() {
     const log = this._editorComplex.log;

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -2,9 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Caret } from 'doc-common';
 import { QuillEvent, QuillGeometry } from 'quill-util';
-import { TObject, TInt, TString } from 'typecheck';
-import { ColorSelector, PromDelay } from 'util-common';
+import { TObject, TString } from 'typecheck';
+import { PromDelay } from 'util-common';
 
 /**
  * {Int} Amount of time (in msec) to wait after receiving a caret update from
@@ -67,12 +68,12 @@ export default class CaretOverlay {
   /**
    * Begin tracking a new session.
    *
-   * @param {string} sessionId The session to track.
+   * @param {Caret} caret The new caret to track (which includes a session ID).
    */
-  _beginSession(sessionId) {
-    TString.check(sessionId);
+  _beginSession(caret) {
+    Caret.check(caret);
 
-    this._sessions.set(sessionId, new Map());
+    this._sessions.set(caret.sessionId, new Map());
   }
 
   /**
@@ -88,31 +89,23 @@ export default class CaretOverlay {
   }
 
   /**
-   * Updates annotation for a remote session's selection, and updates the
-   * display.
+   * Updates annotation for a remote session's caret, and updates the display.
    *
-   * @param {string} sessionId The session whose state we're updating.
-   * @param {Int} index The position of the remote caret or start of the
-   *   selection.
-   * @param {Int} length The extent of the remote selection, or `0` for just the
-   *   caret.
-   * @param {string} color The color to use for the background of the remote
-   *    selection. It must be in hex format (e.g. `#ffb8b8`).
+   * @param {Caret} caret The caret to update.
    */
-  _updateCaret(sessionId, index, length, color) {
-    TString.check(sessionId);
-    TInt.min(index, 0);
-    TInt.min(length, 0);
-    ColorSelector.checkHexColor(color);
+  _updateCaret(caret) {
+    Caret.check(caret);
+
+    const sessionId = caret.sessionId;
 
     if (!this._sessions.has(sessionId)) {
-      this._beginSession(sessionId);
+      this._beginSession(caret);
     }
 
     const info = this._sessions.get(sessionId);
 
-    info.set('selection', { index, length });
-    info.set('color', color);
+    info.set('selection', { index: caret.index, length: caret.length });
+    info.set('color', caret.color);
 
     this._updateDisplay();
   }
@@ -132,7 +125,8 @@ export default class CaretOverlay {
         const range    = selEvent.range;
 
         this._updateCaret(
-          'local-session', range.index, range.length, '#ffb8b8');
+          new Caret('local-session',
+            { index: range.index, length: range.length, color: '#ffb8b8' }));
         currentEvent = selEvent;
       }
     }
@@ -200,7 +194,7 @@ export default class CaretOverlay {
           continue;
         }
 
-        this._updateCaret(c.sessionId, c.index, c.length, c.color);
+        this._updateCaret(c);
         oldSessions.delete(c.sessionId);
       }
 

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -73,6 +73,8 @@ export default class CaretOverlay {
   _beginSession(caret) {
     Caret.check(caret);
 
+    // **TODO:** Things will probably be easier if we just store `caret`
+    // directly in the map.
     this._sessions.set(caret.sessionId, new Map());
   }
 
@@ -104,6 +106,8 @@ export default class CaretOverlay {
 
     const info = this._sessions.get(sessionId);
 
+    // **TODO:** Things will probably be easier if we just store `caret`
+    // directly in the map.
     info.set('selection', { index: caret.index, length: caret.length });
     info.set('color', caret.color);
 

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -226,11 +226,19 @@ export default class CaretOverlay {
     let currentEvent = this._editorComplex.quill.currentEvent;
 
     for (;;) {
+      // Wait for a text change.
       currentEvent = await currentEvent.nextOf(QuillEvent.TEXT_CHANGE);
+
+      // Skip any additional text changes that have already been posted, so that
+      // we won't just be slowly iterating over all changes.
       currentEvent = currentEvent.latestOfNow(QuillEvent.TEXT_CHANGE);
 
       log.detail('Got local edit event.');
       this._updateDisplay();
+
+      // Wait a moment, before looking for more changes. If there are multiple
+      // changes during this time, the `latestOfNow()` call above will elide
+      // them.
       await PromDelay.resolve(LOCAL_EDIT_DELAY_MSEC);
     }
   }

--- a/local-modules/doc-client/CaretTracker.js
+++ b/local-modules/doc-client/CaretTracker.js
@@ -76,8 +76,8 @@ export default class CaretTracker extends CommonBase {
   update(docRevNum, range) {
     RevisionNumber.check(docRevNum);
     TObject.check(range);
-    TInt.min(range.index, 0);
-    TInt.min(range.length, 0);
+    TInt.nonNegative(range.index);
+    TInt.nonNegative(range.length);
 
     this._latestCaret = [docRevNum, range.index, range.length];
     this._runUpdateLoop();

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -27,7 +27,7 @@ const CARET_FIELDS = new Map([
  * {Caret|null} An instance with all default values. Initialized in the static
  * method of the same name.
  */
-let EMPTY = null;
+let DEFAULT = null;
 
 /**
  * Information about the state of a single document editing session. Instances
@@ -40,9 +40,9 @@ let EMPTY = null;
  */
 export default class Caret extends CommonBase {
   /** {Caret} An instance with all default values. */
-  static get EMPTY() {
-    if (EMPTY === null) {
-      EMPTY = new Caret('no-session',
+  static get DEFAULT() {
+    if (DEFAULT === null) {
+      DEFAULT = new Caret('no-session',
         Object.entries({
           lastActive: Timestamp.now(),
           index:      0,
@@ -51,7 +51,7 @@ export default class Caret extends CommonBase {
         }));
     }
 
-    return EMPTY;
+    return DEFAULT;
   }
 
   /**
@@ -82,9 +82,11 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * Constructs an instance. Only the first argument (`sessionId`) is required,
-   * and it is not necessary to specify all the fields in `fields`; those not
-   * listed are set to the default (based on `Caret.EMPTY`).
+   * Constructs an instance. Only the first argument (`sessionIdOrBase`) is
+   * required, and it is not necessary to specify all the fields in `fields`.
+   * Fields not listed are derived from the base caret (first argument) if
+   * specified as such, or from the default value `Caret.DEFAULT` if the first
+   * argument is a session ID.
    *
    * @param {string|Caret} sessionIdOrBase Session ID that identifies the caret,
    *   or a base caret instance which provides the session and default values
@@ -99,7 +101,7 @@ export default class Caret extends CommonBase {
       newFields = new Map(sessionIdOrBase._fields);
       sessionId = sessionIdOrBase.sessionId;
     } else {
-      newFields = EMPTY ? new Map(EMPTY._fields) : new Map();
+      newFields = DEFAULT ? new Map(DEFAULT._fields) : new Map();
       sessionId = TString.check(sessionIdOrBase);
     }
 
@@ -117,7 +119,7 @@ export default class Caret extends CommonBase {
       newFields.set(k, Caret.checkField(k, v));
     }
 
-    if (EMPTY && (newFields.size !== EMPTY._fields.size)) {
+    if (DEFAULT && (newFields.size !== DEFAULT._fields.size)) {
       throw new Error(`Missing field.`);
     }
 
@@ -292,5 +294,5 @@ export default class Caret extends CommonBase {
   }
 }
 
-// Ensure that `EMPTY` is initialized.
-Caret.EMPTY;
+// Ensure that `DEFAULT` is initialized.
+Caret.DEFAULT;

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -84,9 +84,7 @@ export default class Caret extends CommonBase {
   /**
    * Constructs an instance. Only the first argument (`sessionId`) is required,
    * and it is not necessary to specify all the fields in `fields`; those not
-   * listed are set to the default (based on `Caret.EMPTY`). Though generally
-   * short-lived, instances constructed with all defaults are used as the carets
-   * for newly-minted sessions.
+   * listed are set to the default (based on `Caret.EMPTY`).
    *
    * @param {string|Caret} sessionIdOrBase Session ID that identifies the caret,
    *   or a base caret instance which provides the session and default values
@@ -116,10 +114,7 @@ export default class Caret extends CommonBase {
     this._fields = newFields;
 
     for (const [k, v] of fields) {
-      // Construct an `updateField` op, which forces `k` and `v` to be
-      // validated.
-      CaretOp.op_updateField(sessionId, k, v);
-      newFields.set(k, v);
+      newFields.set(k, Caret.checkField(k, v));
     }
 
     if (EMPTY && (newFields.size !== EMPTY._fields.size)) {

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -11,10 +11,10 @@ import Timestamp from './Timestamp';
 
 /**
  * {Map<string,function>} Map from each allowed caret field name to a type
- * checker predicate for same, for use in `updateField` operations.
+ * checker predicate for same.
  *
- * **Note:** `sessionId` is not included, because that can't be altered by those
- * operations.
+ * **Note:** `sessionId` is not included, because that's separate from the
+ * caret's "fields" per se.
  */
 const CARET_FIELDS = new Map([
   ['lastActive', Timestamp.check],

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -5,6 +5,7 @@
 import { TInt, TString } from 'typecheck';
 import { ColorSelector, CommonBase } from 'util-common';
 
+import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
 import Timestamp from './Timestamp';
 
@@ -57,16 +58,17 @@ export default class CaretOp extends CommonBase {
   /**
    * Constructs a new "begin session" operation.
    *
-   * @param {string} sessionId The session ID.
+   * @param {Caret} caret The initial caret for the new session (which includes
+   *   a session ID).
    * @returns {CaretOp} An operation representing the start of the so-IDed
    *   session.
    */
-  static op_beginSession(sessionId) {
-    TString.check(sessionId);
+  static op_beginSession(caret) {
+    Caret.check(caret);
 
     const args = new Map();
 
-    args.set('sessionId', sessionId);
+    args.set('caret', caret);
 
     return new CaretOp(KEY, CaretOp.BEGIN_SESSION, args);
   }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -51,9 +51,7 @@ export default class CaretOp extends CommonBase {
   static op_beginSession(caret) {
     Caret.check(caret);
 
-    const args = new Map(Object.entries({ caret }));
-
-    return new CaretOp(KEY, CaretOp.BEGIN_SESSION, args);
+    return new CaretOp(KEY, CaretOp.BEGIN_SESSION, { caret });
   }
 
   /**
@@ -70,9 +68,7 @@ export default class CaretOp extends CommonBase {
     TString.check(sessionId);
     Caret.checkField(key, value);
 
-    const args = new Map(Object.entries({ sessionId, key, value }));
-
-    return new CaretOp(KEY, CaretOp.UPDATE_FIELD, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_FIELD, { sessionId, key, value });
   }
 
   /**
@@ -85,9 +81,7 @@ export default class CaretOp extends CommonBase {
   static op_endSession(sessionId) {
     TString.check(sessionId);
 
-    const args = new Map(Object.entries({ sessionId }));
-
-    return new CaretOp(KEY, CaretOp.END_SESSION, args);
+    return new CaretOp(KEY, CaretOp.END_SESSION, { sessionId });
   }
 
   /**
@@ -99,9 +93,7 @@ export default class CaretOp extends CommonBase {
   static op_updateDocRevNum(docRevNum) {
     RevisionNumber.check(docRevNum);
 
-    const args = new Map(Object.entries({ docRevNum }));
-
-    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, { docRevNum });
   }
 
   /**
@@ -113,9 +105,7 @@ export default class CaretOp extends CommonBase {
   static op_updateRevNum(revNum) {
     RevisionNumber.check(revNum);
 
-    const args = new Map(Object.entries({ revNum }));
-
-    return new CaretOp(KEY, CaretOp.UPDATE_REV_NUM, args);
+    return new CaretOp(KEY, CaretOp.UPDATE_REV_NUM, { revNum });
   }
 
   /**
@@ -125,7 +115,7 @@ export default class CaretOp extends CommonBase {
    * @param {object} constructorKey The private-to-this-module key that
    *   enforces the exhortation in the method documentation above.
    * @param {string} name The operation name.
-   * @param {Map<string,*>} args Arguments to the operation.
+   * @param {object} args Arguments to the operation.
    */
   constructor(constructorKey, name, args) {
     super();
@@ -138,7 +128,7 @@ export default class CaretOp extends CommonBase {
     this._name = name;
 
     /** {Map<string,*>} args The arguments needed for the operation. */
-    this._args = args;
+    this._args = new Map(Object.entries(args));
 
     Object.freeze(this);
   }
@@ -192,6 +182,6 @@ export default class CaretOp extends CommonBase {
    * @returns {CaretOp} The new instance.
    */
   static fromApi(name, args) {
-    return new CaretOp(KEY, name, new Map(Object.entries(args)));
+    return new CaretOp(KEY, name, args);
   }
 }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -51,9 +51,7 @@ export default class CaretOp extends CommonBase {
   static op_beginSession(caret) {
     Caret.check(caret);
 
-    const args = new Map();
-
-    args.set('caret', caret);
+    const args = new Map(Object.entries({ caret }));
 
     return new CaretOp(KEY, CaretOp.BEGIN_SESSION, args);
   }
@@ -72,11 +70,7 @@ export default class CaretOp extends CommonBase {
     TString.check(sessionId);
     Caret.checkField(key, value);
 
-    const args = new Map();
-
-    args.set('sessionId', sessionId);
-    args.set('key',       key);
-    args.set('value',     value);
+    const args = new Map(Object.entries({ sessionId, key, value }));
 
     return new CaretOp(KEY, CaretOp.UPDATE_FIELD, args);
   }
@@ -91,9 +85,7 @@ export default class CaretOp extends CommonBase {
   static op_endSession(sessionId) {
     TString.check(sessionId);
 
-    const args = new Map();
-
-    args.set('sessionId', sessionId);
+    const args = new Map(Object.entries({ sessionId }));
 
     return new CaretOp(KEY, CaretOp.END_SESSION, args);
   }
@@ -107,9 +99,7 @@ export default class CaretOp extends CommonBase {
   static op_updateDocRevNum(docRevNum) {
     RevisionNumber.check(docRevNum);
 
-    const args = new Map();
-
-    args.set('docRevNum', docRevNum);
+    const args = new Map(Object.entries({ docRevNum }));
 
     return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, args);
   }
@@ -123,9 +113,7 @@ export default class CaretOp extends CommonBase {
   static op_updateRevNum(revNum) {
     RevisionNumber.check(revNum);
 
-    const args = new Map();
-
-    args.set('revNum', revNum);
+    const args = new Map(Object.entries({ revNum }));
 
     return new CaretOp(KEY, CaretOp.UPDATE_REV_NUM, args);
   }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -2,29 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TString } from 'typecheck';
-import { ColorSelector, CommonBase } from 'util-common';
+import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
-import Timestamp from './Timestamp';
 
 /** {Symbol} Key which protects the constructor from being called improperly. */
 const KEY = Symbol('CaretOp constructor key');
-
-/**
- * {Map<string,function>} Map from each allowed caret field name to a type
- * checker predicate for same, for use in `updateField` operations.
- *
- * **Note:** `sessionId` is not included, because that can't be altered by those
- * operations.
- */
-const CARET_FIELDS = new Map([
-  ['lastActive', Timestamp.check],
-  ['index',      TInt.nonNegative],
-  ['length',     TInt.nonNegative],
-  ['color',      ColorSelector.checkHexColor]
-]);
 
 /**
  * Operation which can be applied to a `Caret` or `CaretSnapshot`.
@@ -85,19 +70,7 @@ export default class CaretOp extends CommonBase {
    */
   static op_updateField(sessionId, key, value) {
     TString.check(sessionId);
-    TString.nonempty(key);
-
-    const checker = CARET_FIELDS.get(key);
-    if (!checker) {
-      throw new Error(`Invalid caret field name: ${key}`);
-    } else {
-      try {
-        checker(value);
-      } catch (e) {
-        // Higher-fidelity error.
-        throw new Error(`Invalid value for caret field ${key}: ${value}`);
-      }
-    }
+    Caret.checkField(key, value);
 
     const args = new Map();
 

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -107,8 +107,8 @@ export default class CaretSnapshot extends CommonBase {
     for (const op of delta.ops) {
       switch (op.name) {
         case CaretOp.BEGIN_SESSION: {
-          const sessionId = op.arg('sessionId');
-          newCarets.set(sessionId, new Caret(sessionId));
+          const caret = op.arg('caret');
+          newCarets.set(caret.sessionId, caret);
           break;
         }
 
@@ -192,12 +192,7 @@ export default class CaretSnapshot extends CommonBase {
         }
       } else {
         // The `sessionId` isn't in the older snapshot, so this is an addition.
-        caretOps.push(CaretOp.op_beginSession(sessionId));
-
-        const diff = Caret.EMPTY.diffFields(newerCaret, sessionId);
-        for (const op of diff.ops) {
-          caretOps.push(op);
-        }
+        caretOps.push(CaretOp.op_beginSession(newerCaret));
       }
     }
 

--- a/local-modules/doc-common/RevisionNumber.js
+++ b/local-modules/doc-common/RevisionNumber.js
@@ -18,7 +18,7 @@ export default class RevisionNumber extends UtilityClass {
    */
   static check(value) {
     try {
-      return TInt.min(value, 0);
+      return TInt.nonNegative(value);
     } catch (e) {
       // More appropriate error.
       return TypeError.badValue(value, 'RevisionNumber');

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -56,10 +56,11 @@ describe('doc-common/CaretSnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should add a default caret given the appropriate op', () => {
-      const snap     = new CaretSnapshot(1, 2, [caret1]);
-      const expected = new CaretSnapshot(1, 2, [caret1, new Caret('florp')]);
-      const result   = snap.compose(new CaretDelta([CaretOp.op_beginSession('florp')]));
+    it('should add a new caret given the appropriate op', () => {
+      const snap     = new CaretSnapshot(1, 2, []);
+      const expected = new CaretSnapshot(1, 2, [caret1]);
+      const delta    = new CaretDelta([CaretOp.op_beginSession(caret1)]);
+      const result   = snap.compose(delta);
 
       assert.isTrue(result.equals(expected));
     });
@@ -78,19 +79,6 @@ describe('doc-common/CaretSnapshot', () => {
       const expected = new CaretSnapshot(1, 2, [caret1, c2]);
       const op       = CaretOp.op_updateField('foo', 'index', 3);
       const result   = snap.compose(new CaretDelta([op]));
-
-      assert.isTrue(result.equals(expected));
-    });
-
-    it('should allow introduction of a new caret with value given the appropriate ops', () => {
-      const snap     = new CaretSnapshot(1, 2, []);
-      const expected = new CaretSnapshot(1, 2, [caret1]);
-
-      const delta = new CaretDelta([
-        CaretOp.op_beginSession(caret1.sessionId),
-        ...(Caret.EMPTY.diffFields(caret1, caret1.sessionId).ops)]);
-
-      const result = snap.compose(delta);
 
       assert.isTrue(result.equals(expected));
     });

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -173,9 +173,8 @@ export default class CaretControl extends CommonBase {
       const color      = this._colorSelector.nextColorHex();
       const fields     = { lastActive, index, length, color };
       const newCaret   = new Caret(sessionId, Object.entries(fields));
-      const diff       = Caret.EMPTY.diffFields(newCaret, sessionId);
 
-      ops = [CaretOp.op_beginSession(sessionId), ...diff.ops];
+      ops = [CaretOp.op_beginSession(newCaret)];
     } else {
       const lastActive = Timestamp.now();
       const fields     = { lastActive, index, length };

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -154,8 +154,8 @@ export default class CaretControl extends CommonBase {
   async update(sessionId, docRevNum, index, length = 0) {
     TString.check(sessionId);
     RevisionNumber.check(docRevNum);
-    TInt.min(index, 0);
-    TInt.min(length, 0);
+    TInt.nonNegative(index);
+    TInt.nonNegative(length);
 
     const caretStr = (length === 0)
       ? `@${index}`

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -23,7 +23,7 @@ const APPEND_RETRY_GROWTH_FACTOR = 5;
 const MAX_APPEND_TIME_MSEC = 20 * 1000; // 20 seconds.
 
 /**
- * {nubmer} Maximum number of document changes to request in a single
+ * {number} Maximum number of document changes to request in a single
  * transaction. (The idea is to avoid making a request that would result in
  * running into an upper limit on transaction data size.)
  */

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -262,7 +262,7 @@ export default class DocControl extends CommonBase {
     }
 
     try {
-      TInt.min(revNum, 0);
+      RevisionNumber.check(revNum);
     } catch (e) {
       this._log.info('Corrupt document: Bogus revision number.');
       return DocControl.STATUS_ERROR;

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -4,7 +4,7 @@
 
 import { FileCodec, TransactionSpec } from 'content-store';
 import { DocumentDelta, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber, Timestamp } from 'doc-common';
-import { TInt, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { CommonBase, InfoError, PromDelay } from 'util-common';
 
 import FileComplex from './FileComplex';

--- a/local-modules/quill-util/QuillEvent.js
+++ b/local-modules/quill-util/QuillEvent.js
@@ -144,8 +144,8 @@ export default class QuillEvent extends BaseEvent {
   static _checkAndFreezeRange(range) {
     if (range !== null) {
       TObject.withExactKeys(range, ['index', 'length']);
-      TInt.min(range.index, 0);
-      TInt.min(range.length, 0);
+      TInt.nonNegative(range.index);
+      TInt.nonNegative(range.length);
       Object.freeze(range);
     }
 

--- a/local-modules/util-common/Random.js
+++ b/local-modules/util-common/Random.js
@@ -38,7 +38,7 @@ export default class Random extends UtilityClass {
    * @returns {Array<Int>} Array of `length` random bytes.
    */
   static byteArray(length) {
-    const buffer = crypto.randomBytes(TInt.min(length, 0));
+    const buffer = crypto.randomBytes(TInt.nonNegative(length));
     return [...buffer];
   }
 

--- a/local-modules/util-common/StringUtil.js
+++ b/local-modules/util-common/StringUtil.js
@@ -50,7 +50,7 @@ export default class StringUtil extends UtilityClass {
    */
   static stringWithUtf8ByteLimit(string, limit) {
     TString.check(string);
-    TInt.min(limit, 0);
+    TInt.nonNegative(limit);
 
     let resultString = '';
     let totalByteCount = 0;

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.18.2
+version = 0.18.3


### PR DESCRIPTION
* Make the `beginSession` op take a whole caret. This eliminates a bunch of op spew to establish a caret's initial value.
* In the caret overlay code, pass the full caret through to `_beginSession`, so that the rendering will ultimately be able to come into existence fully formed.
* Move a few bits of code around, and do a bit of renaming, in an attempt to make the code more understandable and maintainable.

**Bonus:** Use `TInt.nonNegative()` where appropriate.