### PR TITLE
Consistency and simplification of file ops.

### DIFF
--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -116,21 +116,21 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkBlobPresent` operations.
-   *
-   * @param {FileOp} op The operation.
-   */
-  _op_checkBlobPresent(op) {
-    // **TODO:** Implement this.
-    Transactor._missingOp(op.name);
-  }
-
-  /**
    * Handler for `checkBlobAbsent` operations.
    *
    * @param {FileOp} op The operation.
    */
   _op_checkBlobAbsent(op) {
+    // **TODO:** Implement this.
+    Transactor._missingOp(op.name);
+  }
+
+  /**
+   * Handler for `checkBlobPresent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkBlobPresent(op) {
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }
@@ -148,18 +148,6 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkPathPresent` operations.
-   *
-   * @param {FileOp} op The operation.
-   */
-  _op_checkPathPresent(op) {
-    const storagePath = op.arg('storagePath');
-    if (this._fileFriend.readPathOrNull(storagePath) === null) {
-      throw Errors.path_not_found(storagePath);
-    }
-  }
-
-  /**
    * Handler for `checkPathIs` operations.
    *
    * @param {FileOp} op The operation.
@@ -173,6 +161,18 @@ export default class Transactor extends CommonBase {
       throw Errors.path_not_found(storagePath);
     } else if (data.hash !== expectedHash) {
       throw Errors.path_hash_mismatch(storagePath, expectedHash);
+    }
+  }
+
+  /**
+   * Handler for `checkPathPresent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_checkPathPresent(op) {
+    const storagePath = op.arg('storagePath');
+    if (this._fileFriend.readPathOrNull(storagePath) === null) {
+      throw Errors.path_not_found(storagePath);
     }
   }
 
