### PR TITLE
Proper `when*` hygiene for remote caret reading.

### DIFF
--- a/local-modules/client-bundle/README.md
+++ b/local-modules/client-bundle/README.md
@@ -13,7 +13,7 @@ with other modules. When you import the CSS module into JavaScript
 you end up with an object that maps the class names that were in the
 CSS file to the unique name.
 
-## Basic Usage
+#### Basic Usage
 
 ```css
 /* some-component.css input */
@@ -52,7 +52,7 @@ header.classList.add(styles.megaheader);
 document.body.appendChild(header);
 ```
 
-## Reference-counted Usage
+#### Reference-counted Usage
 
 If the name of the CSS input file ends with `.ucss` (`use()`-able CSS) then it
 will not be automatically added to the DOM. Instead, it will rely on

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -19,7 +19,7 @@ import Paths from './Paths';
  * timing out. Once it performs real work, this should be changed to something
  * more like 5 minutes.
  */
-const REMOTE_CHANGE_TIMEOUT_MSEC = 60 * 1000; // 1 minute.
+const REMOTE_CHANGE_TIMEOUT_MSEC = 60 * 1000; // One minute.
 
 /**
  * {Int} How long to wait (in msec) after sessions are updated before an attempt
@@ -28,13 +28,13 @@ const REMOTE_CHANGE_TIMEOUT_MSEC = 60 * 1000; // 1 minute.
  * sharing across servers has this much more latency than sharing between
  * sessions that reside on the same machine.
  */
-const WRITE_DELAY_MSEC = 5 * 1000; // 5 seconds.
+const WRITE_DELAY_MSEC = 10 * 1000; // Ten seconds.
 
 /** {Int} How long (in msec) to wait between write retries. */
-const WRITE_RETRY_DELAY_MSEC = 10 * 1000; // Ten seconds.
+const WRITE_RETRY_DELAY_MSEC = 30 * 1000; // 30 seconds.
 
 /** {Int} How many times to retry writes. */
