### PR TITLE
New keyboard subclass and helper.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,10 +6,16 @@ Bayou Authors
   [Website](http://milk.com/) /
   [GitHub](https://github.com/danfuzz)
 
-* Chris DeSalvo
+* Chris DeSalvo:
   [Email](mailto:chris@desalvo.org) /
   [Website](https://desalvo.org/) /
   [GitHub](https://github.com/meantime)
+
+With additional contributions from:
+
+* Andreas Haugstrup Pedersen: [GitHub](https://github.com/haugstrup)
+* Angie Roscioli: [GitHub](https://github.com/ainjii)
+* Chris Montrois: [GitHub](https://github.com/montlebalm)
 
 ### Acknowledgments
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,7 +3,7 @@ Bayou Authors
 
 * Dan Bornstein:
   [Email](mailto:danfuzz@milk.com) /
-  [Website](http://milk.com/) /
+  [Website](https://milk.com/) /
   [GitHub](https://github.com/danfuzz)
 
 * Chris DeSalvo:

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -17,37 +17,27 @@ import DocSession from './DocSession';
 /** {Logger} Logger for this module. */
 const log = new Logger('editor-complex');
 
-/** {array<array<*>>} Default title toolbar configuration. */
-const DEFAULT_TITLE_TOOLBAR_CONFIG = [
-  ['italic', 'underline', 'strike', 'code'], // toggled buttons
-
-  [{ align: [] }],
-
-  ['clean']                                      // remove formatting button
-];
-
-/** {array<array<*>>} Default toolbar configuration. */
-const DEFAULT_BODY_TOOLBAR_CONFIG = [
-  ['bold', 'italic', 'underline', 'strike', 'code'], // toggled buttons
-  ['blockquote', 'code-block'],
-
-  [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
-
-  [{ header: [1, 2, 3, false] }],
-
-  [{ align: [] }],
-
-  ['clean']                                      // remove formatting button
-];
-
 /** {object} Default Quill module configuration for the document body. */
 const DEFAULT_BODY_MODULE_CONFIG = {
-  keyboard: BayouKeyHandlers.defaultKeyHandlers
+  keyboard: BayouKeyHandlers.defaultKeyHandlers,
+  toolbar: [
+    ['bold', 'italic', 'underline', 'strike', 'code'], // Toggled buttons.
+    ['blockquote', 'code-block'],
+    [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
+    [{ header: [1, 2, 3, false] }],
+    [{ align: [] }],
+    ['clean'] // "Remove formatting" button.
+  ]
 };
 
 /** {object} Default Quill module configuration for the title field. */
 const DEFAULT_TITLE_MODULE_CONFIG = {
-  keyboard: BayouKeyHandlers.singleLineKeyHandlers
+  keyboard: BayouKeyHandlers.singleLineKeyHandlers,
+  toolbar: [
+    ['italic', 'underline', 'strike', 'code'], // Toggled buttons.
+    [{ align: [] }],
+    ['clean'] // "Remove formatting" button.
+  ]
 };
 
 /**
@@ -298,11 +288,7 @@ export default class EditorComplex extends CommonBase {
   static get _titleModuleConfig() {
     if (!EditorComplex._titleModuleConfigValue) {
       const moduleConfig =
-        Hooks.theOne.quillTitleModuleConfig(DEFAULT_TITLE_MODULE_CONFIG);
-      const toolbarConfig =
-        Hooks.theOne.quillTitleToolbarConfig(DEFAULT_TITLE_TOOLBAR_CONFIG);
-
-      moduleConfig.toolbar = toolbarConfig;
+        Hooks.theOne.quillModuleConfig('title', DEFAULT_TITLE_MODULE_CONFIG);
       EditorComplex._titleModuleConfigValue = Object.freeze(moduleConfig);
     }
 
@@ -316,11 +302,7 @@ export default class EditorComplex extends CommonBase {
   static get _bodyModuleConfig() {
     if (!EditorComplex._bodyModuleConfigValue) {
       const moduleConfig =
-        Hooks.theOne.quillBodyModuleConfig(DEFAULT_BODY_MODULE_CONFIG);
-      const toolbarConfig =
-        Hooks.theOne.quillBodyToolbarConfig(DEFAULT_BODY_TOOLBAR_CONFIG);
-
-      moduleConfig.toolbar = toolbarConfig;
+        Hooks.theOne.quillModuleConfig('body', DEFAULT_BODY_MODULE_CONFIG);
       EditorComplex._bodyModuleConfigValue = Object.freeze(moduleConfig);
     }
 

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -4,7 +4,7 @@
 
 import { SplitKey } from 'api-common';
 import { Hooks } from 'hooks-client';
-import { QuillProm } from 'quill-util';
+import { BayouKeyHandlers, QuillProm } from 'quill-util';
 import { Logger } from 'see-all';
 import { TObject } from 'typecheck';
 import { DomUtil } from 'util-client';
@@ -40,11 +40,15 @@ const DEFAULT_BODY_TOOLBAR_CONFIG = [
   ['clean']                                      // remove formatting button
 ];
 
-/** {object} Default Quill module configuration for the title field. */
-const DEFAULT_TITLE_MODULE_CONFIG = {};
-
 /** {object} Default Quill module configuration for the document body. */
-const DEFAULT_BODY_MODULE_CONFIG = {};
+const DEFAULT_BODY_MODULE_CONFIG = {
+  keyboard: BayouKeyHandlers.defaultKeyHandlers
+};
+
+/** {object} Default Quill module configuration for the title field. */
+const DEFAULT_TITLE_MODULE_CONFIG = {
+  keyboard: BayouKeyHandlers.singleLineKeyHandlers
+};
 
 /**
  * Manager for the "complex" of objects and DOM nodes which in aggregate form

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -38,50 +38,19 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * Called to construct the Quill module configuration for the title. This is only ever
-   * called once per run of the application (and not, e.g., once per
-   * instantiation of a `Quill` object).
+   * Called to construct the Quill module configuration for the indicated
+   * context. This is only ever called once per context (per run of the
+   * application), and not, e.g., once per instantiation of a `Quill` object).
+   * This (default) implementation returns the given default configuration
+   * as-is.
    *
-   * @param {object} defaultConfig The default module configuration.
+   * @param {string} contextName_unused The name of the context. This is one of
+   *   `body` (for the main editor) or `title` (for the title field editor).
+   * @param {object} defaultConfig The default module configuration for this
+   *   context.
    * @returns {object} The desired module configuration.
    */
-  quillTitleModuleConfig(defaultConfig) {
-    return defaultConfig;
-  }
-
-  /**
-   * Called to construct the Quill toolbar configuration for the title. This is only ever
-   * called once per run of the application (and not, e.g., once per
-   * instantiation of a `Quill` object).
-   *
-   * @param {array<array<*>>} defaultConfig The default toolbar configuration.
-   * @returns {array<array<*>>} The desired toolbar configuration.
-   */
-  quillTitleToolbarConfig(defaultConfig) {
-    return defaultConfig;
-  }
-
-  /**
-   * Called to construct the Quill module configuration. This is only ever
-   * called once per run of the application (and not, e.g., once per
-   * instantiation of a `Quill` object).
-   *
-   * @param {object} defaultConfig The default module configuration.
-   * @returns {object} The desired module configuration.
-   */
-  quillBodyModuleConfig(defaultConfig) {
-    return defaultConfig;
-  }
-
-  /**
-   * Called to construct the Quill toolbar configuration. This is only ever
-   * called once per run of the application (and not, e.g., once per
-   * instantiation of a `Quill` object).
-   *
-   * @param {array<array<*>>} defaultConfig The default toolbar configuration.
-   * @returns {array<array<*>>} The desired toolbar configuration.
-   */
-  quillBodyToolbarConfig(defaultConfig) {
+  quillModuleConfig(contextName_unused, defaultConfig) {
     return defaultConfig;
   }
 }

--- a/local-modules/quill-util/BayouKeyHandlers.js
+++ b/local-modules/quill-util/BayouKeyHandlers.js
@@ -1,0 +1,103 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * The `BayouKeyboard` module is a subclass of the default Quill Keyboard
+ * module, but with a better system of configuring special handlers. For
+ * instance, it makes it easy to override processing of just the `enter` key so
+ * that you could make a Quill instance that only allows a single line of input.
+ *
+ * This class is a collection of those break-out handlers, as well as some
+ * routines for returning bundles of handlers for specific tasks. The individual
+ * handlers can be grouped manually, or the bundled groups of task-specific
+ * handlers can be used as a configuration option when allocating a `QuillProm`.
+ * An example of usage might be:
+ *
+ * ```
+ * const keyHandlers = BayouKeyHandlers.singleLineKeyHandlers;
+ * const quill = new QuillProm(domNode, {
+ *   modules: {
+ *     [ other configuration options ],
+ *     keyboard: keyHandlers
+ *   }
+ * });
+ * ```
+ */
+export default class BayouKeyHandlers {
+  /**
+   * Convenience function that returns the group of key handlers that provide
+   * default behavior (i.e., what you'd get from Quill if this class were not
+   * installed).
+   *
+   * @returns {object} The key handlers.
+   */
+  static get defaultKeyHandlers() {
+    return {
+      onEnter:  BayouKeyHandlers._defaultOnEnter,
+      onEscape: BayouKeyHandlers._defaultOnEscape,
+      onTab:    BayouKeyHandlers._defaultOnTab
+    };
+  }
+
+  /**
+   * Convenience function that returns the group of key handlers that will
+   * transform a Quill instance into a single-line input field.
+   *
+   * @returns {object} The key handlers.
+   */
+  static get singleLineKeyHandlers() {
+    return Object.assign(
+      BayouKeyHandlers.defaultKeyHandlers,
+      { onEnter: BayouKeyHandlers._singleLineOnEnter }
+    );
+  }
+
+  /**
+   * Default handling for the `enter` key. This is just a pass-through that
+   * allows the events to propagate back up to Quill.
+   *
+   * @param {object} metaKeys_unused The state of the meta-keys for this
+   *   keyboard event.
+   * @returns {boolean} `true`, always.
+   */
+  static _defaultOnEnter(metaKeys_unused) {
+    return true;
+  }
+
+  /**
+   * Default handling for the `escape` key. This is just a pass-through that
+   * allows the events to propagate back up to Quill.
+   *
+   * @param {object} metaKeys_unused The state of the meta-keys for this
+   *   keyboard event.
+   * @returns {boolean} `true`, always.
+   */
+  static _defaultOnEscape(metaKeys_unused) {
+    return true;
+  }
+
+  /**
+   * Default handling for the `tab` key. This is just a pass-through that allows
+   * the events to propagate back up to Quill.
+   *
+   * @param {object} metaKeys_unused The state of the meta-keys for this
+   *   keyboard event.
+   * @returns {boolean} `true`, always.
+   */
+  static _defaultOnTab(metaKeys_unused) {
+    return true;
+  }
+
+  /**
+   * A custom key handler for the return/enter key that blocks processing. This
+   * is to support single-line text input fields.
+   *
+   * @param {object} metaKeys_unused The state of the meta-keys for this
+   *   keyboard event.
+   * @returns {boolean} `false`, always.
+   */
+  static _singleLineOnEnter(metaKeys_unused) {
+    return false;
+  }
+}

--- a/local-modules/quill-util/BayouKeyHandlers.js
+++ b/local-modules/quill-util/BayouKeyHandlers.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from 'util-common';
+
 /**
  * The `BayouKeyboard` module is a subclass of the default Quill Keyboard
  * module, but with a better system of configuring special handlers. For
@@ -24,7 +26,7 @@
  * });
  * ```
  */
-export default class BayouKeyHandlers {
+export default class BayouKeyHandlers extends UtilityClass {
   /**
    * Convenience function that returns the group of key handlers that provide
    * default behavior (i.e., what you'd get from Quill if this class were not

--- a/local-modules/quill-util/BayouKeyboard.js
+++ b/local-modules/quill-util/BayouKeyboard.js
@@ -93,15 +93,9 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
  */
 function isMac() {
   const window = ClientEnv.window;
-  let result = false;
+  const userAgentString = window.navigator.userAgent;
 
-  if (window) {
-    const userAgentString = window.navigator.userAgent;
-
-    result = /Mac/i.test(userAgentString);
-  }
-
-  return result;
+  return /Mac/i.test(userAgentString);
 }
 
 /**

--- a/local-modules/quill-util/BayouKeyboard.js
+++ b/local-modules/quill-util/BayouKeyboard.js
@@ -1,0 +1,235 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import Quill from 'quill';
+
+import { ClientEnv } from 'env-client';
+
+// **TODO:** Maybe this can be a regular `import`?
+const Keyboard = Quill.import('modules/keyboard');
+
+/** {object} Map from key names to integer keycodes. */
+const KEYMAP = Object.freeze({
+  TAB:     9,
+  ESCAPE: 27,
+
+  ENTER:  13,
+  SPACE:  32,
+
+  END:    35,
+  HOME:   36,
+
+  LEFT:   37,
+  UP:     38,
+  RIGHT:  39,
+  DOWN:   40
+});
+
+/** No-op function, used for the `DEFAULT_OPTIONS`. */
+function noop() {
+  // This space intentionally left blank.
+}
+
+/**
+ * {object} A collection of no-op keyboard key handlers. This is the base over
+ * which custom options are layered.
+ */
+const DEFAULT_OPTIONS = {
+  bindings:   {},
+  onEnter:    noop,
+  onEscape:   noop,
+  onTab:      noop,
+};
+
+/**
+ * Additional Quill key bindings for macOS environments. There are several references to
+ * `this.quill` in these handlers. That property will be filled in by other layers before
+ * the handlers are called. It is guaranteed to be set.
+ *
+ * @returns {object} Mac-specific bindings for use when configuring Quill.
+ */
+const MAC_SPECIFIC_BINDINGS = Object.freeze({
+  home: {
+    key: KEYMAP.HOME,
+    handler() {
+      // Set selection to beginning of document.
+      this.quill.setSelection(0, 0);
+    },
+  },
+
+  shiftHome: {
+    key: KEYMAP.HOME,
+    shiftKey: true,
+    handler(range) {
+      // Expand selection to the start of the document.
+      this.quill.setSelection(0, range.index + range.length);
+    },
+  },
+
+  end: {
+    key: KEYMAP.END,
+    handler() {
+      // Set selection to the end of the document.
+      this.quill.setSelection(this.quill.getLength(), 0);
+    },
+  },
+
+  shiftEnd: {
+    key: KEYMAP.END,
+    shiftKey: true,
+    handler(range) {
+      // Expand selection to to the end of the document.
+      this.quill.setSelection(range.index, this.quill.getLength() - range.index);
+    },
+  },
+});
+
+/**
+ * Returns `true` if the client environment is macOS, or `false` if it is not or
+ * if the environment cannot be determined.
+ *
+ * @returns {boolean} Whether the client environment is macOS or not.
+ */
+function isMac() {
+  const window = ClientEnv.window;
+  let result = false;
+
+  if (window) {
+    const userAgentString = window.navigator.userAgent;
+
+    result = /Mac/i.test(userAgentString);
+  }
+
+  return result;
+}
+
+/**
+ * Configuration for the Quill Keyboard module. We must pass these binding into
+ * the configuration to have them run before Quill's built-in key bindings.
+ * Otherwise Quill swallows certain key events such as `enter`.
+ *
+ * @param {object} options The configuration options.
+ * @returns {object} The early bindings.
+ */
+function getEarlyBindings({ onEnter, onTab }) {
+  const bindings = {
+    enter: {
+      key: KEYMAP.ENTER,
+      context: {
+        empty: false,
+      },
+      handler: () => onEnter(),
+    },
+
+    shiftEnter: {
+      key: KEYMAP.ENTER,
+      shiftKey: true,
+      context: {
+        empty: false,
+      },
+      handler: () => onEnter({ shiftKey: true }),
+    },
+
+    optionEnter: {
+      key: KEYMAP.ENTER,
+      altKey: true,
+      handler: () => onEnter({ altKey: true }),
+    },
+
+    ctrlEnter: {
+      key: KEYMAP.ENTER,
+      ctrlKey: true,
+      handler: () => onEnter({ ctrlKey: true }),
+    },
+
+    tab: {
+      key: KEYMAP.TAB,
+      handler: () => onTab({ shiftKey: false }),
+    },
+
+    shiftTab: {
+      key: KEYMAP.TAB,
+      shiftKey: true,
+      handler: () => onTab({ shiftKey: true }),
+    },
+  };
+
+  if (isMac()) {
+    return Object.assign(bindings, MAC_SPECIFIC_BINDINGS);
+  }
+
+  return bindings;
+}
+
+/**
+ * Bindings that should run after default Quill bindings.
+ *
+ * @param {object} options The configuration options.
+ * @returns {object} The late bindings.
+*/
+function getLateBindings({ onEscape }) {
+  return {
+    escape: {
+      key: KEYMAP.ESCAPE,
+      handler: () => onEscape(),
+    }
+  };
+}
+
+/**
+ * A subclass of the Quill keyboard module. The purpose of this subclass is to
+ * extend Quill with methods such as `onEnter(metaKeys)`, `onEsc(metaKeys)`,
+ * etc. so that custom behaviors for various configurations can be defined
+ * merely by passing in an appropriately named function to override the default
+ * handler behavior.
+ *
+ * For instance, if you wanted a version of the editor that only allowed a
+ * single line of input then you'd only need to pass in a configuration object
+ * that overrides `onEnter(metaKeys)` so that it ignored the return/enter key.
+ * This greatly simplifies the process of modifying keyboard behavior.
+ */
+export default class BayouKeyboard extends Keyboard {
+  /**
+   * {object} Map from key names to integer keycodes. This is a frozen
+   * (immutable) value.
+   */
+  static get KEYMAP() {
+    return KEYMAP;
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {Quill} quill The quill instance to attach to.
+   * @param {object} options Key handling configuration options.
+   */
+  constructor(quill, options) {
+    let opts = options;
+
+    opts = Object.assign({}, DEFAULT_OPTIONS, opts);
+
+    // Get the bindings that run before Quill's own.
+    const earlyBindings = getEarlyBindings(opts);
+    opts.bindings = Object.assign({}, opts.bindings, earlyBindings);
+
+    // Add our events before Quill has a chance to add its own.
+    quill.root.addEventListener('keydown', (e) => {
+      // Quill will not stop propagation on keyboard events. Hitting HOME or END
+      // will result in the editor window scrolling up or down unless we
+      // specifically stop propagation on those events.
+      if (   (e.keyCode === KEYMAP.HOME || e.keyCode === KEYMAP.END)
+          && (quill.getLength() > 1)) {
+        e.stopPropagation();
+      }
+    });
+
+    super(quill, opts);
+
+    const lateBindings = getLateBindings(opts);
+
+    Object.keys(lateBindings).forEach((name) => {
+      this.addBinding(lateBindings[name]);
+    });
+  }
+}

--- a/local-modules/quill-util/main.js
+++ b/local-modules/quill-util/main.js
@@ -2,9 +2,18 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import BayouKeyHandlers from './BayouKeyHandlers';
+import BayouKeyboard from './BayouKeyboard';
 import QuillEvent from './QuillEvent';
 import QuillGeometry from './QuillGeometry';
 import QuillProm from './QuillProm';
 import QuillUtil from './QuillUtil';
 
-export { QuillEvent, QuillGeometry, QuillProm, QuillUtil };
+export {
+  BayouKeyHandlers,
+  BayouKeyboard,
+  QuillEvent,
+  QuillGeometry,
+  QuillProm,
+  QuillUtil
+};

--- a/local-modules/quill-util/main.js
+++ b/local-modules/quill-util/main.js
@@ -9,6 +9,10 @@ import QuillGeometry from './QuillGeometry';
 import QuillProm from './QuillProm';
 import QuillUtil from './QuillUtil';
 
+// Register this module's keyboard handler as an override of Quill's built-in
+// one.
+QuillProm.register({ 'modules/keyboard': BayouKeyboard }, true);
+
 export {
   BayouKeyHandlers,
   BayouKeyboard,


### PR DESCRIPTION
This PR adds a new subclass of Quill's built-in keyboard module, along with a use of it. The subclass makes it easy to override behavior of specific keys. The first use of it is to make it so that the `enter` key is a no-op when editing the title field (because we only want to support single-line titles).

The new code is based on work by @haugstrup, @ainjii, and @montlebalm; and was adapted for use here mostly by @meantime (and a bit by me).

**Bonus:** Caret-related tweaks that I probably should have included with my last PR.