### PR TITLE
Next iteration of caret storage.

### DIFF
--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -238,6 +238,22 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
+   * Constructs an instance just like this one, except with a different
+   * caret revision number. If the given revision number is the same as what
+   * this instance already stores, this method returns `this`.
+   *
+   * @param {Int} revNum The new caret revision number.
+   * @returns {CaretSnapshot} An appropriately-constructed instance.
+   */
+  withRevNum(revNum) {
+    RevisionNumber.check(revNum);
+
+    return (revNum === this._revNum)
+      ? this
+      : new CaretSnapshot(revNum, this._carets.values());
+  }
+
+  /**
    * Constructs an instance just like this one, except without any reference to
    * the session indicated by the given caret. If there is no session for the
    * given caret, this method returns `this`.

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -211,4 +211,29 @@ export default class CaretSnapshot extends CommonBase {
 
     return true;
   }
+
+  /**
+   * Constructs an instance just like this one, except without any reference to
+   * the session indicated by the given caret. If there is no session for the
+   * given caret, this method returns `this`.
+   *
+   * @param {Caret} caret The caret whose session should not be represented in
+   *   the result. Only the `sessionId` of the caret is consulted; it doesn't
+   *   matter if other caret fields match.
+   * @returns {CaretSnapshot} An appropriately-constructed instance.
+   */
+  withoutCaret(caret) {
+    Caret.check(caret);
+    const sessionId = caret.sessionId;
+    const carets    = this._carets;
+
+    if (!carets.has(sessionId)) {
+      return this;
+    }
+
+    const newCarets = new Map(carets);
+    newCarets.delete(sessionId);
+
+    return new CaretSnapshot(this._revNum, newCarets.values());
+  }
 }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -213,6 +213,31 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
