### PR TITLE
Smarter caret reading.

### DIFF
--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -82,6 +82,14 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
+   * {array<string>} Array of session IDs for all active carets. It is
+   * guaranteed to be a frozen (immutable) value.
+   */
+  get sessionIds() {
+    return Object.freeze([...this._carets.keys()]);
+  }
+
+  /**
    * Gets the caret info for the given session, if any.
    *
    * @param {string} sessionId Session in question.
@@ -89,6 +97,17 @@ export default class CaretSnapshot extends CommonBase {
    */
   caretForSession(sessionId) {
     return this._carets.get(sessionId) || null;
+  }
+
+  /**
+   * Gets whether or not this instance represents the given session.
+   *
+   * @param {string} sessionId Session in question.
+   * @returns {boolean} `true` if this instance has info for the indicated
+   *   session, or `false` if not.
+   */
+  hasSession(sessionId) {
+    return this.caretForSession(sessionId) !== null;
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -185,19 +185,10 @@ export default class CaretControl extends CommonBase {
    * Merges any new remote session info into the snapshot.
    */
   _integrateRemoteSessions() {
-    const snapshot = this._snapshot;
-    const remotes = this._caretStorage.remoteSnapshot();
+    const oldSnapshot = this._snapshot;
+    const newSnapshot = this._caretStorage.integrateRemotes(oldSnapshot);
 
-    // **TODO:** This fails to notice when remote sessions have gone away. The
-    // solution is probably to add a new method to `CaretStorage` which can do
-    // the appropriate wrangling, instead of implementing it here.
-
-    let newSnapshot = snapshot;
-    for (const c of remotes.carets) {
-      newSnapshot = newSnapshot.withCaret(c);
-    }
-
-    if (newSnapshot !== snapshot) {
+    if (newSnapshot !== oldSnapshot) {
       this._updateSnapshot(newSnapshot);
     }
   }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -188,6 +188,10 @@ export default class CaretControl extends CommonBase {
     const snapshot = this._snapshot;
     const remotes = this._caretStorage.remoteSnapshot();
 
+    // **TODO:** This fails to notice when remote sessions have gone away. The
+    // solution is probably to add a new method to `CaretStorage` which can do
+    // the appropriate wrangling, instead of implementing it here.
+
     let newSnapshot = snapshot;
     for (const c of remotes.carets) {
       newSnapshot = newSnapshot.withCaret(c);

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -302,7 +302,8 @@ export default class CaretStorage extends CommonBase {
   }
 
   /**
-   * Gets a list of the currently-known remote session IDs.
+   * Gets a list of the currently-known remote session IDs. This returns the
+   * information that is on hand and does not initiate any storage requests.
    *
    * @returns {array<string>} Array of the session IDs in question.
    */


### PR DESCRIPTION
This PR follows on from the previous one, with some of the promised improvements. Specifically, when remote caret changes are detected, the system now only does the file storage read operations that are necessary to get the updates, instead of always reading the entire caret directory. It also now understands that remote sessions sometimes go away, and that that means that the local representation of those sessions should also go away.
