### PR TITLE
CAS file operations and stubs

### DIFF
--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -88,6 +88,16 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `checkBlobHash` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkBlobHash(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `checkPathEmpty` operations.
    *
    * @param {FileOp} op The operation.
@@ -170,6 +180,16 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `readBlob` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_readBlob(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `readPath` operations.
    *
    * @param {FileOp} op The operation.
@@ -194,6 +214,16 @@ export default class Transactor extends CommonBase {
    */
   _op_timeout(op_unused) {
     // This space intentionally left blank.
+  }
+
+  /**
+   * Handler for `writeBlob` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_writeBlob(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -88,11 +88,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkBlobHash` operations.
+   * Handler for `checkBlob` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_checkBlobHash(op) {
+  _op_checkBlob(op) {
     // **TODO:** Implement this.
     throw new InfoError('not_implemented', op.name);
   }

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -98,11 +98,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkPathEmpty` operations.
+   * Handler for `checkPathAbsent` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_checkPathEmpty(op) {
+  _op_checkPathAbsent(op) {
     const storagePath = op.arg('storagePath');
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
       throw new InfoError('path_not_empty', storagePath);

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -139,6 +139,16 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `deleteBlob` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_deleteBlob(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `deletePath` operations.
    *
    * @param {FileOp} op The operation.

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -98,6 +98,16 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `checkBlobAbsent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkBlobAbsent(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `checkPathAbsent` operations.
    *
    * @param {FileOp} op The operation.

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -85,7 +85,7 @@ export default class FileCodec extends CommonBase {
       const methodName = `op_${opName}`;
       const originalMethod = FileOp[methodName].bind(FileOp);
 
-      // Figure out if which arguments are buffers, if any.
+      // Figure out which arguments are buffers, if any.
       const bufferAt = [];
       for (let i = 0; i < argInfo.length; i++) {
         const [name_unused, type] = argInfo[i];

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -76,7 +76,7 @@ export default class FileCodec extends CommonBase {
 
   /**
    * Adds `FileOp` constructor methods to this class. These are _instance_
-   * methods that are aware of the codec being used. (Look at the bottome of
+   * methods that are aware of the codec being used. (Look at the bottom of
    * this file for the call.)
    */
   static _addFileOpConstructorMethods() {

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -113,6 +113,24 @@ const OPERATIONS = DataUtil.deepFreeze([
   ],
 
   /*
+   * A `deleteBlob` operation. This is a write operation that the blob with the
+   * indicated hash, if any. If there was no such blob, then this operation does
+   * nothing.
+   *
+   * @param {string} hash The hash of the blob to delete.
+   */
+  [CAT_WRITE, 'deleteBlob', ['hash', TYPE_HASH]],
+
+  /*
+   * Convenience wrapper for `deleteBlob` operations, which uses a given
+   * buffer's data. This is equivalent to `deleteBlob(buffer.hash)`.
+   *
+   * @param {FrozenBuffer} value Buffer whose hash should be taken, indicating a
+   *   blob to delete.
+   */
+  [CAT_CONVENIENCE, 'deleteBlobHash', ['value', TYPE_BUFFER]],
+
+  /*
    * A `deletePath` operation. This is a write operation that deletes the
    * binding for the given path, if any. If the path wasn't bound, then this
    * operation does nothing.
@@ -510,6 +528,16 @@ export default class FileOp extends CommonBase {
    */
   static _xform_checkPathBufferHash(storagePath, value) {
     return ['checkPathHash', storagePath, value.hash];
+  }
+
+  /**
+   * Transformer for the convenience op `deleteBlobBuffer`.
+   *
+   * @param {FrozenBuffer} value The value.
+   * @returns {array<*>} Replacement constructor info.
+   */
+  static _xform_deleteBlobBuffer(value) {
+    return ['deleteBlob', value.hash];
   }
 
   /**

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -46,6 +46,22 @@ const TYPE_REV_NUM_1 = 'RevNum1';
 // So it goes.
 const OPERATIONS = DataUtil.deepFreeze([
   /*
+   * A `checkBlob` operation. This is a prerequisite operation that verifies
+   * that the file stores a blob with the indicated hash.
+   *
+   * @param {string} hash The expected hash.
+   */
+  [CAT_PREREQUISITE, 'checkBlob', ['hash', TYPE_HASH]],
+
+  /*
+   * A `checkBlobAbsent` operation. This is a prerequisite operation that
+   * verifies that the file does not store a blob with the indicated hash.
+   *
+   * @param {string} hash The expected-to-be-absent hash.
+   */
+  [CAT_PREREQUISITE, 'checkBlobAbsent', ['hash', TYPE_HASH]],
+
+  /*
    * Convenience wrapper for `checkBlob` operations, which uses a given buffer's
    * data. This is equivalent to `checkBlob(buffer.hash)`.
    *
@@ -54,12 +70,12 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_CONVENIENCE, 'checkBlobBuffer', ['value', TYPE_BUFFER]],
 
   /*
-   * A `checkBlob` operation. This is a prerequisite operation that verifies
-   * that the file stores a blob with the indicated hash.
+   * Convenience wrapper for `checkBlobAbsent` operations, which uses a given
+   * buffer's data. This is equivalent to `checkBlobAbsent(buffer.hash)`.
    *
-   * @param {string} hash The expected hash.
+   * @param {FrozenBuffer} value Buffer whose hash should be taken.
    */
-  [CAT_PREREQUISITE, 'checkBlob', ['hash', TYPE_HASH]],
+  [CAT_CONVENIENCE, 'checkBlobBufferAbsent', ['value', TYPE_BUFFER]],
 
   /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
@@ -511,6 +527,16 @@ export default class FileOp extends CommonBase {
    */
   static _xform_checkBlobBuffer(value) {
     return ['checkBlob', value.hash];
+  }
+
+  /**
+   * Transformer for the convenience op `checkBlobBufferAbsent`.
+   *
+   * @param {FrozenBuffer} value The value.
+   * @returns {array<*>} Replacement constructor info.
+   */
+  static _xform_checkBlobBufferAbsent(value) {
+    return ['checkBlobAbsent', value.hash];
   }
 
   /**

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -46,26 +46,20 @@ const TYPE_REV_NUM_1 = 'RevNum1';
 // So it goes.
 const OPERATIONS = DataUtil.deepFreeze([
   /*
-   * Convenience wrapper for `checkBlobHash` operation, which uses a given
-   * buffer's data. This is equivalent to `checkBlobHash(buffer.hash)`.
+   * Convenience wrapper for `checkBlob` operations, which uses a given buffer's
+   * data. This is equivalent to `checkBlob(buffer.hash)`.
    *
    * @param {FrozenBuffer} value Buffer whose hash should be taken.
    */
-  [
-    CAT_CONVENIENCE, 'checkBlobBufferHash',
-    ['value', TYPE_BUFFER]
-  ],
+  [CAT_CONVENIENCE, 'checkBlobBuffer', ['value', TYPE_BUFFER]],
 
   /*
-   * A `checkBlobHash` operation. This is a prerequisite operation that
-   * verifies that the file stores a blob with the indicated hash.
+   * A `checkBlob` operation. This is a prerequisite operation that verifies
+   * that the file stores a blob with the indicated hash.
    *
    * @param {string} hash The expected hash.
    */
-  [
-    CAT_PREREQUISITE, 'checkBlobHash',
-    ['hash', TYPE_HASH]
-  ],
+  [CAT_PREREQUISITE, 'checkBlob', ['hash', TYPE_HASH]],
 
   /*
    * A `checkPathEmpty` operation. This is a prerequisite operation that
@@ -510,13 +504,13 @@ export default class FileOp extends CommonBase {
   }
 
   /**
-   * Transformer for the convenience op `checkBlobBufferHash`.
+   * Transformer for the convenience op `checkBlobBuffer`.
    *
    * @param {FrozenBuffer} value The value.
    * @returns {array<*>} Replacement constructor info.
    */
-  static _xform_checkBlobBufferHash(value) {
-    return ['checkBlobHash', value.hash];
+  static _xform_checkBlobBuffer(value) {
+    return ['checkBlob', value.hash];
   }
 
   /**

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -62,19 +62,19 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_PREREQUISITE, 'checkBlob', ['hash', TYPE_HASH]],
 
   /*
-   * A `checkPathEmpty` operation. This is a prerequisite operation that
+   * A `checkPathAbsent` operation. This is a prerequisite operation that
    * verifies that a given storage path is not bound to any value. This is the
    * opposite of `checkPathExists`.
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_PREREQUISITE, 'checkPathEmpty', ['storagePath', TYPE_PATH]],
+  [CAT_PREREQUISITE, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `checkPathExists` operation. This is a prerequisite operation that
    * verifies that a given storage path is bound to a value (any value,
-   * including one of zero length). This is the opposite of the `checkPathEmpty`
-   * operation.
+   * including one of zero length). This is the opposite of the
+   * `checkPathAbsent` operation.
    *
    * @param {string} storagePath The storage path to check.
    */
@@ -285,9 +285,9 @@ export default class FileOp extends CommonBase {
   }
 
   /**
-   * {array<array>} List of operation schemata. These are used to programatically
-   * define static methods on `FileOp` for constructing instances. Each element
-   * consists of three parts, as follows:
+   * {array<array>} List of operation schemata. These are used to
+   * programatically define static methods on `FileOp` for constructing
+   * instances. Each element consists of three parts, as follows:
    *
    * * `category` &mdash; The category of the operation.
    * * `name` &mdsah; The name of the operation.

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -97,7 +97,7 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_PREREQUISITE, 'checkPathExists', ['storagePath', TYPE_PATH]],
 
   /*
-   * Convenience wrapper for `checkPathHash` operation, which uses a given
+   * Convenience wrapper for `checkPathHash` operations, which uses a given
    * buffer's data. This is equivalent to `checkPathHash(storagePath,
    * buffer.hash)`.
    *

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -123,8 +123,8 @@ export default class DocControl extends CommonBase {
     const spec = new TransactionSpec(
       // These make the transaction fail if we lose a race to (re)create the
       // file.
-      fc.op_checkPathEmpty(Paths.FORMAT_VERSION),
-      fc.op_checkPathEmpty(Paths.REVISION_NUMBER),
+      fc.op_checkPathAbsent(Paths.FORMAT_VERSION),
+      fc.op_checkPathAbsent(Paths.REVISION_NUMBER),
 
       // Version for the file format.
       fc.op_writePath(Paths.FORMAT_VERSION, this._fileComplex.formatVersion),
@@ -570,7 +570,7 @@ export default class DocControl extends CommonBase {
 
     const fc   = this._fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
-      fc.op_checkPathEmpty(changePath),
+      fc.op_checkPathAbsent(changePath),
       fc.op_checkPathBufferHash(Paths.REVISION_NUMBER, baseRevNum),
       fc.op_writePath(changePath, change),
       fc.op_writePath(Paths.REVISION_NUMBER, revNum)


### PR DESCRIPTION
This PR adds to `content-store.FileOp` definitions for CAS (content-addressable storage) operations, and stubs out the implementations for same in `content-store-local`. In addition, I did some minor tweakage of the code in the general vicinity.