### PR TITLE
The start of "real" caret storage.

### DIFF
--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -47,6 +47,7 @@ export default class Caret extends CommonBase {
       DEFAULT = new Caret('no-session',
         Object.entries({
           lastActive: Timestamp.now(),
+          revNum:     0,
           index:      0,
           length:     0,
           color:      '#000000'

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -7,6 +7,7 @@ import { ColorSelector, CommonBase } from 'util-common';
 
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
+import RevisionNumber from './RevisionNumber';
 import Timestamp from './Timestamp';
 
 /**
@@ -18,6 +19,7 @@ import Timestamp from './Timestamp';
  */
 const CARET_FIELDS = new Map([
   ['lastActive', Timestamp.check],
+  ['revNum',     RevisionNumber.check],
   ['index',      TInt.nonNegative],
   ['length',     TInt.nonNegative],
   ['color',      ColorSelector.checkHexColor]
@@ -127,15 +129,15 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {string} Opaque reference to be used with other APIs to get information
-   * about the author whose caret this is.
+   * {string} The color to be used when annotating this selection. It is in CSS
+   * three-byte hex format (e.g. `'#ffeab9'`).
    */
-  get sessionId() {
-    return this._sessionId;
+  get color() {
+    return this._fields.get('color');
   }
 
   /**
-   * {Int} The zero-based leading position of this caret/selection.
+   * {Int} The zero-based leading position of this caret / selection.
    */
   get index() {
     return this._fields.get('index');
@@ -157,11 +159,19 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {string} The color to be used when annotating this selection. It is in CSS
-   * three-byte hex format (e.g. `'#ffeab9'`).
+   * {Int} Document revision number which the instances position / selection is
+   * with respect to.
    */
-  get color() {
-    return this._fields.get('color');
+  get revNum() {
+    return this._fields.get('revNum');
+  }
+
+  /**
+   * {string} Opaque reference to be used with other APIs to get information
+   * about the author whose caret this is.
+   */
+  get sessionId() {
+    return this._sessionId;
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -30,11 +30,6 @@ export default class CaretOp extends CommonBase {
     return 'end-session';
   }
 
-  /** {string} Operation name for "update document rev-num" operations. */
-  static get UPDATE_DOC_REV_NUM() {
-    return 'update-doc-rev-num';
-  }
-
   /** {string} Operation name for "update rev-num" operations. */
   static get UPDATE_REV_NUM() {
     return 'update-rev-num';
@@ -82,18 +77,6 @@ export default class CaretOp extends CommonBase {
     TString.check(sessionId);
 
     return new CaretOp(KEY, CaretOp.END_SESSION, { sessionId });
-  }
-
-  /**
-   * Constructs a new instance of an update-doc-rev-num operation.
-   *
-   * @param {Int} docRevNum The new revision number.
-   * @returns {CaretOp} The corresponding operation.
-   */
-  static op_updateDocRevNum(docRevNum) {
-    RevisionNumber.check(docRevNum);
-
-    return new CaretOp(KEY, CaretOp.UPDATE_DOC_REV_NUM, { docRevNum });
   }
 
   /**

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -34,31 +34,23 @@ describe('doc-common/CaretSnapshot', () => {
         assert.deepEqual(result, snap, `#${which}`);
       }
 
-      test(new CaretSnapshot(123, 456, []));
-      test(new CaretSnapshot(0,   234, [caret1]));
-      test(new CaretSnapshot(321, 0,   [caret1, caret2]));
-      test(new CaretSnapshot(999, 888, [caret1, caret2, caret3]));
-    });
-
-    it('should update `docRevNum` given the appropriate op', () => {
-      const snap     = new CaretSnapshot(1, 2,   [caret1]);
-      const expected = new CaretSnapshot(1, 999, [caret1]);
-      const result   = snap.compose(new CaretDelta([CaretOp.op_updateDocRevNum(999)]));
-
-      assert.isTrue(result.equals(expected));
+      test(new CaretSnapshot(123, []));
+      test(new CaretSnapshot(0,   [caret1]));
+      test(new CaretSnapshot(321, [caret1, caret2]));
+      test(new CaretSnapshot(999, [caret1, caret2, caret3]));
     });
 
     it('should update `revNum` given the appropriate op', () => {
-      const snap     = new CaretSnapshot(1,   2, [caret1, caret2]);
-      const expected = new CaretSnapshot(999, 2, [caret1, caret2]);
+      const snap     = new CaretSnapshot(1,  [caret1, caret2]);
+      const expected = new CaretSnapshot(999,[caret1, caret2]);
       const result   = snap.compose(new CaretDelta([CaretOp.op_updateRevNum(999)]));
 
       assert.isTrue(result.equals(expected));
     });
 
     it('should add a new caret given the appropriate op', () => {
-      const snap     = new CaretSnapshot(1, 2, []);
-      const expected = new CaretSnapshot(1, 2, [caret1]);
+      const snap     = new CaretSnapshot(1, []);
+      const expected = new CaretSnapshot(1, [caret1]);
       const delta    = new CaretDelta([CaretOp.op_beginSession(caret1)]);
       const result   = snap.compose(delta);
 
@@ -66,7 +58,7 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should refuse to update a nonexistent caret', () => {
-      const snap  = new CaretSnapshot(1, 2, [caret1]);
+      const snap  = new CaretSnapshot(1, [caret1]);
       const delta = new CaretDelta([CaretOp.op_updateField('florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(delta); });
@@ -75,8 +67,8 @@ describe('doc-common/CaretSnapshot', () => {
     it('should update a pre-existing caret given an appropriate op', () => {
       const c1       = newCaret('foo', 1, 2, '#333333');
       const c2       = newCaret('foo', 3, 2, '#333333');
-      const snap     = new CaretSnapshot(1, 2, [caret1, c1]);
-      const expected = new CaretSnapshot(1, 2, [caret1, c2]);
+      const snap     = new CaretSnapshot(1, [caret1, c1]);
+      const expected = new CaretSnapshot(1, [caret1, c2]);
       const op       = CaretOp.op_updateField('foo', 'index', 3);
       const result   = snap.compose(new CaretDelta([op]));
 
@@ -84,8 +76,8 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should remove a caret given the appropriate op', () => {
-      const snap     = new CaretSnapshot(1, 2, [caret1, caret2]);
-      const expected = new CaretSnapshot(1, 2, [caret2]);
+      const snap     = new CaretSnapshot(1, [caret1, caret2]);
+      const expected = new CaretSnapshot(1, [caret2]);
       const result =
         snap.compose(new CaretDelta([CaretOp.op_endSession(caret1.sessionId)]));
 
@@ -95,50 +87,40 @@ describe('doc-common/CaretSnapshot', () => {
 
   describe('diff()', () => {
     it('should produce an empty diff when passed itself', () => {
-      const snap = new CaretSnapshot(123, 234, [caret1, caret2]);
+      const snap = new CaretSnapshot(123, [caret1, caret2]);
       const result = snap.diff(snap);
 
       assert.instanceOf(result, CaretDelta);
       assert.deepEqual(result.ops, []);
     });
 
-    it('should result in a `docRevNum` diff if that in fact changes', () => {
-      const snap1 = new CaretSnapshot(1, 2, [caret1, caret2]);
-      const snap2 = new CaretSnapshot(1, 9, [caret1, caret2]);
-      const result = snap1.diff(snap2);
-
-      const composed = new CaretSnapshot(0, 0, []).compose(result);
-      const expected = new CaretSnapshot(0, 9, []);
-      assert.isTrue(composed.equals(expected));
-    });
-
     it('should result in a `revNum` diff if that in fact changes', () => {
-      const snap1 = new CaretSnapshot(1, 2, [caret1, caret2]);
-      const snap2 = new CaretSnapshot(9, 2, [caret1, caret2]);
+      const snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      const snap2 = new CaretSnapshot(9, [caret1, caret2]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, 0, []).compose(result);
-      const expected = new CaretSnapshot(9, 0, []);
+      const composed = new CaretSnapshot(0, []).compose(result);
+      const expected = new CaretSnapshot(9, []);
       assert.isTrue(composed.equals(expected));
     });
 
     it('should result in a caret removal if that in fact happens', () => {
-      const snap1 = new CaretSnapshot(1, 2, [caret1, caret2]);
-      const snap2 = new CaretSnapshot(1, 2, [caret1]);
+      const snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      const snap2 = new CaretSnapshot(1, [caret1]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, 0, [caret2, caret3]).compose(result);
-      const expected = new CaretSnapshot(0, 0, [caret3]);
+      const composed = new CaretSnapshot(0, [caret2, caret3]).compose(result);
+      const expected = new CaretSnapshot(0, [caret3]);
       assert.isTrue(composed.equals(expected));
     });
 
     it('should result in a caret addition if that in fact happens', () => {
-      const snap1 = new CaretSnapshot(1, 2, [caret1]);
-      const snap2 = new CaretSnapshot(1, 2, [caret1, caret2]);
+      const snap1 = new CaretSnapshot(1, [caret1]);
+      const snap2 = new CaretSnapshot(1, [caret1, caret2]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, 0, []).compose(result);
-      const expected = new CaretSnapshot(0, 0, [caret2]);
+      const composed = new CaretSnapshot(0, []).compose(result);
+      const expected = new CaretSnapshot(0, [caret2]);
       assert.isTrue(composed.equals(expected));
     });
 
@@ -146,12 +128,12 @@ describe('doc-common/CaretSnapshot', () => {
       const c1 = newCaret('florp', 1, 3, '#444444');
       const c2 = newCaret('florp', 2, 4, '#555555');
       const c3 = newCaret('florp', 3, 5, '#666666');
-      const snap1 = new CaretSnapshot(1, 2, [c1]);
-      const snap2 = new CaretSnapshot(1, 2, [c2]);
+      const snap1 = new CaretSnapshot(1, [c1]);
+      const snap2 = new CaretSnapshot(1, [c2]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, 0, [caret1, c3]).compose(result);
-      const expected = new CaretSnapshot(0, 0, [caret1, c2]);
+      const composed = new CaretSnapshot(0, [caret1, c3]).compose(result);
+      const expected = new CaretSnapshot(0, [caret1, c2]);
       assert.isTrue(composed.equals(expected));
     });
   });
@@ -160,35 +142,35 @@ describe('doc-common/CaretSnapshot', () => {
     it('should return `true` when passed itself', () => {
       let snap;
 
-      snap = new CaretSnapshot(0, 1, []);
+      snap = new CaretSnapshot(0, []);
       assert.isTrue(snap.equals(snap));
 
-      snap = new CaretSnapshot(12, 23, [caret1]);
+      snap = new CaretSnapshot(12, [caret1]);
       assert.isTrue(snap.equals(snap));
 
-      snap = new CaretSnapshot(234, 345, [caret1, caret2]);
+      snap = new CaretSnapshot(234, [caret1, caret2]);
       assert.isTrue(snap.equals(snap));
     });
 
     it('should return `true` when passed an identically-constructed value', () => {
       let snap1, snap2;
 
-      snap1 = new CaretSnapshot(0, 1, []);
-      snap2 = new CaretSnapshot(0, 1, []);
+      snap1 = new CaretSnapshot(0, []);
+      snap2 = new CaretSnapshot(0, []);
       assert.isTrue(snap1.equals(snap2));
 
-      snap1 = new CaretSnapshot(12, 23, [caret1]);
-      snap2 = new CaretSnapshot(12, 23, [caret1]);
+      snap1 = new CaretSnapshot(12, [caret1]);
+      snap2 = new CaretSnapshot(12, [caret1]);
       assert.isTrue(snap1.equals(snap2));
 
-      snap1 = new CaretSnapshot(234, 345, [caret1, caret2]);
-      snap2 = new CaretSnapshot(234, 345, [caret1, caret2]);
+      snap1 = new CaretSnapshot(234, [caret1, caret2]);
+      snap2 = new CaretSnapshot(234, [caret1, caret2]);
       assert.isTrue(snap1.equals(snap2));
     });
 
     it('should return `true` when identical carets are passed in different orders', () => {
-      const snap1 = new CaretSnapshot(37, 914, [caret1, caret2, caret3]);
-      const snap2 = new CaretSnapshot(37, 914, [caret3, caret1, caret2]);
+      const snap1 = new CaretSnapshot(37, [caret1, caret2, caret3]);
+      const snap2 = new CaretSnapshot(37, [caret3, caret1, caret2]);
       assert.isTrue(snap1.equals(snap2));
     });
 
@@ -198,68 +180,62 @@ describe('doc-common/CaretSnapshot', () => {
       const c2a = newCaret('like',  3, 0, '#dbdbdb');
       const c2b = newCaret('like',  3, 0, '#dbdbdb');
 
-      const snap1 = new CaretSnapshot(1, 2, [c1a, c2a]);
-      const snap2 = new CaretSnapshot(1, 2, [c1b, c2b]);
+      const snap1 = new CaretSnapshot(1, [c1a, c2a]);
+      const snap2 = new CaretSnapshot(1, [c1b, c2b]);
       assert.isTrue(snap1.equals(snap2));
     });
 
     it('should return `false` when `revNum`s differ', () => {
-      const snap1 = new CaretSnapshot(1, 20, [caret1, caret2, caret3]);
-      const snap2 = new CaretSnapshot(2, 20, [caret1, caret2, caret3]);
-      assert.isFalse(snap1.equals(snap2));
-    });
-
-    it('should return `false` when `docRevNum`s differ', () => {
-      const snap1 = new CaretSnapshot(1, 20, [caret1, caret2, caret3]);
-      const snap2 = new CaretSnapshot(1, 30, [caret1, caret2, caret3]);
+      const snap1 = new CaretSnapshot(1, [caret1, caret2, caret3]);
+      const snap2 = new CaretSnapshot(2, [caret1, caret2, caret3]);
       assert.isFalse(snap1.equals(snap2));
     });
 
     it('should return `false` when caret contents differ', () => {
       let snap1, snap2;
 
-      snap1 = new CaretSnapshot(1, 1, [caret1]);
-      snap2 = new CaretSnapshot(1, 1, []);
+      snap1 = new CaretSnapshot(1, [caret1]);
+      snap2 = new CaretSnapshot(1, []);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2]);
-      snap2 = new CaretSnapshot(1, 1, []);
+      snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      snap2 = new CaretSnapshot(1, []);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2]);
-      snap2 = new CaretSnapshot(1, 1, [caret1]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      snap2 = new CaretSnapshot(1, [caret1]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2]);
-      snap2 = new CaretSnapshot(1, 1, [caret3]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      snap2 = new CaretSnapshot(1, [caret3]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2]);
-      snap2 = new CaretSnapshot(1, 1, [caret3, caret1]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      snap2 = new CaretSnapshot(1, [caret3, caret1]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2]);
-      snap2 = new CaretSnapshot(1, 1, [caret1, caret3]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2]);
+      snap2 = new CaretSnapshot(1, [caret1, caret3]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2, caret3]);
-      snap2 = new CaretSnapshot(1, 1, []);
+      snap1 = new CaretSnapshot(1, [caret1, caret2, caret3]);
+      snap2 = new CaretSnapshot(1, []);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2, caret3]);
-      snap2 = new CaretSnapshot(1, 1, [caret1]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2, caret3]);
+      snap2 = new CaretSnapshot(1, [caret1]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
 
-      snap1 = new CaretSnapshot(1, 1, [caret1, caret2, caret3]);
-      snap2 = new CaretSnapshot(1, 1, [caret1, caret2]);
+      snap1 = new CaretSnapshot(1, [caret1, caret2, caret3]);
+      snap2 = new CaretSnapshot(1, [caret1, caret2]);
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
     });

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -50,7 +50,7 @@ export default class CaretControl extends CommonBase {
      * {CaretSnapshot} Latest caret info. Starts out as an empty stub; gets
      * filled in as updates arrive.
      */
-    this._snapshot = new CaretSnapshot(0, 0, []);
+    this._snapshot = new CaretSnapshot(0, []);
 
     /**
      * {array<CaretSnapshot>} Array of older caret snapshots, available for use

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -84,7 +84,7 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretDelta} Delta from the base caret revision to a newer one.
    */
   async deltaAfter(baseRevNum) {
-    this._removeInactiveSessions();
+    await this._removeInactiveSessions();
 
     const minRevNum     = this._oldSnapshots[0].revNum;
     const currentRevNum = this._snapshot.revNum;
@@ -118,7 +118,7 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretSnapshot} Snapshot of all the active carets.
    */
   async snapshot(revNum = null) {
-    this._removeInactiveSessions();
+    await this._removeInactiveSessions();
 
     const minRevNum     = this._oldSnapshots[0].revNum;
     const currentRevNum = this._snapshot.revNum;
@@ -224,7 +224,7 @@ export default class CaretControl extends CommonBase {
   /**
    * Removes sessions that haven't been active recently out of the snapshot.
    */
-  _removeInactiveSessions() {
+  async _removeInactiveSessions() {
     const minTime = Timestamp.now().addMsec(-MAX_SESSION_IDLE_MSEC);
     const ops = [];
 
@@ -247,7 +247,7 @@ export default class CaretControl extends CommonBase {
    *
    * @param {string} sessionId ID of the session that got reaped.
    */
-  _sessionReaped(sessionId) {
+  async _sessionReaped(sessionId) {
     const snapshot = this._snapshot;
 
     // **TODO:** These conditionals check for a weird case that has shown up

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -6,7 +6,7 @@ import {
   DocumentDelta, DocumentChange, DocumentSnapshot, FrozenDelta, RevisionNumber,
   Timestamp
 } from 'doc-common';
-import { Errors, FileCodec, TransactionSpec } from 'file-store';
+import { Errors, TransactionSpec } from 'file-store';
 import { TString } from 'typecheck';
 import { CommonBase, InfoError, PromDelay } from 'util-common';
 
@@ -78,7 +78,7 @@ export default class DocControl extends CommonBase {
     this._file = fileComplex.file;
 
     /** {FileCodec} File-codec wrapper to use. */
-    this._fileCodec = new FileCodec(fileComplex.file, fileComplex.codec);
+    this._fileCodec = fileComplex.fileCodec;
 
     /**
      * {Map<RevisionNumber, DocumentSnapshot>} Mapping from revision numbers to

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -131,7 +131,7 @@ export default class DocControl extends CommonBase {
       fc.op_writePath(Paths.FORMAT_VERSION, this._fileComplex.formatVersion),
 
       // Initial revision number.
-      fc.op_writePath(Paths.REVISION_NUMBER, revNum),
+      fc.op_writePath(Paths.CHANGE_REVISION_NUMBER, revNum),
 
       // Empty change #0 (per documented interface).
       fc.op_writePath(Paths.forDocumentChange(0), change0),
@@ -233,7 +233,7 @@ export default class DocControl extends CommonBase {
       const fc = this._fileCodec;
       const spec = new TransactionSpec(
         fc.op_readPath(Paths.FORMAT_VERSION),
-        fc.op_readPath(Paths.REVISION_NUMBER)
+        fc.op_readPath(Paths.CHANGE_REVISION_NUMBER)
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
@@ -243,7 +243,7 @@ export default class DocControl extends CommonBase {
 
     const data          = transactionResult.data;
     const formatVersion = data.get(Paths.FORMAT_VERSION);
-    const revNum        = data.get(Paths.REVISION_NUMBER);
+    const revNum        = data.get(Paths.CHANGE_REVISION_NUMBER);
 
     if (!formatVersion) {
       this._log.info('Corrupt document: Missing format version.');
@@ -346,7 +346,7 @@ export default class DocControl extends CommonBase {
       // then iterate to see if in fact the change updated the document revision
       // number.
       const fc   = this._fileCodec;
-      const ops  = [fc.op_whenPathNot(Paths.REVISION_NUMBER, revNum)];
+      const ops  = [fc.op_whenPathNot(Paths.CHANGE_REVISION_NUMBER, revNum)];
       const spec = new TransactionSpec(...ops);
       try {
         await fc.transact(spec);
@@ -584,9 +584,9 @@ export default class DocControl extends CommonBase {
     const fc   = this._fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
       fc.op_checkPathAbsent(changePath),
-      fc.op_checkPathIs(Paths.REVISION_NUMBER, baseRevNum),
+      fc.op_checkPathIs(Paths.CHANGE_REVISION_NUMBER, baseRevNum),
       fc.op_writePath(changePath, change),
-      fc.op_writePath(Paths.REVISION_NUMBER, revNum)
+      fc.op_writePath(Paths.CHANGE_REVISION_NUMBER, revNum)
     );
 
     try {
@@ -661,7 +661,7 @@ export default class DocControl extends CommonBase {
    */
   async _currentRevNum() {
     const fc = this._fileCodec;
-    const storagePath = Paths.REVISION_NUMBER;
+    const storagePath = Paths.CHANGE_REVISION_NUMBER;
     const spec = new TransactionSpec(
       fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)

--- a/local-modules/doc-server/DocControl.js
+++ b/local-modules/doc-server/DocControl.js
@@ -116,7 +116,7 @@ export default class DocControl extends CommonBase {
     const maybeChange1 = [];
     if (contents !== null) {
       const change = new DocumentChange(1, contents, Timestamp.now(), null);
-      const op     = fc.op_writePath(Paths.forRevNum(1), change);
+      const op     = fc.op_writePath(Paths.forDocumentChange(1), change);
       maybeChange1.push(op);
     }
 
@@ -134,7 +134,7 @@ export default class DocControl extends CommonBase {
       fc.op_writePath(Paths.REVISION_NUMBER, revNum),
 
       // Empty change #0 (per documented interface).
-      fc.op_writePath(Paths.forRevNum(0), change0),
+      fc.op_writePath(Paths.forDocumentChange(0), change0),
 
       // The given `content` (if any) for change #1.
       ...maybeChange1
@@ -289,7 +289,7 @@ export default class DocControl extends CommonBase {
       const fc  = this._fileCodec;
       const ops = [];
       for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(Paths.forRevNum(i)));
+        ops.push(fc.op_readPath(Paths.forDocumentChange(i)));
       }
       const spec = new TransactionSpec(...ops);
       transactionResult = await fc.transact(spec);
@@ -579,7 +579,7 @@ export default class DocControl extends CommonBase {
 
     const revNum     = change.revNum;
     const baseRevNum = revNum - 1;
-    const changePath = Paths.forRevNum(revNum);
+    const changePath = Paths.forDocumentChange(revNum);
 
     const fc   = this._fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
@@ -708,7 +708,7 @@ export default class DocControl extends CommonBase {
 
     const paths = [];
     for (let i = start; i < endExc; i++) {
-      paths.push(Paths.forRevNum(i));
+      paths.push(Paths.forDocumentChange(i));
     }
 
     const fc = this._fileCodec;

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -187,9 +187,16 @@ export default class DocServer extends Singleton {
    * @returns {function} An appropriately-constructed function.
    */
   _sessionReaper(fileComplex, sessionId) {
-    return () => {
-      fileComplex._sessionReaped(sessionId);
+    return async () => {
       this._sessions.delete(sessionId);
+
+      try {
+        await fileComplex._sessionReaped(sessionId);
+      } catch (e) {
+        // Ignore the error, except to report it.
+        log.error(`Trouble reaping session ${sessionId}.`, e);
+      }
+
       log.info(`Reaped idle session: ${sessionId}`);
     };
   }

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -4,7 +4,7 @@
 
 import { Codec } from 'codec';
 import { FrozenDelta } from 'doc-common';
-import { BaseFile } from 'file-store';
+import { BaseFile, FileCodec } from 'file-store';
 import { DEFAULT_DOCUMENT } from 'hooks-server';
 import { Logger } from 'see-all';
 import { ProductInfo } from 'server-env';
@@ -64,6 +64,9 @@ export default class FileComplex extends CommonBase {
     /** {string} The document format version to use and expect. */
     this._formatVersion = TString.nonempty(ProductInfo.theOne.INFO.version);
 
+    /** {FileCodec} File-codec wrapper to use. */
+    this._fileCodec = new FileCodec(file, codec);
+
     /**
      * {CaretControl|null} Caret info controller. Set to non-`null` in the
      * corresponding getter.
@@ -108,6 +111,11 @@ export default class FileComplex extends CommonBase {
   /** {BaseFile} The underlying document storage. */
   get file() {
     return this._file;
+  }
+
+  /** {FileCodec} File-codec wrapper to use. */
+  get fileCodec() {
+    return this._fileCodec;
   }
 
   /**

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -181,11 +181,11 @@ export default class FileComplex extends CommonBase {
    *
    * @param {string} sessionId ID of the session that got reaped.
    */
-  _sessionReaped(sessionId) {
+  async _sessionReaped(sessionId) {
     // Pass through to the caret controller (if present), since it might have a
     // record of the session.
     if (this._caretControl) {
-      this._caretControl._sessionReaped(sessionId);
+      await this._caretControl._sessionReaped(sessionId);
     }
   }
 }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -18,17 +18,17 @@ export default class Paths extends UtilityClass {
     return '/caret/revision_number';
   }
 
-  /** {string} `StoragePath` string for the document format version. */
-  static get FORMAT_VERSION() {
-    return '/format_version';
-  }
-
   /**
    * {string} `StoragePath` string for the document content revision number.
    * This corresponds to the highest change number.
    */
   static get CHANGE_REVISION_NUMBER() {
     return '/change/revision_number';
+  }
+
+  /** {string} `StoragePath` string for the document format version. */
+  static get FORMAT_VERSION() {
+    return '/format_version';
   }
 
   /**

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -27,7 +27,7 @@ export default class Paths extends UtilityClass {
    * {string} `StoragePath` string for the document content revision number.
    * This corresponds to the highest change number.
    */
-  static get REVISION_NUMBER() {
+  static get CHANGE_REVISION_NUMBER() {
     return '/revision_number';
   }
 

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -28,7 +28,7 @@ export default class Paths extends UtilityClass {
    * @param {RevisionNumber} revNum The revision number.
    * @returns {string} The corresponding `StoragePath` string.
    */
-  static forRevNum(revNum) {
+  static forDocumentChange(revNum) {
     RevisionNumber.check(revNum);
     return `/change/${revNum}`;
   }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -15,7 +15,7 @@ export default class Paths extends UtilityClass {
    * {string} `StoragePath` string for the caret information revision number.
    */
   static get CARET_REVISION_NUMBER() {
-    return '/carets/revision_number';
+    return '/caret/revision_number';
   }
 
   /** {string} `StoragePath` string for the document format version. */
@@ -55,6 +55,6 @@ export default class Paths extends UtilityClass {
    */
   static forCaret(sessionId) {
     TString.check(sessionId);
-    return `/carets/${sessionId}`;
+    return `/caret/${sessionId}`;
   }
 }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -28,7 +28,7 @@ export default class Paths extends UtilityClass {
    * This corresponds to the highest change number.
    */
   static get CHANGE_REVISION_NUMBER() {
-    return '/revision_number';
+    return '/change/revision_number';
   }
 
   /**

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { RevisionNumber } from 'doc-common';
+import { TString } from 'typecheck';
 import { UtilityClass } from 'util-common';
 
 /**
@@ -10,12 +11,22 @@ import { UtilityClass } from 'util-common';
  * by the document storage format.
  */
 export default class Paths extends UtilityClass {
+  /**
+   * {string} `StoragePath` string for the caret information revision number.
+   */
+  static get CARET_REVISION_NUMBER() {
+    return '/carets/revision_number';
+  }
+
   /** {string} `StoragePath` string for the document format version. */
   static get FORMAT_VERSION() {
     return '/format_version';
   }
 
-  /** {string} `StoragePath` string for the document revision number. */
+  /**
+   * {string} `StoragePath` string for the document content revision number.
+   * This corresponds to the highest change number.
+   */
   static get REVISION_NUMBER() {
     return '/revision_number';
   }
@@ -26,10 +37,24 @@ export default class Paths extends UtilityClass {
    * revision.
    *
    * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string.
+   * @returns {string} The corresponding `StoragePath` string for document
+   *   change storage.
    */
   static forDocumentChange(revNum) {
     RevisionNumber.check(revNum);
     return `/change/${revNum}`;
+  }
+
+  /**
+   * Gets the `StoragePath` string corresponding to the indicated session,
+   * specifically to store caret data for that session.
+   *
+   * @param {string} sessionId The session ID.
+   * @returns {string} The corresponding `StoragePath` string for caret
+   *   information.
+   */
+  static forCaret(sessionId) {
+    TString.check(sessionId);
+    return `/carets/${sessionId}`;
   }
 }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.21.0
+version = 0.22.0


### PR DESCRIPTION
This PR is the start of using the `file-store` layer to store caret info. Most of the changes here are rearrangements "around" the area of interest, with only a couple bits actually purporting to do the storage in question. I left a bit of "work in progress" on the code as a reminder for the next round of work, though I won't be surprised if that code turns out to be mostly wrong.

I bumped the file version number because of a change to the storage path used for the _document_ revision number.