### PR TITLE
Type annotation consistency

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -28,45 +28,18 @@ taking into account recent additions to the language.
 
 ### Other conventions in this codebase
 
-* There are specific conventions of how local module exports are set up. Find
-  that info in the [`local-modules/` README file](../local-modules/README.md).
+#### Documentation comments
 
-* `import` order &mdash; Separate imports into three sections, in the following
-  order and separated with a single blank line:
+* We use JSDoc-style annotations on classes, methods, and properties (including
+  instance variables), using `/** ... */` cladding.
 
-  * Built-in Node modules and modules imported from the public registry.
-  * Local modules defined in this product.
-  * Module-private files defined as a peer to the file doing the importing.
+* The type annotation used for arrays is `{array}` or `{array<elementType>}`,
+  with a lower case `a`.
 
-  Within each section, sort lines alphabetically by name of file or module (not
-  name within same). Within a multi-name `import` _line_, sort names
-  alphabetically. Complete example:
-
-  ```javascript
-  import express from 'express';
-  import fs from 'fs';
-
-  import { BaseFile, FileOp } from 'content-store';
-  import { DataUtil, InfoError, Singleton } from 'util-common';
-
-  import RegularBlort from './RegularBlort';
-  import SpecialBlort from './SpecialBlort';
-  ```
-
-* Private fields and methods &mdash; This project is coded as if JavaScript
-  will grow the ability to have private fields and methods on classes. As such,
-  an underscore (`_`) prefix is used on names that are supposed to be treated as
-  private. If and when the facility is added to the language, it will be a Small
-  Matter Of Coding to programmatically replace the underscored declarations and
-  use sites with the real syntax.
-
-  **Note:** This is an intentional deviation from Airbnb style.
-
-* Websockets &mdash; JavaScript has a `WebSocket` class, but when talking about
-  them in prose or in our own variable or class names, we use "websocket" (one
-  word, all lower case, though capitalized as appropriate for prose or
-  `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
-  variable that contains an instance of one (or something related).
+* We define a `typecheck` module which effectively defines a few primitive
+  "types" that aren't actually real types in JavaScript, most notably `Int` to
+  represent primitive numbers that are in fact integers. We use these type names
+  in annotations as if they were real types. The names are always capitalized.
 
 * When documenting functions marked `async`, the implicit promise returned by
   the function should _not_ be represented in its prose or `@returns`
@@ -96,6 +69,67 @@ taking into account recent additions to the language.
     return 'frobnicator';
   }
   ```
+
+#### Module imports and exports
+
+* There are specific conventions of how local module exports are set up. Find
+  that info in the [`local-modules/` README file](../local-modules/README.md).
+
+* `import` order &mdash; Separate imports into three sections, in the following
+  order and separated with a single blank line:
+
+  * Built-in Node modules and modules imported from the public registry.
+  * Local modules defined in this product.
+  * Module-private files defined as a peer to the file doing the importing.
+
+  Within each section, sort lines alphabetically by name of file or module (not
+  name within same). Within a multi-name `import` _line_, sort names
+  alphabetically. Complete example:
+
+  ```javascript
+  import express from 'express';
+  import fs from 'fs';
+
+  import { BaseFile, FileOp } from 'content-store';
+  import { DataUtil, InfoError, Singleton } from 'util-common';
+
+  import RegularBlort from './RegularBlort';
+  import SpecialBlort from './SpecialBlort';
+  ```
+
+#### Class definitions
+
+* Private fields and methods &mdash; This project is coded as if JavaScript
+  will grow the ability to have private fields and methods on classes. As such,
+  an underscore (`_`) prefix is used on names that are supposed to be treated as
+  private. If and when the facility is added to the language, it will be a Small
+  Matter Of Coding to programmatically replace the underscored declarations and
+  use sites with the real syntax.
+
+  **Note:** This is an intentional deviation from Airbnb style.
+
+* Utility classes &mdash; Utility classes are classes which only serve as a
+  collection of functionality exposed as static methods (and sometimes static
+  properties). Utility classes should be defined as `extends UtilityClass` both
+  to document the intent and to provide enforced guarantees.
+  **Note:** Preferably, utility classes are _not_ a vector for exposing
+  application state and are merely holders of "pure" functionality. For a
+  utility-like class that maintains and/or exposes state, it is better to use
+  a singleton.
+
+* Singleton classes &mdash; Singleton classes are classes which should only
+  ever have a single instance within the system. These should be defined as
+  `extends Singleton` both to document the intent and to provide enforced
+  guarantees. Additionally, instead of explicitly constructing singletons,
+  the convention is to use the static property `theOne` on the so-defined class.
+
+#### Other items
+
+* Websockets &mdash; JavaScript has a `WebSocket` class, but when talking about
+  them in prose or in our own variable or class names, we use "websocket" (one
+  word, all lower case, though capitalized as appropriate for prose or
+  `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
+  variable that contains an instance of one (or something related).
 
 * Immediate-async blocks &mdash; When programming in the `async`/`await` style,
   sometimes it's useful to to "spawn" an independent thread of control which
@@ -134,19 +168,3 @@ taking into account recent additions to the language.
     ...
   }
   ```
-
-* Utility classes &mdash; Utility classes are classes which only serve as a
-  collection of functionality exposed as static methods (and sometimes static
-  properties). Utility classes should be defined as `extends UtilityClass` both
-  to document the intent and to provide enforced guarantees.
-
-  **Note:** Preferably, utility classes are _not_ a vector for exposing
-  application state and are merely holders of "pure" functionality. For a
-  utility-like class that maintains and/or exposes state, it is better to use
-  a singleton.
-
-* Singleton classes &mdash; Singleton classes are classes which should only
-  ever have a single instance within the system. These should be defined as
-  `extends Singleton` both to document the intent and to provide enforced
-  guarantees. Additionally, instead of explicitly constructing singletons,
-  the convention is to use the static property `theOne` on the so-defined class.

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -43,8 +43,8 @@ export default class TargetHandler {
     this._targetId = targetId;
 
     /**
-     * {Map<string, function>} Cached method call handlers, as a map from name to
-     * handler.
+     * {Map<string, function>} Cached method call handlers, as a map from name
+     * to handler.
      */
     this._methods = new Map();
 

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -43,7 +43,7 @@ export default class TargetHandler {
     this._targetId = targetId;
 
     /**
-     * {Map<string,function>} Cached method call handlers, as a map from name to
+     * {Map<string, function>} Cached method call handlers, as a map from name to
      * handler.
      */
     this._methods = new Map();

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -34,7 +34,7 @@ export default class Message {
    * @param {string} action Kind of action to take. Currently, the only valid
    *   values are `call`.
    * @param {string} name Method (or property) name to access.
-   * @param {Array<*>} args Arguments to include with the message.
+   * @param {array<*>} args Arguments to include with the message.
    */
   constructor(id, target, action, name, args) {
     /** {Int} Message ID. `-1` is only used in case of (some) errors. */
@@ -49,7 +49,7 @@ export default class Message {
     /** {string} Method / property name to access. */
     this._name = TString.nonempty(name);
 
-    /** {Array<*>} Arguments of the message. */
+    /** {array<*>} Arguments of the message. */
     this._args = TArray.check(args);
 
     // Validate `action`.
@@ -133,7 +133,7 @@ export default class Message {
     return this._name;
   }
 
-  /** {Array<*>} Arguments of the message. */
+  /** {array<*>} Arguments of the message. */
   get args() {
     return this._args;
   }

--- a/local-modules/api-common/Registry.js
+++ b/local-modules/api-common/Registry.js
@@ -21,13 +21,13 @@ export default class Registry extends CommonBase {
     super();
 
     /**
-     * {Map<string,ItemCodec>} Map of registered item tags to their respective
+     * {Map<string, ItemCodec>} Map of registered item tags to their respective
      * item codecs.
      */
     this._tagToCodec = new Map();
 
     /**
-     * {Map<class,array<ItemCodec>>} Map of classes that have `ItemCodec`s
+     * {Map<class, array<ItemCodec>>} Map of classes that have `ItemCodec`s
      * registered to the set of such codecs. The reason there can be more than
      * one is that some classes can be encoded multiple ways, with the multiple
      * `ItemCodec`'s `predicate`s determining which one applies.
@@ -35,7 +35,7 @@ export default class Registry extends CommonBase {
     this._classToCodecs = new Map();
 
     /**
-     * {Map<string,array<ItemCodec>} Map of non-class types that have
+     * {Map<string, array<ItemCodec>} Map of non-class types that have
      * `ItemCodec`s registered to the set of such codecs. There can be more
      * than one codec per type for the same reason as `_classToCodecs` can (see
      * which).

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -35,7 +35,7 @@ export default class ApiLog extends Singleton {
    *
    * @param {string} connectionId Identifier for the connection.
    * @param {object} msg Incoming message.
-   * @returns {int} Standard msec timestamp indicating the start time of the API
+   * @returns {Int} Standard msec timestamp indicating the start time of the API
    *   call being represented here.
    */
   incomingMessage(connectionId, msg) {
@@ -51,7 +51,7 @@ export default class ApiLog extends Singleton {
    * to be sent.
    *
    * @param {string} connectionId Identifier for the connection.
-   * @param {int} startTime Standard msec timestamp indicating the start time of
+   * @param {Int} startTime Standard msec timestamp indicating the start time of
    *   the API call being represented here. Should be the value returned from
    *   the earlier call to `incomingMessage()` for `msg`.
    * @param {object} msg Incoming message.

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -29,7 +29,7 @@ export default class Context extends CommonBase {
   constructor() {
     super();
 
-    /** {Map<string,Target>} The underlying map. */
+    /** {Map<string, Target>} The underlying map. */
     this._map = new Map();
 
     Object.freeze(this);

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -30,7 +30,7 @@ export default class PostConnection extends Connection {
     /** {object} The HTTP response. */
     this._res = res;
 
-    /** {Array<Buffer>} The request POST payload, as individual chunks. */
+    /** {array<Buffer>} The request POST payload, as individual chunks. */
     this._chunks = [];
 
     const contentTypeError = this._validateContentType();

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -136,7 +136,7 @@ export default class Target {
    * result or (directly) throwing an error.
    *
    * @param {string} name The method name.
-   * @param {Array} args Arguments to the method.
+   * @param {array} args Arguments to the method.
    * @returns {*} The result of calling. Because `undefined` isn't used across
    *   the API, this method returns `null` if the original method returned
    *   `undefined`.

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -183,7 +183,7 @@ export default class ClientBundle extends Singleton {
      */
     this._fs = new memory_fs();
 
-    /** {Map<string,Buffer>} Current (most recently built) compiled bundles. */
+    /** {Map<string, Buffer>} Current (most recently built) compiled bundles. */
     this._currentBundles = new Map();
 
     /** {boolean} Dev mode running? */

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -61,14 +61,14 @@ export default class LocalFile extends BaseFile {
     this._revNum = null;
 
     /**
-     * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to
+     * {Map<string, FrozenBuffer>|null} Map from `StoragePath` strings to
      * corresponding stored data, for the entire file. `null` indicates that
      * the map is not yet initialized.
      */
     this._storage = null;
 
     /**
-     * {Map<string,FrozenBuffer>|null} Map from `StoragePath` strings to
+     * {Map<string, FrozenBuffer>|null} Map from `StoragePath` strings to
      * corresponding stored data, for file contents that have not yet been
      * written to disk.
      */

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -16,7 +16,7 @@ import Transactor from './Transactor';
 const log = new Logger('local-file');
 
 /**
- * {int} How long to wait (in msec) after a file becomes dirty and before it
+ * {Int} How long to wait (in msec) after a file becomes dirty and before it
  * gets written to disk. This keeps the system from thrashing the disk while
  * a file is being actively updated.
  */

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -38,7 +38,7 @@ export default class Transactor extends CommonBase {
     this._fileFriend = fileFriend;
 
     /**
-     * {Map<string,FrozenBuffer|null>|null} Map from paths retrieved while
+     * {Map<string, FrozenBuffer|null>|null} Map from paths retrieved while
      * running the transaction to the retrieved contents, or `null` if the
      * transaction has no data read operations.
      */
@@ -47,7 +47,7 @@ export default class Transactor extends CommonBase {
       : new Map();
 
     /**
-     * {Map<string,FrozenBuffer|null>} Map from paths updated while running the
+     * {Map<string, FrozenBuffer|null>} Map from paths updated while running the
      * transaction to the updated data or `null` for deleted paths.
      */
     this._updatedStorage = new Map();
@@ -62,8 +62,8 @@ export default class Transactor extends CommonBase {
    * Runs the transaction.
    *
    * @returns {object} Object that binds `data` to a
-   *   `{Map<string,FrozenBuffer|null>}` of retrieved data and `updatedStorage`
-   *   to a `{Map<string,FrozenBuffer|null>}` of updated storage (paths to be
+   *   `{Map<string, FrozenBuffer|null>}` of retrieved data and `updatedStorage`
+   *   to a `{Map<string, FrozenBuffer|null>}` of updated storage (paths to be
    *   written or deleted).
    */
   run() {

--- a/local-modules/content-store/StoragePath.js
+++ b/local-modules/content-store/StoragePath.js
@@ -100,7 +100,7 @@ export default class StoragePath extends UtilityClass {
    * the inverse of `join()`.
    *
    * @param {string} path Storage path.
-   * @returns {Array<string>} Array consisting of the components of `path`.
+   * @returns {array<string>} Array consisting of the components of `path`.
    */
   static split(path) {
     StoragePath.check(path);

--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -57,7 +57,7 @@ export default class DevMode extends Singleton {
    * Constructs and returns the source mappings.
    *
    * @param {string} copyTo Destination directory.
-   * @param {Array} [soFar = []] Partial result (passed through to recursive
+   * @param {array} [soFar = []] Partial result (passed through to recursive
    *   calls).
    * @param {boolean} [first = true] Whether this is the top-level call.
    * @returns {object} The constructed mappings.

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -149,7 +149,8 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {Int} The length of the selection, or zero if it is just an insertion point.
+   * {Int} The length of the selection, or zero if it is just an insertion
+   * point.
    */
   get length() {
     return this._fields.get('length');

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -10,7 +10,7 @@ import CaretOp from './CaretOp';
 import Timestamp from './Timestamp';
 
 /**
- * {Map<string,function>} Map from each allowed caret field name to a type
+ * {Map<string, function>} Map from each allowed caret field name to a type
  * checker predicate for same.
  *
  * **Note:** `sessionId` is not included, because that's separate from the

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -37,7 +37,7 @@ export default class CaretSnapshot extends CommonBase {
     /** {Int} The associated document information revision number. */
     this._docRevNum = docRevNum;
 
-    /** {Map<string,Caret>} Map of session ID to corresponding caret. */
+    /** {Map<string, Caret>} Map of session ID to corresponding caret. */
     this._carets = new Map();
     for (const c of carets) {
       Caret.check(c);

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -78,7 +78,7 @@ export default class DocControl extends CommonBase {
     this._fileCodec = new FileCodec(fileComplex.file, fileComplex.codec);
 
     /**
-     * {Map<RevisionNumber,DocumentSnapshot>} Mapping from revision numbers to
+     * {Map<RevisionNumber, DocumentSnapshot>} Mapping from revision numbers to
      * corresponding document snapshots. Sparse.
      */
     this._snapshots = new Map();

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -672,7 +672,7 @@ export default class DocControl extends CommonBase {
    *
    * @param {Int} start Start change number (inclusive) of changes to read.
    * @param {Int} endExc End change number (exclusive) of changes to read.
-   * @returns {Array<DocumentChange>} Array of changes, in order by change
+   * @returns {array<DocumentChange>} Array of changes, in order by change
    *   number.
    */
   async _readChangeRange(start, endExc) {

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -39,7 +39,7 @@ export default class DocServer extends Singleton {
     this._codec = Codec.theOne;
 
     /**
-     * {Map<string,Weak<FileComplex>|Promise<FileComplex>>} Map from document
+     * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document
      * IDs to either a weak-reference or a promise to a `FileComplex`, for the
      * so-IDed document. During asynchrounous construction, the binding is to a
      * promise, and once constructed it becomes a weak reference. The weak
@@ -49,7 +49,7 @@ export default class DocServer extends Singleton {
     this._complexes = new Map();
 
     /**
-     * {Map<string,Weak<DocSession>>} Map from session IDs to corresponding
+     * {Map<string, Weak<DocSession>>} Map from session IDs to corresponding
      * weak-reference-wrapped `DocSession` instances. See `_complexes` for
      * rationale on weakness.
      */

--- a/local-modules/quill-util/QuillGeometry.js
+++ b/local-modules/quill-util/QuillGeometry.js
@@ -37,7 +37,7 @@ export default class QuillGeometry {
    *  successive lines of text should be included in the result. If
    *  set to `true` then a rectangle representing the leading will be inserted
    *  between each pair of line bounds.
-   * @returns {Array<object>} An array of bounds objects representing the
+   * @returns {array<object>} An array of bounds objects representing the
    *  screen bounds of each line of the provided range in top-to-bottom
    *  visual order. A bounds object is
    *  `{ left, top, right (exclusive), bottom (exclusive), width, height }`.

--- a/local-modules/quill-util/QuillGeometry.js
+++ b/local-modules/quill-util/QuillGeometry.js
@@ -8,8 +8,8 @@
  */
 export default class QuillGeometry {
   /**
-   * Takes a Quill character offset and returns a bounding rectangle for an insertion point
-   * cursor at that offset.
+   * Takes a Quill character offset and returns a bounding rectangle for an
+   * insertion point cursor at that offset.
    *
    * @param {Quill} quill The Quill editor instance that we're measuring against
    * @param {Int} offset The character offset within the Quill document.
@@ -70,13 +70,13 @@ export default class QuillGeometry {
       return bounds;
     });
 
-    // At this point we have the bounds of each whole line. However, the first and
-    // last lines of a selection may not be completely selected.
-    // So, offset those line bounds. Note that in the case of a single line
-    // the first and last line are the same line.
+    // At this point we have the bounds of each whole line. However, the first
+    // and last lines of a selection may not be completely selected. So, offset
+    // those line bounds. Note that in the case of a single line the first and
+    // last line are the same line.
 
-    // Start by getting the leftmost pixel position of the first character
-    // in the range.
+    // Start by getting the leftmost pixel position of the first character in
+    // the range.
     const leadingBounds = quill.getBounds(index, 1);
 
     lineBounds[0].left = leadingBounds.left;

--- a/local-modules/state-machine/StateMachine.js
+++ b/local-modules/state-machine/StateMachine.js
@@ -90,7 +90,7 @@ export default class StateMachine {
     this._anyEventPending = new PromCondition(false);
 
     /**
-     * {Map<string,PromCondition>} Map from state names to conditions which
+     * {Map<string, PromCondition>} Map from state names to conditions which
      * become momentarily `true` when transitioning into those states. Populated
      * only as needed.
      */

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -33,7 +33,7 @@ export default class TObject extends UtilityClass {
    * of keys as "own" properties.
    *
    * @param {*} value Value to check.
-   * @param {Array<string>} keys Keys that must be present in `value`.
+   * @param {array<string>} keys Keys that must be present in `value`.
    * @returns {object} `value`.
    */
   static withExactKeys(value, keys) {

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -39,7 +39,7 @@ export default class ColorSelector {
   /**
    * Constructs a new ColorSelector object.
    *
-   * @param {int} [seed = 0] The initial hue angle to be used. This value will
+   * @param {Int} [seed = 0] The initial hue angle to be used. This value will
    * be MODed with 360 to get a valid angle. The default is 0, which is pure red.
    * @param {number} [stride=53] The number of degrees of hue angle to advance on
    * each iteration.

--- a/local-modules/util-common/PromMutex.js
+++ b/local-modules/util-common/PromMutex.js
@@ -25,7 +25,7 @@ export default class PromMutex extends CommonBase {
     this._lockedBy = null;
 
     /**
-     * {Array<object>} Array of waiters for lock acquisition, in FIFO order.
+     * {array<object>} Array of waiters for lock acquisition, in FIFO order.
      * Each element binds `key` to the would-be holder key (see `_lockedBy`) and
      * `release` to a function which indicates that the key's owner can now
      * acquire the lock.

--- a/local-modules/util-common/StringUtil.js
+++ b/local-modules/util-common/StringUtil.js
@@ -8,17 +8,17 @@ import { TInt, TString } from 'typecheck';
 import { UtilityClass } from 'util-common-base';
 
 /**
- * Several (hopefully) useful routines to make dealing with strings (especially some
- * of the finer points of dealing with Unicdode) a little nicer.
+ * Several (hopefully) useful routines to make dealing with strings (especially
+ * some of the finer points of dealing with Unicdode) a little nicer.
  */
 export default class StringUtil extends UtilityClass {
   /**
-   * Splits a string into its distinct grapheme clusters. For instance, the letter
-   * 'ñ' could be represented as the single Unicode code point `0x00F1`, or as the
-   * the letter 'n' (`0x63`) plus the '~' combinding mark (`0x0303`). The built-in
-   * splitting routines for JavaScript strings do not take care to not split the string
-   * in the middle of such clusters. The function knows about combining marks,
-   * surrogate pairs, etc.
+   * Splits a string into its distinct grapheme clusters. For instance, the
+   * letter `ñ` could be represented as the single Unicode code point `0x00F1`,
+   * or as the the letter `n` (`0x63`) plus the `~` combinding mark (`0x0303`).
+   * The built-in splitting routines for JavaScript strings do not take care to
+   * not split the string in the middle of such clusters. The function knows
+   * about combining marks, surrogate pairs, etc.
    *
    * @param {string} string The string to split.
    * @returns {array<string>} An array of strings, one for each grapheme cluster
@@ -41,11 +41,13 @@ export default class StringUtil extends UtilityClass {
   }
 
   /**
-   * Takes a string and trims grapheme clusters off of its end until the new string whose
-   * UTF-8-encoded form is less than, or equal to, a given number of bytes.
+   * Takes a string and trims grapheme clusters off of its end until the new
+   * string whose UTF-8-encoded form is less than, or equal to, a given number
+   * of bytes.
    *
    * @param {string} string The string to trim.
-   * @param {Int} limit The upper limit (inclusive) for the output counted as UTF-8 bytes.
+   * @param {Int} limit The upper limit (inclusive) for the output counted as
+   *   UTF-8 bytes.
    * @returns {string} The trimmed string.
    */
   static stringWithUtf8ByteLimit(string, limit) {
@@ -56,8 +58,8 @@ export default class StringUtil extends UtilityClass {
     let totalByteCount = 0;
     const graphemes = StringUtil.graphemesForString(string);
 
-    // Add grapheme clusters to the output, one at a time, until doing so would make a string whose
-    // UTF-8 encoded form would excede the limit.
+    // Add grapheme clusters to the output, one at a time, until doing so would
+    // make a string whose UTF-8 encoded form would excede the limit.
     for (const grapheme of graphemes) {
       const graphemeByteCount = Buffer.byteLength(grapheme, 'utf8');
 

--- a/local-modules/util-common/StringUtil.js
+++ b/local-modules/util-common/StringUtil.js
@@ -15,10 +15,10 @@ export default class StringUtil extends UtilityClass {
   /**
    * Splits a string into its distinct grapheme clusters. For instance, the
    * letter `ñ` could be represented as the single Unicode code point `0x00F1`,
-   * or as the the letter `n` (`0x63`) plus the `~` combinding mark (`0x0303`).
-   * The built-in splitting routines for JavaScript strings do not take care to
-   * not split the string in the middle of such clusters. The function knows
-   * about combining marks, surrogate pairs, etc.
+   * or as the letter `n` (`0x63`) plus the `~` combinding mark (`0x0303`). The
+   * built-in splitting routines for JavaScript strings do not take care to not
+   * split the string in the middle of such clusters. The function knows about
+   * combining marks, surrogate pairs, etc.
    *
    * @param {string} string The string to split.
    * @returns {array<string>} An array of strings, one for each grapheme cluster

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -64,12 +64,12 @@ describe('util-common/PropertyIterable', () => {
  * was specifically checked.
  *
  * @param {PropertyIterable} iter The iterator we are testing.
- * @param {Array<string>|null} [expectedProperties=[]] A list of property
+ * @param {array<string>|null} [expectedProperties=[]] A list of property
  *   names. The iterator must return _at least_ all of the properties in this
  *   list.
- * @param {Array<string>|null} [unexpectedProperties=[]] A list of property
+ * @param {array<string>|null} [unexpectedProperties=[]] A list of property
  *   names. The iterator must not return any of the properties in this list.
- * @returns {Array<string>} An array of property names returned by the iterator.
+ * @returns {array<string>} An array of property names returned by the iterator.
  */
 function _testIterator(iter, expectedProperties = [], unexpectedProperties = []) {
   const result = {};


### PR DESCRIPTION
Just a pass over the code to fix `{array}` and `{Int}` type annotations, and some salient additions to the documentation.