### PR TITLE
Fix keyboard stuff I broke.

### DIFF
--- a/local-modules/quill-util/BayouKeyboard.js
+++ b/local-modules/quill-util/BayouKeyboard.js
@@ -50,6 +50,7 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
     handler() {
       // Set selection to beginning of document.
       this.quill.setSelection(0, 0);
+      return false;
     }
   },
 
@@ -59,6 +60,7 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
     handler(range) {
       // Expand selection to the start of the document.
       this.quill.setSelection(0, range.index + range.length);
+      return false;
     }
   },
 
@@ -67,6 +69,7 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
     handler() {
       // Set selection to the end of the document.
       this.quill.setSelection(this.quill.getLength(), 0);
+      return false;
     }
   },
 
@@ -76,6 +79,7 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
     handler(range) {
       // Expand selection to to the end of the document.
       this.quill.setSelection(range.index, this.quill.getLength() - range.index);
+      return false;
     }
   }
 });

--- a/local-modules/quill-util/BayouKeyboard.js
+++ b/local-modules/quill-util/BayouKeyboard.js
@@ -32,9 +32,9 @@ const KEYMAP = Object.freeze({
  */
 const DEFAULT_OPTIONS = {
   bindings:  {},
-  onEnter()  { /*empty*/ },
-  onEscape() { /*empty*/ },
-  onTab()    { /*empty*/ }
+  onEnter()  { return true; },
+  onEscape() { return true; },
+  onTab()    { return true; }
 };
 
 /**

--- a/local-modules/quill-util/BayouKeyboard.js
+++ b/local-modules/quill-util/BayouKeyboard.js
@@ -157,37 +157,37 @@ export default class BayouKeyboard extends Keyboard {
       enter: {
         key:      KEYMAP.ENTER,
         context:  { empty: false },
-        handler() { onEnter(); }
+        handler() { return onEnter(); }
       },
 
       shiftEnter: {
         key:      KEYMAP.ENTER,
         shiftKey: true,
         context:  { empty: false },
-        handler() { onEnter({ shiftKey: true }); }
+        handler() { return onEnter({ shiftKey: true }); }
       },
 
       optionEnter: {
         key:      KEYMAP.ENTER,
         altKey:   true,
-        handler() { onEnter({ altKey: true }); }
+        handler() { return onEnter({ altKey: true }); }
       },
 
       ctrlEnter: {
         key:      KEYMAP.ENTER,
         ctrlKey:  true,
-        handler() { onEnter({ ctrlKey: true }); }
+        handler() { return onEnter({ ctrlKey: true }); }
       },
 
       tab: {
         key:      KEYMAP.TAB,
-        handler() { onTab({ shiftKey: false }); }
+        handler() { return onTab({ shiftKey: false }); }
       },
 
       shiftTab: {
         key:      KEYMAP.TAB,
         shiftKey: true,
-        handler() { onTab({ shiftKey: true }); }
+        handler() { return onTab({ shiftKey: true }); }
       }
     };
 
@@ -209,7 +209,7 @@ export default class BayouKeyboard extends Keyboard {
     return {
       escape: {
         key:      KEYMAP.ESCAPE,
-        handler() { onEscape(); }
+        handler() { return onEscape(); }
       }
     };
   }

--- a/local-modules/quill-util/package.json
+++ b/local-modules/quill-util/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
-    "quill": "^1.1.7",
+    "quill": "^1.3.1",
 
     "doc-common": "local",
     "typecheck": "local",


### PR DESCRIPTION
Not sure how I managed to not catch it, but I broke keyboard event propagation in the earlier keyboard-related PR. This on fixes the problem, and also tweaks things to help prevent future surprises and generally make the code just a wee bit more obvious.

**Bonus:** Updated the `quill` dependency spec to be what we're actually getting in practice. (This basically acts as a "known good version" indicator.)