+   * Constructs an instance just like this one, except with an additional or
+   * updated reference to the indicated caret. If the given caret (including all
+   * fields) is already represented in this instance, this method returns
+   * `this`.
+   *
+   * @param {Caret} caret The caret to include in the result.
+   * @returns {CaretSnapshot} An appropriately-constructed instance.
+   */
+  withCaret(caret) {
+    Caret.check(caret);
+    const sessionId = caret.sessionId;
+    const carets    = this._carets;
+    const already   = carets.get(sessionId);
+
+    if (already && already.equals(caret)) {
+      return this;
+    }
+
+    const newCarets = new Map(carets);
+    newCarets.set(sessionId, caret);
+
+    return new CaretSnapshot(this._revNum, newCarets.values());
+  }
+
+  /**
    * Constructs an instance just like this one, except without any reference to
    * the session indicated by the given caret. If there is no session for the
    * given caret, this method returns `this`.

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -60,6 +60,13 @@ describe('doc-common/Caret', () => {
       assert.strictEqual(result.color, '#aabbcc');
     });
 
+    it('should update `revNum` given the appropriate op', () => {
+      const op     = CaretOp.op_updateField(caret1.sessionId, 'revNum', 12345);
+      const result = caret1.compose(new CaretDelta([op]));
+
+      assert.strictEqual(result.revNum, 12345);
+    });
+
     it('should refuse to compose if given a non-matching session ID', () => {
       const op = CaretOp.op_updateField(caret2.sessionId, 'index', 55);
 

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -267,6 +267,21 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
+  describe('withRevNum()', () => {
+    it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
+      const snap = new CaretSnapshot(1, [caret1]);
+
+      assert.strictEqual(snap.withRevNum(1), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a different `revNum`', () => {
+      const snap =     new CaretSnapshot(1, [caret1, caret2]);
+      const expected = new CaretSnapshot(2, [caret1, caret2]);
+
+      assert.isTrue(snap.withRevNum(2).equals(expected));
+    });
+  });
+
   describe('withoutCaret()', () => {
     it('should return `this` if there is no matching session', () => {
       const snap = new CaretSnapshot(1, [caret1]);

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -241,6 +241,32 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
+  describe('withCaret()', () => {
+    it('should return `this` if the exact caret is already in the snapshot', () => {
+      const snap = new CaretSnapshot(1, [caret1]);
+
+      assert.strictEqual(snap.withCaret(caret1), snap);
+
+      const cloneCaret = new Caret(caret1, []);
+      assert.strictEqual(snap.withCaret(cloneCaret), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a new caret', () => {
+      const snap =     new CaretSnapshot(1, [caret1]);
+      const expected = new CaretSnapshot(1, [caret1, caret2]);
+
+      assert.isTrue(snap.withCaret(caret2).equals(expected));
+    });
+
+    it('should return an appropriately-constructed instance given an updated caret', () => {
+      const modCaret = new Caret(caret1, Object.entries({ index: 321 }));
+      const snap =     new CaretSnapshot(1, [caret1,   caret2]);
+      const expected = new CaretSnapshot(1, [modCaret, caret2]);
+
+      assert.isTrue(snap.withCaret(modCaret).equals(expected));
+    });
+  });
+
   describe('withoutCaret()', () => {
     it('should return `this` if there is no matching session', () => {
       const snap = new CaretSnapshot(1, [caret1]);

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -240,4 +240,28 @@ describe('doc-common/CaretSnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
   });
+
+  describe('withoutCaret()', () => {
+    it('should return `this` if there is no matching session', () => {
+      const snap = new CaretSnapshot(1, [caret1]);
+
+      assert.strictEqual(snap.withoutCaret(caret2), snap);
+      assert.strictEqual(snap.withoutCaret(caret3), snap);
+    });
+
+    it('should return an appropriately-constructed instance if there is a matching session', () => {
+      const snap =     new CaretSnapshot(1, [caret1, caret2]);
+      const expected = new CaretSnapshot(1, [caret2]);
+
+      assert.isTrue(snap.withoutCaret(caret1).equals(expected));
+    });
+
+    it('should only pay attention to the session ID of the given caret', () => {
+      const snap =     new CaretSnapshot(1, [caret1, caret2]);
+      const expected = new CaretSnapshot(1, [caret2]);
+      const modCaret = new Caret(caret1, Object.entries({ revNum: 999999, index: 99 }));
+
+      assert.isTrue(snap.withoutCaret(modCaret).equals(expected));
+    });
+  });
 });

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -2,15 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Caret, CaretDelta, CaretOp, CaretSnapshot, RevisionNumber, Timestamp }
-  from 'doc-common';
-import { TransactionSpec } from 'file-store';
+import { Caret, CaretSnapshot, RevisionNumber, Timestamp } from 'doc-common';
 import { TInt, TString } from 'typecheck';
-import { ColorSelector, CommonBase, PromCondition, PromDelay }
-  from 'util-common';
+import { ColorSelector, CommonBase, PromCondition } from 'util-common';
 
-import FileComplex from './FileComplex';
-import Paths from './Paths';
+import CaretStorage from './CaretStorage';
 
 /**
  * {Int} How many older caret snapshots should be maintained for potential use
@@ -24,12 +20,6 @@ const MAX_OLD_SNAPSHOTS = 20;
  */
 const MAX_SESSION_IDLE_MSEC = 10 * 60 * 1000; // Ten minutes.
 
