### PR TITLE
Read carets from storage.

### DIFF
--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -244,11 +244,11 @@ export default class Caret extends CommonBase {
     Caret.check(newerCaret);
     TString.nonempty(sessionId);
 
-    const fields    = this._fields;
-    const ops       = [];
+    const fields = this._fields;
+    const ops    = [];
 
     for (const [k, v] of newerCaret._fields) {
-      if (v !== fields.get(k)) {
+      if (!Caret._equalFields(v, fields.get(k))) {
         ops.push(CaretOp.op_updateField(sessionId, k, v));
       }
     }
@@ -271,7 +271,7 @@ export default class Caret extends CommonBase {
 
     const fields = this._fields;
     for (const [k, v] of other._fields) {
-      if (v !== fields.get(k)) {
+      if (!Caret._equalFields(v, fields.get(k))) {
         return false;
       }
     }
@@ -303,6 +303,34 @@ export default class Caret extends CommonBase {
    */
   static fromApi(sessionId, fields) {
     return new Caret(sessionId, Object.entries(fields));
+  }
+
+  /**
+   * Helper for `diff()` and `equals()` which compares two corresponding fields
+   * for equality.
+   *
+   * @param {*} v1 Value to compare.
+   * @param {*} v2 Value to compare.
+   * @returns {boolean} `true` iff they should be considered equal.
+   */
+  static _equalFields(v1, v2) {
+    if (v1 === v2) {
+      return true;
+    }
+
+    // For non-primitive values, both must be objects of the same class to be
+    // considered equal. And that class must define an `equals()` method.
+
+    const t1 = typeof v1;
+    const t2 = typeof v2;
+
+    if (   ((t1 !== 'object') || (t2 !== 'object'))
+        || (v1.constructor !== v2.constructor)
+        || !v1.equals) {
+      return false;
+    }
+
+    return v1.equals(v2);
   }
 }
 

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -59,4 +59,33 @@ export default class CaretDelta extends CommonBase {
   get ops() {
     return this._ops;
   }
+
+  /**
+   * Gets a human-oriented string representation of this instance.
+   *
+   * @returns {string} The human-oriented representation.
+   */
+  toString() {
+    const result = ['CaretDelta ['];
+
+    let first = true;
+    for (const op of this._ops) {
+      if (first) {
+        first = false;
+        result.push('\n  ');
+      } else {
+        result.push(',\n  ');
+      }
+
+      result.push(op.toString());
+    }
+
+    if (!first) {
+      result.push('\n');
+    }
+
+    result.push(']');
+
+    return result.join('');
+  }
 }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -167,4 +167,31 @@ export default class CaretOp extends CommonBase {
   static fromApi(name, args) {
     return new CaretOp(KEY, name, args);
   }
+
+  /**
+   * Gets a human-oriented string representation of this instance.
+   *
+   * @returns {string} The human-oriented representation.
+   */
+  toString() {
+    const result = ['CaretOp ', this._name, ' {'];
+
+    let first = true;
+    for (const [k, v] of this._args) {
+      if (first) {
+        first = false;
+      } else {
+        result.push(', ');
+      }
+
+      result.push(' ');
+      result.push(k);
+      result.push(': ');
+      result.push(v.toString());
+    }
+
+    result.push('}');
+
+    return result.join('');
+  }
 }

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -179,6 +179,16 @@ export default class Timestamp extends CommonBase {
   }
 
   /**
+   * Compares this to another instance for equality.
+   *
+   * @param {Timestamp} other Timestamp to compare to.
+   * @returns {boolean} `true` if the two have equal values, or `false` if not.
+   */
+  equals(other) {
+    return this.compareTo(other) === 0;
+  }
+
+  /**
    * Returns a string form for this instance. This is always of the form
    * `<secs>.<usecs>` where `<usecs>` is always six digits long.
    *

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -63,6 +63,12 @@ export default class CaretControl extends CommonBase {
      */
     this._updatedCondition = new PromCondition();
 
+    /**
+     * {Promise|null} Promise that gets fulfilled when a pending
+     * `whenRemoteChange()` returns. If `null`, there is no such call pending.
+     */
+    this._remoteChangeProm = null;
+
     /** {ColorSelector} Provider of well-distributed colors. */
     this._colorSelector = new ColorSelector();
 
@@ -91,9 +97,27 @@ export default class CaretControl extends CommonBase {
     // actual change happening.
     while (oldSnapshot.revNum === this._snapshot.revNum) {
       // Wait for either a local or remote update, whichever comes first.
+
+      if (!this._remoteChangeProm) {
+        // This arrangement guarantees that we only ever have one pending call
+        // at any given time to `whenRemoteChange()`.
+        const prom = this._caretStorage.whenRemoteChange();
+        this._remoteChangeProm = prom;
+
+        (async () => {
+          try {
+            await prom;
+          } finally {
+            if (this._remoteChangeProm === prom) {
+              this._remoteChangeProm = null;
+            }
+          }
+        })();
+      }
+
       await Promise.race([
         this._updatedCondition.whenTrue(),
-        this._caretStorage.whenRemoteChange()
+        this._remoteChangeProm
       ]);
 
       // If there were remote changes, this will cause the snapshot to get

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -10,6 +10,11 @@ import FileComplex from './FileComplex';
 import Paths from './Paths';
 
 /**
+ * {Int} Minimum amount of time (in msec) to wait between reading stored carets.
+ */
+const READ_DELAY_MSEC = 10 * 1000; // 10 seconds.
+
+/**
  * {Int} Maximum amount of time that a call to `whenRemoteChange()` will take
  * before timing out.
  *
@@ -18,7 +23,7 @@ import Paths from './Paths';
  * timing out. Once it performs real work, this should be changed to something
  * more like 5 minutes.
  */
-const REMOTE_CHANGE_TIMEOUT_MSEC = 10 * 1000; // 10 seconds.
+const REMOTE_CHANGE_TIMEOUT_MSEC = 60 * 1000; // 1 minute.
 
 /**
  * {Int} How long to wait (in msec) after sessions are updated before an attempt
@@ -80,11 +85,23 @@ export default class CaretStorage extends CommonBase {
     this._carets = CaretSnapshot.EMPTY;
 
     /**
-     * {CaretSnapshot} Snapshot of carets as believed to be in file storage.
-     * (It is a combination of values read from and written to storage.) This
-     * is used to drive synchronization between `_carets` and file storage.
+     * {CaretSnapshot} Snapshot of carets as stored from this instance into file
+     * storage. This is used to drive synchronization between `_carets` and file
+     * storage.
      */
     this._storedCarets = CaretSnapshot.EMPTY;
+
+    /**
+     * {Int} Last time (in msec since the Unix Epoch) that carets were read
+     * from storage.
+     */
+    this._lastReadTime = 0;
+
+    /**
+     * {Promise|null} Promise for the result of a pending storage read, or
+     * `null` if no storage read is currently pending.
+     */
+    this._readResultProm = null;
 
     /**
      * {Promise|null} Promise for the result of a pending storage write, or
@@ -120,12 +137,18 @@ export default class CaretStorage extends CommonBase {
    * storage that haven't been pushed there by this server. The resulting
    * snapshot always has a revision number of `0`.
    *
-   * **Note:** This returns the locally-cached information about the stored
-   * state. To make sure the local state gets updated, use `whenRemoteChange()`.
+   * This method doesn't wait for data to be read from storage &mdash; it always
+   * returns immediately with whatever info is at hand &mdash; but if it has
+   * been a while since the data was updated, this method will fire off an
+   * asynchronous read, the results of which will eventually get integrated.
    *
    * @returns {CaretSnapshot} Snapshot of remote carets.
    */
   remoteSnapshot() {
+    if (Date.now() >= (this._lastReadTime + READ_DELAY_MSEC)) {
+      this._needsRead();
+    }
+
     let result = this._carets;
 
     for (const s of this._localSessions) {
@@ -163,8 +186,79 @@ export default class CaretStorage extends CommonBase {
    * @returns {boolean} `true` if a change was detected, or `false` if not.
    */
   async whenRemoteChange() {
-    await PromDelay.resolve(REMOTE_CHANGE_TIMEOUT_MSEC);
+    const startSnapshot = this.remoteSnapshot();
+    const timeoutAt = Date.now() + REMOTE_CHANGE_TIMEOUT_MSEC;
+
+    // Loop until change detected or timeout.
+    for (;;) {
+      const now = Date.now();
+      if (now >= timeoutAt) {
+        break;
+      }
+
+      // Wait until the next allowed caret read, or figure out that we don't
+      // need to wait at all.
+      const readDelay = (this._lastReadTime + READ_DELAY_MSEC) - now;
+      if (readDelay > 0) {
+        this._log.info(`Pre-read wait in \`whenRemoteChange\`: ${readDelay} msec`);
+        // Wait the prescribed amount of time.
+        await PromDelay.resolve(readDelay);
+
+        // And see if there was already a change.
+        const newSnapshot = this.remoteSnapshot();
+        if (!newSnapshot.equals(startSnapshot)) {
+          // Yes, change!
+          return true;
+        }
+      }
+
+      // No change after waiting (or no waiting yet), so wait for the next read
+      // to complete (triggering that read if it wasn't already in-progress).
+      this._log.info('Waiting for read results in `whenRemoteChange`.');
+      await this._needsRead();
+
+      // And see if that caused a change.
+      const newSnapshot = this.remoteSnapshot();
+      if (!newSnapshot.equals(startSnapshot)) {
+        // Yes, change!
+        return true;
+      }
+    }
+
+    // No change detected, and we timed out.
+    this._log.info('Timeout reached in `whenRemoteChange`.');
     return false;
+  }
+
+  /**
+   * Indicates that caret information should be read from file storage. This
+   * will ultimately cause such reading to be done.
+   *
+   * **Note:** This method only returns after the reading is done.
+   */
+  async _needsRead() {
+    if (this._readResultProm === null) {
+      this._readResultProm = this._readCarets();
+    }
+
+    // Note the current promise, so as to prevent us from messing with the
+    // next round of reading.
+    const currentProm = this._readResultProm;
+
+    try {
+      await currentProm;
+    } finally {
+      if (this._readResultProm === currentProm) {
+        // This round of reading is done, but the promise hasn't yet been reset
+        // (either to `null` or to a new promise). `null` it out, so that the
+        // next call to `_needsRead()` will in fact kick off a new round of
+        // reading.
+        this._readResultProm = null;
+
+        // And update the last-read time, so we know when to try reading again.
+        this._lastReadTime = Date.now();
+      }
+    }
   }
 
   /**
@@ -178,7 +272,7 @@ export default class CaretStorage extends CommonBase {
    */
   async _needsWrite() {
     if (this._writeResultProm === null) {
-      this._writeResultProm = this._waitThenWrite();
+      this._writeResultProm = this._waitThenWriteCarets();
     }
 
     // Note the current promise, so as to prevent us from messing with the
@@ -199,6 +293,74 @@ export default class CaretStorage extends CommonBase {
   }
 
   /**
+   * Reads carets from storage, updating `_carets` as a result.
+   *
+   * **Note:** This doesn't update `_storedCarets`, which are the carets as
+   * stored from this instance. (That is, those represent carets moving in the
+   * other direction from what's being done here.)
+   */
+  async _readCarets() {
+    // **TODO:** For now, we are just reading all carets, always, instead of
+    // waiting for changes from the current known state. This should be fixed to
+    // use `when*` ops instead, which will avoid this kind of polling behavior.
+
+    // Get a set of all session IDs currently stored.
+
+    this._log.info('Reading caret directory...');
+
+    const fc = this._fileCodec;
+    let caretPaths;
+
+    try {
+      const spec = new TransactionSpec(
+        fc.op_listPath(Paths.CARET_PREFIX));
+      const transactionResult = await fc.transact(spec);
+      caretPaths = transactionResult.paths;
+    } catch (e) {
+      this._log.error('Could not read caret directory.', e);
+      throw e;
+    }
+
+    // Filter out all the sessions that are controlled locally, and read all the
+    // the other carets.
+
+    this._log.info('Reading remote carets...');
+
+    const ops = [];
+    let caretData;
+
+    for (const path of caretPaths) {
+      const sessionId = Paths.sessionFromCaretPath(path);
+      if (!this._localSessions.has(sessionId)) {
+        ops.push(fc.op_readPath(path));
+      }
+    }
+
+    try {
+      const spec = new TransactionSpec(...ops);
+      const transactionResult = await fc.transact(spec);
+      caretData = transactionResult.data;
+    } catch (e) {
+      this._log.error('Could not read carets.', e);
+      throw e;
+    }
+
+    const carets  = this._carets;
+    let newCarets = carets;
+
+    for (const c of caretData.values()) {
+      newCarets = newCarets.withCaret(c);
+    }
+
+    if (carets === newCarets) {
+      this._log.info('Done reading carets. No remote changes.');
+    } else {
+      this._log.info('Done reading carets. Integrated changes.');
+      this._carets = newCarets;
+    }
+  }
+
+  /**
    * Waits a moment, and then writes all locally-controlled carets to file
    * storage.
    *
@@ -207,7 +369,7 @@ export default class CaretStorage extends CommonBase {
    * rather offer degraded service (i.e. not sharing carets even while other
    * things are working) than hard failure.
    */
-  async _waitThenWrite() {
+  async _waitThenWriteCarets() {
     await PromDelay.resolve(WRITE_DELAY_MSEC);
 
     // Build up a transaction spec to perform all the caret updates, and extract

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -203,24 +203,16 @@ export default class CaretStorage extends CommonBase {
         this._log.info(`Pre-read wait in \`whenRemoteChange\`: ${readDelay} msec`);
         // Wait the prescribed amount of time.
         await PromDelay.resolve(readDelay);
-
-        // And see if there was already a change.
-        const newSnapshot = this.remoteSnapshot();
-        if (!newSnapshot.equals(startSnapshot)) {
-          // Yes, change!
-          return true;
-        }
+      } else {
+        // No need to wait. Just indicate that a read should be in progress, and
+        // wait for it to be done.
+        this._log.info('Waiting for read results in `whenRemoteChange`.');
+        await this._needsRead();
       }
 
-      // No change after waiting (or no waiting yet), so wait for the next read
-      // to complete (triggering that read if it wasn't already in-progress).
-      this._log.info('Waiting for read results in `whenRemoteChange`.');
-      await this._needsRead();
-
-      // And see if that caused a change.
       const newSnapshot = this.remoteSnapshot();
       if (!newSnapshot.equals(startSnapshot)) {
-        // Yes, change!
+        // Yes, there was a change!
         return true;
       }
     }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { RevisionNumber } from 'doc-common';
+import { StoragePath } from 'file-store';
 import { TString } from 'typecheck';
 import { UtilityClass } from 'util-common';
 
@@ -12,10 +13,10 @@ import { UtilityClass } from 'util-common';
  */
 export default class Paths extends UtilityClass {
   /**
-   * {string} `StoragePath` string for the caret information revision number.
+   * {string} `StoragePath` string for the caret information path prefix.
    */
-  static get CARET_REVISION_NUMBER() {
-    return '/caret/revision_number';
+  static get CARET_PREFIX() {
+    return '/caret';
   }
 
   /**
@@ -55,6 +56,22 @@ export default class Paths extends UtilityClass {
    */
   static forCaret(sessionId) {
     TString.check(sessionId);
-    return `/caret/${sessionId}`;
+    return `${Paths.CARET_PREFIX}/${sessionId}`;
+  }
+
+  /**
+   * Takes a full storage path for a caret and returns the session ID part of
+   * it. This is the reverse of `forCaret()`.
+   *
+   * @param {string} path The full storage path.
+   * @returns {string} The corresponding caret session ID.
+   */
+  static sessionFromCaretPath(path) {
+    if (!StoragePath.isPrefix(Paths.CARET_PREFIX, path)) {
+      throw new Error(`Not a caret path: ${path}`);
+    }
+
+    const split = StoragePath.split(path);
+    return split[1];
   }
 }

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -217,7 +217,11 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_deletePath(op) {
-    this._updatedStorage.set(op.arg('storagePath'), null);
+    const storagePath = op.arg('storagePath');
+
+    if (this._fileFriend.readPathOrNull(storagePath) !== null) {
+      this._updatedStorage.set(storagePath, null);
+    }
   }
 
   /**

--- a/local-modules/file-store/StoragePath.js
+++ b/local-modules/file-store/StoragePath.js
@@ -91,6 +91,23 @@ export default class StoragePath extends UtilityClass {
   }
 
   /**
+   * Indicates whether the first path is a prefix of the second. In filesystem
+   * terms, this indicates whether the first path names a directory above the
+   * second path.
+   *
+   * @param {string} prefix Path prefix.
+   * @param {string} path Path which might start with `prefix`.
+   * @returns {boolean} `true` if `prefix` is indeed a path prefix of `path`, or
+   *   `false` if not.
+   */
+  static isPrefix(prefix, path) {
+    StoragePath.check(prefix);
+    StoragePath.check(path);
+
+    return path.startsWith(`${prefix}/`);
+  }
+
+  /**
    * Joins an array of components into a single storage path string. Components
    * must _not_ include slashes (`/`). This operation is the inverse of
    * `split()`.

--- a/local-modules/file-store/tests/test_StoragePath.js
+++ b/local-modules/file-store/tests/test_StoragePath.js
@@ -140,6 +140,36 @@ describe('file-store/StoragePath', () => {
     });
   });
 
+  describe('isPrefix()', () => {
+    it('should return `true` for prefix relationships', () => {
+      function test(prefix, path) {
+        assert.isTrue(StoragePath.isPrefix(prefix, path));
+      }
+
+      test('/a', '/a/b');
+      test('/a', '/a/b/c');
+      test('/a', '/a/b/c/d');
+      test('/a', '/a/b/c/d/e');
+      test('/a', '/a/b/c/d/e/f');
+      test('/blort/florp', '/blort/florp/a');
+      test('/blort/florp', '/blort/florp/aa');
+      test('/blort/florp', '/blort/florp/aa/b');
+      test('/blort/florp', '/blort/florp/aa/bb');
+    });
+
+    it('should return `false` for non-prefix relationships', () => {
+      function test(prefix, path) {
+        assert.isFalse(StoragePath.isPrefix(prefix, path));
+      }
+
+      test('/a', '/b');
+      test('/a', '/b/a');
+      test('/a/b', '/a');
+      test('/a', '/aa');
+      test('/a/b', '/a/bb');
+    });
+  });
+
   describe('join()', () => {
     it('should join as expected', () => {
       function test(value, expected) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.22.0
+version = 0.22.1

--- a/scripts/develop
+++ b/scripts/develop
@@ -118,24 +118,42 @@ while true; do
     fi
 
     echo ''
-    "${progDir}/build" "${cleanArg[@]}" "${buildOpts[@]}" || exit 1
+
+    "${progDir}/build" "${cleanArg[@]}" "${buildOpts[@]}"
+    if (( $? != 0 )); then
+        echo "Build failure. Waiting a moment before trying again..."
+        echo ''
+        sleep 15
+        continue
+    fi
+
     echo ''
 
     "${outDir}/final/bin/run" --dev
     status="$?"
-    if (( ${status} != 0 )); then
-        # Not a clean exit, so better to err on the side of not looping. This
-        # most notably happens when the developer hits ctrl-C on the console.
 
-        # Wait a second for "last licks" console logging.
-        sleep 2
-
-        # We suppress the error message in the ctrl-C case by checking for the
-        # distinctive exit code used in that case.
-        if (( ${status} != 130 )); then
-            echo "Application exited with non-zero status: ${status}"
+    if (( ${status} >= 128 && ${status} <= 191 )); then
+        # `130` is the status code if the developer hits `ctrl-C` on the
+        # console. `131` is the status code for a `QUIT` signal (`ctrl-\` or
+        # via `kill`). We don't really need to note those.
+        if (( ${status} != 130 && ${status} != 131 )); then
+            echo "Application halted via signal: $((status - 128))"
         fi
+        break # out of the loop.
+    elif (( ${status} != 0 )); then
+        # Not a clean exit, probably due to the application failing to catch an
+        # exception. This is most commonly a transient error during development.
+        #
+        # We wait a few seconds, both so that lingering console logs can make it
+        # out, and to give a little breathing room during development (instead
+        # of pegging the CPU in case of repeated failure). Then, we iterate and
+        # run again.
 
-        break
+        echo "Application halted with status: ${status}"
+        echo 'Probably an uncaught exception.' \
+            'Waiting a moment before trying again...'
+        echo ''
+
+        sleep 15
     fi
 done


### PR DESCRIPTION
This PR implements the read-from-storage part of caret sharing as well as fixes a few other related aspects of the system. With this PR, reading is done on a polling basis; a future PR will make it more properly patient and wait-y.

**Bonus:** Tweaked the `develop` script to not give up so easily in the face of adversity.