-const MAX_WRITE_RETRIES = 10;
+const MAX_WRITE_RETRIES = 5;
 
 /**
  * Helper class for `CaretControl` which handles the underlying file storage of

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -11,11 +11,6 @@ import FileComplex from './FileComplex';
 import Paths from './Paths';
 
 /**
- * {Int} Minimum amount of time (in msec) to wait between reading stored carets.
- */
-const READ_DELAY_MSEC = 10 * 1000; // 10 seconds.
-
-/**
  * {Int} Maximum amount of time that a call to `whenRemoteChange()` will take
  * before timing out.
  *
@@ -145,18 +140,13 @@ export default class CaretStorage extends CommonBase {
    * storage that were pushed there by other servers (that is, not by this
    * server). The resulting snapshot always has a revision number of `0`.
    *
-   * This method doesn't wait for data to be read from storage &mdash; it always
-   * returns immediately with whatever info is at hand &mdash; but if it has
-   * been a while since the data was updated, this method will fire off an
-   * asynchronous read, the results of which will eventually get integrated.
+   * This method doesn't wait for data to be read from storage; it always
+   * returns immediately with whatever info is at hand. To get the remote data
+   * to become updated, it is necessary to call `whenRemoteChange()`.
    *
    * @returns {CaretSnapshot} Snapshot of remote carets.
    */
   remoteSnapshot() {
-    if (Date.now() >= (this._lastReadTime + READ_DELAY_MSEC)) {
-      this._needsRead();
-    }
-
     let result = this._carets;
 
     for (const s of this._localSessions) {

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -13,13 +13,8 @@ import Paths from './Paths';
 /**
  * {Int} Maximum amount of time that a call to `whenRemoteChange()` will take
  * before timing out.
- *
- * **TODO:** The timeout is set to be quite low right now because the method
- * in question isn't really checking for anything, and so every call ends up
- * timing out. Once it performs real work, this should be changed to something
- * more like 5 minutes.
  */
-const REMOTE_CHANGE_TIMEOUT_MSEC = 60 * 1000; // One minute.
+const REMOTE_CHANGE_TIMEOUT_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /**
  * {Int} How long to wait (in msec) after sessions are updated before an attempt

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -46,9 +46,9 @@ export default class Transactor extends CommonBase {
 
     /**
      * {Set<string>|null} Set of paths listed while running the transaction, or
-     * `null` if the transaction has no path list operations.
+     * `null` if the transaction has no path-returning operations.
      */
-    this._paths = spec.hasListOps() ? new Set() : null;
+    this._paths = spec.hasPathOps() ? new Set() : null;
 
     /** {boolean} Whether or not this transaction has any wait operations. */
     this._hasWaitOps = spec.hasWaitOps();
@@ -323,6 +323,7 @@ export default class Transactor extends CommonBase {
     const value       = this._fileFriend.readPathOrNull(storagePath);
 
     if (value === null) {
+      this._paths.add(storagePath);
       this._waitSatisfied = true;
     }
 
@@ -340,6 +341,7 @@ export default class Transactor extends CommonBase {
     const value       = this._fileFriend.readPathOrNull(storagePath);
 
     if ((value === null) || (value.hash !== hash)) {
+      this._paths.add(storagePath);
       this._waitSatisfied = true;
     }
 
@@ -356,6 +358,7 @@ export default class Transactor extends CommonBase {
     const value       = this._fileFriend.readPathOrNull(storagePath);
 
     if (value !== null) {
+      this._paths.add(storagePath);
       this._waitSatisfied = true;
     }
 

--- a/local-modules/file-store/BaseFile.js
+++ b/local-modules/file-store/BaseFile.js
@@ -174,11 +174,11 @@ export default class BaseFile extends CommonBase {
    *   read. **Note:** Even if there was no data to read (e.g., all read
    *   operations were for non-bound paths), as long as the spec included any
    *   read operations, this property will still be present.
-   * * `paths` &mdash; If the transaction spec included any path list
+   * * `paths` &mdash; If the transaction spec included any wait or path list
    *   operations, a `Set<string>` of storage paths that resulted from the
    *   operations. **Note:** Even if there were no found paths (e.g., no
-   *   operations matched any paths), as long as the spec included any path list
-   *   operations, this property will still be present.
+   *   operations matched any paths), as long as the spec included any wait or
+   *   path list operations, this property will still be present.
    *
    * It is an error to call this method on a file that doesn't exist, in the
    * sense of the `exists()` method. That is, if `exists()` would return
@@ -218,7 +218,7 @@ export default class BaseFile extends CommonBase {
       delete result.data;
     }
 
-    if (spec.hasListOps()) {
+    if (spec.hasPathOps()) {
       if (result.paths === null) {
         throw InfoError.wtf('Improper subclass behavior: Expected non-`null` `paths`.');
       }

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -270,10 +270,13 @@ const OPERATIONS = DataUtil.deepFreeze([
  *   within a file.
  * * Data writes &mdash; A data write stores new data into a file.
  * * Waits &mdash; A wait operation blocks a transaction until some condition
- *   holds. **Note:** If a transaction includes any wait operations, it must not
- *   perform any lists, reads, deletes, or writes. If a transaction includes
- *   more than one wait operation, the transaction will complete when _any_ of
- *   the operations' conditions is satisfied.
+ *   holds. When a wait operation completes having detected one or more
+ *   conditions, the paths related to the conditions that were satisfied are
+ *   yielded in the results from the transaction. **Note:** If a transaction
+ *   includes any wait operations, it must not perform any lists, reads,
+ *   deletes, or writes. If a transaction includes more than one wait operation,
+ *   the transaction will complete when _any_ of the operations' conditions is
+ *   satisfied.
  *
  * When executed, the operations of a transaction are effectively performed in
  * order by category; but within a category there is no effective ordering.

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -62,14 +62,16 @@ export default class TransactionSpec extends CommonBase {
   }
 
   /**
-   * Indicates whether or not this instance has any path list operations, that
-   * is, any operations with category `CAT_LIST`.
+   * Indicates whether or not this instance has any operations which return
+   * path results, that is, any operations with category `CAT_LIST` or
+   * `CAT_WAIT`.
    *
-   * @returns {boolean} `true` iff there are any path list operations in this
+   * @returns {boolean} `true` iff there are any push operations in this
    *   instance.
    */
-  hasListOps() {
-    return this.opsWithCategory(FileOp.CAT_LIST).length !== 0;
+  hasPathOps() {
+    return (this.opsWithCategory(FileOp.CAT_LIST).length !== 0)
+      || (this.opsWithCategory(FileOp.CAT_WAIT).length !== 0);
   }
 
   /**


### PR DESCRIPTION
This PR reworks `CaretStorage.whenRemoteChange()` to use blocking `when*` operations instead of just polling, when looking for remote caret changes. There's further work that should be done to simplify the code and make it read more selectively, but at this point the basic structure is (arguably) correct.

**Bonus:** Minor reformatting of the Webpack config, to make it a bit more readable.