### PR TITLE
Compiler stuff.

### DIFF
--- a/compiler/main.js
+++ b/compiler/main.js
@@ -102,6 +102,16 @@ function compileFile(inputFile, outputFile) {
   if (output !== null) {
     fs_extra.ensureDirSync(path.dirname(outputFile));
     fs.writeFileSync(outputFile, output.code);
+
+    // Update the access and modification time to make it look like the output
+    // file was written one second after the original instead of when it was
+    // actually written (which will generally be much later). This is done to
+    // make it so that subsequent builds won't mistakenly think a compiled file
+    // is up-to-date in the case where the source file was updated in the
+    // middle of a build.
+    const newTime = Math.ceil(inputStat.mtimeMs / 1000) + 1;
+    fs.utimesSync(outputFile, newTime, newTime);
+
     console.log(chalk.green.bold('Compiled: '), pathToLog);
   }
 }

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -17,10 +17,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "babel-core": "^6.22.0",
-    "babel-polyfill": "^6.22.0",
-    "babel-preset-env": "^1.4.0",
     "chalk": "^1.1.1",
-    "fs-extra": "^3.0.1"
+    "fs-extra": "^3.0.1",
+
+    "compiler-dependencies": "local"
   }
 }

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -4,17 +4,10 @@
   "main": "main.js",
 
   "dependencies": {
-    "babel-core": "^6.22.0",
-    "babel-loader": "^7.0.0",
-    "babel-polyfill": "^6.22.0",
-    "babel-preset-env": "^1.4.0",
-    "html-loader": "^0.4.4",
     "memory-fs": "^0.4.1",
-    "ts-loader": "^2.0.3",
-    "typescript": "^2.1.4",
-    "webpack": "^3.4.1",
 
     "client-tests-loader": "local",
+    "compiler-dependencies": "local",
     "env-server": "local",
     "see-all": "local",
     "util-common": "local"

--- a/local-modules/compiler-dependencies/README.md
+++ b/local-modules/compiler-dependencies/README.md
@@ -1,0 +1,6 @@
+compiler-dependencies
+=====================
+
+This module just serves as a single location to hold all of the compiler-related
+dependencies, for compiling code per se (both server and client code) and for
+packaging it for use on the client.

--- a/local-modules/compiler-dependencies/main.js
+++ b/local-modules/compiler-dependencies/main.js
@@ -1,0 +1,12 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// **Note:** This file gets loaded by the `compiler` subproject, which means it
+// can only use JavaScript as supported directly by Node. This is why we use
+// `module.exports = ...` and not `export ...`. Not that we are exporting
+// anything anyway... just sayin'.
+
+// This module serves only to hold common dependencies, so there's nothing to
+// export.
+module.exports = {};

--- a/local-modules/compiler-dependencies/package.json
+++ b/local-modules/compiler-dependencies/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "compiler-dependencies",
+  "version": "1.0.0",
+  "main": "main.js",
+
+  "dependencies": {
+    "babel-core": "^6.22.0",
+    "babel-loader": "^7.0.0",
+    "babel-polyfill": "^6.22.0",
+    "babel-preset-env": "^1.4.0",
+    "html-loader": "^0.4.4",
+    "ts-loader": "^2.0.3",
+    "typescript": "^2.1.4",
+    "webpack": "^3.4.1"
+  }
+}

--- a/scripts/build
+++ b/scripts/build
@@ -334,7 +334,7 @@ function do-install {
     # this back to just doing `npm install` in the main directory, should npm
     # ever gain a way to understand that there are some module directories that
     # it shouldn't touch. See <https://github.com/npm/npm/issues/18062>.
-    
+
     rm -rf "${npmDir}"
     mkdir -p "${npmDir}"
     rsync --archive "${packageJson}" "${npmDir}/package.json"
@@ -371,6 +371,9 @@ function do-install {
     # directory, because we want to keep our local modules, and if we don't
     # `--delete` then we could end up with weird module amalgams in cases where
     # an external module got updated.
+
+    echo "${dir}:" 'Moving external dependencies into place...'
+
     local d
     for d in $(cd "${npmDir}/node_modules"; /bin/ls); do
         rsync --archive --delete \
@@ -383,7 +386,7 @@ function do-install {
     # subsequent builds.
     rsync --archive "${packageJson}" "${npmPackageJson}" || return 1
 
-    echo "${dir}:" 'Installing external dependencies... done.'
+    echo "${dir}:" 'External dependencies... done.'
 }
 
 # Builds the server code. This builds from `server` into `final/server`. The


### PR DESCRIPTION
This PR has three compiler-related tweaks:

* Extract all the compiler-related dependencies (Babel, Typescript, and Webpack) into its own module. This avoids duplicating dependencies in both the `compiler` subproject and the `client-bundle` local module.
* Change the file modtime when writing out compiled files, so that they appear to have been written just a second after the original, instead of when they were really written (which is much later). This fixes a case where the build system would get confused if you edit a source file while a build is in progress. In such cases, there was a good chance that it wouldn't notice the file had changed on a subsequent build. This caused confusion, despair, and angst.
* Add a console log during the build when npm-sourced modules get copied into place. (This can take several seconds.)