### PR TITLE
Getting ready to read carets.

### DIFF
--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -11,10 +11,28 @@ import CaretOp from './CaretOp';
 import RevisionNumber from './RevisionNumber';
 
 /**
+ * {CaretSnapshot|null} Empty instance. Initialized in the `EMPTY` property
+ * accessor.
+ */
+let emptyInstance = null;
+
+/**
  * Snapshot of information about all active sessions on a particular document.
  * Instances of this class are always frozen (immutable).
  */
 export default class CaretSnapshot extends CommonBase {
+  /**
+   * {CaretSnapshot} Empty instance of this class. It has no carets and a
+   * revision number of `0`.
+   */
+  static get EMPTY() {
+    if (emptyInstance === null) {
+      emptyInstance = new CaretSnapshot(0, []);
+    }
+
+    return emptyInstance;
+  }
+
   /**
    * Constructs an instance.
    *

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TIterable } from 'typecheck';
+import { TIterable, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import Caret from './Caret';
@@ -283,8 +283,21 @@ export default class CaretSnapshot extends CommonBase {
    */
   withoutCaret(caret) {
     Caret.check(caret);
-    const sessionId = caret.sessionId;
-    const carets    = this._carets;
+    return this.withoutSession(caret.sessionId);
+  }
+
+  /**
+   * Constructs an instance just like this one, except without any reference to
+   * the indicated session. If the session is not represented in this instance,
+   * this method returns `this`.
+   *
+   * @param {string} sessionId ID of the session which should not be represented
+   *   in the result.
+   * @returns {CaretSnapshot} An appropriately-constructed instance.
+   */
+  withoutSession(sessionId) {
+    TString.nonempty(sessionId);
+    const carets = this._carets;
 
     if (!carets.has(sessionId)) {
       return this;

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -25,6 +25,15 @@ const caret2 = newCaret('session-2', 2, 6,  '#222222');
 const caret3 = newCaret('session-3', 3, 99, '#333333');
 
 describe('doc-common/CaretSnapshot', () => {
+  describe('.EMPTY', () => {
+    it('should be an empty instance', () => {
+      const EMPTY = CaretSnapshot.EMPTY;
+
+      assert.strictEqual(EMPTY.revNum, 0);
+      assert.deepEqual(EMPTY.carets, []);
+    });
+  });
+
   describe('compose()', () => {
     it('should produce an equal instance when passed an empty delta', () => {
       let which = 0;
@@ -303,6 +312,21 @@ describe('doc-common/CaretSnapshot', () => {
       const modCaret = new Caret(caret1, Object.entries({ revNum: 999999, index: 99 }));
 
       assert.isTrue(snap.withoutCaret(modCaret).equals(expected));
+    });
+  });
+
+  describe('withoutSession()', () => {
+    it('should return `this` if there is no matching session', () => {
+      const snap = new CaretSnapshot(1, [caret1]);
+
+      assert.strictEqual(snap.withoutSession('blort-is-not-a-session'), snap);
+    });
+
+    it('should return an appropriately-constructed instance if there is a matching session', () => {
+      const snap =     new CaretSnapshot(1, [caret1, caret2]);
+      const expected = new CaretSnapshot(1, [caret2]);
+
+      assert.isTrue(snap.withoutSession(caret1.sessionId).equals(expected));
     });
   });
 });

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -49,7 +49,7 @@ export default class CaretControl extends CommonBase {
      * {CaretSnapshot} Latest caret info. Starts out as an empty stub; gets
      * filled in as updates arrive.
      */
-    this._snapshot = new CaretSnapshot(0, []);
+    this._snapshot = CaretSnapshot.EMPTY;
 
     /**
      * {array<CaretSnapshot>} Array of older caret snapshots, available for use

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -109,6 +109,7 @@ export default class CaretControl extends CommonBase {
    */
   async snapshot(revNum = null) {
     this._removeInactiveSessions();
+    this._integrateRemoteSessions();
 
     const minRevNum     = this._oldSnapshots[0].revNum;
     const currentRevNum = this._snapshot.revNum;
@@ -172,6 +173,23 @@ export default class CaretControl extends CommonBase {
     this._caretStorage.update(newCaret);
 
     return this._updateSnapshot(snapshot);
+  }
+
+  /**
+   * Merges any new remote session info into the snapshot.
+   */
+  _integrateRemoteSessions() {
+    const snapshot = this._snapshot;
+    const remotes = this._caretStorage.remoteSnapshot();
+
+    let newSnapshot = snapshot;
+    for (const c of remotes.carets) {
+      newSnapshot = newSnapshot.withCaret(c);
+    }
+
+    if (newSnapshot !== snapshot) {
+      this._updateSnapshot(newSnapshot);
+    }
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -83,22 +83,13 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretDelta} Delta from the base caret revision to a newer one.
    */
   async deltaAfter(baseRevNum) {
-    this._removeInactiveSessions();
+    const oldSnapshot = await this.snapshot(baseRevNum);
 
-    const minRevNum     = this._oldSnapshots[0].revNum;
+    // **Note:** Can only do this after the above `await` returns (because the
+    // current snapshot from before the `await` may be out-of-date).
     const currentRevNum = this._snapshot.revNum;
 
-    if ((baseRevNum < minRevNum) || (baseRevNum > currentRevNum)) {
-      throw new Error(`Revision not available: ${baseRevNum}`);
-    }
-
-    // Grab the snapshot to use as the base. **Note:** If `baseRevNum` is in
-    // fact the current revision number, this will turn out to be the same as
-    // `_snapshot` because `_snapshot` is always the last element of
-    // `_oldSnapshots`.
-    const oldSnapshot = this._oldSnapshots[baseRevNum - minRevNum];
-
-    if (baseRevNum === currentRevNum) {
+    if (oldSnapshot.revNum === currentRevNum) {
       // We've been asked for a revision newer than the most recent one, so we
       // have to wait for a change to be made. `_snapshot` will have been
       // changed by the time this `await` returns.

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Caret } from 'doc-common';
+import { Caret, CaretSnapshot } from 'doc-common';
 import { TransactionSpec } from 'file-store';
 import { CommonBase, PromDelay } from 'util-common';
 
@@ -62,17 +62,18 @@ export default class CaretStorage extends CommonBase {
     this._localSessions = new Set();
 
     /**
-     * {Map<string,Caret>} Map from session IDs to carets, for all
-     * currently-known carets, both from local sessions and from file storage.
+     * {CaretSnapshot} Snapshot containing all currently-known carets, both
+     * from local sessions and from file storage. **Note:** The `revNum` of this
+     * snapshot never changes.
      */
-    this._carets = new Map();
+    this._carets = CaretSnapshot.EMPTY;
 
     /**
-     * {Map<string,Caret>} Map from session IDs to carets, for carets that are
-     * believed to be currently represented in file storage. The differences
-     * between this and `_carets` are what get written to file storage.
+     * {CaretSnapshot} Snapshot of carets as believed to be in file storage.
+     * (It is a combination of values read from and written to storage.) This
+     * is used to drive synchronization between `_carets` and file storage.
      */
-    this._storedCarets = new Map();
+    this._storedCarets = CaretSnapshot.EMPTY;
 
     /**
      * {Promise|null} Promise for the result of a pending storage write, or
@@ -93,14 +94,13 @@ export default class CaretStorage extends CommonBase {
    */
   delete(caret) {
     Caret.check(caret);
-    const sessionId = caret.sessionId;
 
     // Indicate that the local server is asserting authority over this session.
     // This means that, when it comes time to write out caret info, this session
     // will be removed from file storage.
-    this._localSessions.add(sessionId);
+    this._localSessions.add(caret.sessionId);
 
-    this._carets.delete(sessionId);
+    this._carets = this._carets.withoutCaret(caret);
     this._needsWrite();
   }
 
@@ -113,14 +113,13 @@ export default class CaretStorage extends CommonBase {
    */
   update(caret) {
     Caret.check(caret);
-    const sessionId = caret.sessionId;
 
     // Indicate that the local server is asserting authority over this session.
     // This means that, when it comes time to write out caret info, this session
     // will be written to file storage.
-    this._localSessions.add(sessionId);
+    this._localSessions.add(caret.sessionId);
 
-    this._carets.set(sessionId, caret);
+    this._carets = this._carets.withCaret(caret);
     this._needsWrite();
   }
 
@@ -177,8 +176,8 @@ export default class CaretStorage extends CommonBase {
     const updatedCarets = new Map();
 
     for (const s of this._localSessions) {
-      const caret       = this._carets.get(s) || null;
-      const storedCaret = this._storedCarets.get(s) || null;
+      const caret       = this._carets.caretForSession(s);
+      const storedCaret = this._storedCarets.caretForSession(s);
       const path        = Paths.forCaret(s);
 
       if (   (caret === storedCaret)
@@ -218,17 +217,27 @@ export default class CaretStorage extends CommonBase {
 
     // Update instance variables to reflect the new state of affairs.
 
+    let storedCarets    = this._storedCarets;
+    const localSessions = this._localSessions;
+
     for (const [s, caret] of updatedCarets) {
       if (caret) {
-        this._storedCarets.set(s, caret);
+        storedCarets = storedCarets.withCaret(caret);
       } else {
         // The session has ended. In addition to deleting the caret from the
         // file storage model, this removes the session from the set of
         // locally-controlled sessions. This is done because we only ever have
         // to delete a given session from file storage once.
-        this._storedCarets.delete(s);
-        this._localSessions.delete(s);
+
+        const already = storedCarets.caretForSession(s);
+        if (already) {
+          storedCarets = storedCarets.withoutCaret(s);
+        }
+
+        localSessions.delete(s);
       }
     }
+
+    this._storedCarets = storedCarets;
   }
 }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -12,8 +12,13 @@ import Paths from './Paths';
 /**
  * {Int} Maximum amount of time that a call to `whenRemoteChange()` will take
  * before timing out.
+ *
+ * **TODO:** The timeout is set to be quite low right now because the method
+ * in question isn't really checking for anything, and so every call ends up
+ * timing out. Once it performs real work, this should be changed to something
+ * more like 5 minutes.
  */
-const REMOTE_CHANGE_TIMEOUT_MSEC = 5 * 60 * 1000; // 5 minutes;
+const REMOTE_CHANGE_TIMEOUT_MSEC = 10 * 1000; // 10 seconds.
 
 /**
  * {Int} How long to wait (in msec) after sessions are updated before an attempt

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -267,12 +267,7 @@ export default class CaretStorage extends CommonBase {
         // file storage model, this removes the session from the set of
         // locally-controlled sessions. This is done because we only ever have
         // to delete a given session from file storage once.
-
-        const already = storedCarets.caretForSession(s);
-        if (already) {
-          storedCarets = storedCarets.withoutCaret(s);
-        }
-
+        storedCarets = storedCarets.withoutSession(s);
         localSessions.delete(s);
       }
     }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -10,6 +10,12 @@ import FileComplex from './FileComplex';
 import Paths from './Paths';
 
 /**
+ * {Int} Maximum amount of time that a call to `whenRemoteChange()` will take
+ * before timing out.
+ */
+const REMOTE_CHANGE_TIMEOUT_MSEC = 5 * 60 * 1000; // 5 minutes;
+
+/**
  * {Int} How long to wait (in msec) after sessions are updated before an attempt
  * is made to write session info to file storage. This keeps the system from
  * storing too many ephemeral session updates, with the downside that caret
@@ -105,6 +111,26 @@ export default class CaretStorage extends CommonBase {
   }
 
   /**
+   * Gets a snapshot of all remote carets, that is, carets represented in file
+   * storage that haven't been pushed there by this server. The resulting
+   * snapshot always has a revision number of `0`.
+   *
+   * **Note:** This returns the locally-cached information about the stored
+   * state. To make sure the local state gets updated, use `whenRemoteChange()`.
+   *
+   * @returns {CaretSnapshot} Snapshot of remote carets.
+   */
+  remoteSnapshot() {
+    let result = this._carets;
+
+    for (const s of this._localSessions) {
+      result = result.withoutSession(s);
+    }
+
+    return result;
+  }
+
+  /**
    * Updates a caret for a locally-controlled session. This update will
    * eventually get written to file storage (unless superseded by another change
    * to the same session in the meantime).
@@ -121,6 +147,19 @@ export default class CaretStorage extends CommonBase {
 
     this._carets = this._carets.withCaret(caret);
     this._needsWrite();
+  }
+
+  /**
+   * Waits for a change to the stored caret state. This method returns when a
+   * change has been detected, or after the request times out.
+   *
+   * **TODO:** This is currently a no-op. It should be filled in.
+   *
+   * @returns {boolean} `true` if a change was detected, or `false` if not.
+   */
+  async whenRemoteChange() {
+    await PromDelay.resolve(REMOTE_CHANGE_TIMEOUT_MSEC);
+    return false;
   }
 
   /**

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -173,8 +173,8 @@ export default class FileComplex extends CommonBase {
    * Makes a new author-associated session for this instance.
    *
    * @param {string} authorId ID for the author.
-   * @param {function} makeSessionId Function of no argument which should return
-   *   a randomly-generated string to use as a session ID. This will get called
+   * @param {function} makeSessionId No-argument function which should return a
+   *   randomly-generated string to use as a session ID. This will get called
    *   more than once if the string happens to be a duplicate in the namespace
    *   for session IDs.
    * @returns {DocSession} A newly-constructed session.


### PR DESCRIPTION
This PR adds the code to `CaretControl` to integrate remote carets, by calling on new methods in `CaretStorage`… except those latter methods are basically no-ops right now. They will be filled in in a follow-on PR.