### PR TITLE
Fix session timeout handling… and clean up some random code.

### DIFF
--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -29,23 +29,6 @@ export default class ApiLog extends Singleton {
   }
 
   /**
-   * Logs an incoming message. This should be called just after the message was
-   * decoded off of an incoming connection. This method returns the timestamp
-   * that should be used as the `startTime` when logging the completed API call.
-   *
-   * @param {string} connectionId Identifier for the connection.
-   * @param {object} msg Incoming message.
-   * @returns {Int} Standard msec timestamp indicating the start time of the API
-   *   call being represented here.
-   */
-  incomingMessage(connectionId, msg) {
-    // TODO: This will ultimately need to redact some information.
-    this._console.detail(`[${connectionId}] Message:`, msg.toLog());
-
-    return Date.now();
-  }
-
-  /**
    * Logs a full API call. This should be called after the message has been
    * fully handled, and the response either has been sent or is at least _ready_
    * to be sent.
@@ -89,6 +72,23 @@ export default class ApiLog extends Singleton {
     }
 
     this._writeJson(details);
+  }
+
+  /**
+   * Logs an incoming message. This should be called just after the message was
+   * decoded off of an incoming connection. This method returns the timestamp
+   * that should be used as the `startTime` when logging the completed API call.
+   *
+   * @param {string} connectionId Identifier for the connection.
+   * @param {object} msg Incoming message.
+   * @returns {Int} Standard msec timestamp indicating the start time of the API
+   *   call being represented here.
+   */
+  incomingMessage(connectionId, msg) {
+    // TODO: This will ultimately need to redact some information.
+    this._console.detail(`[${connectionId}] Message:`, msg.toLog());
+
+    return Date.now();
   }
 
   /**

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -50,16 +50,6 @@ export default class BearerToken extends BaseKey {
   }
 
   /**
-   * Gets the printable form of the ID. This class adds an "ASCII ellipsis" to
-   * the ID, to make it clear that the ID is a redaction of the full token.
-   *
-   * @returns {string} The printable form of the ID.
-   */
-  _impl_printableId() {
-    return `${this.id}...`;
-  }
-
-  /**
    * {string} Full secret token. **Note:** It is important to _never_ reveal
    * this value across an unencrypted API boundary or to log it.
    */
@@ -87,6 +77,16 @@ export default class BearerToken extends BaseKey {
     }
 
     return this._secretToken === other._secretToken;
+  }
+
+  /**
+   * Gets the printable form of the ID. This class adds an "ASCII ellipsis" to
+   * the ID, to make it clear that the ID is a redaction of the full token.
+   *
+   * @returns {string} The printable form of the ID.
+   */
+  _impl_printableId() {
+    return `${this.id}...`;
   }
 
   /**

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -247,9 +247,9 @@ export default class Connection extends CommonBase {
    * requested by the given message.
    *
    * @param {object} msg Parsed message.
-   * @returns {Promise} Promise for the result (or error).
+   * @returns {*} Whatever the dispatched message returns.
    */
