### PR TITLE
`ColorUtil` and testing.

### DIFF
--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TInt, TIterable, TString } from 'typecheck';
-import { ColorSelector, CommonBase } from 'util-common';
+import { ColorUtil, CommonBase } from 'util-common';
 
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
@@ -22,7 +22,7 @@ const CARET_FIELDS = new Map([
   ['revNum',     RevisionNumber.check],
   ['index',      TInt.nonNegative],
   ['length',     TInt.nonNegative],
-  ['color',      ColorSelector.checkHexColor]
+  ['color',      ColorUtil.checkCss]
 ]);
 
 /**

--- a/local-modules/doc-server/CaretColor.js
+++ b/local-modules/doc-server/CaretColor.js
@@ -2,8 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from 'typecheck';
-import { StringUtil, UtilityClass } from 'util-common';
+import { ColorUtil, StringUtil, UtilityClass } from 'util-common';
 
 /**
  * {number} Saturation (in the HSL color model) of colors returned by this
@@ -51,13 +50,13 @@ export default class CaretColor extends UtilityClass {
     if (usedColors.length === 0) {
       // No other colors to avoid. Just reduce the seed to a hue directly.
       const hue = seed % 360;
-      return CaretColor._hslToRgb(hue, COLOR_SATURATION, COLOR_LEVEL);
+      return ColorUtil.hslToCss(hue, COLOR_SATURATION, COLOR_LEVEL);
     }
 
     // All the used hues, sorted by hue and with the first and last hue
     // duplicated onto ends to make distance calculations easy. **Note:**
     // Without a sort function argument, `Array.sort()` sorts in string order.
-    const usedHues = usedColors.map(CaretColor._hueFromColor).sort((h1, h2) => {
+    const usedHues = usedColors.map(ColorUtil.hueFromCss).sort((h1, h2) => {
       if      (h1 < h2) { return -1; }
       else if (h1 > h2) { return 1;  }
       else              { return 0;  }
@@ -95,78 +94,6 @@ export default class CaretColor extends UtilityClass {
     // Pick one of the top N based on the seed.
     const hue = candidateHues[seed % TOP_CANDIDATES].hue;
 
-    return CaretColor._hslToRgb(hue, COLOR_SATURATION, COLOR_LEVEL);
-  }
-
-  /**
-   * Converts a value in the range `[0..255]` to a two-digit hex string.
-   *
-   * @param {Int} value The number to convert. It should be in the range
-   *   `[0..255]`, although no error checking is performed.
-   * @returns {string} The value converted to a hexadecimal byte string.
-   */
-  static _hexByte(value) {
-    return `${(value < 16) ? '0' : ''}${value.toString(16)}`;
-  }
-
-  /**
-   * Converts an HSL color value to RGB.
-   *
-   * @param {number} hue The hue, which must be in the range `[0..360)`.
-   * @param {number} saturation The saturation, which must be in the range
-   *   `[0..1]`.
-   * @param {number} level The level, which must be in the range `[0..1]`.
-   * @returns {string} The color value as a CSS hex string.
-   */
-  static _hslToRgb(hue, saturation, level) {
-    // Algorithm taken from
-    // <https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL>.
-    const c = (1.0 - Math.abs((2.0 * level) - 1.0) * saturation);
-    const huePrime = hue / 60.0;
-    const x = c * (1.0 - Math.abs((huePrime % 2) - 1.0));
-    const m = level - (c / 2.0);
-
-    let red = 0;
-    let green = 0;
-    let blue = 0;
-
-    if      (huePrime <= 1) { red = c; green = x; blue = 0; }
-    else if (huePrime <= 2) { red = x; green = c; blue = 0; }
-    else if (huePrime <= 3) { red = 0; green = c; blue = x; }
-    else if (huePrime <= 4) { red = 0; green = x; blue = c; }
-    else if (huePrime <= 5) { red = x; green = 0; blue = c; }
-    else                    { red = c; green = 0; blue = x; }
-
-    red   = CaretColor._hexByte(Math.floor((red + m)   * 255));
-    green = CaretColor._hexByte(Math.floor((green + m) * 255));
-    blue  = CaretColor._hexByte(Math.floor((blue + m)  * 255));
-
-    return `#${red}${green}${blue}`;
-  }
-
-  /**
-   * Extracts the hue component from an RGB color.
-   *
-   * @param {string} color The color, in CSS hex form.
-   * @returns {number} The hue, as an angle in degrees, in the range `[0..360)`.
-   */
-  static _hueFromColor(color) {
-    TString.check(color, /^#[0-9a-f]{6}$/);
-
-    // Algorithm taken from
-    // <https://en.wikipedia.org/wiki/HSL_and_HSV#Hue_and_chroma>.
-
-    const rgb    = parseInt(color.slice(1), 16);
-    const r      = rgb >> 16;
-    const g      = (rgb >> 8) & 0xff;
-    const b      = rgb & 0xff;
-
-    const alpha  = 0.5 * ((r * 2) - g - b);
-    const beta   = (Math.sqrt(3) / 2) * (g - b);
-    const hue    = Math.atan2(beta, alpha);
-
-    // `hue` above is in radians in the range `[-PI..PI)`, and we want degrees
-    // in the range `[0..360)`.
-    return ((hue / (Math.PI * 2) * 360) + 360) % 360;
+    return ColorUtil.hslToCss(hue, COLOR_SATURATION, COLOR_LEVEL);
   }
 }

