### PR TITLE
More build cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-# Directory where build results / artifacts land
+# Directory where build results / artifacts land.
 out/
+
+# Directory created by by macOS.
+.DS_Store

--- a/doc/development.md
+++ b/doc/development.md
@@ -68,14 +68,12 @@ $ ./scripts/build --boxes=<box-dir>
 
 ### Testing
 
-There are a couple options on the `build` script that cause tests to be run.
+The script `run-tests` will run all of the existing tests, sending output to the
+console as well as saving it in files under the output directory.
 
-* `--client-bundle` &mdash; Build the client code bundle, reporting any errors.
-* `--server-test` &mdash; Run the tests for the server code.
-
-In addition, if you have already made a build, you can provide either of these
-options to the built script `out/final/bin/run`, to run the tests in question
-with respect to the built product.
+This script wraps calls to the build script `out/final/bin/run`, passing it
+various testing options. You can also call this script directly, as needed or
+desired.
 
 ### Cleanup
 

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -102,7 +102,7 @@ export default class ServerSink extends Singleton {
           l = l.substring(chunk.length);
           // eslint-disable-next-line no-console
           console.log(`${indent}${chunk}`);
-          indent = ' +';
+          indent = '+ ';
         }
       }
     } else {

--- a/local-modules/util-common/tests/test_StringUtil.js
+++ b/local-modules/util-common/tests/test_StringUtil.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { StringUtil } from 'util-common';
 
 describe('util-common/StringUtil', () => {
-  describe('graphemesForString(string)', () => {
+  describe('graphemesForString()', () => {
     it('should return `.length` graphemes when passed ASCII input', () => {
       const input = 'this is a string';
       const asciiLength = input.length;
@@ -32,7 +32,7 @@ describe('util-common/StringUtil', () => {
     });
   });
 
-  describe('utf8LengthForString(strig)', () => {
+  describe('utf8LengthForString()', () => {
     it('should return a UTF-8 length of 1 for ASCII characters', () => {
       const input = 'this is a string';
       const asciiLength = input.length;
@@ -66,7 +66,7 @@ describe('util-common/StringUtil', () => {
     });
   });
 
-  describe('stringWithUtf8ByteLimit(string, limit)', () => {
+  describe('stringWithUtf8ByteLimit()', () => {
     it('should pass-through inputs that fit within the byte limit', () => {
       const input = '🇫🇷'; // If your editor doesn't render this, it's the flag of France.
       const output = StringUtil.stringWithUtf8ByteLimit(input, 100);

--- a/scripts/build
+++ b/scripts/build
@@ -165,10 +165,11 @@ function check-environment-dependencies {
 # final built product.
 function set-up-out {
     outDir="$(${progDir}/lib/out-dir-setup "${outOpts[@]}")"
-    finalDir="${outDir}/final"
-    if [[ $? != 0 ]]; then
+    if (( $? != 0 )); then
         return 1
     fi
+
+    finalDir="${outDir}/final"
 }
 
 # Gets a list of all the local module names. The output is a series of

--- a/scripts/build
+++ b/scripts/build
@@ -39,14 +39,8 @@ buildProjects=(compiler server client bin)
 # Boxed dependency directory, if any.
 boxDir=''
 
-# Try building a client bundle?
-clientBundle=0
-
 # Overlay source directory, if any.
 overlayDir=''
-
-# Run server tests?
-serverTest=0
 
 # Options to pass to `out-dir-setup`.
 outOpts=()
@@ -60,8 +54,6 @@ while (( $# != 0 )); do
         boxDir="${BASH_REMATCH[1]}"
     elif [[ ${opt} == '--clean' ]]; then
         outOpts+=("${opt}")
-    elif [[ ${opt} == '--client-bundle' ]]; then
-        clientBundle=1
     elif [[    ${opt} == '--help'
             || ${opt} == '-h' ]]; then
         showHelp=1
@@ -71,8 +63,6 @@ while (( $# != 0 )); do
         outOpts+=("${opt}")
     elif [[ ${opt} =~ ^--overlay=(.*) ]]; then
         overlayDir="${BASH_REMATCH[1]}"
-    elif [[ ${opt} == '--server-test' ]]; then
-        serverTest=1
     elif [[ ${opt} =~ ^- ]]; then
         echo "Unknown option: ${opt}" 1>&2
         argError=1
@@ -94,16 +84,12 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Find boxed dependencies in directory <dir>.'
     echo '  --clean'
     echo '    Start from a clean build.'
-    echo '  --client-bundle'
-    echo '    On successful build, also try building a client bundle.'
     echo '  --linter'
     echo '    Just build the linter.'
     echo '  --out=<dir>'
     echo '    Place output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
-    echo '  --server-test'
-    echo '    On successful build, also try running the server tests.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -523,13 +509,5 @@ fi
 for proj in "${buildProjects[@]}"; do
     "build-${proj}" || exit 1
 done
-
-if (( ${clientBundle} )); then
-    "${finalDir}/bin/run" --client-bundle || exit 1
-fi
-
-if (( ${serverTest} )); then
-    "${finalDir}/bin/run" --server-test || exit 1
-fi
 
 echo 'Done with build!'

--- a/scripts/clean
+++ b/scripts/clean
@@ -84,15 +84,17 @@ fi
 # Main script
 #
 
-# Options to pass to `out-dir-setup`
+# Options to pass to `out-dir-setup`.
 setupOpts=()
 
 if [[ ${outDir} != '' ]]; then
     setupOpts+=("--out=${outDir}")
 fi
 
-if (( !${create} )); then
+if (( ${create} )); then
+    setupOpts+=('--clean')
+else
     setupOpts+=('--just-clean')
 fi
 
-"${progDir}/lib/out-dir-setup" "${setupOpts[@]}"
+"${progDir}/lib/out-dir-setup" --no-print "${setupOpts[@]}"

--- a/scripts/lib/out-dir-setup
+++ b/scripts/lib/out-dir-setup
@@ -46,6 +46,9 @@ clean=0
 # Just clean? (Don't create directory.)
 justClean=0
 
+# Print out directory name?
+printDir=1
+
 # Directory for the built output.
 outDir=''
 
@@ -62,6 +65,8 @@ while (( $# != 0 )); do
     elif [[ ${opt} == '--just-clean' ]]; then
         clean=1
         justClean=1
+    elif [[ ${opt} == '--no-print' ]]; then
+        printDir=0
     elif [[ ${opt} =~ ^--out=(.*) ]]; then
         outDir="${BASH_REMATCH[1]}"
     elif [[ ${opt} =~ ^- ]]; then
@@ -80,12 +85,16 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo "${progName} [--clean] [--out=<dir>] [--overlay=<dir>]"
     echo '  Sets up and/or cleans the built output directory. Prints the'
-    echo '  directory name.'
+    echo '  absolute path of the output directory. This uses a default output'
+    echo '  directory relative to the project base if `--out=` is not'
+    echo '  specified.'
     echo ''
     echo '  --clean'
     echo '    Start from a clean build.'
     echo '  --just-clean'
-    echo '    Just clean (and do not recreate out directory).'
+    echo '    Just clean (and do not recreate the output directory).'
+    echo '  --no-print'
+    echo '    Do not print out the directory name.'
     echo '  --out=<dir>'
     echo '    Place output in directory <dir>.'
     echo ''
@@ -93,11 +102,6 @@ if (( ${showHelp} || ${argError} )); then
     echo '  Display this message.'
     exit ${argError}
 fi
-
-
-#
-# Helper functions
-#
 
 
 #
@@ -122,7 +126,9 @@ fi
 
 if (( !${justClean} )); then
     mkdir -p "${outDir}" || exit 1
+fi
 
+if (( ${printDir} )); then
     # Print it out as an absolute path.
     cd ${outDir}
     /bin/pwd -P

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Runs all the tests.
+#
+
+# Set `progName` to the program name, `progDir` to its directory, and `baseDir`
+# to `progDir`'s directory. Follows symlinks.
+function init-prog {
+    local newp p="$0"
+
+    while newp="$(readlink "$p")"; do
+        [[ ${newp} =~ ^/ ]] && p="${newp}" || p="$(dirname "$p")/${newp}"
+    done
+
+    progName="${p##*/}"
+    progDir="$(cd "$(dirname "$p")"; /bin/pwd -P)"
+    baseDir="$(cd "${progDir}/.."; /bin/pwd -P)"
+}
+init-prog
+
+
+#
+# Argument parsing
+#
+
+# Error during argument processing?
+argError=0
+
+# Need help?
+showHelp=0
+
+# Output directory option, if any.
+outDirOpt=()
+
+while (( $# != 0 )); do
+    opt="$1"
+    if [[ ${opt} == '--' ]]; then
+        shift
+        break
+    elif [[ ${opt} == '--create' ]]; then
+        create=1
+    elif [[    ${opt} == '--help'
+            || ${opt} == '-h' ]]; then
+        showHelp=1
+    elif [[ ${opt} =~ ^--out= ]]; then
+        outDirOpt="${opt}"
+    elif [[ ${opt} =~ ^- ]]; then
+        echo "Unknown option: ${opt}" 1>&2
+        argError=1
+        break
+    else
+        break
+    fi
+    shift
+done
+unset opt
+
+if (( ${showHelp} || ${argError} )); then
+    echo 'Usage:'
+    echo ''
+    echo "${progName} [--out=<dir>]"
+    echo '  Runs the project tests.'
+    echo ''
+    echo '  --out=<dir>'
+    echo '    Directory containing the built output, and where test results are'
+    echo '    stored.'
+    echo ''
+    echo "${progName} [--help | -h]"
+    echo '  Display this message.'
+    exit ${argError}
+fi
+
+
+#
+# Main script
+#
+
+outDir="$(${progDir}/lib/out-dir-setup "${outDirOpt[@]}")"
+if (( $? != 0 )); then
+    return 1
+fi
+
+runProduct="${outDir}/final/bin/run"
+testOutDir="${outDir}/test-results"
+error=0
+
+if [[ ! -e ${runProduct} ]]; then
+    echo 'Could not find `run` script. Did you forget to build?' 1>&2
+    exit 1
+fi
+
+mkdir -p "${testOutDir}"
+
+"${runProduct}" --client-bundle | tee "${testOutDir}/client-bundle.txt"
+if (( $? != 0 )); then
+    error=1
+fi
+
+"${runProduct}" --server-test | tee "${testOutDir}/server-test.txt"
+if (( $? != 0 )); then
+    error=1
+fi
+
+exit "${error}"


### PR DESCRIPTION
* Fix the `clean` script.
* Augment the `out-dir-setup` script just a bit (in support of the former).
* Split out a `run-tests` script from `build`. This is a better separation of concerns.
* Make `run-tests` save the test output in files under `out`, with reasonably indicative names.

**Bonuses:**
* DRY out a test file.
* Console logging tweak.