### PR TITLE
Enable npm v5.

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -20,8 +20,8 @@ Development Guide
 Bayou uses [Node](https://nodejs.org) on the server side, and it uses
 [npm](https://npmjs,com) for module management. Install both of these if you
 haven't already done so. As of this writing, the bulk of development and
-testing have been done using `node` versions 7 and 8, and `npm` version 4.
-Notably, the server code is _not_ expected to run on `node` versions earlier
+testing have been done using `node` versions 7 and 8, and `npm` versions 4 and
+5. Notably, the server code is _not_ expected to run on `node` versions earlier
 than 7, and it may soon (probably some time in 2017) require version 8.
 
 To build and run, say:

--- a/scripts/build
+++ b/scripts/build
@@ -148,7 +148,7 @@ function check-dependency {
 # including Node and npm.
 function check-environment-dependencies {
     check-dependency 'Node' 'node --version' '^v[78]\.'
-    check-dependency 'npm' 'npm --version' '^4\.'
+    check-dependency 'npm' 'npm --version' '^[45]\.'
     check-dependency 'jq' 'jq --version' '^jq-1\.'
     check-dependency 'rsync' 'rsync --version' '.' # No actual version check.
 }

--- a/scripts/build
+++ b/scripts/build
@@ -327,6 +327,13 @@ function do-install {
 
     echo "${dir}:" 'Installing external dependencies...'
 
+    # This runs `npm install` in a new empty directory, because as of npm v5,
+    # npm _really really_ wants to manage all modules under `node_modules`, and
+    # in our case we have local modules which npm doesn't know about and
+    # therefore wants to remove whenever we do `npm install`. **TODO:** Simplify
+    # this back to just doing `npm install` in the main directory, should npm
+    # ever gain a way to understand that there are some module directories that
+    # it shouldn't touch. See <https://github.com/npm/npm/issues/18062>.
     rm -rf "${npmDir}"
     mkdir -p "${npmDir}"
     rsync --archive "${packageJson}" "${npmDir}/package.json"

--- a/scripts/build
+++ b/scripts/build
@@ -334,6 +334,7 @@ function do-install {
     # this back to just doing `npm install` in the main directory, should npm
     # ever gain a way to understand that there are some module directories that
     # it shouldn't touch. See <https://github.com/npm/npm/issues/18062>.
+    
     rm -rf "${npmDir}"
     mkdir -p "${npmDir}"
     rsync --archive "${packageJson}" "${npmDir}/package.json"


### PR DESCRIPTION
Having tested it and verified that it works, this PR changes the build preflight checks to allow npm v5 to be used.