### PR TITLE
Prepare for `whenChange` to become an op.

### DIFF
--- a/local-modules/content-store-local/LocalFile.js
+++ b/local-modules/content-store-local/LocalFile.js
@@ -6,7 +6,7 @@ import afs from 'async-file';
 import path from 'path';
 
 import { Codec } from 'codec';
-import { BaseFile } from 'content-store';
+import { BaseFile, Errors } from 'content-store';
 import { Logger } from 'see-all';
 import { FrozenBuffer, PromCondition, PromDelay, PromMutex } from 'util-common';
 
@@ -207,11 +207,11 @@ export default class LocalFile extends BaseFile {
 
     await Promise.race([this._readStorageIfNecessary(), timeoutProm]);
     if (timeout) {
-      throw new Error('Transaction timed out.');
+      throw Errors.transaction_timed_out(timeoutMsec);
     }
 
     if (!this._fileShouldExist) {
-      throw new Error('Cannot operate on non-existent file.');
+      throw Errors.file_not_found(this.id);
     }
 
     // Construct the "file friend" object. This exposes just enough private
@@ -303,7 +303,7 @@ export default class LocalFile extends BaseFile {
     }
 
     if (!this._fileShouldExist) {
-      throw new Error('Cannot operate on non-existent file.');
+      throw Errors.file_not_found(this.id);
     }
 
     if (valueOrHash === null) {

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -228,6 +228,26 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `whenPath` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_whenPath(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
+   * Handler for `whenPathAbsent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_whenPathAbsent(op) {
+    // **TODO:** Implement this.
+    throw new InfoError('not_implemented', op.name);
+  }
+
+  /**
    * Handler for `writeBlob` operations.
    *
    * @param {FileOp} op The operation.

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -91,7 +91,7 @@ export default class Transactor extends CommonBase {
    */
   _op_checkBlob(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -101,7 +101,7 @@ export default class Transactor extends CommonBase {
    */
   _op_checkBlobAbsent(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -163,7 +163,7 @@ export default class Transactor extends CommonBase {
    */
   _op_deleteBlob(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -182,7 +182,7 @@ export default class Transactor extends CommonBase {
    */
   _op_readBlob(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -234,7 +234,7 @@ export default class Transactor extends CommonBase {
    */
   _op_whenPath(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -244,7 +244,7 @@ export default class Transactor extends CommonBase {
    */
   _op_whenPathAbsent(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -254,7 +254,7 @@ export default class Transactor extends CommonBase {
    */
   _op_writeBlob(op) {
     // **TODO:** Implement this.
-    throw new InfoError('not_implemented', op.name);
+    Transactor._missingOp(op.name);
   }
 
   /**
@@ -264,5 +264,14 @@ export default class Transactor extends CommonBase {
    */
   _op_writePath(op) {
     this._updatedStorage.set(op.arg('storagePath'), op.arg('value'));
+  }
+
+  /**
+   * Indicate a missing op implementation. **TODO:** Fix all these!
+   *
+   * @param {string} name Name of the missing op.
+   */
+  static _missingOp(name) {
+    throw InfoError.wtf(`Missing op implementation: ${name}`);
   }
 }

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Errors } from 'content-store';
 import { CommonBase, InfoError } from 'util-common';
 
 /**
@@ -71,7 +72,7 @@ export default class Transactor extends CommonBase {
 
       const handler = this[`_op_${op.name}`];
       if (!handler) {
-        throw new Error(`Missing handler for op: ${op.name}`);
+        throw InfoError.wtf(`Missing handler for op: ${op.name}`);
       }
 
       handler.call(this, op);
@@ -112,7 +113,7 @@ export default class Transactor extends CommonBase {
   _op_checkPathAbsent(op) {
     const storagePath = op.arg('storagePath');
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
-      throw new InfoError('path_not_empty', storagePath);
+      throw Errors.path_not_absent(storagePath);
     }
   }
 
@@ -124,7 +125,7 @@ export default class Transactor extends CommonBase {
   _op_checkPathExists(op) {
     const storagePath = op.arg('storagePath');
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
-      throw new InfoError('path_not_found', storagePath);
+      throw Errors.path_not_found(storagePath);
     }
   }
 
@@ -139,9 +140,9 @@ export default class Transactor extends CommonBase {
     const data         = this._fileFriend.readPathOrNull(storagePath);
 
     if (data === null) {
-      throw new InfoError('path_not_found', storagePath);
+      throw Errors.path_not_found(storagePath);
     } else if (data.hash !== expectedHash) {
-      throw new InfoError('path_hash_mismatch', storagePath, expectedHash);
+      throw Errors.path_hash_mismatch(storagePath, expectedHash);
     }
   }
 
@@ -212,7 +213,7 @@ export default class Transactor extends CommonBase {
     const revNum = op.arg('revNum');
 
     if (this._fileFriend.revNum !== revNum) {
-      throw new InfoError('revision_not_available', revNum);
+      throw Errors.revision_not_available(revNum);
     }
   }
 

--- a/local-modules/content-store/BaseFile.js
+++ b/local-modules/content-store/BaseFile.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TBoolean, TInt, TMap, TObject, TString } from 'typecheck';
-import { CommonBase, FrozenBuffer } from 'util-common';
+import { CommonBase, FrozenBuffer, InfoError } from 'util-common';
 
 import StoragePath from './StoragePath';
 import TransactionSpec from './TransactionSpec';
@@ -166,9 +166,9 @@ export default class BaseFile extends CommonBase {
    *   given the restrictions defined in the transaction spec (if any). If there
    *   are no restrictions, then this is always the most recent revision at the
    *   instant the transaction was run.
-   * * `newRevNum` &mdash; If the transaction spec included any write
+   * * `newRevNum` &mdash; If the transaction spec included any modification
    *   operations, the revision number of the file that resulted from those
-   *   writes.
+   *   modifications.
    * * `data` &mdash; If the transaction spec included any read operations, a
    *   `Map<string, FrozenBuffer>` from storage paths to the data which was
    *   read. **Note:** Even if there was no data to read (e.g., all read
@@ -203,12 +203,12 @@ export default class BaseFile extends CommonBase {
 
     if (spec.hasReadOps()) {
       if (result.data === null) {
-        throw new Error('Improper subclass behavior: Expected non-`null` `data`.');
+        throw InfoError.wtf('Improper subclass behavior: Expected non-`null` `data`.');
       }
       TMap.check(result.data, TString.check, FrozenBuffer.check);
     } else {
       if (result.data !== null) {
-        throw new Error('Improper subclass behavior: Expected `null` `data`.');
+        throw InfoError.wtf('Improper subclass behavior: Expected `null` `data`.');
       }
       delete result.data;
     }

--- a/local-modules/content-store/Errors.js
+++ b/local-modules/content-store/Errors.js
@@ -5,6 +5,8 @@
 import { TInt, TString } from 'typecheck';
 import { InfoError, UtilityClass } from 'util-common';
 
+import StoragePath from './StoragePath';
+
 /**
  * Utility class for constructing errors salient to this module.
  *
@@ -12,17 +14,6 @@ import { InfoError, UtilityClass } from 'util-common';
  * convention for those is `lowercase_underscore`, that is what's used.
  */
 export default class Errors extends UtilityClass {
-  /**
-   * Constructs an error indicating that a transaction timed out.
-   *
-   * @param {Int} timeoutMsec The original length of the timeout, in msec.
-   * @returns {InfoError} An appropriately-constructed error.
-   */
-  static transaction_timed_out(timeoutMsec) {
-    TInt.check(timeoutMsec);
-    return new InfoError('transaction_timed_out', timeoutMsec);
-  }
-
   /**
    * Constructs an error indicating that a file does not exist.
    *
@@ -32,5 +23,66 @@ export default class Errors extends UtilityClass {
   static file_not_found(id) {
     TString.check(id);
     return new InfoError('file_not_found', id);
+  }
+
+  /**
+   * Constructs an error indicating that a storage path contains data with a
+   * different hash than expected.
+   *
+   * @param {string} storagePath Path in question.
+   * @param {string} hash The expected hash.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static path_hash_mismatch(storagePath, hash) {
+    StoragePath.check(storagePath);
+    TString.nonempty(hash);
+    return new InfoError('path_hash_mismatch', storagePath, hash);
+  }
+
+  /**
+   * Constructs an error indicating that a storage path was expected to be
+   * absent (that is, not store any data) but turned out to have data.
+   *
+   * @param {string} storagePath Path in question.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static path_not_absent(storagePath) {
+    StoragePath.check(storagePath);
+    return new InfoError('path_not_absent', storagePath);
+  }
+
+  /**
+   * Constructs an error indicating that a storage path was expected to have
+   * data but turned out not to.
+   *
+   * @param {string} storagePath Path in question.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static path_not_found(storagePath) {
+    StoragePath.check(storagePath);
+    return new InfoError('path_not_found', storagePath);
+  }
+
+  /**
+   * Constructs an error indicating that a requested file revision is not
+   * available.
+   *
+   * @param {Int} revNum Requested revision number.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static revision_not_available(revNum) {
+    TInt.nonNegative(revNum);
+    return new InfoError('revision_not_available', revNum);
+  }
+
+  /**
+   * Constructs an error indicating that a transaction timed out.
+   *
+   * @param {Int} timeoutMsec The original length of the timeout, in msec.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static transaction_timed_out(timeoutMsec) {
+    TInt.check(timeoutMsec);
+    return new InfoError('transaction_timed_out', timeoutMsec);
   }
 }

--- a/local-modules/content-store/Errors.js
+++ b/local-modules/content-store/Errors.js
@@ -1,0 +1,36 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TInt, TString } from 'typecheck';
+import { InfoError, UtilityClass } from 'util-common';
+
+/**
+ * Utility class for constructing errors salient to this module.
+ *
+ * **Note:** The names of the methods match the functor names, and because the
+ * convention for those is `lowercase_underscore`, that is what's used.
+ */
+export default class Errors extends UtilityClass {
+  /**
+   * Constructs an error indicating that a transaction timed out.
+   *
+   * @param {Int} timeoutMsec The original length of the timeout, in msec.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static transaction_timed_out(timeoutMsec) {
+    TInt.check(timeoutMsec);
+    return new InfoError('transaction_timed_out', timeoutMsec);
+  }
+
+  /**
+   * Constructs an error indicating that a file does not exist.
+   *
+   * @param {string} id ID of the file.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static file_not_found(id) {
+    TString.check(id);
+    return new InfoError('file_not_found', id);
+  }
+}

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -29,7 +29,7 @@ const CAT_WRITE        = 'write';
 /** {array<string>} List of categories in defined execution order. */
 const CATEGORY_EXECUTION_ORDER = [
   CAT_ENVIRONMENT, CAT_REVISION, CAT_PREREQUISITE, CAT_READ, CAT_DELETE,
-  CAT_WRITE
+  CAT_WRITE, CAT_WAIT
 ];
 
 // Schema argument type constants. See docs on the static properties for
@@ -331,6 +331,11 @@ export default class FileOp extends CommonBase {
     return CAT_REVISION;
   }
 
+  /** {string} Operation category for waits. */
+  static get CAT_WAIT() {
+    return CAT_WAIT;
+  }
+
   /** {string} Operation category for data writes. */
   static get CAT_WRITE() {
     return CAT_WRITE;
@@ -419,6 +424,7 @@ export default class FileOp extends CommonBase {
       case CAT_PREREQUISITE:
       case CAT_READ:
       case CAT_REVISION:
+      case CAT_WAIT:
       case CAT_WRITE: {
         return category;
       }

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -216,8 +216,9 @@ const OPERATIONS = DataUtil.deepFreeze([
 
   /*
    * A `whenPath` operation. This is a wait operation that blocks the
-   * transaction until a specific path stores data other than as given, or until
-   * the path is deleted.
+   * transaction until a specific path does not store data which hashes as
+   * given. This includes both storing data with other hashes as well as the
+   * path being absent (not storing any data).
    *
    * @param {string} storagePath The storage path to observe.
    * @param {string} hash Hash of the blob which must _not_ be at `storagePath`

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -244,7 +244,7 @@ const OPERATIONS = DataUtil.deepFreeze([
    */
   [
     CAT_CONVENIENCE, 'whenPathBuffer',
-    ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
+    ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]
   ],
 
   /*

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -236,7 +236,7 @@ const OPERATIONS = DataUtil.deepFreeze([
 
   /*
    * Convenience wrapper for `whenPath` operations, which hashes a given
-   * buffer's data. This is equivalent to `whenPaath(buffer.hash)`.
+   * buffer's data. This is equivalent to `whenPath(buffer.hash)`.
    *
    * @param {string} storagePath The storage path to observe.
    * @param {string} hash Hash of the blob which must _not_ be at `storagePath`

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -23,6 +23,7 @@ const CAT_ENVIRONMENT  = 'environment';
 const CAT_PREREQUISITE = 'prerequisite';
 const CAT_READ         = 'read';
 const CAT_REVISION     = 'revision';
+const CAT_WAIT         = 'wait';
 const CAT_WRITE        = 'write';
 
 /** {array<string>} List of categories in defined execution order. */
@@ -214,7 +215,39 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_ENVIRONMENT, 'timeout', ['durMsec', TYPE_DUR_MSEC]],
 
   /*
-   * A a `writeBlob` operation. This is a write operation that stores the
+   * A `whenPath` operation. This is a wait operation that blocks the
+   * transaction until a specific path stores data other than as given, or until
+   * the path is deleted.
+   *
+   * @param {string} storagePath The storage path to observe.
+   * @param {string} hash Hash of the blob which must _not_ be at `storagePath`
+   *   for the operation to complete.
+   */
+  [CAT_WAIT, 'whenPath', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
+
+  /*
+   * A `whenPathAbsent` operation. This is a wait operation that blocks the
+   * transaction until a specific path _does not_ have any data stored.
+   *
+   * @param {string} storagePath The storage path to observe.
+   */
+  [CAT_WAIT, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
+
+  /*
+   * Convenience wrapper for `whenPath` operations, which hashes a given
+   * buffer's data. This is equivalent to `whenPaath(buffer.hash)`.
+   *
+   * @param {string} storagePath The storage path to observe.
+   * @param {string} hash Hash of the blob which must _not_ be at `storagePath`
+   *   for the operation to complete.
+   */
+  [
+    CAT_CONVENIENCE, 'whenPathBuffer',
+    ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
+  ],
+
+  /*
+   * A `writeBlob` operation. This is a write operation that stores the
    * indicated value in the file, binding it to its content hash. If the content
    * hash was already bound, then this operation does nothing.
    *
@@ -223,7 +256,7 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_WRITE, 'writeBlob', ['value', TYPE_BUFFER]],
 
   /*
-   * A a `writePath` operation. This is a write operation that stores the
+   * A `writePath` operation. This is a write operation that stores the
    * indicated value in the file, binding it to the given path. If the path was
    * already bound to that value, then this operation does nothing.
    *
@@ -250,6 +283,10 @@ const OPERATIONS = DataUtil.deepFreeze([
  * * Data deletions &mdash; A data deletion erases previously-existing data
  *   within a file.
  * * Data writes &mdash; A data write stores new data into a file.
+ * * Waits &mdash; A wait operation blocks a transaction until some condition
+ *   holds. **Note:** A transaction specification must not include more than
+ *   one wait operation, and if it has one, the transaction must not perform any
+ *   reads, deletes, or writes.
  *
  * When executed, the operations of a transaction are effectively performed in
  * order by category; but within a category there is no effective ordering.
@@ -549,6 +586,17 @@ export default class FileOp extends CommonBase {
    */
   static _xform_deleteBlobBuffer(value) {
     return ['deleteBlob', value.hash];
+  }
+
+  /**
+   * Transformer for the convenience op `whenPathBuffer`.
+   *
+   * @param {string} storagePath The storage path.
+   * @param {FrozenBuffer} value The value.
+   * @returns {array<*>} Replacement constructor info.
+   */
+  static _xform_whenPathBuffer(storagePath, value) {
+    return ['whenPath', storagePath, value.hash];
   }
 }
 

--- a/local-modules/content-store/TransactionSpec.js
+++ b/local-modules/content-store/TransactionSpec.js
@@ -34,6 +34,15 @@ export default class TransactionSpec extends CommonBase {
     if (this.opsWithName('revNum').length > 1) {
       throw new Error('Too many `revNum` operations.');
     }
+
+    const waitCount = this.opsWithCategory(FileOp.CAT_WAIT);
+    if (waitCount === 1) {
+      if (this.hasReadOps() || this.hasModificationOps()) {
+        throw new Error('Cannot mix wait operations with reads and modifications.');
+      }
+    } else if (waitCount > 1) {
+      throw new Error('Too many wait operations.');
+    }
   }
 
   /**
@@ -78,6 +87,17 @@ export default class TransactionSpec extends CommonBase {
   hasModificationOps() {
     return (this.opsWithCategory(FileOp.CAT_DELETE).length !== 0)
       || (this.opsWithCategory(FileOp.CAT_WRITE).length !== 0);
+  }
+
+  /**
+   * Indicates whether or not this instance has any wait operations, that is,
+   * any operations with category `CAT_WAIT`.
+   *
+   * @returns {boolean} `true` iff there are any wait operations in this
+   *   instance.
+   */
+  hasWaitOps() {
+    return this.opsWithCategory(FileOp.CAT_WAIT).length !== 0;
   }
 
   /**

--- a/local-modules/content-store/main.js
+++ b/local-modules/content-store/main.js
@@ -4,6 +4,7 @@
 
 import BaseContentStore from './BaseContentStore';
 import BaseFile from './BaseFile';
+import Errors from './Errors';
 import FileCodec from './FileCodec';
 import FileId from './FileId';
 import FileOp from './FileOp';
@@ -13,6 +14,7 @@ import TransactionSpec from './TransactionSpec';
 export {
   BaseContentStore,
   BaseFile,
+  Errors,
   FileCodec,
   FileId,
   FileOp,

--- a/local-modules/typecheck/TMap.js
+++ b/local-modules/typecheck/TMap.js
@@ -18,7 +18,7 @@ export default class TMap extends UtilityClass {
    * @param {Function} [keyCheck = null] Key type checker. If passed as
    *   non-`null`, must be a function that behaves like a standard
    *   `<type>.check()` method.
-   * @param {Function} [valueCheck = null] Key type checker. If passed as,
+   * @param {Function} [valueCheck = null] Value type checker. If passed as,
    *   non-`null`, must be a function that behaves like a standard
    *   `<type>.check()` method.
    * @returns {Map} `value`.

--- a/local-modules/typecheck/TSet.js
+++ b/local-modules/typecheck/TSet.js
@@ -1,0 +1,35 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from 'util-common-base';
+
+import TypeError from './TypeError';
+
+/**
+ * Type checker for type `Set`.
+ */
+export default class TSet extends UtilityClass {
+  /**
+   * Checks a value of type `Set`. Optionally checks the types of values.
+   *
+   * @param {*} value The (alleged) `Set`.
+   * @param {Function} [valueCheck = null] Value type checker. If passed as,
+   *   non-`null`, must be a function that behaves like a standard
+   *   `<type>.check()` method.
+   * @returns {Set} `value`.
+   */
+  static check(value, valueCheck = null) {
+    if (!(value instanceof Set)) {
+      return TypeError.badValue(value, 'Set');
+    }
+
+    if (valueCheck !== null) {
+      for (const v of value) {
+        valueCheck(v);
+      }
+    }
+
+    return value;
+  }
+}

--- a/local-modules/typecheck/main.js
+++ b/local-modules/typecheck/main.js
@@ -11,6 +11,7 @@ import TInt from './TInt';
 import TIterable from './TIterable';
 import TMap from './TMap';
 import TObject from './TObject';
+import TSet from './TSet';
 import TString from './TString';
 import TypeError from './TypeError';
 
@@ -24,6 +25,7 @@ export {
   TIterable,
   TMap,
   TObject,
+  TSet,
   TString,
   TypeError
 };

--- a/local-modules/util-common/CommonBase.js
+++ b/local-modules/util-common/CommonBase.js
@@ -4,6 +4,8 @@
 
 import { TObject } from 'typecheck';
 
+import InfoError from './InfoError';
+
 /**
  * Base class which provides a couple conveniences beyond what baseline
  * JavaScript has.
@@ -76,7 +78,7 @@ export default class CommonBase {
       if (!(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
-        throw new Error('Invalid `_impl_coerce()` implementation.');
+        throw InfoError.wtf('Invalid `_impl_coerce()` implementation.');
       }
       return result;
     }
@@ -127,7 +129,7 @@ export default class CommonBase {
       if ((result !== null) && !(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
-        throw new Error('Invalid `_impl_coerceOrNull()` implementation.');
+        throw InfoError.wtf('Invalid `_impl_coerceOrNull()` implementation.');
       }
       return result;
     }
@@ -175,6 +177,6 @@ export default class CommonBase {
    * @param {...*} args_unused Anything you want, to keep the linter happy.
    */
   static _mustOverride(...args_unused) {
-    throw new Error('Must override.');
+    throw InfoError.wtf('Must override.');
   }
 }

--- a/local-modules/util-common/InfoError.js
+++ b/local-modules/util-common/InfoError.js
@@ -4,7 +4,6 @@
 
 import { TString } from 'typecheck';
 
-import CommonBase from './CommonBase';
 import DataUtil from './DataUtil';
 
 /**
@@ -19,6 +18,19 @@ import DataUtil from './DataUtil';
  * can succeed in doing something useful with it, should it be useful to do so.
  */
 export default class InfoError extends Error {
+  /**
+   * Constructs an instance which is meant to indicate that the program
+   * exhibited unexpected behavior. This should be used as an indication of a
+   * likely bug in the program.
+   *
+   * @param {string} message Human-oriented message with some indication of what
+   *   went wrong.
+   */
+  static wtf(message) {
+    TString.check(message);
+    throw new InfoError('wtf', message);
+  }
+
   /**
    * Makes a message for passing to the superclass constructor.
    *
@@ -109,7 +121,3 @@ export default class InfoError extends Error {
     }
   }
 }
-
-// Add `CommonBase` as a mixin, because the main inheritence is the `Error`
-// class.
-CommonBase.mixInto(InfoError);


### PR DESCRIPTION
This PR is a bit of a hodge-podge, but it's all in service of transitioning `whenChange()` to being a transaction op instead of its own method. The new op is stubbed out here; the actual implementation and switchover will come in a future PR.

If you're wondering why all the error construction stuff, it's because timeout is a transaction error, whereas `whenChange()` treats it as a non-error return. The callers of `whenChange()` will have to switch over to catching errors, and that means we need to get our error ducks in a row.