### PR TITLE
File creation and deletion, and related stuff.

### DIFF
--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -230,6 +230,17 @@ export default class LocalFile extends BaseFile {
        */
       readPathOrNull(storagePath) {
         return storage.get(storagePath) || null;
+      },
+
+      /**
+       * Gets an iterator over all path-based storage. Yielded elements are
+       * entries of the form `[path, data]`.
+       *
+       * @returns {Iterator<string, FrozenBuffer>} Iterator over all path-based
+       *   storage.
+       */
+      pathStorage() {
+        return storage.entries();
       }
     };
 

--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -158,6 +158,24 @@ export default class LocalFile extends BaseFile {
 
   /**
    * Implementation as required by the superclass.
+   */
+  async _impl_delete() {
+    await this._readStorageIfNecessary();
+
+    if (this._fileShouldExist) {
+      // Indicate that the file should not exist, and reset the storage (to be
+      // ready for potential re-creation).
+      this._fileShouldExist = false;
+      this._revNum          = 0;
+      this._storage         = new Map();
+
+      // Get it erased.
+      this._storageNeedsWrite();
+    }
+  }
+
+  /**
+   * Implementation as required by the superclass.
    *
    * @returns {boolean} `true` iff this file exists.
    */

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -149,6 +149,16 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `deleteAll` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_deleteAll(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `deleteBlob` operations.
    *
    * @param {FileOp} op The operation.

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -42,7 +42,7 @@ export default class Transactor extends CommonBase {
      * running the transaction to the retrieved contents, or `null` if the
      * transaction has no data read operations.
      */
-    this._data = (spec.opsWithCategory(FileOp.CAT_READ).size === 0)
+    this._data = (spec.opsWithCategory(FileOp.CAT_READ).length === 0)
       ? null
       : new Map();
 

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -151,11 +151,12 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `deleteAll` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {FileOp} op_unused The operation.
    */
-  _op_deleteAll(op) {
-    // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+  _op_deleteAll(op_unused) {
+    for (const [path, value_unused] of this._fileFriend.pathStorage()) {
+      this._updatedStorage.set(path, null);
+    }
   }
 
   /**

--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -44,23 +44,8 @@ describe('content-store-local/LocalFile', () => {
     });
   });
 
-  describe('exists()', () => {
-    it('should return `false` if the underlying storage does not exist.', async () => {
-      const file = new LocalFile('0', filePath('non-existent-file'));
-      assert.isFalse(await file.exists());
-    });
-
-    it('should return `true` if the underlying storage does exist.', async () => {
-      const dir = filePath('exist-already');
-      const file = new LocalFile('0', dir);
-
-      fs.mkdirSync(dir);
-      assert.isTrue(await file.exists());
-    });
-  });
-
   describe('create()', () => {
-    it('should cause a non-existent file to come into existence.', async () => {
+    it('should cause a non-existent file to come into existence', async () => {
       const file = new LocalFile('0', filePath('will-exist'));
 
       assert.isFalse(await file.exists()); // Baseline assumption.
@@ -104,13 +89,50 @@ describe('content-store-local/LocalFile', () => {
   });
 
   describe('delete()', () => {
-    it('should cause an existing file to stop existing.', async () => {
+    it('should cause an existing file to stop existing', async () => {
       const file = new LocalFile('0', filePath('will-be-deleted'));
       await file.create();
       assert.isTrue(await file.exists()); // Baseline assumption.
 
       await file.delete();
       assert.isFalse(await file.exists()); // The actual test.
+    });
+  });
+
+  describe('exists()', () => {
+    it('should return `false` if the underlying storage does not exis.', async () => {
+      const file = new LocalFile('0', filePath('non-existent-file'));
+      assert.isFalse(await file.exists());
+    });
+
+    it('should return `true` if the underlying storage does exist', async () => {
+      const dir = filePath('exist-already');
+      const file = new LocalFile('0', dir);
+
+      fs.mkdirSync(dir);
+      assert.isTrue(await file.exists());
+    });
+  });
+
+  describe('transact()', () => {
+    it('should succeed and return no data from an empty transaction on an existing file', async () => {
+      const file = new LocalFile('0', filePath('empty-file-for-transact'));
+      await file.create();
+
+      const spec = new TransactionSpec();
+      const result = await file.transact(spec);
+      assert.strictEqual(result.revNum, 0);
+      assert.isUndefined(result.newRevNum);
+      assert.isUndefined(result.data);
+    });
+
+    it('should throw an error if the file doesn\'t exist', async () => {
+      const file = new LocalFile('0', filePath('non-existent-file'));
+      assert.isFalse(await file.exists()); // Baseline assumption.
+
+      // The actual test.
+      const spec = new TransactionSpec();
+      await assert.isRejected(file.transact(spec));
     });
   });
 });

--- a/local-modules/content-store-local/tests/test_LocalFile.js
+++ b/local-modules/content-store-local/tests/test_LocalFile.js
@@ -14,6 +14,10 @@ import { FrozenBuffer } from 'util-common';
 const STORE_PREFIX = 'bayou-test-';
 let storeDir = null;
 
+function filePath() {
+  return path.join(storeDir, 'test_file');
+}
+
 describe('content-store-local/LocalFile', () => {
   before(() => {
     storeDir = fs.mkdtempSync(STORE_PREFIX);
@@ -34,16 +38,14 @@ describe('content-store-local/LocalFile', () => {
     // }, 2000);
   });
 
-  describe('constructor(fileId, filePath)', () => {
-    it('should create a local dir for storing files at the specified path', () => {
-      const file = new LocalFile('0', filePath());
-
-      assert.isNotNull(file);
+  describe('constructor()', () => {
+    it('should not throw given valid arguments', () => {
+      assert.doesNotThrow(() => { new LocalFile('0', filePath()); });
     });
   });
 
   describe('create()', () => {
-    it('should erase the file if called on a non-empty file', async () => {
+    it('should do nothing if called on a non-empty file', async () => {
       const file = new LocalFile('0', filePath());
       const storagePath = '/abc';
       const value = FrozenBuffer.coerce('x');
@@ -70,11 +72,7 @@ describe('content-store-local/LocalFile', () => {
 
       // Same transaction as above.
       result = (await file.transact(spec)).data.get(storagePath);
-      assert.strictEqual(result, undefined);
+      assert.strictEqual(result.string, value.string);
     });
   });
 });
-
-function filePath() {
-  return path.join(storeDir, 'test_file');
-}

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -170,10 +170,10 @@ export default class BaseFile extends CommonBase {
    *   operations, the revision number of the file that resulted from those
    *   writes.
    * * `data` &mdash; If the transaction spec included any read operations, a
-   *   `Map<string,FrozenBuffer>` from storage paths to the data which was read.
-   *   **Note:** Even if there was no data to read (e.g., all read operations
-   *   were for non-bound paths) as long as the spec included read operations,
-   *   this property will still be present.
+   *   `Map<string, FrozenBuffer>` from storage paths to the data which was
+   *   read. **Note:** Even if there was no data to read (e.g., all read
+   *   operations were for non-bound paths) as long as the spec included read
+   *   operations, this property will still be present.
    *
    * It is an error to call this method on a file that doesn't exist, in the
    * sense of the `exists()` method. That is, if `exists()` would return

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -93,11 +93,11 @@ export default class BaseFile extends CommonBase {
 
   /**
    * Creates this file if it does not already exist. This does nothing if the
-   * file already exists. After this call returns (successfully), the file is
-   * guaranteed to exist but might not be empty.
+   * file already exists. Immediately after this call returns successfully, the
+   * file is guaranteed to exist but might not be empty.
    *
-   * **Note:** To erase the contents of a file, use the `deleteAll` operation in
-   * a transaction.
+   * **Note:** To erase the contents of a file without deleting the file itself,
+   * use the `deleteAll` operation in a transaction.
    */
   async create() {
     await this._impl_create();
@@ -109,6 +109,24 @@ export default class BaseFile extends CommonBase {
    * @abstract
    */
   async _impl_create() {
+    this._mustOverride();
+  }
+
+  /**
+   * Deletes the storage for this file if it exists. This does nothing if the
+   * file does not exist. Immediately after this call returns successfully, the
+   * file is guaranteed not to exist.
+   */
+  async delete() {
+    await this._impl_delete();
+  }
+
+  /**
+   * Main implementation of `delete()`.
+   *
+   * @abstract
+   */
+  async _impl_delete() {
     this._mustOverride();
   }
 

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -157,6 +157,10 @@ export default class BaseFile extends CommonBase {
    *   were for non-bound paths) as long as the spec included read operations,
    *   this property will still be present.
    *
+   * It is an error to call this method on a file that doesn't exist, in the
+   * sense of the `exists()` method. That is, if `exists()` would return
+   * `false`, then this method will fail.
+   *
    * @param {TransactionSpec} spec Specification for the transaction, that is,
    *   the set of operations to perform.
    * @returns {object} Object with mappings as described above.
@@ -209,6 +213,10 @@ export default class BaseFile extends CommonBase {
    * Waits for a change to be made to a file at a specific path, including both
    * updating and deleting a value at the path. The return value becomes
    * resolved soon after a change is made or the specified timeout elapses.
+   *
+   * It is an error to call this method on a file that doesn't exist, in the
+   * sense of the `exists()` method. That is, if `exists()` would return
+   * `false`, then this method will fail.
    *
    * **Note:** Subclasses are allowed to silently increase the given
    * `timeoutMsec` if they have a _minimum_ timeout. In such cases, it is

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -92,9 +92,12 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Creates this file if it does not already exist, or re-creates it if it does
-   * already exist. After this call, the file both exists and is empty (that is,
-   * has no stored values). In addition, the revision number of the file is `0`.
+   * Creates this file if it does not already exist. This does nothing if the
+   * file already exists. After this call returns (successfully), the file is
+   * guaranteed to exist but might not be empty.
+   *
+   * **Note:** To erase the contents of a file, use the `deleteAll` operation in
+   * a transaction.
    */
   async create() {
     await this._impl_create();

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -122,9 +122,16 @@ const OPERATIONS = DataUtil.deepFreeze([
   ],
 
   /*
-   * A `deleteBlob` operation. This is a write operation that the blob with the
-   * indicated hash, if any. If there was no such blob, then this operation does
+   * A `deleteAll` operation. This is a write operation that removes all stored
+   * items in the file. If the file was already empty, then this operation does
    * nothing.
+   */
+  [CAT_WRITE, 'deleteAll'],
+
+  /*
+   * A `deleteBlob` operation. This is a write operation that removes from the
+   * file the blob with the indicated hash, if any. If there was no such blob,
+   * then this operation does nothing.
    *
    * @param {string} hash The hash of the blob to delete.
    */

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -121,10 +121,8 @@ export default class DocControl extends CommonBase {
     const revNum = (contents === null) ? 0 : 1;
 
     const spec = new TransactionSpec(
-      // These make the transaction fail if we lose a race to (re)create the
-      // file.
-      fc.op_checkPathAbsent(Paths.FORMAT_VERSION),
-      fc.op_checkPathAbsent(Paths.REVISION_NUMBER),
+      // If the file already existed, this clears out the old contents.
+      fc.op_deleteAll(),
 
       // Version for the file format.
       fc.op_writePath(Paths.FORMAT_VERSION, this._fileComplex.formatVersion),


### PR DESCRIPTION
This PR changes the `content-store` model in a few ways to make its interface more obvious and (hopefully) easier to implement.

* `BaseFile.create()` no longer erases existing files. Instead…
* New file operator `deleteAll` to delete all the contents of an existing file (and leave the file as a thing that exists).
* New method `BaseFile.delete()` to delete the actual file storage (as opposed to emptying it out but leaving the overall file as a thing that exists).
* Implemented all the above additions/changes in semantics in `content-store-local`, and added a bunch of tests for it.