### PR TITLE
Sort stuff

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -123,6 +123,30 @@ taking into account recent additions to the language.
   guarantees. Additionally, instead of explicitly constructing singletons,
   the convention is to use the static property `theOne` on the so-defined class.
 
+* Order of definitions &mdash; The canonical ordering of definitions in class
+  bodies is as follows. Within each "leaf" section, items are sorted
+  alphabetically. The intent of this is to make it easy to find stuff when
+  browsing the code.
+
+  * Public properties
+    * static
+      * synthetic fields
+      * methods
+    * constructor
+    * instance
+      * synthetic fields
+      * methods
+  * Private properties
+    * static
+      * synthetic fields
+      * methods
+    * instance
+      * synthetic fields
+      * methods
+
+  As an exception, methods that only serve as helpers for one other method will
+  sometimes get located immediately below the method being helped.
+
 #### Other items
 
 * Websockets &mdash; JavaScript has a `WebSocket` class, but when talking about

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -137,15 +137,18 @@ taking into account recent additions to the language.
       * synthetic fields
       * methods
   * Private properties
-    * static
+    * instance
       * synthetic fields
       * methods
-    * instance
+    * static
       * synthetic fields
       * methods
 
   As an exception, methods that only serve as helpers for one other method will
   sometimes get located immediately below the method being helped.
+
+  Roughly speaking, you can think of this as an "instance sandwich on static
+  bread."
 
 #### Other items
 

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -199,48 +199,6 @@ export default class CaretStorage extends CommonBase {
   }
 
   /**
-   * Main implementation of `whenRemoteChange()`, see which for details.
-   *
-   * @returns {boolean} `true` if a change was detected, or `false` if not.
-   */
-  async _whenRemoteChange() {
-    const startSnapshot = this.remoteSnapshot();
-    const timeoutAt = Date.now() + REMOTE_CHANGE_TIMEOUT_MSEC;
-
-    // Loop until change detected or timeout.
-    for (;;) {
-      const now = Date.now();
-      if (now >= timeoutAt) {
-        break;
-      }
-
-      // Wait until the next allowed caret read, or figure out that we don't
-      // need to wait at all.
-      const readDelay = (this._lastReadTime + READ_DELAY_MSEC) - now;
-      if (readDelay > 0) {
-        this._log.info(`Pre-read wait in \`whenRemoteChange\`: ${readDelay} msec`);
-        // Wait the prescribed amount of time.
-        await Delay.resolve(readDelay);
-      } else {
-        // No need to wait. Just indicate that a read should be in progress, and
-        // wait for it to be done.
-        this._log.info('Waiting for read results in `whenRemoteChange`.');
-        await this._needsRead();
-      }
-
-      const newSnapshot = this.remoteSnapshot();
-      if (!newSnapshot.equals(startSnapshot)) {
-        // Yes, there was a change!
-        return true;
-      }
-    }
-
-    // No change detected, and we timed out.
-    this._log.info('Timeout reached in `whenRemoteChange`.');
-    return false;
-  }
-
-  /**
    * Indicates that caret information should be read from file storage. This
    * will ultimately cause such reading to be done.
    *
@@ -488,5 +446,47 @@ export default class CaretStorage extends CommonBase {
 
     this._storedCarets = storedCarets;
     this._log.info('Carets are now updated in storage.');
+  }
+
+  /**
+   * Main implementation of `whenRemoteChange()`, see which for details.
+   *
+   * @returns {boolean} `true` if a change was detected, or `false` if not.
+   */
+  async _whenRemoteChange() {
+    const startSnapshot = this.remoteSnapshot();
+    const timeoutAt = Date.now() + REMOTE_CHANGE_TIMEOUT_MSEC;
+
+    // Loop until change detected or timeout.
+    for (;;) {
+      const now = Date.now();
+      if (now >= timeoutAt) {
+        break;
+      }
+
+      // Wait until the next allowed caret read, or figure out that we don't
+      // need to wait at all.
+      const readDelay = (this._lastReadTime + READ_DELAY_MSEC) - now;
+      if (readDelay > 0) {
+        this._log.info(`Pre-read wait in \`whenRemoteChange\`: ${readDelay} msec`);
+        // Wait the prescribed amount of time.
+        await Delay.resolve(readDelay);
+      } else {
+        // No need to wait. Just indicate that a read should be in progress, and
+        // wait for it to be done.
+        this._log.info('Waiting for read results in `whenRemoteChange`.');
+        await this._needsRead();
+      }
+
+      const newSnapshot = this.remoteSnapshot();
+      if (!newSnapshot.equals(startSnapshot)) {
+        // Yes, there was a change!
+        return true;
+      }
+    }
+
+    // No change detected, and we timed out.
+    this._log.info('Timeout reached in `whenRemoteChange`.');
+    return false;
   }
 }

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -120,19 +120,19 @@ export default class FileComplex extends CommonBase {
   }
 
   /**
-   * {string} The document schema version to use for new documents and to expect
-   * in existing documents.
-   */
-  get schemaVersion() {
-    return this._schemaVersion;
-  }
-
-  /**
    * {Logger} Logger to use with this instance. It prefixes logged items with
    * the file's ID.
    */
   get log() {
     return this._log;
+  }
+
+  /**
+   * {string} The document schema version to use for new documents and to expect
+   * in existing documents.
+   */
+  get schemaVersion() {
+    return this._schemaVersion;
   }
 
   /**

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -53,6 +53,19 @@ export default class Paths extends UtilityClass {
   }
 
   /**
+   * Gets the `StoragePath` string corresponding to the indicated session,
+   * specifically to store caret data for that session.
+   *
+   * @param {string} sessionId The session ID.
+   * @returns {string} The corresponding `StoragePath` string for caret
+   *   information.
+   */
+  static forCaret(sessionId) {
+    TString.check(sessionId);
+    return `${Paths.CARET_SESSION_PREFIX}/${sessionId}`;
+  }
+
+  /**
    * Gets the `StoragePath` string corresponding to the indicated revision
    * number, specifically to store the document change that results in that
    * revision.
@@ -64,19 +77,6 @@ export default class Paths extends UtilityClass {
   static forDocumentChange(revNum) {
     RevisionNumber.check(revNum);
     return `${Paths.CHANGE_PREFIX}/${revNum}`;
-  }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated session,
-   * specifically to store caret data for that session.
-   *
-   * @param {string} sessionId The session ID.
-   * @returns {string} The corresponding `StoragePath` string for caret
-   *   information.
-   */
-  static forCaret(sessionId) {
-    TString.check(sessionId);
-    return `${Paths.CARET_SESSION_PREFIX}/${sessionId}`;
   }
 
   /**


### PR DESCRIPTION
Concentration has been difficult in my immediate environs, so I just took the opportunity to do some fairly mechanical code maintenance…

This cleans up the method ordering in a few files, and adds documentation for the de facto dominant ordering in the codebase.