-/** {Int} How many times to retry session removal. */
-const MAX_SESSION_REMOVAL_RETRIES = 10;
-
-/** {Int} How long (in msec) to wait between session removal retries. */
-const SESSION_REMOVAL_RETRY_DELAY_MSEC = 10 * 1000; // Ten seconds.
-
 /**
  * Controller for the active caret info for a given document.
  *
@@ -38,9 +28,6 @@ const SESSION_REMOVAL_RETRY_DELAY_MSEC = 10 * 1000; // Ten seconds.
  * provided by virtue of the fact that `DocServer` only ever creates one
  * `FileComplex` per document, and each `FileComplex` instance only ever makes
  * one instance of this class.
- *
- * **TODO:** This class needs to store caret info via the `file-store`,
- * instead of being purely ephemeral.
  */
 export default class CaretControl extends CommonBase {
   /**
@@ -52,11 +39,11 @@ export default class CaretControl extends CommonBase {
   constructor(fileComplex) {
     super();
 
-    /** {FileComplex} File complex that this instance is part of. */
-    this._fileComplex = FileComplex.check(fileComplex);
-
-    /** {FileCodec} File-codec wrapper to use. */
-    this._fileCodec = fileComplex.fileCodec;
+    /**
+     * {CaretStorage} File storage handler. This is responsible for all of the
+     * file reading and writing.
+     */
+    this._caretStorage = new CaretStorage(fileComplex);
 
     /**
      * {CaretSnapshot} Latest caret info. Starts out as an empty stub; gets
@@ -96,7 +83,7 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretDelta} Delta from the base caret revision to a newer one.
    */
   async deltaAfter(baseRevNum) {
-    await this._removeInactiveSessions();
+    this._removeInactiveSessions();
 
     const minRevNum     = this._oldSnapshots[0].revNum;
     const currentRevNum = this._snapshot.revNum;
@@ -130,7 +117,7 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretSnapshot} Snapshot of all the active carets.
    */
   async snapshot(revNum = null) {
-    await this._removeInactiveSessions();
+    this._removeInactiveSessions();
 
     const minRevNum     = this._oldSnapshots[0].revNum;
     const currentRevNum = this._snapshot.revNum;
@@ -166,180 +153,63 @@ export default class CaretControl extends CommonBase {
     TInt.nonNegative(index);
     TInt.nonNegative(length);
 
-    // Rename for method-internal convenience. (The argument name serves a
-    // didactic purpose.)
-    const revNum = docRevNum;
+    // Construct the new/updated caret and updated snapshot.
+
+    let snapshot     = this._snapshot;
+    const oldCaret   = snapshot.caretForSession(sessionId);
+    const revNum     = docRevNum; // Done to match the caret field name.
+    const lastActive = Timestamp.now();
+    const newFields  = { revNum, lastActive, index, length };
+    let newCaret;
+
+    if (oldCaret === null) {
+      newFields.color = this._colorSelector.nextColorHex();
+      newCaret = new Caret(sessionId, Object.entries(newFields));
+    } else {
+      newCaret = new Caret(oldCaret, Object.entries(newFields));
+    }
+
+    snapshot = snapshot.withCaret(newCaret);
+
+    // Apply the update, and inform both the storage layer and any waiters.
 
     const caretStr = (length === 0)
       ? `@${index}`
       : `[${index}..${index + length - 1}]`;
     this._log.info(`[${sessionId}] Caret update: r${revNum}, ${caretStr}`);
 
-    // Build up an array of ops to apply to the current snapshot.
+    this._caretStorage.update(newCaret);
 
-    const snapshot = this._snapshot;
-    const oldCaret = snapshot.caretForSession(sessionId);
-    let ops;
-
-    if (oldCaret === null) {
-      const lastActive = Timestamp.now();
-      const color      = this._colorSelector.nextColorHex();
-      const fields     = { revNum, lastActive, index, length, color };
-      const newCaret   = new Caret(sessionId, Object.entries(fields));
-
-      ops = [CaretOp.op_beginSession(newCaret)];
-    } else {
-      const lastActive = Timestamp.now();
-      const fields     = { revNum, lastActive, index, length };
-      const newCaret   = new Caret(oldCaret, Object.entries(fields));
-      const diff       = oldCaret.diff(newCaret);
-
-      ops = [...diff.ops]; // `[...x]` so as to be mutable for `push()` below.
-    }
-
-    // Apply the ops, and inform any waiters.
-    return this._applyOps(ops);
+    return this._updateSnapshot(snapshot);
   }
 
   /**
-   * Applies the given operations to the current snapshot, producing a new
-   * snapshot with an incremented caret revision number.
-   *
-   * @param {array<CaretOp>} ops Operations to apply.
-   * @returns {Int} The _caret_ revision number at which this information was
-   *   integrated.
+   * Removes sessions out of the snapshot that haven't been active recently.
    */
-  async _applyOps(ops) {
-    const snapshot  = this._snapshot;
-    const newRevNum = snapshot.revNum + 1;
-
-    // Add the op to bump up the revision number, and construct the new
-    // snapshot.
-    ops.push(CaretOp.op_updateRevNum(newRevNum));
-    const newSnapshot = snapshot.compose(new CaretDelta(ops));
-
-    // Perform a transaction to update the stored carets to match the new
-    // state of affairs. This can fail if there is a data storage race. (Higher
-    // level logic will need to retry, if appropriate.)
-    await this._storeCarets(newSnapshot);
-
-    // Update the snapshot locally, and wake up any waiters.
-    this._snapshot = newSnapshot;
-    this._oldSnapshots.push(newSnapshot);
-    this._updatedCondition.onOff();
-
-    while (this._oldSnapshots.length > MAX_OLD_SNAPSHOTS) {
-      // Trim `_oldSnapshots` down to its allowed length.
-      this._oldSnapshots.shift();
-    }
-
-    this._log.info(`Updated carets: Caret revision ${newRevNum}.`);
-
-    return newRevNum;
-  }
-
-  /**
-   * Removes sessions that haven't been active recently out of the snapshot.
-   */
-  async _removeInactiveSessions() {
+  _removeInactiveSessions() {
     const minTime = Timestamp.now().addMsec(-MAX_SESSION_IDLE_MSEC);
-    const ops = [];
 
     for (const c of this._snapshot.carets) {
       if (minTime.compareTo(c.lastActive) > 0) {
         // Too old!
         this._log.info(`[${c.sessionId}] Caret became inactive.`);
-        ops.push(CaretOp.op_endSession(c.sessionId));
+        this._removeSession(c);
       }
     }
-
-    if (ops.length !== 0) {
-      await this._removeSessionsWithRetry(ops);
-    }
   }
 
   /**
-   * Stores the carets represented in the given new snapshot, to the underlying
-   * file storage. This throws an error if there was a storage race and this
-   * call lost.
+   * Removes the indicated caret from the local snapshot, and also pushes the
+   * removal to the storage layer.
    *
-   * @param {CaretSnapshot} snapshot Carets to store.
+   * @param {Caret} caret Caret representing the session to be removed.
    */
-  async _storeCarets(snapshot) {
-    const oldRevNum = this._snapshot.revNum;
-    const newRevNum = snapshot.revNum;
-    const fc        = this._fileCodec;
+  _removeSession(caret) {
+    Caret.check(caret);
 
-    if (newRevNum !== (oldRevNum + 1)) {
-      throw new Error('Unexpected `revNum` for `_storeCarets()`.');
-    }
-
-    // **TODO:** For now, we just update the caret revision number without even
-    // checking for races. Ultimately, this needs to do a lot more! See the
-    // work-in-progress version of this, below.
-    const spec = new TransactionSpec(
-      fc.op_writePath(Paths.CARET_REVISION_NUMBER, newRevNum));
-    await this._fileCodec.transact(spec);
-  }
-
-  /**
-   * Stores the carets represented in the given new snapshot, to the underlying
-   * file storage. This throws an error if there was a storage race and this
-   * call lost.
-   *
-   * **TODO:** This is a non-functional work-in-progress version of the method.
-   *
-   * @param {CaretSnapshot} snapshot Carets to store.
-   */
-  async _storeCarets_workInProgress(snapshot) {
-    const oldRevNum = this._snapshot.revNum;
-    const newRevNum = snapshot.revNum;
-    const fc        = this._fileCodec;
-
-    if (newRevNum !== (oldRevNum + 1)) {
-      throw new Error('Unexpected `revNum` for `_storeCarets()`.');
-    }
-
-    try {
-      // **TODO:** For now, we just update the caret revision number.
-      // Ultimately, we should also be storing carets.
-      const spec = new TransactionSpec(
-        fc.op_checkPathIs(Paths.CARET_REVISION_NUMBER, oldRevNum),
-        fc.op_writePath(Paths.CARET_REVISION_NUMBER, newRevNum));
-      await this._fileCodec.transact(spec);
-    } catch (e) {
-      // We probably lost a race, but it could also be that the caret revision
-      // number is missing (new-ish file) or corrupt. The code below tries to
-      // sort it all out.
-      this._log.info('Failed to write carets.', e);
-    }
-
-    // Read the revision number (which might be absent), and take further action
-    // based on it. We don't try to catch errors here, because there's nothing
-    // we can do to recover at this point. Moreover, we always throw at the end
-    // of whatever we do, so that the higher layer will be set up to retry (or
-    // it might just itself fail).
-
-    let spec = new TransactionSpec(fc.op_readPath(Paths.CARET_REVISION_NUMBER));
-    const transactionResult = await this._fileCodec.transact(spec);
-    const revNum = transactionResult.data[Paths.CARET_REVISION_NUMBER];
-
-    if (((typeof revNum) === 'number') && (revNum >= newRevNum)) {
-      // Stored revision number indicates a data storage race loss. Just throw,
-      // so that the higher layer can recover (or fail).
-      throw new Error('Lost data storage race.');
-    }
-
-    if (revNum === undefined) {
-      // No carets ever stored.
-      this._log.info('Writing initial caret revision number.');
-    } else {
-      // The revision number is probably corrupt.
-      this._log.warn('Likely corrupt caret info. Resetting.');
-    }
-
-    spec = new TransactionSpec(fc.op_writePath(Paths.CARET_REVISION_NUMBER, 0));
-    await this._fileCodec.transact(spec);
+    const snapshot = this._snapshot.withoutCaret(caret);
+    this._updateSnapshot(snapshot);
+    this._caretStorage.delete(caret);
   }
 
   /**
@@ -358,46 +228,40 @@ export default class CaretControl extends CommonBase {
     if (!snapshot) {
       this._log.wtf('Snapshot not set? Currently:', snapshot);
     } else if (!snapshot.caretForSession) {
-      this._log.wtf('`caretForSnapshot` not defined? Snapshot:', snapshot);
+      this._log.wtf('`caretForSession` not defined? Snapshot:', snapshot);
     }
 
     const oldCaret = snapshot.caretForSession(sessionId);
 
     if (oldCaret !== null) {
-      const ops   = [CaretOp.op_endSession(sessionId)];
-
-      this._log.info(`[${sessionId}] Caret removed.`);
-      await this._removeSessionsWithRetry(ops);
+      this._removeSession(oldCaret);
     }
   }
 
   /**
-   * Apply ops which are session removals, with retry logic. This is called
-   * during session cleanup, in a context where it's okay if it ultimately
-   * fails, which is why we just warn when that happens.
+   * Updates the stored snapshot to the one given, with an incremented
+   * caret revision number.
    *
-   * @param {array<CaretOp>} ops Session removal ops.
+   * @param {CaretSnapshot} snapshot The new snapshot.
+   * @returns {Int} The new caret revision number.
    */
-  async _removeSessionsWithRetry(ops) {
-    for (let i = 0; i < MAX_SESSION_REMOVAL_RETRIES; i++) {
-      try {
-        await this._applyOps(ops);
-      } catch (e) {
-        this._log.warn('Caret removal failed.', e);
-      }
+  _updateSnapshot(snapshot) {
+    const oldSnapshot = this._snapshot;
+    const newRevNum   = oldSnapshot.revNum + 1;
+    const newSnapshot = snapshot.withRevNum(newRevNum);
 
-      // Wait a moment, and then make sure we have the latest snapshot (but we
-      // still might lose another update race).
+    // Update the snapshot instance variable, and wake up any waiters.
+    this._snapshot = newSnapshot;
+    this._oldSnapshots.push(newSnapshot);
+    this._updatedCondition.onOff();
 
-      await PromDelay.resolve(SESSION_REMOVAL_RETRY_DELAY_MSEC);
-
-      try {
-        await this.snapshot();
-      } catch (e) {
-        this._log.warn('`snapshot()` failed during caret removal.', e);
-      }
+    while (this._oldSnapshots.length > MAX_OLD_SNAPSHOTS) {
+      // Trim `_oldSnapshots` down to its allowed length.
+      this._oldSnapshots.shift();
     }
 
-    this._log.warn('Caret removal failed too many times. Giving up!');
+    this._log.info(`Updated carets: Caret revision ${newRevNum}.`);
+
+    return newRevNum;
   }
 }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -1,0 +1,234 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Caret } from 'doc-common';
+import { TransactionSpec } from 'file-store';
+import { CommonBase, PromDelay } from 'util-common';
+
+import FileComplex from './FileComplex';
+import Paths from './Paths';
+
+/**
+ * {Int} How long to wait (in msec) after sessions are updated before an attempt
+ * is made to write session info to file storage. This keeps the system from
+ * storing too many ephemeral session updates, with the downside that caret
+ * sharing across servers has this much more latency than sharing between
+ * sessions that reside on the same machine.
+ */
+const WRITE_DELAY_MSEC = 5 * 1000; // 5 seconds.
+
+/** {Int} How long (in msec) to wait between write retries. */
+const WRITE_RETRY_DELAY_MSEC = 10 * 1000; // Ten seconds.
+
+/** {Int} How many times to retry writes. */
+const MAX_WRITE_RETRIES = 10;
+
+/**
+ * Helper class for `CaretControl` which handles the underlying file storage of
+ * caret information. Every caret that gets updated or removed via the public
+ * methods on this class is considered to be "locally controlled," and so such
+ * caret updates are pushed to the file storage.
+ *
+ * **TODO:** This class currently only ever _writes_ carets to storage but
+ * doesn't ever read carets that might have been written by other servers. It
+ * should in fact also try reading other carets, providing a way for the
+ * caret controller to see them and get them updated in a timely fashion.
+ */
+export default class CaretStorage extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileComplex} fileComplex File complex that this instance is part
+   *   of.
+   */
+  constructor(fileComplex) {
+    super();
+
+    /** {FileComplex} File complex that this instance is part of. */
+    this._fileComplex = FileComplex.check(fileComplex);
+
+    /** {FileCodec} File-codec wrapper to use. */
+    this._fileCodec = fileComplex.fileCodec;
+
+    /** {Logger} Logger specific to this document's ID. */
+    this._log = fileComplex.log;
+
+    /**
+     * {Set<string>} Set of session IDs, indicating all of the editing sessions
+     * which are being managed directly by this instance (and by extension, this
+     * server).
+     */
+    this._localSessions = new Set();
+
+    /**
+     * {Map<string,Caret>} Map from session IDs to carets, for all
+     * currently-known carets, both from local sessions and from file storage.
+     */
+    this._carets = new Map();
+
+    /**
+     * {Map<string,Caret>} Map from session IDs to carets, for carets that are
+     * believed to be currently represented in file storage. The differences
+     * between this and `_carets` are what get written to file storage.
+     */
+    this._storedCarets = new Map();
+
+    /**
+     * {Promise|null} Promise for the result of a pending storage write, or
+     * `null` if no storage write is currently pending.
+     */
+    this._writeResultProm = null;
+
+    Object.seal(this);
+  }
+
+  /**
+   * Deletes a locally-controlled session. This update will eventually get
+   * written to file storage (unless superseded by another change to the same
+   * session in the meantime).
+   *
+   * @param {Caret} caret Caret for the session to be deleted. Only the
+   *   `sessionId` of the caret is actually used.
+   */
+  delete(caret) {
+    Caret.check(caret);
+    const sessionId = caret.sessionId;
+
+    // Indicate that the local server is asserting authority over this session.
+    // This means that, when it comes time to write out caret info, this session
+    // will be removed from file storage.
+    this._localSessions.add(sessionId);
+
+    this._carets.delete(sessionId);
+    this._needsWrite();
+  }
+
+  /**
+   * Updates a caret for a locally-controlled session. This update will
+   * eventually get written to file storage (unless superseded by another change
+   * to the same session in the meantime).
+   *
+   * @param {Caret} caret Caret information to update.
+   */
+  update(caret) {
+    Caret.check(caret);
+    const sessionId = caret.sessionId;
+
+    // Indicate that the local server is asserting authority over this session.
+    // This means that, when it comes time to write out caret info, this session
+    // will be written to file storage.
+    this._localSessions.add(sessionId);
+
+    this._carets.set(sessionId, caret);
+    this._needsWrite();
+  }
+
+  /**
+   * Indicates that there is local session data that needs to be written to
+   * file storage. This will ultimately cause such writing to be done.
+   *
+   * **Note:** This method only returns after the writing is done, which to
+   * reiterate only happens after a delay. If you want to make a bunch of writes
+   * that all end up written (approximately) together, do _not_ `await` the
+   * result of this call.
+   */
+  async _needsWrite() {
+    if (this._writeResultProm === null) {
+      this._writeResultProm = this._waitThenWrite();
+    }
+
+    // Note the current promise, so as to prevent us from messing with the
+    // next round of writing.
+    const currentProm = this._writeResultProm;
+
+    try {
+      await currentProm;
+    } finally {
+      if (this._writeResultProm === currentProm) {
+        // This round of writing is done, but the promise hasn't yet been reset
+        // (either to `null` or to a new promise). `null` it out, so that the
+        // next call to `_needsWrite()` will in fact kick off a new round of
+        // writing.
+        this._writeResultProm = null;
+      }
+    }
+  }
+
+  /**
+   * Waits a moment, and then writes all locally-controlled carets to file
+   * storage.
+   *
+   * **Note:** This method swallows errors (just reporting them via the log),
+   * because ultimately caret sharing is done on a "best effort" basis. We'd
+   * rather offer degraded service (i.e. not sharing carets even while other
+   * things are working) than hard failure.
+   */
+  async _waitThenWrite() {
+    await PromDelay.resolve(WRITE_DELAY_MSEC);
+
+    // Build up a transaction spec to perform all the caret updates, and extract
+    // a set of changes to make to instance variables should the transaction
+    // succeed. (We have to do this latter part before we `await` the
+    // transaction, since otherwise we could be looking at stale state.)
+
+    const fc            = this._fileCodec;
+    const ops           = [];
+    const updatedCarets = new Map();
+
+    for (const s of this._localSessions) {
+      const caret       = this._carets.get(s) || null;
+      const storedCaret = this._storedCarets.get(s) || null;
+      const path        = Paths.forCaret(s);
+
+      if (   (caret === storedCaret)
+          || (caret && storedCaret && caret.equals(storedCaret))) {
+        // The file already stores this caret info (or properly doesn't-store
+        // a caret for a terminated session).
+        continue;
+      }
+
+      if (caret) {
+        ops.push(fc.op_writePath(path, caret));
+      } else {
+        ops.push(fc.op_deletePath(path));
+      }
+
+      updatedCarets.set(path, caret);
+    }
+
+    // Run the transaction, retrying a few times on failure.
+
+    const spec = new TransactionSpec(...ops);
+
+    for (let i = 0; i < MAX_WRITE_RETRIES; i++) {
+      if (i !== 0) {
+        this._log.info(`Caret write attempt #${i+1}.`);
+      }
+
+      try {
+        await fc.transact(spec);
+        break;
+      } catch (e) {
+        this._log.warn('Failed to write carets.', e);
+      }
+
+      await PromDelay.resolve(WRITE_RETRY_DELAY_MSEC);
+    }
+
+    // Update instance variables to reflect the new state of affairs.
+
+    for (const [s, caret] of updatedCarets) {
+      if (caret) {
+        this._storedCarets.set(s, caret);
+      } else {
+        // The session has ended. In addition to deleting the caret from the
+        // file storage model, this removes the session from the set of
+        // locally-controlled sessions. This is done because we only ever have
+        // to delete a given session from file storage once.
+        this._storedCarets.delete(s);
+        this._localSessions.delete(s);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a rewrite of much of the caret storage back-end, including the addition of code which in fact stores carets via the `file-store` API, for the first time ever. (In the last PR, we wrote a caret revision number but no actual carets.)

This PR still leaves one major bit hanging (represented as a `TODO` in the code), specifically: While carets are now getting written to and deleted from storage in an appropriate way, nothing is ever actually trying to read them back in. This deficiency will of course be addressed in a subsequent PR.