--- a/local-modules/doc-server/CaretColor.js
+++ b/local-modules/doc-server/CaretColor.js
@@ -50,7 +50,7 @@ export default class CaretColor extends UtilityClass {
     if (usedColors.length === 0) {
       // No other colors to avoid. Just reduce the seed to a hue directly.
       const hue = seed % 360;
-      return ColorUtil.hslToCss(hue, COLOR_SATURATION, COLOR_LEVEL);
+      return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LEVEL);
     }
 
     // All the used hues, sorted by hue and with the first and last hue
@@ -94,6 +94,6 @@ export default class CaretColor extends UtilityClass {
     // Pick one of the top N based on the seed.
     const hue = candidateHues[seed % TOP_CANDIDATES].hue;
 
-    return ColorUtil.hslToCss(hue, COLOR_SATURATION, COLOR_LEVEL);
+    return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LEVEL);
   }
 }

--- a/local-modules/doc-server/CaretColor.js
+++ b/local-modules/doc-server/CaretColor.js
@@ -11,11 +11,11 @@ import { ColorUtil, StringUtil, UtilityClass } from 'util-common';
 const COLOR_SATURATION = 1.0;
 
 /**
- * {number} Level (in the HSL color model) of colors returned by this class.
- * Because HSL is biconic, a level of 50% is actually full saturation. The 87.5%
- * we use here makes all the colors pastels.
+ * {number} Lightness (in the HSL color model) of colors returned by this class.
+ * Because HSL is biconic, a lightness of 50% is actually full saturation. The
+ * 87.5% we use here makes all the colors pastels.
  */
-const COLOR_LEVEL = 0.875;
+const COLOR_LIGHTNESS = 0.875;
 
 /** {Int} Number of initial candidate hues to use, when picking a new color. */
 const INITIAL_CANDIDATES = 36; // That is, 10 degrees difference per candidate.
@@ -50,7 +50,7 @@ export default class CaretColor extends UtilityClass {
     if (usedColors.length === 0) {
       // No other colors to avoid. Just reduce the seed to a hue directly.
       const hue = seed % 360;
-      return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LEVEL);
+      return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LIGHTNESS);
     }
 
     // All the used hues, sorted by hue and with the first and last hue
