### PR TITLE
Implement all of the blob ops in `file-store-local`.

### DIFF
--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -236,6 +236,24 @@ export default class LocalFile extends BaseFile {
       },
 
       /**
+       * Gets an iterator over all storage (not including internal-only
+       * entries). Yielded elements are entries of the form `[storageId, data]`.
+       *
+       * @returns {Iterator<string, FrozenBuffer>} Iterator over all storage.
+       */
+      allStorage() {
+        function* yieldEntries() {
+          for (const [storageId, value] of outerThis._storage) {
+            if (!outerThis._isInternalStorageId(storageId)) {
+              yield [storageId, value];
+            }
+          }
+        }
+
+        return yieldEntries();
+      },
+
+      /**
        * Gets the content blob from the file which has the indicated hash, if
        * any.
        *
@@ -268,7 +286,7 @@ export default class LocalFile extends BaseFile {
        *   storage.
        */
       pathStorage() {
-        function* pathEntries() {
+        function* yieldEntries() {
           for (const [storageId, value] of outerThis._storage) {
             if (StoragePath.isInstance(storageId)) {
               yield [storageId, value];
@@ -276,7 +294,7 @@ export default class LocalFile extends BaseFile {
           }
         }
 
-        return pathEntries();
+        return yieldEntries();
       }
     };
 

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -236,6 +236,19 @@ export default class LocalFile extends BaseFile {
       },
 
       /**
+       * Gets the content blob from the file which has the indicated hash, if
+       * any.
+       *
+       * @param {string} hash The content hash.
+       * @returns {FrozenBuffer|null} The corresponding stored blob value, or
+       *   `null` if there is none.
+       */
+      readBlobOrNull(hash) {
+        FrozenBuffer.checkHash(hash);
+        return outerThis._storage.get(hash) || null;
+      },
+
+      /**
        * Gets the value stored at the given path, if any.
        *
        * @param {string} storagePath The path.

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -141,6 +141,8 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkBlobAbsent(op) {
+    const hash_unused = op.arg('hash');
+
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }
@@ -151,6 +153,8 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkBlobPresent(op) {
+    const hash_unused = op.arg('hash');
+
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }
@@ -228,6 +232,8 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_deleteBlob(op) {
+    const hash_unused = op.arg('hash');
+
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }
@@ -272,6 +278,8 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_readBlob(op) {
+    const hash_unused = op.arg('hash');
+
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }
@@ -376,6 +384,8 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_writeBlob(op) {
+    const value_unused = op.arg('value');
+
     // **TODO:** Implement this.
     Transactor._missingOp(op.name);
   }

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -221,7 +221,7 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op_unused The operation.
    */
   _op_deleteAll(op_unused) {
-    for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {
+    for (const [storagePath, value_unused] of this._fileFriend.allStorage()) {
       this._updatedStorage.set(storagePath, null);
     }
   }

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -141,10 +141,10 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkBlobAbsent(op) {
-    const hash_unused = op.arg('hash');
-
-    // **TODO:** Implement this.
-    Transactor._missingOp(op.name);
+    const hash = op.arg('hash');
+    if (this._fileFriend.readBlobOrNull(hash) !== null) {
+      throw Errors.blob_not_absent(hash);
+    }
   }
 
   /**
@@ -153,10 +153,10 @@ export default class Transactor extends CommonBase {
    * @param {FileOp} op The operation.
    */
   _op_checkBlobPresent(op) {
-    const hash_unused = op.arg('hash');
-
-    // **TODO:** Implement this.
-    Transactor._missingOp(op.name);
+    const hash = op.arg('hash');
+    if (this._fileFriend.readBlobOrNull(hash) === null) {
+      throw Errors.blob_not_found(hash);
+    }
   }
 
   /**

--- a/local-modules/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/file-store-local/tests/test_LocalFile.js
@@ -90,7 +90,7 @@ describe('file-store-local/LocalFile', () => {
   });
 
   describe('exists()', () => {
-    it('should return `false` if the underlying storage does not exis.', async () => {
+    it('should return `false` if the underlying storage does not exist', async () => {
       const file = new LocalFile('0', TempFiles.uniquePath());
       assert.isFalse(await file.exists());
     });

--- a/local-modules/file-store-local/tests/test_LocalFile_transact.js
+++ b/local-modules/file-store-local/tests/test_LocalFile_transact.js
@@ -283,4 +283,25 @@ describe('file-store-local/LocalFile.transact', () => {
       assert.strictEqual(transactionResult.data.size, 0);
     });
   });
+
+  describe('op writeBlob', () => {
+    it('should succeed in writing a blob', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      const blob = new FrozenBuffer('Puffins are now dinosaurs.');
+      await file.create();
+
+      const spec = new TransactionSpec(FileOp.op_writeBlob(blob));
+      await assert.isFulfilled(file.transact(spec));
+    });
+
+    it('should succeed in writing an already-present blob', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      const blob = new FrozenBuffer('Puffins are now dinosaurs.');
+      await file.create();
+
+      const spec = new TransactionSpec(FileOp.op_writeBlob(blob));
+      await assert.isFulfilled(file.transact(spec));
+      await assert.isFulfilled(file.transact(spec));
+    });
+  });
 });

--- a/local-modules/file-store-local/tests/test_LocalFile_transact.js
+++ b/local-modules/file-store-local/tests/test_LocalFile_transact.js
@@ -256,4 +256,31 @@ describe('file-store-local/LocalFile.transact', () => {
       assert.isTrue(paths.has('/blort/x/definitely'));
     });
   });
+
+  describe('op readBlob', () => {
+    it('should succeed in reading a blob that is in the file', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      const blob = new FrozenBuffer('Muffins are now biscuits.');
+      await file.create();
+      await file.transact(new TransactionSpec(FileOp.op_writeBlob(blob)));
+
+      // The reading is based on the hash of `blob`, so it's irrelevant that
+      // the given argument is actually the content in question.
+      const spec = new TransactionSpec(FileOp.op_readBlob(blob));
+      const transactionResult = await assert.isFulfilled(file.transact(spec));
+
+      assert.strictEqual(transactionResult.data.get(blob.hash), blob);
+    });
+
+    it('should succeed even if the blob is not present', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      const blob = new FrozenBuffer('Muffins are now biscuits.');
+      await file.create();
+
+      const spec = new TransactionSpec(FileOp.op_readBlob(blob));
+      const transactionResult = await assert.isFulfilled(file.transact(spec));
+
+      assert.strictEqual(transactionResult.data.size, 0);
+    });
+  });
 });

--- a/local-modules/file-store/BaseFile.js
+++ b/local-modules/file-store/BaseFile.js
@@ -5,6 +5,7 @@
 import { TBoolean, TInt, TMap, TObject, TSet, TString } from 'typecheck';
 import { CommonBase, FrozenBuffer, InfoError } from 'util-common';
 
+import StorageId from './StorageId';
 import StoragePath from './StoragePath';
 import TransactionSpec from './TransactionSpec';
 
@@ -170,10 +171,11 @@ export default class BaseFile extends CommonBase {
    *   operations, the revision number of the file that resulted from those
    *   modifications.
    * * `data` &mdash; If the transaction spec included any data read operations,
-   *   a `Map<string, FrozenBuffer>` from storage paths to the data which was
-   *   read. **Note:** Even if there was no data to read (e.g., all read
-   *   operations were for non-bound paths), as long as the spec included any
-   *   read operations, this property will still be present.
+   *   a `Map<string, FrozenBuffer>` from storage ID strings (`StoragePath`s or
+   *   content hashes) to the data which was read. **Note:** Even if there was
+   *   no data to read (e.g., all read operations were for non-bound paths), as
+   *   long as the spec included any read operations, this property will still
+   *   be present.
    * * `paths` &mdash; If the transaction spec included any wait or path list
    *   operations, a `Set<string>` of storage paths that resulted from the
    *   operations. **Note:** Even if there were no found paths (e.g., no
@@ -210,7 +212,7 @@ export default class BaseFile extends CommonBase {
       if (result.data === null) {
         throw InfoError.wtf('Improper subclass behavior: Expected non-`null` `data`.');
       }
-      TMap.check(result.data, StoragePath.check, FrozenBuffer.check);
+      TMap.check(result.data, StorageId.check, FrozenBuffer.check);
     } else {
       if (result.data !== null) {
         throw InfoError.wtf('Improper subclass behavior: Expected `null` `data`.');

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TInt, TString } from 'typecheck';
-import { InfoError, UtilityClass } from 'util-common';
+import { FrozenBuffer, InfoError, UtilityClass } from 'util-common';
 
 import StoragePath from './StoragePath';
 
@@ -14,6 +14,30 @@ import StoragePath from './StoragePath';
  * convention for those is `lowercase_underscore`, that is what's used.
  */
 export default class Errors extends UtilityClass {
+  /**
+   * Constructs an error indicating that a content blob was expected to be
+   * absent from the file, but turns out to be present.
+   *
+   * @param {string} hash Hash of the blob in question.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static blob_not_absent(hash) {
+    FrozenBuffer.checkHash(hash);
+    return new InfoError('blob_not_absent', hash);
+  }
+
+  /**
+   * Constructs an error indicating that a content blob was expected to be
+   * present in the file, but turns out to be absent.
+   *
+   * @param {string} hash Hash of the blob in question.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static blob_not_found(hash) {
+    FrozenBuffer.checkHash(hash);
+    return new InfoError('blob_not_found', hash);
+  }
+
   /**
    * Constructs an error indicating that a file does not exist.
    *

--- a/local-modules/file-store/StorageId.js
+++ b/local-modules/file-store/StorageId.js
@@ -1,0 +1,43 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TypeError } from 'typecheck';
+import { FrozenBuffer, UtilityClass } from 'util-common';
+
+import StoragePath from './StoragePath';
+
+/**
+ * Utility class for handling storage IDs. A storage ID is (generally speaking)
+ * the identifier of an atomic item of data within a file. Storage IDs are all
+ * strings. There are two valid kinds of storage ID:
+ *
+ * * paths &mdash; Storage paths as defined by {@link StoragePath}.
+ * * content hashes &mdash; Content hashes as defined by
+ *   {@link util-common.FrozenBuffer}.
+ */
+export default class StorageId extends UtilityClass {
+  /**
+   * Validates that the given value is a valid storage ID string. Throws an
+   * error if not.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is in fact a valid storage ID string.
+   */
+  static check(value) {
+    return StorageId.isInstance(value)
+      ? value
+      : TypeError.badValue(value, 'StorageId');
+  }
+
+  /**
+   * Indicates whether the given value is a valid storage ID string.
+   *
+   * @param {*} value Value in question.
+   * @returns {boolean} `true` if `value` is indeed a valid storage ID string,
+   *   or `false` if not.
+   */
+  static isInstance(value) {
+    return StoragePath.isInstance(value) || FrozenBuffer.isHash(value);
+  }
+}

--- a/local-modules/file-store/main.js
+++ b/local-modules/file-store/main.js
@@ -8,6 +8,7 @@ import Errors from './Errors';
 import FileCodec from './FileCodec';
 import FileId from './FileId';
 import FileOp from './FileOp';
+import StorageId from './StorageId';
 import StoragePath from './StoragePath';
 import TransactionSpec from './TransactionSpec';
 
@@ -18,6 +19,7 @@ export {
   FileCodec,
   FileId,
   FileOp,
+  StorageId,
   StoragePath,
   TransactionSpec
 };


### PR DESCRIPTION
This PR implements all of the `*blob*` ops that have been defined as part of the `file-store` API, for use in our usual all-local development environment (that is, when not connected to an external DB). With that, we finally have a complete `file-store` API implementation… though I expected that the API will still be evolving a bit before we can call it done.