@@ -259,6 +259,22 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `whenPathAbsent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_whenPathAbsent(op) {
+    const storagePath = op.arg('storagePath');
+    const value       = this._fileFriend.readPathOrNull(storagePath);
+
+    if (value === null) {
+      this._completed = false;
+    }
+
+    this._logAboutWaiting(`whenPathAbsent: ${storagePath}`);
+  }
+
+  /**
    * Handler for `whenPathNot` operations.
    *
    * @param {FileOp} op The operation.
@@ -273,22 +289,6 @@ export default class Transactor extends CommonBase {
     }
 
     this._logAboutWaiting(`whenPathNot: ${storagePath}`);
-  }
-
-  /**
-   * Handler for `whenPathAbsent` operations.
-   *
-   * @param {FileOp} op The operation.
-   */
-  _op_whenPathAbsent(op) {
-    const storagePath = op.arg('storagePath');
-    const value       = this._fileFriend.readPathOrNull(storagePath);
-
-    if (value === null) {
-      this._completed = false;
-    }
-
-    this._logAboutWaiting(`whenPathAbsent: ${storagePath}`);
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -160,11 +160,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkPathHash` operations.
+   * Handler for `checkPathIs` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_checkPathHash(op) {
+  _op_checkPathIs(op) {
     const storagePath  = op.arg('storagePath');
     const expectedHash = op.arg('hash');
     const data         = this._fileFriend.readPathOrNull(storagePath);

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -116,11 +116,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkBlob` operations.
+   * Handler for `checkBlobPresent` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_checkBlob(op) {
+  _op_checkBlobPresent(op) {
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -267,7 +267,7 @@ export default class Transactor extends CommonBase {
     const storagePath = op.arg('storagePath');
     const value       = this._fileFriend.readPathOrNull(storagePath);
 
-    if (value === null) {
+    if (value !== null) {
       this._completed = false;
     }
 
@@ -289,6 +289,22 @@ export default class Transactor extends CommonBase {
     }
 
     this._logAboutWaiting(`whenPathNot: ${storagePath}`);
+  }
+
+  /**
+   * Handler for `whenPathPresent` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_whenPathPresent(op) {
+    const storagePath = op.arg('storagePath');
+    const value       = this._fileFriend.readPathOrNull(storagePath);
+
+    if (value === null) {
+      this._completed = false;
+    }
+
+    this._logAboutWaiting(`whenPathPresent: ${storagePath}`);
   }
 
   /**

--- a/local-modules/content-store-local/Transactor.js
+++ b/local-modules/content-store-local/Transactor.js
@@ -148,11 +148,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `checkPathExists` operations.
+   * Handler for `checkPathPresent` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_checkPathExists(op) {
+  _op_checkPathPresent(op) {
     const storagePath = op.arg('storagePath');
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
       throw Errors.path_not_found(storagePath);

--- a/local-modules/content-store/FileCodec.js
+++ b/local-modules/content-store/FileCodec.js
@@ -17,10 +17,10 @@ import FileOp from './FileOp';
  * defines a set of instance methods for constructing transaction operations,
  * that is, instances of `FileOp`, with the same method names as the static
  * constructor methods defined by `FileOp`. In the case of the methods defined
- * here, instead of accepting `FrozenBuffer` arguments where `FileOp` so defines
- * them, this class accepts any objects at all, so long as they can successfully
- * be encoded by the codec with which the instance of this class was
- * instantiated.
+ * here, instead of accepting `FrozenBuffer` or hash string arguments where
+ * `FileOp` so defines them, this class accepts any objects at all, so long as
+ * they can successfully be encoded by the codec with which the instance of this
+ * class was instantiated.
  *
  * **Note:** This class is _intentionally_ not a full wrapper over `BaseFile`.
  * It _just_ provides operations that benefit from the application of a `Codec`.
@@ -89,7 +89,7 @@ export default class FileCodec extends CommonBase {
       const bufferAt = [];
       for (let i = 0; i < argInfo.length; i++) {
         const [name_unused, type] = argInfo[i];
-        if (type === FileOp.TYPE_BUFFER) {
+        if ((type === FileOp.TYPE_BUFFER) || (type === FileOp.TYPE_HASH)) {
           bufferAt.push(i);
         }
       }

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -47,20 +47,20 @@ const TYPE_REV_NUM   = 'RevNum';
 // So it goes.
 const OPERATIONS = DataUtil.deepFreeze([
   /*
-   * A `checkBlobPresent` operation. This is a prerequisite operation that
-   * verifies that the file stores a blob with the indicated hash.
-   *
-   * @param {string} hash The expected hash.
-   */
-  [CAT_PREREQUISITE, 'checkBlobPresent', ['hash', TYPE_HASH]],
-
-  /*
    * A `checkBlobAbsent` operation. This is a prerequisite operation that
    * verifies that the file does not store a blob with the indicated hash.
    *
    * @param {string} hash The expected-to-be-absent hash.
    */
   [CAT_PREREQUISITE, 'checkBlobAbsent', ['hash', TYPE_HASH]],
+
+  /*
+   * A `checkBlobPresent` operation. This is a prerequisite operation that
+   * verifies that the file stores a blob with the indicated hash.
+   *
+   * @param {string} hash The expected hash.
+   */
+  [CAT_PREREQUISITE, 'checkBlobPresent', ['hash', TYPE_HASH]],
 
   /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
@@ -70,16 +70,6 @@ const OPERATIONS = DataUtil.deepFreeze([
    * @param {string} storagePath The storage path to check.
    */
   [CAT_PREREQUISITE, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
-
-  /*
-   * A `checkPathPresent` operation. This is a prerequisite operation that
-   * verifies that a given storage path is bound to a value (any value,
-   * including one of zero length). This is the opposite of the
-   * `checkPathAbsent` operation.
-   *
-   * @param {string} storagePath The storage path to check.
-   */
-  [CAT_PREREQUISITE, 'checkPathPresent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `checkPathIs` operation. This is a prerequisite operation that verifies
@@ -92,6 +82,16 @@ const OPERATIONS = DataUtil.deepFreeze([
     CAT_PREREQUISITE, 'checkPathIs',
     ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
   ],
+
+  /*
+   * A `checkPathPresent` operation. This is a prerequisite operation that
+   * verifies that a given storage path is bound to a value (any value,
+   * including one of zero length). This is the opposite of the
+   * `checkPathAbsent` operation.
+   *
+   * @param {string} storagePath The storage path to check.
+   */
+  [CAT_PREREQUISITE, 'checkPathPresent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `deleteAll` operation. This is a write operation that removes all stored
@@ -175,6 +175,14 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_ENVIRONMENT, 'timeout', ['durMsec', TYPE_DUR_MSEC]],
 
   /*
+   * A `whenPathAbsent` operation. This is a wait operation that blocks the
+   * transaction until a specific path _does not_ have any data stored.
+   *
+   * @param {string} storagePath The storage path to observe.
+   */
+  [CAT_WAIT, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
+
+  /*
    * A `whenPathNot` operation. This is a wait operation that blocks the
    * transaction until a specific path does not store data which hashes as
    * given. This includes both storing data with other hashes as well as the
@@ -185,14 +193,6 @@ const OPERATIONS = DataUtil.deepFreeze([
    *   for the operation to complete.
    */
   [CAT_WAIT, 'whenPathNot', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
-
-  /*
-   * A `whenPathAbsent` operation. This is a wait operation that blocks the
-   * transaction until a specific path _does not_ have any data stored.
-   *
-   * @param {string} storagePath The storage path to observe.
-   */
-  [CAT_WAIT, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `writeBlob` operation. This is a write operation that stores the

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -83,19 +83,6 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_PREREQUISITE, 'checkPathExists', ['storagePath', TYPE_PATH]],
 
   /*
-   * Convenience wrapper for `checkPathHash` operations, which uses a given
-   * buffer's data. This is equivalent to `checkPathHash(storagePath,
-   * buffer.hash)`.
-   *
-   * @param {string} storagePath The storage path to check.
-   * @param {FrozenBuffer} value Buffer whose hash should be taken.
-   */
-  [
-    CAT_CONVENIENCE, 'checkPathBufferHash',
-    ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]
-  ],
-
-  /*
    * A `checkPathHash` operation. This is a prerequisite operation that
    * verifies that a given storage path is bound to a value whose hash is as
    * given.
@@ -208,19 +195,6 @@ const OPERATIONS = DataUtil.deepFreeze([
    * @param {string} storagePath The storage path to observe.
    */
   [CAT_WAIT, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
-
-  /*
-   * Convenience wrapper for `whenPathNot` operations, which hashes a given
-   * buffer's data. This is equivalent to `whenPathNot(buffer.hash)`.
-   *
-   * @param {string} storagePath The storage path to observe.
-   * @param {string} hash Hash of the blob which must _not_ be at `storagePath`
-   *   for the operation to complete.
-   */
-  [
-    CAT_CONVENIENCE, 'whenPathNotBuffer',
-    ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]
-  ],
 
   /*
    * A `writeBlob` operation. This is a write operation that stores the
@@ -535,28 +509,6 @@ export default class FileOp extends CommonBase {
 
       FileOp[`op_${opName}`] = constructorMethod;
     }
-  }
-
-  /**
-   * Transformer for the convenience op `checkPathBufferHash`.
-   *
-   * @param {string} storagePath The storage path.
-   * @param {FrozenBuffer} value The value.
-   * @returns {array<*>} Replacement constructor info.
-   */
-  static _xform_checkPathBufferHash(storagePath, value) {
-    return ['checkPathHash', storagePath, value.hash];
-  }
-
-  /**
-   * Transformer for the convenience op `whenPathNotBuffer`.
-   *
-   * @param {string} storagePath The storage path.
-   * @param {FrozenBuffer} value The value.
-   * @returns {array<*>} Replacement constructor info.
-   */
-  static _xform_whenPathNotBuffer(storagePath, value) {
-    return ['whenPathNot', storagePath, value.hash];
   }
 }
 

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -82,15 +82,14 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_PREREQUISITE, 'checkPathExists', ['storagePath', TYPE_PATH]],
 
   /*
-   * A `checkPathHash` operation. This is a prerequisite operation that
-   * verifies that a given storage path is bound to a value whose hash is as
-   * given.
+   * A `checkPathIs` operation. This is a prerequisite operation that verifies
+   * that a given storage path is bound to a value whose hash is as given.
    *
    * @param {string} storagePath The storage path to check.
    * @param {string} hash The expected hash.
    */
   [
-    CAT_PREREQUISITE, 'checkPathHash',
+    CAT_PREREQUISITE, 'checkPathIs',
     ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
   ],
 

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -64,22 +64,6 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_PREREQUISITE, 'checkBlobAbsent', ['hash', TYPE_HASH]],
 
   /*
-   * Convenience wrapper for `checkBlob` operations, which uses a given buffer's
-   * data. This is equivalent to `checkBlob(buffer.hash)`.
-   *
-   * @param {FrozenBuffer} value Buffer whose hash should be taken.
-   */
-  [CAT_CONVENIENCE, 'checkBlobBuffer', ['value', TYPE_BUFFER]],
-
-  /*
-   * Convenience wrapper for `checkBlobAbsent` operations, which uses a given
-   * buffer's data. This is equivalent to `checkBlobAbsent(buffer.hash)`.
-   *
-   * @param {FrozenBuffer} value Buffer whose hash should be taken.
-   */
-  [CAT_CONVENIENCE, 'checkBlobBufferAbsent', ['value', TYPE_BUFFER]],
-
-  /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
    * verifies that a given storage path is not bound to any value. This is the
    * opposite of `checkPathExists`.
@@ -139,15 +123,6 @@ const OPERATIONS = DataUtil.deepFreeze([
    * @param {string} hash The hash of the blob to delete.
    */
   [CAT_DELETE, 'deleteBlob', ['hash', TYPE_HASH]],
-
-  /*
-   * Convenience wrapper for `deleteBlob` operations, which uses a given
-   * buffer's data. This is equivalent to `deleteBlob(buffer.hash)`.
-   *
-   * @param {FrozenBuffer} value Buffer whose hash should be taken, indicating a
-   *   blob to delete.
-   */
-  [CAT_CONVENIENCE, 'deleteBlobHash', ['value', TYPE_BUFFER]],
 
   /*
    * A `deletePath` operation. This is a write operation that deletes the
@@ -563,26 +538,6 @@ export default class FileOp extends CommonBase {
   }
 
   /**
-   * Transformer for the convenience op `checkBlobBuffer`.
-   *
-   * @param {FrozenBuffer} value The value.
-   * @returns {array<*>} Replacement constructor info.
-   */
-  static _xform_checkBlobBuffer(value) {
-    return ['checkBlob', value.hash];
-  }
-
-  /**
-   * Transformer for the convenience op `checkBlobBufferAbsent`.
-   *
-   * @param {FrozenBuffer} value The value.
-   * @returns {array<*>} Replacement constructor info.
-   */
-  static _xform_checkBlobBufferAbsent(value) {
-    return ['checkBlobAbsent', value.hash];
-  }
-
-  /**
    * Transformer for the convenience op `checkPathBufferHash`.
    *
    * @param {string} storagePath The storage path.
@@ -591,16 +546,6 @@ export default class FileOp extends CommonBase {
    */
   static _xform_checkPathBufferHash(storagePath, value) {
     return ['checkPathHash', storagePath, value.hash];
-  }
-
-  /**
-   * Transformer for the convenience op `deleteBlobBuffer`.
-   *
-   * @param {FrozenBuffer} value The value.
-   * @returns {array<*>} Replacement constructor info.
-   */
-  static _xform_deleteBlobBuffer(value) {
-    return ['deleteBlob', value.hash];
   }
 
   /**

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -17,7 +17,6 @@ import StoragePath from './StoragePath';
 const KEY = Symbol('FileOp constructor key');
 
 // Operation category constants. See docs on the static properties for details.
-const CAT_CONVENIENCE  = 'convenience';
 const CAT_DELETE       = 'delete';
 const CAT_ENVIRONMENT  = 'environment';
 const CAT_PREREQUISITE = 'prerequisite';
@@ -243,19 +242,10 @@ const OPERATIONS = DataUtil.deepFreeze([
  * Specifically, the category ordering is as listed above.
  *
  * There are static methods on this class to construct each named operation,
- * named `op_<name>`, as well as some convenience methods to construct variants.
- * See documentation on those methods for details about the meaning and
- * arguments of each of these.
+ * named `op_<name>`. See documentation on those methods for details about the
+ * meaning and arguments of each of these.
  */
 export default class FileOp extends CommonBase {
-  /**
-   * {string} Operation category for convenience wrapper ops. This category only
-   * shows up in `OPERATIONS`, not in actual operation instances.
-   */
-  static get CAT_CONVENIENCE() {
-    return CAT_CONVENIENCE;
-  }
-
   /** {string} Operation category for deletion ops. */
   static get CAT_DELETE() {
     return CAT_DELETE;
@@ -452,13 +442,12 @@ export default class FileOp extends CommonBase {
    */
   static _addConstructorMethods() {
     for (const [category, opName, ...argInfo] of OPERATIONS) {
-      const isConvenience = (category === CAT_CONVENIENCE);
       const constructorMethod = (...args) => {
         if (args.length !== argInfo.length) {
           throw new Error(`Wrong argument count for op constructor. Expected ${argInfo.length}.`);
         }
 
-        const argMap = isConvenience ? null : new Map();
+        const argMap = new Map();
         for (let i = 0; i < argInfo.length; i++) {
           const [name, type] = argInfo[i];
           let arg = args[i];
@@ -494,17 +483,10 @@ export default class FileOp extends CommonBase {
             }
           }
 
-          if (argMap) {
-            argMap.set(name, arg);
-          }
+          argMap.set(name, arg);
         }
 
-        if (isConvenience) {
-          const [newOpName, ...newArgs] = FileOp[`_xform_${opName}`](...args);
-          return FileOp[`op_${newOpName}`](...newArgs);
-        } else {
-          return new FileOp(KEY, category, opName, argMap);
-        }
+        return new FileOp(KEY, category, opName, argMap);
       };
 
       FileOp[`op_${opName}`] = constructorMethod;

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -195,6 +195,14 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_WAIT, 'whenPathNot', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
 
   /*
+   * A `whenPathPresent` operation. This is a wait operation that blocks the
+   * transaction until a specific path has some data (any value) stored.
+   *
+   * @param {string} storagePath The storage path to observe.
+   */
+  [CAT_WAIT, 'whenPathPresent', ['storagePath', TYPE_PATH]],
+
+  /*
    * A `writeBlob` operation. This is a write operation that stores the
    * indicated value in the file, binding it to its content hash. If the content
    * hash was already bound, then this operation does nothing.

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -47,12 +47,12 @@ const TYPE_REV_NUM   = 'RevNum';
 // So it goes.
 const OPERATIONS = DataUtil.deepFreeze([
   /*
-   * A `checkBlob` operation. This is a prerequisite operation that verifies
-   * that the file stores a blob with the indicated hash.
+   * A `checkBlobPresent` operation. This is a prerequisite operation that
+   * verifies that the file stores a blob with the indicated hash.
    *
    * @param {string} hash The expected hash.
    */
-  [CAT_PREREQUISITE, 'checkBlob', ['hash', TYPE_HASH]],
+  [CAT_PREREQUISITE, 'checkBlobPresent', ['hash', TYPE_HASH]],
 
   /*
    * A `checkBlobAbsent` operation. This is a prerequisite operation that

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -375,7 +375,11 @@ export default class FileOp extends CommonBase {
     return TYPE_PATH;
   }
 
-  /** {string} Type name for hash values. */
+  /**
+   * {string} Type name for hash values. Arguments of this type will also
+   * accept instances of `FrozenBuffer`. When given a buffer, the constructor
+   * automatically converts it to its hash.
+   */
   static get TYPE_HASH() {
     return TYPE_HASH;
   }
@@ -508,7 +512,7 @@ export default class FileOp extends CommonBase {
         const argMap = isConvenience ? null : new Map();
         for (let i = 0; i < argInfo.length; i++) {
           const [name, type] = argInfo[i];
-          const arg  = args[i];
+          let arg = args[i];
           switch (type) {
             case TYPE_BUFFER: {
               FrozenBuffer.check(arg);
@@ -519,8 +523,12 @@ export default class FileOp extends CommonBase {
               break;
             }
             case TYPE_HASH: {
-              // **TODO:** Better validation of hashes.
-              TString.nonempty(arg);
+              if (arg instanceof FrozenBuffer) {
+                arg = arg.hash;
+              } else {
+                // **TODO:** Better validation of hashes.
+                TString.nonempty(arg);
+              }
               break;
             }
             case TYPE_PATH: {

--- a/local-modules/content-store/FileOp.js
+++ b/local-modules/content-store/FileOp.js
@@ -65,21 +65,21 @@ const OPERATIONS = DataUtil.deepFreeze([
   /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
    * verifies that a given storage path is not bound to any value. This is the
-   * opposite of `checkPathExists`.
+   * opposite of `checkPathPresent`.
    *
    * @param {string} storagePath The storage path to check.
    */
   [CAT_PREREQUISITE, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
 
   /*
-   * A `checkPathExists` operation. This is a prerequisite operation that
+   * A `checkPathPresent` operation. This is a prerequisite operation that
    * verifies that a given storage path is bound to a value (any value,
    * including one of zero length). This is the opposite of the
    * `checkPathAbsent` operation.
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_PREREQUISITE, 'checkPathExists', ['storagePath', TYPE_PATH]],
+  [CAT_PREREQUISITE, 'checkPathPresent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `checkPathIs` operation. This is a prerequisite operation that verifies

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -660,7 +660,7 @@ export default class DocControl extends CommonBase {
     const fc = this._fileCodec;
     const storagePath = Paths.REVISION_NUMBER;
     const spec = new TransactionSpec(
-      fc.op_checkPathExists(storagePath),
+      fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)
     );
 
@@ -711,7 +711,7 @@ export default class DocControl extends CommonBase {
     const fc = this._fileCodec;
     const ops = [];
     for (const p of paths) {
-      ops.push(fc.op_checkPathExists(p));
+      ops.push(fc.op_checkPathPresent(p));
       ops.push(fc.op_readPath(p));
     }
 

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -581,7 +581,7 @@ export default class DocControl extends CommonBase {
     const fc   = this._fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
       fc.op_checkPathAbsent(changePath),
-      fc.op_checkPathBufferHash(Paths.REVISION_NUMBER, baseRevNum),
+      fc.op_checkPathHash(Paths.REVISION_NUMBER, baseRevNum),
       fc.op_writePath(changePath, change),
       fc.op_writePath(Paths.REVISION_NUMBER, revNum)
     );

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -581,7 +581,7 @@ export default class DocControl extends CommonBase {
     const fc   = this._fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
       fc.op_checkPathAbsent(changePath),
-      fc.op_checkPathHash(Paths.REVISION_NUMBER, baseRevNum),
+      fc.op_checkPathIs(Paths.REVISION_NUMBER, baseRevNum),
       fc.op_writePath(changePath, change),
       fc.op_writePath(Paths.REVISION_NUMBER, revNum)
     );

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -343,7 +343,7 @@ export default class DocControl extends CommonBase {
       // then iterate to see if in fact the change updated the document revision
       // number.
       const fc   = this._fileCodec;
-      const ops  = [fc.op_whenPathNotBuffer(Paths.REVISION_NUMBER, revNum)];
+      const ops  = [fc.op_whenPathNot(Paths.REVISION_NUMBER, revNum)];
       const spec = new TransactionSpec(...ops);
       try {
         await fc.transact(spec);


### PR DESCRIPTION
This PR cleans up the naming of the file ops so that they're more self-consistent. In addition, they get simplified by removing the convenience wrapper ops which converted buffers to hashes. Instead, the ops that take hashes are polymorphic now; if given a buffer, they automatically take the hash. (This introduces no ambiguities.)

**Bonus:** Added `whenPathPresent` op to match the other `absent`/`present` op pairs.