### PR TITLE
Ignore `unlinkSync()` failure here, except to log it.

### DIFF
--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -266,7 +266,15 @@ export default class DevMode extends Singleton {
 
     if (fromPath === null) {
       // The source file was deleted.
-      fs.unlinkSync(toPath);
+      try {
+        fs.unlinkSync(toPath);
+      } catch (e) {
+        // Ignore the error. The file was probably removed out from under us,
+        // which is no big deal. This has been observed to happen when
+        // development is done semi-remotely, e.g. `rsync`ing files from a
+        // laptop to a machine in a dev-production environment.
+        log.info(`Already removed: ${toPath}`);
+      }
     } else {
       // The source file changed.
       fs_extra.ensureDirSync(path.dirname(toPath));


### PR DESCRIPTION
See comment for details.