### PR TITLE
Author overlay alignment.

### DIFF
--- a/client/assets/static/content.css
+++ b/client/assets/static/content.css
@@ -23,18 +23,10 @@ html.bayou-page {
 
 /* Top-level container for all the nodes for a single editor "complex." */
 .bayou-top {
-  /*
-   * When not given any offset, specifying `position: relative` is equivalent to
-   * not saying `position` at all, with one exception: Enclosed nodes that have
-   * `position: absolute` are defined to actually mean "relative with respect to
-   * the closest enclosing explicitly positioned node." So, by doing this, we
-   * are arranging for the enclosed author overlay to find this node and not
-   * walk all the way up to the root node.
-   */
-  position: relative;
+  /* Nothing needed here... yet. */
 }
 
-/* Container for the Quill editor for the document title field */
+/* Container for the Quill editor for the document title field. */
 .bayou-title-editor .ql-editor {
   color: #2c2d30;
   font-weight: 900;
@@ -55,6 +47,43 @@ html.bayou-page {
 .bayou-title-editor .ql-editor a:hover {
   text-decoration:       underline;
   text-decoration-color: #007ab8;
+}
+
+/*
+ * Container for the editor "body." Within this container are the main text
+ * and the author overlay.
+ */
+.bayou-body {
+  /*
+   * When not given any offset, specifying `position: relative` is equivalent to
+   * not saying `position` at all, with one exception: Enclosed nodes that have
+   * `position: absolute` are defined to actually mean "relative with respect to
+   * the closest enclosing explicitly positioned node." So, by doing this, we
+   * are arranging for the enclosed author overlay to find this node and not
+   * walk further up the containership hierarchy.
+   */
+  position: relative;
+}
+
+/*
+ * The <svg> layer on top of the Quill editor that is used to show things such
+ * as remote author highlights.
+ */
+.bayou-author-overlay {
+  /*
+   * This positions the author overlay with respect to the outer node being
+   * managed here, sizing it to exactly match it, which means (by construction)
+   * that it exactly overlays the actual editor.
+   */
+  position: absolute;
+  width:    100%;
+  height:   100%;
+  left:     0px;
+  top:      0px;
+  z-index:  2;
+
+  /* The editor, not this node, is what listens to pointer events. */
+  pointer-events: none;
 }
 
 /* Container for the Quill editor for the document body text. */
@@ -100,27 +129,6 @@ html.bayou-page {
   font-size:     1.125rem;
   line-height:   1.75rem;
   margin-bottom: 1.75rem;
-}
-
-/*
- * The <svg> layer on top of the Quill editor that is used to show things such
- * as remote author highlights.
- */
-.bayou-author-overlay {
-  /*
-   * This positions the author overlay with respect to the outer node being
-   * managed here, sizing it to exactly match it, which means (by construction)
-   * that it exactly overlays the actual editor.
-   */
-  position: absolute;
-  width:    100%;
-  height:   100%;
-  left:     0px;
-  top:      0px;
-  z-index:  2;
-
-  /* The editor, not this node, is what listens to pointer events. */
-  pointer-events: none;
 }
 
 /*

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -115,8 +115,8 @@ export default class EditorComplex extends CommonBase {
       });
 
       // Let the overlay do extra initialization.
-      Hooks.theOne.quillInstanceInit(this._titleQuill);
-      Hooks.theOne.quillInstanceInit(this._bodyQuill);
+      Hooks.theOne.quillInstanceInit('title', this._titleQuill);
+      Hooks.theOne.quillInstanceInit('body', this._bodyQuill);
 
       /** {CaretOverlay} The remote caret overlay controller. */
       this._caretOverlay = new CaretOverlay(this, authorOverlayNode);

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -261,6 +261,10 @@ export default class EditorComplex extends CommonBase {
     const titleNode = document.createElement('div');
     titleNode.classList.add('bayou-title-editor');
 
+    // Default title contents. **TODO:** This should be coming from the server.
+    // Remove this once that is hooked up.
+    titleNode.appendChild(document.createTextNode('Untitled'));
+
     topNode.appendChild(titleNode);
 
     // Make the node for the document body section. The most prominent part of

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -249,34 +249,39 @@ export default class EditorComplex extends CommonBase {
     await hookDone;
     log.detail('Done with async operations.');
 
-    // The "top" node that gets passed in actually ends up being a container
-    // for both the editor per se as well as other bits. The node we make here
-    // is the one that actually ends up getting controlled by Quill. The loop
-    // re-parents all the default content under the original editor to instead
-    // be under the Quill node.
-    const quillNode = document.createElement('div');
-    quillNode.classList.add('bayou-editor');
-    for (;;) {
-      const node = topNode.firstChild;
-      if (!node) {
-        break;
-      }
-      topNode.removeChild(node);
-      quillNode.appendChild(node);
+    // Remove the static content from the original "top" node (which is a
+    // "loading..." message).
+    while (topNode.firstChild) {
+      topNode.removeChild(topNode.firstChild);
     }
-    topNode.appendChild(quillNode);
 
-    // Make the author overlay node. **Note:** The wacky namespace URL is
-    // required. Without it, the "SVG" element is actually left uninterpreted.
-    const authorOverlayNode =
-      document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    authorOverlayNode.classList.add('bayou-author-overlay');
-    topNode.appendChild(authorOverlayNode);
+    // Make the node for the document title. **TODO:** This may want to expand
+    // to be a more general document header section.
 
     const titleNode = document.createElement('div');
     titleNode.classList.add('bayou-title-editor');
 
-    topNode.insertBefore(titleNode, quillNode);
+    topNode.appendChild(titleNode);
+
+    // Make the node for the document body section. The most prominent part of
+    // this section is the `<div>` managed by Quill. In addition, this is where
+    // the author overlay goes.
+
+    const bodyNode = document.createElement('div');
+    bodyNode.classList.add('bayou-body');
+    topNode.appendChild(bodyNode);
+
+    // Make the `<div>` that actually ends up getting controlled by Quill.
+    const quillNode = document.createElement('div');
+    quillNode.classList.add('bayou-editor');
+    bodyNode.appendChild(quillNode);
+
+    // Make the author overlay node. **Note:** The wacky namespace URL is
+    // required. Without it, the `<svg>` element is actually left uninterpreted.
+    const authorOverlayNode =
+      document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    authorOverlayNode.classList.add('bayou-author-overlay');
+    bodyNode.appendChild(authorOverlayNode);
 
     return [titleNode, quillNode, authorOverlayNode];
   }

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -30,10 +30,12 @@ export default class Hooks extends Singleton {
    * Called on every `Quill` instance that is constructed, just before returning
    * it to the client.
    *
+   * @param {string} contextName_unused The name of the context. This is one of
+   *   `body` (for the main editor) or `title` (for the title field editor).
    * @param {Quill} quill_unused The initialized instance (except for whatever
    *   needs to be done here).
    */
-  quillInstanceInit(quill_unused) {
+  quillInstanceInit(contextName_unused, quill_unused) {
     // This space intentionally left blank.
   }
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.23.0
+version = 0.23.1

--- a/scripts/build
+++ b/scripts/build
@@ -365,20 +365,23 @@ function do-install {
     "${progDir}/lib/fix-modules" "${baseDir}/etc/module-overlay" "${npmDir}" \
     || return 1
 
-    # Copy each of the directories that `npm` got for us.
+    # Move each of the directories that `npm` got for us into the subproject's
+    # `node_modules`.
     #
-    # **Note:** We don't just `rsync --delete` the whole `node_modules`
-    # directory, because we want to keep our local modules, and if we don't
-    # `--delete` then we could end up with weird module amalgams in cases where
-    # an external module got updated.
+    # **Note:** We don't just `mv` (or `rsync --delete`) the whole
+    # `node_modules` directory, because we want to keep our local modules, and
+    # if we don't `--delete` then we could end up with weird module amalgams in
+    # cases where an external module got updated.
 
     echo "${dir}:" 'Moving external dependencies into place...'
 
     local d
     for d in $(cd "${npmDir}/node_modules"; /bin/ls -A); do
-        rsync-archive --delete \
-            "${npmDir}/node_modules/${d}" "${toDir}/node_modules" \
-            || return 1
+        (
+            fromDir="${npmDir}/node_modules/${d}"
+            toDir="${toDir}/node_modules/${d}"
+            rm -rf "${toDir}" && mv "${fromDir}" "${toDir}"
+        ) || return 1
     done
 
     rm -rf "${npmDir}" || return 1

--- a/scripts/build
+++ b/scripts/build
@@ -369,9 +369,7 @@ function do-install {
     # `node_modules`.
     #
     # **Note:** We don't just `mv` (or `rsync --delete`) the whole
-    # `node_modules` directory, because we want to keep our local modules, and
-    # if we don't `--delete` then we could end up with weird module amalgams in
-    # cases where an external module got updated.
+    # `node_modules` directory, because we want to keep our local modules.
 
     echo "${dir}:" 'Moving external dependencies into place...'
 


### PR DESCRIPTION
This PR reworks the DOM initialization code a bit, in order to bring the author overlay back into alignment with the Quill editor `div`. In addition, I took the opportunity to clean up some of the related surrounding code.

**Bonus:** Build system tweak to speed up module installation. (Makes a difference but not a _huge_ difference.)