@@ -94,6 +94,6 @@ export default class CaretColor extends UtilityClass {
     // Pick one of the top N based on the seed.
     const hue = candidateHues[seed % TOP_CANDIDATES].hue;
 
-    return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LEVEL);
+    return ColorUtil.cssFromHsl(hue, COLOR_SATURATION, COLOR_LIGHTNESS);
   }
 }

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -39,11 +39,11 @@ export default class ColorSelector {
     this._saturation = 1.0;
 
     /**
-     * {number} The level; the L component of an HSV color. Because HSL is biconic, a level
-     * of 50% is actually full saturation. The 87.5% we use here makes all the colors
-     * pastels.
+     * {number} The lightness; the L component of an HSV color. Because HSL is
+     * biconic, a lightness of 50% is actually full saturation. The 87.5% we use
+     * here makes all the colors pastels.
      */
-    this._level = 0.875;
+    this._lightness = 0.875;
 
     /**
      * {number} The angular amount, in degrees, that we'll advance the hue for each color.
@@ -58,15 +58,15 @@ export default class ColorSelector {
    */
   nextCssColor() {
     const hsl = this.nextColorHSL();
-    return ColorUtil.cssFromHsl(hsl.hue, hsl.saturation, hsl.level);
+    return ColorUtil.cssFromHsl(hsl.hue, hsl.saturation, hsl.lightness);
   }
 
   /**
    * Returns the next color in the progression in HSL form.
    *
    * @returns {object} The color value. The object returned will have keys of
-   * `hue`, `saturation`, and `level`. Hue is an integer `[0 .. 360)`; saturation and level
-   * are numbers from `[0.0 .. 1.0]`.
+   * `hue`, `saturation`, and `lightness`. Hue is an integer `[0 .. 360)`;
+   * saturation and lightness are numbers from `[0.0 .. 1.0]`.
    */
   nextColorHSL() {
     return this._nextColor();
@@ -79,7 +79,7 @@ export default class ColorSelector {
    * @returns {object} The HSL color value.
    */
   _nextColor() {
-    const result = { hue: this._hue, saturation: this._saturation, level: this._level };
+    const result = { hue: this._hue, saturation: this._saturation, lightness: this._lightness };
 
     this._advance();
 

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -39,7 +39,7 @@ export default class ColorSelector {
     this._saturation = 1.0;
 
     /**
-     * {number} The lightness; the L component of an HSV color. Because HSL is
+     * {number} The lightness; the L component of an HSL color. Because HSL is
      * biconic, a lightness of 50% is actually full saturation. The 87.5% we use
      * here makes all the colors pastels.
      */

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -58,7 +58,7 @@ export default class ColorSelector {
    */
   nextCssColor() {
     const hsl = this.nextColorHSL();
-    return ColorUtil.hslToCss(hsl.hue, hsl.saturation, hsl.level);
+    return ColorUtil.cssFromHsl(hsl.hue, hsl.saturation, hsl.level);
   }
 
   /**

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -2,13 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from 'typecheck';
-
-/**
- * {RegExp} Regular expression that can be used to validate colors that are
- * expected to be in CSS three-byte hex format (e.g. `'#fe8ef1'`).
- */
-const HEX_COLOR_REGEXP = /^#[a-fA-F0-9]{6}$/;
+import ColorUtil from './ColorUtil';
 
 /**
  * Generator of an unending progression of colors. The original
@@ -25,17 +19,6 @@ const HEX_COLOR_REGEXP = /^#[a-fA-F0-9]{6}$/;
  * pastel range.
  */
 export default class ColorSelector {
-  /**
-   * Checks whether a given string matches this module's requirements form
-   * color hex strings.
-   *
-   * @param {string} hexColor The string to check.
-   * @returns {string} Returns the input as-is if it meets requirements.
-   */
-  static checkHexColor(hexColor) {
-    return TString.check(hexColor, HEX_COLOR_REGEXP);
-  }
-
   /**
    * Constructs a new ColorSelector object.
    *
@@ -69,44 +52,13 @@ export default class ColorSelector {
   }
 
   /**
-   * Returns the next color in the form of a CSS hex color value (e.g. #70E4FE for a pastel blue).
-   *
-   * @returns {string} The hex string color value.
-   */
-  nextColorHex() {
-    const rgb = this.nextColorRGB();
-    const r = this._hexByte(rgb.red);
-    const b = this._hexByte(rgb.blue);
-    const g = this._hexByte(rgb.green);
-
-    return '#' + r + g + b;
-  }
-
-  /**
-   * Converts a value from 0-255 to a hex string in the range '00' .. 'ff'
-   *
-   * @param {number} value The number to convert. It should be in the range
-   * of 0 .. 255, although no error checking is performed.
-   * @returns {string} The value converted to a hexadecimal byte string.
-   */
-  _hexByte(value) {
-    const prefix = value < 16 ? '0' : '';
-
-    return prefix + Number(value).toString(16);
-  }
-
-  /**
    * Returns the next color in the progression in RGB form.
    *
-   * @returns {object} The color value. The object returned will have keys of
-   * `red`, `green`, and `blue`. The values for each key will be an integer
-   * from `[0 .. 255]`.
+   * @returns {string} The color value, as a CSS hex string.
    */
-  nextColorRGB() {
+  nextCssColor() {
     const hsl = this.nextColorHSL();
-    const rgb = this._HSLToRGB(hsl);
-
-    return rgb;
+    return ColorUtil.hslToCss(hsl.hue, hsl.saturation, hsl.level);
   }
 
   /**
@@ -118,41 +70,6 @@ export default class ColorSelector {
    */
   nextColorHSL() {
     return this._nextColor();
-  }
-
-  /**
-   * Converts an HSL color value to RGB.
-   *
-   * @param {object} hsl The HSL color value to convert. The value must have keys of
-   * `hue`, `saturation`, and `level`. Hue is an integer `[0 .. 360)`; saturation and level
-   * are numbers from `[0.0 .. 1.0]`. No validation of the input is performed.
-   * @returns {object} The color value. The object returned will have keys of
-   * `red`, `green`, and `blue`. The values for each key will be an integer
-   * from `[0 .. 255]`.
-   */
-  _HSLToRGB(hsl) {
-    // Algorithm taken from https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL
-    const c = (1.0 - Math.abs((2.0 * hsl.level) - 1.0) * hsl.saturation);
-    const huePrime = hsl.hue / 60.0;
-    const x = c * (1.0 - Math.abs((huePrime % 2) - 1.0));
-    const m = hsl.level - (c / 2.0);
-
-    let red = 0;
-    let green = 0;
-    let blue = 0;
-
-    if      (huePrime <= 1) { red = c; green = x; blue = 0; }
-    else if (huePrime <= 2) { red = x; green = c; blue = 0; }
-    else if (huePrime <= 3) { red = 0; green = c; blue = x; }
-    else if (huePrime <= 4) { red = 0; green = x; blue = c; }
-    else if (huePrime <= 5) { red = x; green = 0; blue = c; }
-    else                    { red = c; green = 0; blue = x; }
-
-    return {
-      red:   Math.floor((red + m) * 255),
-      green: Math.floor((green + m) * 255),
-      blue:  Math.floor((blue + m) * 255),
-    };
   }
 
   /**

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -36,7 +36,7 @@ export default class ColorUtil extends UtilityClass {
    *   `[0..1]`.
    * @returns {string} The color value as a CSS hex string.
    */
-  static hslToCss(hue, saturation, lightness) {
+  static cssFromHsl(hue, saturation, lightness) {
     // Algorithm taken from
     // <https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL>.
     const c = (1.0 - Math.abs((2.0 * lightness) - 1.0)) * saturation;

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -1,0 +1,100 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+import { UtilityClass } from 'util-common-base';
+
+/**
+ * {RegExp} Regular expression that can be used to validate colors that are
+ * expected to be in CSS three-byte hex format (e.g., `#fe8ef1`).
+ */
+const CSS_COLOR_REGEXP = /^#[a-f0-9]{6}$/;
+
+/**
+ * Color manipulation utilities.
+ */
+export default class ColorUtil extends UtilityClass {
+  /**
+   * Checks whether a given string matches this module's requirements for a
+   * CSS-style color hex string.
+   *
+   * @param {string} hexColor The string to check.
+   * @returns {string} The input as-is if it meets requirements.
+   */
+  static checkCss(hexColor) {
+    return TString.check(hexColor, CSS_COLOR_REGEXP);
+  }
+
+  /**
+   * Converts an HSL color value to RGB in CSS hex string form.
+   *
+   * @param {number} hue The hue, which must be in the range `[0..360)`.
+   * @param {number} saturation The saturation, which must be in the range
+   *   `[0..1]`.
+   * @param {number} level The level, which must be in the range `[0..1]`.
+   * @returns {string} The color value as a CSS hex string.
+   */
+  static hslToCss(hue, saturation, level) {
+    // Algorithm taken from
+    // <https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL>.
+    const c = (1.0 - Math.abs((2.0 * level) - 1.0) * saturation);
+    const huePrime = hue / 60.0;
+    const x = c * (1.0 - Math.abs((huePrime % 2) - 1.0));
+    const m = level - (c / 2.0);
+
+    let red = 0;
+    let green = 0;
+    let blue = 0;
+
+    if      (huePrime <= 1) { red = c; green = x; blue = 0; }
+    else if (huePrime <= 2) { red = x; green = c; blue = 0; }
+    else if (huePrime <= 3) { red = 0; green = c; blue = x; }
+    else if (huePrime <= 4) { red = 0; green = x; blue = c; }
+    else if (huePrime <= 5) { red = x; green = 0; blue = c; }
+    else                    { red = c; green = 0; blue = x; }
+
+    red   = ColorUtil._hexByte(Math.floor((red   + m) * 255));
+    green = ColorUtil._hexByte(Math.floor((green + m) * 255));
+    blue  = ColorUtil._hexByte(Math.floor((blue  + m) * 255));
+
+    return `#${red}${green}${blue}`;
+  }
+
+  /**
+   * Extracts the hue component from an RGB color.
+   *
+   * @param {string} color The color, in CSS hex form.
+   * @returns {number} The hue, as an angle in degrees, in the range `[0..360)`.
+   */
+  static hueFromCss(color) {
+    ColorUtil.checkCss(color);
+
+    // Algorithm taken from
+    // <https://en.wikipedia.org/wiki/HSL_and_HSV#Hue_and_chroma>.
+
+    const rgb    = parseInt(color.slice(1), 16);
+    const r      = rgb >> 16;
+    const g      = (rgb >> 8) & 0xff;
+    const b      = rgb & 0xff;
+
+    const alpha  = 0.5 * ((r * 2) - g - b);
+    const beta   = (Math.sqrt(3) / 2) * (g - b);
+    const hue    = Math.atan2(beta, alpha);
+
+    // `hue` above is in radians in the range `[-PI..PI)`, and we want degrees
+    // in the range `[0..360)`.
+    return ((hue / (Math.PI * 2) * 360) + 360) % 360;
+  }
+
+  /**
+   * Converts a value in the range `[0..255]` to a two-digit hex string.
+   *
+   * @param {Int} value The number to convert. It should be in the range
+   *   `[0..255]`, although no error checking is performed.
+   * @returns {string} The value converted to a hexadecimal byte string.
+   */
+  static _hexByte(value) {
+    return `${(value < 16) ? '0' : ''}${value.toString(16)}`;
+  }
+}

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -32,20 +32,19 @@ export default class ColorUtil extends UtilityClass {
    * @param {number} hue The hue, which must be in the range `[0..360)`.
    * @param {number} saturation The saturation, which must be in the range
    *   `[0..1]`.
-   * @param {number} level The level, which must be in the range `[0..1]`.
+   * @param {number} lightness The lightness, which must be in the range
+   *   `[0..1]`.
    * @returns {string} The color value as a CSS hex string.
    */
-  static hslToCss(hue, saturation, level) {
+  static hslToCss(hue, saturation, lightness) {
     // Algorithm taken from
     // <https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL>.
-    const c = (1.0 - Math.abs((2.0 * level) - 1.0) * saturation);
+    const c = (1.0 - Math.abs((2.0 * lightness) - 1.0) * saturation);
     const huePrime = hue / 60.0;
     const x = c * (1.0 - Math.abs((huePrime % 2) - 1.0));
-    const m = level - (c / 2.0);
+    const m = lightness - (c / 2.0);
 
-    let red = 0;
-    let green = 0;
-    let blue = 0;
+    let red, green, blue;
 
     if      (huePrime <= 1) { red = c; green = x; blue = 0; }
     else if (huePrime <= 2) { red = x; green = c; blue = 0; }

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -39,7 +39,7 @@ export default class ColorUtil extends UtilityClass {
   static hslToCss(hue, saturation, lightness) {
     // Algorithm taken from
     // <https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL>.
-    const c = (1.0 - Math.abs((2.0 * lightness) - 1.0) * saturation);
+    const c = (1.0 - Math.abs((2.0 * lightness) - 1.0)) * saturation;
     const huePrime = hue / 60.0;
     const x = c * (1.0 - Math.abs((huePrime % 2) - 1.0));
     const m = lightness - (c / 2.0);

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -7,7 +7,8 @@ import { UtilityClass } from 'util-common-base';
 
 /**
  * {RegExp} Regular expression that can be used to validate colors that are
- * expected to be in CSS three-byte hex format (e.g., `#fe8ef1`).
+ * expected to be in CSS three-byte hex format, with lowercase letters (e.g.,
+ * `#fe8ef1`).
  */
 const CSS_COLOR_REGEXP = /^#[a-f0-9]{6}$/;
 
@@ -17,7 +18,8 @@ const CSS_COLOR_REGEXP = /^#[a-f0-9]{6}$/;
 export default class ColorUtil extends UtilityClass {
   /**
    * Checks whether a given string matches this module's requirements for a
-   * CSS-style color hex string.
+   * CSS-style color hex string, with all lowercase letters and no alpha
+   * component.
    *
    * @param {string} hexColor The string to check.
    * @returns {string} The input as-is if it meets requirements.
@@ -27,7 +29,8 @@ export default class ColorUtil extends UtilityClass {
   }
 
   /**
-   * Converts an HSL color value to RGB in CSS hex string form.
+   * Converts an HSL color value to the three-byte CSS hex form, with lowercase
+   * letters.
    *
    * @param {number} hue The hue, which must be in the range `[0..360)`.
    * @param {number} saturation The saturation, which must be in the range
@@ -61,9 +64,10 @@ export default class ColorUtil extends UtilityClass {
   }
 
   /**
-   * Extracts the hue component from an RGB color.
+   * Extracts the hue component from an RGB color given as a three-byte
+   * lowercase CSS hex string.
    *
-   * @param {string} color The color, in CSS hex form.
+   * @param {string} color The color, in lowercase CSS hex form.
    * @returns {number} The hue, as an angle in degrees, in the range `[0..360)`.
    */
   static hueFromCss(color) {

--- a/local-modules/util-common/StringUtil.js
+++ b/local-modules/util-common/StringUtil.js
@@ -42,6 +42,7 @@ export default class StringUtil extends UtilityClass {
    * @returns {Int} The corresponding hashcode.
    */
   static hash32(string) {
+    TString.check(string);
     const hash = crypto.createHash('sha256'); // Good enough for 32-bit output.
 
     hash.update(string, 'utf8');

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import ColorSelector from './ColorSelector';
+import ColorUtil from './ColorUtil';
 import CommonBase from './CommonBase';
 import DataUtil from './DataUtil';
 import DeferredLoader from './DeferredLoader';
@@ -18,6 +19,7 @@ import WebsocketCodes from './WebsocketCodes';
 
 export {
   ColorSelector,
+  ColorUtil,
   CommonBase,
   DataUtil,
   DeferredLoader,

--- a/local-modules/util-common/tests/test_ColorSelector.js
+++ b/local-modules/util-common/tests/test_ColorSelector.js
@@ -46,19 +46,10 @@ describe('ColorSelector', () => {
       assert.equal(colorA.hue, colorB.hue - 37);
     });
 
-    describe('.nextColorRGB()', () => {
-      it('should return a valid RGB conversion of the given HSL color', () => {
-        const selector = new ColorSelector();
-        const rgb = selector.nextColorRGB();
-
-        assert.deepEqual(rgb, { red: 255, green: 191, blue: 191 });
-      });
-    });
-
-    describe('.nextColorHex()', () => {
+    describe('.nextCssColor()', () => {
       it('should return a valid hex string representation of the RGB value of a given color', () => {
         const selector = new ColorSelector();
-        const hex = selector.nextColorHex();
+        const hex = selector.nextCssColor();
 
         assert.equal(hex, '#ffbfbf');
       });

--- a/local-modules/util-common/tests/test_ColorSelector.js
+++ b/local-modules/util-common/tests/test_ColorSelector.js
@@ -24,11 +24,11 @@ describe('ColorSelector', () => {
       assert.equal(colorA.hue, colorB.hue - 53);
     });
 
-    it('should have a default HSL level of 87.5%', () => {
+    it('should have a default HSL lightness of 87.5%', () => {
       const selector = new ColorSelector();
       const hsl = selector.nextColorHSL();
 
-      assert.equal(hsl.level, 0.875);
+      assert.equal(hsl.lightness, 0.875);
     });
 
     it('should set the initial hue angle to the seed value MOD 360', () => {

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -67,7 +67,10 @@ describe('ColorUtil', () => {
       test(180, 0.5, 1.0, '#ffffff');
       test(270, 1.0, 1.0, '#ffffff');
 
-      test(0, 0, 0.5, '#7f7f7f'); // Medium gray.
+      // Grays.
+      test(0, 0, 0.25, '#3f3f3f'); // Dark.
+      test(0, 0, 0.5,  '#7f7f7f'); // Medium.
+      test(0, 0, 0.75, '#bfbfbf'); // Light.
 
       test(0,   1.0, 0.5, '#ff0000'); // Pure red.
       test(60,  1.0, 0.5, '#ffff00'); // Pure yellow.

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -55,8 +55,18 @@ describe('ColorUtil', () => {
         assert.strictEqual(ColorUtil.cssFromHsl(h, s, l), expected);
       }
 
-      test(0, 0, 0,   '#000000'); // Black.
-      test(0, 0, 1.0, '#ffffff'); // White.
+      // Black.
+      test(0,   0,   0, '#000000');
+      test(90,  0,   0, '#000000');
+      test(180, 0.5, 0, '#000000');
+      test(270, 1.0, 0, '#000000');
+
+      // White.
+      test(0,   0,   1.0, '#ffffff');
+      test(90,  0,   1.0, '#ffffff');
+      test(180, 0.5, 1.0, '#ffffff');
+      test(270, 1.0, 1.0, '#ffffff');
+
       test(0, 0, 0.5, '#7f7f7f'); // Medium gray.
 
       test(0,   1.0, 0.5, '#ff0000'); // Pure red.

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -55,9 +55,9 @@ describe('ColorUtil', () => {
         assert.strictEqual(ColorUtil.hslToCss(h, s, l), expected);
       }
 
-      //test(0, 0, 0,   '#000000'); // Black.
-      //test(0, 0, 1.0, '#ffffff'); // White.
-      //test(0, 0, 0.5, '#777777'); // Medium gray.
+      test(0, 0, 0,   '#000000'); // Black.
+      test(0, 0, 1.0, '#ffffff'); // White.
+      test(0, 0, 0.5, '#7f7f7f'); // Medium gray.
 
       test(0,   1.0, 0.5, '#ff0000'); // Pure red.
       test(60,  1.0, 0.5, '#ffff00'); // Pure yellow.

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -48,4 +48,48 @@ describe('ColorUtil', () => {
       test({ foo: 'bar' });
     });
   });
+
+  describe('hueFromCss()', () => {
+    it('should provide expected results', () => {
+      function test(color, expected) {
+        assert.strictEqual(ColorUtil.hueFromCss(color), expected, color);
+      }
+
+      // Black, white, and gray don't have a defined hue in the abstract, but we
+      // expect the implementation to say their hue is `0`.
+      test('#000000', 0);
+      test('#ffffff', 0);
+      test('#010101', 0);
+
+      // Red.
+      test('#ff0000', 0);
+      test('#010000', 0);
+      test('#881111', 0);
+
+      // Yellow.
+      test('#ffff00', 60);
+      test('#010100', 60);
+      test('#888811', 60);
+
+      // Green.
+      test('#00ff00', 120);
+      test('#000100', 120);
+      test('#118811', 120);
+
+      // Cyan.
+      test('#00ffff', 180);
+      test('#000101', 180);
+      test('#118888', 180);
+
+      // Blue.
+      test('#0000ff', 240);
+      test('#000001', 240);
+      test('#111188', 240);
+
+      // Magenta.
+      test('#ff00ff', 300);
+      test('#010001', 300);
+      test('#881188', 300);
+    });
+  });
 });

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -49,10 +49,10 @@ describe('ColorUtil', () => {
     });
   });
 
-  describe('hslToCss()', () => {
+  describe('cssFromHsl()', () => {
     it('should provide expected results', () => {
       function test(h, s, l, expected) {
-        assert.strictEqual(ColorUtil.hslToCss(h, s, l), expected);
+        assert.strictEqual(ColorUtil.cssFromHsl(h, s, l), expected);
       }
 
       test(0, 0, 0,   '#000000'); // Black.

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -49,6 +49,25 @@ describe('ColorUtil', () => {
     });
   });
 
+  describe('hslToCss()', () => {
+    it('should provide expected results', () => {
+      function test(h, s, l, expected) {
+        assert.strictEqual(ColorUtil.hslToCss(h, s, l), expected);
+      }
+
+      //test(0, 0, 0,   '#000000'); // Black.
+      //test(0, 0, 1.0, '#ffffff'); // White.
+      //test(0, 0, 0.5, '#777777'); // Medium gray.
+
+      test(0,   1.0, 0.5, '#ff0000'); // Pure red.
+      test(60,  1.0, 0.5, '#ffff00'); // Pure yellow.
+      test(120, 1.0, 0.5, '#00ff00'); // Pure green.
+      test(180, 1.0, 0.5, '#00ffff'); // Pure cyan.
+      test(240, 1.0, 0.5, '#0000ff'); // Pure blue.
+      test(300, 1.0, 0.5, '#ff00ff'); // Pure magenta.
+    });
+  });
+
   describe('hueFromCss()', () => {
     it('should provide expected results', () => {
       function test(color, expected) {

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -1,0 +1,51 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ColorUtil } from 'util-common';
+
+describe('ColorUtil', () => {
+  describe('checkCss()', () => {
+    it('should accept proper strings', () => {
+      function test(v) {
+        assert.doesNotThrow(() => ColorUtil.checkCss(v));
+      }
+
+      test('#000000');
+      test('#123456');
+      test('#789abc');
+      test('#def012');
+    });
+
+    it('should reject improper strings', () => {
+      function test(v) {
+        assert.throws(() => ColorUtil.checkCss(v));
+      }
+
+      test('000000');   // Missing `#` prefix.
+      test('#1');       // Too few characters.
+      test('#1234567'); // Too many characters.
+      test('#A00000');  // Uppercase hex.
+      test('#0B0000');  // Uppercase hex.
+      test('#00C000');  // Uppercase hex.
+      test('#000D00');  // Uppercase hex.
+      test('#0000E0');  // Uppercase hex.
+      test('#00000F');  // Uppercase hex.
+      test('#?@%^()');  // Oddball characters.
+    });
+
+    it('should reject non-strings', () => {
+      function test(v) {
+        assert.throws(() => ColorUtil.checkCss(v));
+      }
+
+      test(undefined);
+      test(true);
+      test([]);
+      test({ foo: 'bar' });
+    });
+  });
+});

--- a/local-modules/util-common/tests/test_StringUtil.js
+++ b/local-modules/util-common/tests/test_StringUtil.js
@@ -32,6 +32,30 @@ describe('util-common/StringUtil', () => {
     });
   });
 
+  describe('hash32()', () => {
+    it('should hash as expected', () => {
+      function test(expected, s) {
+        assert.strictEqual(StringUtil.hash32(s), expected);
+      }
+
+      // These hashes can be verified by running this (and similar) from a
+      // shell console:
+      //
+      // ```
+      // $ printf '<text>' | openssl dgst -sha256 | cut -c 1-8
+      // 27ce5aa0
+      // ```
+
+      test(0xe3b0c442, '');
+      test(0x7ace431c, '~');
+      test(0xc775e7b7, '1234567890');
+      test(0x42146b29, '/a/b/c');
+      test(0x15363cf2, 'blort');
+      test(0x27ce5aa0, '<text>');
+      test(0x86bda720, 'These pretzels are making me thirsty.');
+    });
+  });
+
   describe('utf8LengthForString()', () => {
     it('should return a UTF-8 length of 1 for ASCII characters', () => {
       const input = 'this is a string';

--- a/local-modules/util-common/tests/test_StringUtil.js
+++ b/local-modules/util-common/tests/test_StringUtil.js
@@ -54,6 +54,17 @@ describe('util-common/StringUtil', () => {
       test(0x27ce5aa0, '<text>');
       test(0x86bda720, 'These pretzels are making me thirsty.');
     });
+
+    it('should reject non-strings', () => {
+      function test(v) {
+        assert.throws(() => StringUtil.hash32(v));
+      }
+
+      test(undefined);
+      test(true);
+      test([]);
+      test({ foo: 'bar' });
+    });
   });
 
   describe('utf8LengthForString()', () => {


### PR DESCRIPTION
This PR factors out a new `ColorUtil` class from the various other color-manipulating code in the system, fixes a subtle bug in one of the methods, and adds a bunch of tests.

**Bonus:** Also added a test for `StringUtil.hash32()`.