-  _actOnMessage(msg) {
+  async _actOnMessage(msg) {
     const target = this.getTarget(msg.target);
     const action = msg.action;
     const name   = msg.name;
@@ -257,15 +257,12 @@ export default class Connection extends CommonBase {
 
     switch (action) {
       case 'call': {
-        return new Promise((res, rej) => {
-          activeNow = this;
-          try {
-            res(target.call(name, args));
-          } catch (e) {
-            rej(e);
-          }
+        activeNow = this;
+        try {
+          return target.call(name, args);
+        } finally {
           activeNow = null;
-        });
+        }
       }
 
       // **Note:** Ultimately we might accept `get` and `set`, for example, thus

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -72,6 +72,17 @@ export default class MetaHandler {
   }
 
   /**
+   * API meta-method `connectionId`: Returns the connection ID that is assigned
+   * to this connection. This is only meant to be used for logging. For example,
+   * it is _not_ guaranteed to be unique.
+   *
+   * @returns {string} The connection ID.
+   */
+  connectionId() {
+    return this._connection.connectionId;
+  }
+
+  /**
    * Generates and returns a challenge for the key that controls the target with
    * the given ID. It is an error to request a challenge for a nonexistent or
    * uncontrolled target. Once returned, challenges are considered active only
@@ -118,17 +129,6 @@ export default class MetaHandler {
     this._log.info(`  => ${response}`);
 
     return challenge;
-  }
-
-  /**
-   * API meta-method `connectionId`: Returns the connection ID that is assigned
-   * to this connection. This is only meant to be used for logging. For example,
-   * it is _not_ guaranteed to be unique.
-   *
-   * @returns {string} The connection ID.
-   */
-  connectionId() {
-    return this._connection.connectionId;
   }
 
   /**

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -45,38 +45,6 @@ export default class PostConnection extends Connection {
   }
 
   /**
-   * Validates the `Content-Type` header. Returns `null` if valid or an error
-   * string if invalid.
-   *
-   * @returns {string|null} The error, if any.
-   */
-  _validateContentType() {
-    const headerString = this._req.headers['content-type'];
-    if (!headerString) {
-      return 'Missing header.';
-    }
-
-    try {
-      const parsed = contentType.parse(headerString);
-      const type = parsed.type;
-      const params = parsed.parameters;
-      if (type !== 'application/json') {
-        return 'Must specify media type `application/json`.';
-      } else if (!params.charset) {
-        return 'Missing `charset` specifier.';
-      } else if (params.charset !== 'utf-8') {
-        return 'Must specify `charset` as `utf-8`.';
-      } else if (Object.keys(params).length !== 1) {
-        return 'Superfluous parameters.';
-      }
-    } catch (e) {
-      return 'Invalid syntax.';
-    }
-
-    return null;
-  }
-
-  /**
    * Handles a `data` event coming from the request input stream.
    *
    * @param {Buffer} chunk Incoming data chunk.
@@ -132,5 +100,37 @@ export default class PostConnection extends Connection {
     .status(400)
     .type('application/json')
     .send(payload);
+  }
+
+  /**
+   * Validates the `Content-Type` header. Returns `null` if valid or an error
+   * string if invalid.
+   *
+   * @returns {string|null} The error, if any.
+   */
+  _validateContentType() {
+    const headerString = this._req.headers['content-type'];
+    if (!headerString) {
+      return 'Missing header.';
+    }
+
+    try {
+      const parsed = contentType.parse(headerString);
+      const type = parsed.type;
+      const params = parsed.parameters;
+      if (type !== 'application/json') {
+        return 'Must specify media type `application/json`.';
+      } else if (!params.charset) {
+        return 'Missing `charset` specifier.';
+      } else if (params.charset !== 'utf-8') {
+        return 'Must specify `charset` as `utf-8`.';
+      } else if (Object.keys(params).length !== 1) {
+        return 'Superfluous parameters.';
+      }
+    } catch (e) {
+      return 'Invalid syntax.';
+    }
+
+    return null;
   }
 }

--- a/local-modules/api-server/Schema.js
+++ b/local-modules/api-server/Schema.js
@@ -41,27 +41,18 @@ export default class Schema {
   }
 
   /**
-   * Generates the actual property map (schema payload) for the given object.
+   * Returns a plain object (JSON-encodable map) for the property map of this
+   * instance.
    *
-   * @param {object} target Object from which to derive the schema.
-   * @returns {Map<string, string>} The corresponding property map.
+   * @returns {object<string, string>} The plain object representation.
    */
-  static _makeSchemaFor(target) {
-    const result = new Map();
-
-    for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
-      const name = desc.name;
-
-      if (name.match(/^_/) || (name === 'constructor')) {
-        // Because we don't want properties whose names are prefixed with `_`,
-        // and we don't want to expose the constructor function.
-        continue;
-      }
-
-      result.set(name, 'method');
+  get propertiesObject() {
+    const result = {};
+    for (const [key, value] of this._properties) {
+      result[key] = value;
     }
 
-    return result;
+    return Object.freeze(result);
   }
 
   /**
@@ -84,17 +75,26 @@ export default class Schema {
   }
 
   /**
-   * Returns a plain object (JSON-encodable map) for the property map of this
-   * instance.
+   * Generates the actual property map (schema payload) for the given object.
    *
-   * @returns {object<string, string>} The plain object representation.
+   * @param {object} target Object from which to derive the schema.
+   * @returns {Map<string, string>} The corresponding property map.
    */
-  get propertiesObject() {
-    const result = {};
-    for (const [key, value] of this._properties) {
-      result[key] = value;
+  static _makeSchemaFor(target) {
+    const result = new Map();
+
+    for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
+      const name = desc.name;
+
+      if (name.match(/^_/) || (name === 'constructor')) {
+        // Because we don't want properties whose names are prefixed with `_`,
+        // and we don't want to expose the constructor function.
+        continue;
+      }
+
+      result.set(name, 'method');
     }
 
-    return Object.freeze(result);
+    return result;
   }
 }

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -60,6 +60,11 @@ export default class Target {
     Object.seal(this);
   }
 
+  /** {string} The target ID. */
+  get id() {
+    return this._id;
+  }
+
   /**
    * {BaseKey|null} The access control key or `null` if this is an
    * uncontrolled target.
@@ -68,67 +73,15 @@ export default class Target {
     return this._key;
   }
 
-  /** {string} The target ID. */
-  get id() {
-    return this._id;
+  /** {Schema} The target's schema. */
+  get schema() {
+    return this._schema;
   }
 
   /** {object} The underlying target object. */
   get target() {
     this.refresh();
     return this._target;
-  }
-
-  /** {Schema} The target's schema. */
-  get schema() {
-    return this._schema;
-  }
-
-  /**
-   * Takes a timestamp (standard Unix-ish msec) and indicates whether this
-   * instance was considered idle as of that time.
-   *
-   * @param {Int} whenMsec Timestamp which the questions is with respect to.
-   * @returns {boolean} `true` iff this instance has been idle since `whenMsec`
-   *   or earlier.
-   */
-  wasIdleAsOf(whenMsec) {
-    const lastAccess = this._lastAccess;
-
-    if (lastAccess === EVERGREEN) {
-      return false;
-    } else {
-      return (lastAccess <= whenMsec);
-    }
-  }
-
-  /**
-   * "Refreshes" this instance in terms of access time. This is no different
-   * than just saying `this.target` and merely exists so as to provide a solid
-   * way to convey intent in client code.
-   */
-  refresh() {
-    if (this._lastAccess !== EVERGREEN) {
-      this._lastAccess = Date.now();
-    }
-  }
-
-  /**
-   * Sets this instance to be "evergreen," that is, to never be considered
-   * idle.
-   */
-  setEvergreen() {
-    this._lastAccess = EVERGREEN;
-  }
-
-  /**
-   * Returns an instance just like this one, except without the `key`. This
-   * method is used during resource authorization.
-   *
-   * @returns {Target} An "uncontrolled" version of this instance.
-   */
-  withoutKey() {
-    return new Target(this._id, this._target, this._schema);
   }
 
   /**
@@ -162,5 +115,52 @@ export default class Target {
     const result = impl.apply(target, args);
 
     return (result === undefined) ? null : result;
+  }
+
+  /**
+   * "Refreshes" this instance in terms of access time. This is no different
+   * than just saying `this.target` and merely exists so as to provide a solid
+   * way to convey intent at the call sites for this method.
+   */
+  refresh() {
+    if (this._lastAccess !== EVERGREEN) {
+      this._lastAccess = Date.now();
+    }
+  }
+
+  /**
+   * Sets this instance to be "evergreen," that is, to never be considered
+   * idle.
+   */
+  setEvergreen() {
+    this._lastAccess = EVERGREEN;
+  }
+
+  /**
+   * Takes a timestamp (standard Unix-ish msec) and indicates whether this
+   * instance was considered idle as of that time.
+   *
+   * @param {Int} whenMsec Timestamp which the questions is with respect to.
+   * @returns {boolean} `true` iff this instance has been idle since `whenMsec`
+   *   or earlier.
+   */
+  wasIdleAsOf(whenMsec) {
+    const lastAccess = this._lastAccess;
+
+    if (lastAccess === EVERGREEN) {
+      return false;
+    } else {
+      return (lastAccess <= whenMsec);
+    }
+  }
+
+  /**
+   * Returns an instance just like this one, except without the `key`. This
+   * method is used during resource authorization.
+   *
+   * @returns {Target} An "uncontrolled" version of this instance.
+   */
+  withoutKey() {
+    return new Target(this._id, this._target, this._schema);
   }
 }

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -31,21 +31,6 @@ export default class WsConnection extends Connection {
   }
 
   /**
-   * Handles a `message` event coming from the underlying websocket. Calls on
-   * the superclass (see which) for processing.
-   *
-   * @param {string} msg Incoming message, in JSON string form.
-   */
-  async _handleMessage(msg) {
-    try {
-      const response = await this.handleJsonMessage(msg);
-      this._ws.send(response);
-    } catch (e) {
-      this._handleError(e);
-    }
-  }
-
-  /**
    * Handles a `close` event coming from the underlying websocket.
    *
    * @param {number} code The reason code for why the socket was closed.
@@ -67,5 +52,20 @@ export default class WsConnection extends Connection {
   _handleError(error) {
     this._log.info('Error:', error);
     this.close();
+  }
+
+  /**
+   * Handles a `message` event coming from the underlying websocket. Calls on
+   * the superclass (see which) for processing.
+   *
+   * @param {string} msg Incoming message, in JSON string form.
+   */
+  async _handleMessage(msg) {
+    try {
+      const response = await this.handleJsonMessage(msg);
+      this._ws.send(response);
+    } catch (e) {
+      this._handleError(e);
+    }
   }
 }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -20,7 +20,7 @@ const MAX_OLD_SNAPSHOTS = 20;
  * {Int} How long (in msec) that a session must be inactive before it gets
  * culled from the current caret snapshot.
  */
-const MAX_SESSION_IDLE_MSEC = 10 * 60 * 1000; // Ten minutes.
+const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /**
  * Controller for the active caret info for a given document.

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -358,10 +358,10 @@ export default class CaretStorage extends CommonBase {
     const updatedCarets = new Map();
     const setUpdates    = []; // List of new and deleted sessions.
 
-    for (const s of this._localSessions) {
-      const caret       = this._carets.caretForSession(s);
-      const storedCaret = this._storedCarets.caretForSession(s);
-      const path        = Paths.forCaret(s);
+    for (const sessionId of this._localSessions) {
+      const caret       = this._carets.caretForSession(sessionId);
+      const storedCaret = this._storedCarets.caretForSession(sessionId);
+      const path        = Paths.forCaret(sessionId);
 
       if (caret && storedCaret && caret.equals(storedCaret)) {
         // The file already stores this caret info.
@@ -369,19 +369,19 @@ export default class CaretStorage extends CommonBase {
       }
 
       if (caret) {
-        this._log.detail(`Updating caret: ${s}`);
+        this._log.detail(`Updating caret: ${sessionId}`);
         ops.push(fc.op_writePath(path, caret));
         if (!storedCaret) {
           // First time this session is being stored.
-          setUpdates.push(s);
+          setUpdates.push(sessionId);
         }
       } else {
-        this._log.detail(`Deleting caret: ${s}`);
+        this._log.detail(`Deleting caret: ${sessionId}`);
         ops.push(fc.op_deletePath(path));
-        setUpdates.push(s);
+        setUpdates.push(sessionId);
       }
 
-      updatedCarets.set(path, caret);
+      updatedCarets.set(sessionId, caret);
     }
 
     if (ops.length === 0) {
@@ -450,7 +450,7 @@ export default class CaretStorage extends CommonBase {
     let storedCarets    = this._storedCarets;
     const localSessions = this._localSessions;
 
-    for (const [s, caret] of updatedCarets) {
+    for (const [sessionId, caret] of updatedCarets) {
       if (caret) {
         storedCarets = storedCarets.withCaret(caret);
       } else {
@@ -458,8 +458,8 @@ export default class CaretStorage extends CommonBase {
         // file storage model, this removes the session from the set of
         // locally-controlled sessions. This is done because we only ever have
         // to delete a given session from file storage once.
-        storedCarets = storedCarets.withoutSession(s);
-        localSessions.delete(s);
+        storedCarets = storedCarets.withoutSession(sessionId);
+        localSessions.delete(sessionId);
       }
     }
 

--- a/local-modules/util-common/ColorUtil.js
+++ b/local-modules/util-common/ColorUtil.js
@@ -80,14 +80,14 @@ export default class ColorUtil extends UtilityClass {
     // Algorithm taken from
     // <https://en.wikipedia.org/wiki/HSL_and_HSV#Hue_and_chroma>.
 
-    const rgb    = parseInt(color.slice(1), 16);
-    const r      = rgb >> 16;
-    const g      = (rgb >> 8) & 0xff;
-    const b      = rgb & 0xff;
+    const rgb   = parseInt(color.slice(1), 16);
+    const r     = rgb >> 16;
+    const g     = (rgb >> 8) & 0xff;
+    const b     = rgb & 0xff;
 
-    const alpha  = 0.5 * ((r * 2) - g - b);
-    const beta   = (Math.sqrt(3) / 2) * (g - b);
-    const hue    = Math.atan2(beta, alpha);
+    const alpha = 0.5 * ((r * 2) - g - b);
+    const beta  = (Math.sqrt(3) / 2) * (g - b);
+    const hue   = Math.atan2(beta, alpha);
 
     // `hue` above is in radians in the range `[-PI..PI)`, and we want degrees
     // in the range `[0..360)`.


### PR DESCRIPTION
Two changes here that actually change code:

* Fix how the caret storage layer handles session timeout.
* Use an `async` method instead of a manual `Promise` when dispatching API calls.

The rest of the changes were just me cleaning up the `api-server` module to better adhere to our — ever less nominal — conventions and to fix comments that had become skewed from consensus reality.