### PR TITLE
API messages and responses

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseKey, ConnectionError, Message } from 'api-common';
+import { BaseKey, ConnectionError, Message, Response } from 'api-common';
 import { Codec } from 'codec';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
@@ -245,30 +245,21 @@ export default class ApiClient {
     this._log.detail('Received raw payload:', event.data);
 
     const payload = Codec.theOne.decodeJson(event.data);
+
+    if (!(payload instanceof Response)) {
+      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response payload.');
+    }
+
     const id = payload.id;
-    let result = payload.result;
+    const result = payload.result;
     const error = payload.error;
-
-    if (result === undefined) {
-      result = null;
-    }
-
-    if (typeof id !== 'number') {
-      // We handle these as a `server_bug` and not, e.g. logging as `wtf()` and
-      // aborting, because this is indicative of a server-side problem and not
-      // an unrecoverable local problem.
-      const detail = id
-        ? `Strange ID type \`${typeof id}\` on API response.`
-        : 'Missing ID on API response.';
-      throw ConnectionError.connection_nonsense(this._connectionId, detail);
-    }
 
     const callback = this._callbacks[id];
     if (callback) {
       delete this._callbacks[id];
       if (error) {
         this._log.detail(`Reject ${id}:`, error);
-        callback.reject(new InfoError('remote_error', this.connectionId, error));
+        callback.reject(new InfoError('remote_error', this.connectionId, error.message));
       } else {
         this._log.detail(`Resolve ${id}:`, result);
         callback.resolve(result);

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -329,14 +329,13 @@ export default class ApiClient {
    * Sends the given call to the server.
    *
    * @param {string} target Name of the target object.
-   * @param {string} action_unused Action to invoke.
    * @param {string} name Name of method (or meta-method) to call on the server.
    * @param {object} [args = []] API-encodable object of arguments.
    * @returns {Promise} Promise for the result (or error) of the call. In the
    *   case of an error, the rejection reason will always be an instance of
    *   `ConnectionError` (see which for details).
    */
-  _send(target, action_unused, name, args = []) {
+  _send(target, name, args = []) {
     const wsState = (this._ws === null)
       ? WebSocket.CLOSED
       : this._ws.readyState;

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -329,14 +329,14 @@ export default class ApiClient {
    * Sends the given call to the server.
    *
    * @param {string} target Name of the target object.
-   * @param {string} action Action to invoke.
+   * @param {string} action_unused Action to invoke.
    * @param {string} name Name of method (or meta-method) to call on the server.
    * @param {object} [args = []] API-encodable object of arguments.
    * @returns {Promise} Promise for the result (or error) of the call. In the
    *   case of an error, the rejection reason will always be an instance of
    *   `ConnectionError` (see which for details).
    */
-  _send(target, action, name, args = []) {
+  _send(target, action_unused, name, args = []) {
     const wsState = (this._ws === null)
       ? WebSocket.CLOSED
       : this._ws.readyState;
@@ -359,7 +359,7 @@ export default class ApiClient {
     const id = this._nextId;
     this._nextId++;
 
-    const payloadObj = new Message(id, target, action, name, args);
+    const payloadObj = new Message(id, target, name, args);
     const payload = Codec.theOne.encodeJson(payloadObj);
 
     switch (wsState) {

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -256,7 +256,7 @@ export default class TargetHandler {
     const apiClient = this._apiClient;  // Avoid re-(re-)lookup on every call.
     const targetId  = this._targetId;   // Likewise.
     return (...args) => {
-      return apiClient._send(targetId, 'call', name, args);
+      return apiClient._send(targetId, name, args);
     };
   }
 }

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -25,9 +25,6 @@ export default class Message {
     /** {string} ID of the target object. */
     this._target = TString.nonempty(target);
 
-    /** {string} Action to take / being taken. */
-    this._action = 'call';
-
     /** {string} Method / property name to access. */
     this._name = TString.nonempty(name);
 
@@ -68,11 +65,6 @@ export default class Message {
   /** {string} ID of the target object. */
   get target() {
     return this._target;
-  }
-
-  /** {string} Action to take / being taken. */
-  get action() {
-    return 'call';
   }
 
   /** {string} Method / property name to access. */

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -15,12 +15,10 @@ export default class Message {
    * @param {Int} id Message ID, used to match requests and responses. Must be
    *   a non-negative integer.
    * @param {string} target ID of the target object to send to.
-   * @param {string} action Kind of action to take. Currently, the only valid
-   *   value is `call`.
    * @param {string} name Method (or property) name to access.
    * @param {array<*>} args Arguments to include with the message.
    */
-  constructor(id, target, action, name, args) {
+  constructor(id, target, name, args) {
     /** {Int} Message ID. */
     this._id = TInt.nonNegative(id);
 
@@ -28,24 +26,13 @@ export default class Message {
     this._target = TString.nonempty(target);
 
     /** {string} Action to take / being taken. */
-    this._action = TString.nonempty(action);
+    this._action = 'call';
 
     /** {string} Method / property name to access. */
     this._name = TString.nonempty(name);
 
     /** {array<*>} Arguments of the message. */
     this._args = TArray.check(args);
-
-    // Validate `action`.
-    switch (action) {
-      case 'call': {
-        // Valid.
-        break;
-      }
-      default: {
-        throw new Error(`Invalid value for \`action\`: \`${action}\``);
-      }
-    }
 
     Object.freeze(this);
   }
@@ -56,7 +43,7 @@ export default class Message {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this._id, this._target, this._action, this._name, this._args];
+    return [this._id, this._target, this._name, this._args];
   }
 
   /**
@@ -68,7 +55,6 @@ export default class Message {
     return {
       id:     this._id,
       target: this._target,
-      action: this._action,
       name:   this._name,
       args:   this._args
     };
@@ -86,7 +72,7 @@ export default class Message {
 
   /** {string} Action to take / being taken. */
   get action() {
-    return this._action;
+    return 'call';
   }
 
   /** {string} Method / property name to access. */

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -1,0 +1,178 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import util from 'util';
+
+import { TInt } from 'typecheck';
+import { CommonBase, InfoError } from 'util-common';
+
+/**
+ * Payload sent as a response to a method call.
+ *
+ * **Note:** In the case of error responses, the given `error` is converted so
+ * that it is always something that is expected to be codable across the API,
+ * such that it will be decoded into an `Error` instance of some sort on the
+ * far side of the connection.
+ */
+export default class Response extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} id Message ID, used to match requests and responses. Must be
+   *   a non-negative integer.
+   * @param {*} result Non-error result. Must be `null` if `error` is non-`null`
+   *   (but note that `null` is a valid non-error result).
+   * @param {*|null} error Error response, or `null` if there is no error.
+   *   `null` here definitively indicates that the instance is not
+   *   error-bearing.
+   */
+  constructor(id, result, error) {
+    super();
+
+    // Validate the `error`/`result` combo.
+    if ((result !== null) && (error !== null)) {
+      throw new Error('`result` and `error` cannot both be non-`null`.');
+    }
+
+    /** {Int} Message ID. */
+    this._id = TInt.nonNegative(id);
+
+    /**
+     * {*} Non-error result, if any. Always `null` if this is an error
+     * response.
+     */
+    this._result = result;
+
+    /**
+     * {InfoError|null} Error response, or `null` if this instance doesn't
+     * represent an error.
+     */
+    this._error = Response._fixError(error);
+
+    /**
+     * {array<string>|null} Error stack, or `null` if unavailable (including if
+     * this instance doesn't represent an error at all).
+     */
+    this._errorStack = Response._fixErrorStack(error);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    // We intentionally strip the `error` down to just a message for encoding,
+    // because the stack can leak security-sensitive info. **TODO:** We should
+    // aim for a bit higher-fidelity transfer. E.g., with `InfoError`, it is
+    // possible to encode the full error functor. This will probably best be
+    // achieved by making a codec to handle `InfoError` (or perhaps an
+    // API-specific subclass thereof.
+    return [this._id, this._result, this._error.message];
+  }
+
+  /**
+   * {InfoError|null} Error result, or `null` if this instance doesn't represent
+   * an error.
+   */
+  get error() {
+    return this._error;
+  }
+
+  /**
+   * {array<string>|null} Clean error stack, or `null` if this instance doesn't
+   * represent an error.
+   */
+  get errorStack() {
+    return this._errorStack;
+  }
+
+  /** {Int} Message ID. */
+  get id() {
+    return this._id;
+  }
+
+  /**
+   * {*} Non-error result. Always `null` if this instance represents an error.
+   */
+  get result() {
+    return this._result;
+  }
+
+  /**
+   * Fixes up an incoming `error` argument. `null` gets returned as-is.
+   * Everything else gets converted into an `InfoError` of some sort.
+   *
+   * @param {*} error Error value.
+   * @returns {InfoError|null} Cleaned up error value.
+   */
+  static _fixError(error) {
+    if (error === null) {
+      return null;
+    } else if (error instanceof InfoError) {
+      return error;
+    } else if (error instanceof Error) {
+      const result = new InfoError('general_error', error.message);
+      result.stack = error.stack;
+    }
+
+    const message = (typeof error === 'string')
+      ? error
+      : util.inspect(error);
+
+    return new InfoError('general_error', message);
+  }
+
+  /**
+   * Makes a cleaned-up stack from an incoming `error` argument. This returns
+   * `null` if `error` doesn't come with a stack.
+   *
+   * @param {*} error Error value.
+   * @returns {string|null} Cleaned up error stack, or `null` if there is no
+   *   stack to clean up.
+   */
+  static _fixErrorStack(error) {
+    if (!(error instanceof Error)) {
+      return null;
+    }
+
+    const stack = error.stack;
+
+    if (typeof stack !== 'string') {
+      return null;
+    }
+
+    // Match on each line of the stack that looks like a function/method call
+    // (`...at...`). Using `map()` strip each one of the unintersting parts.
+    return stack.match(/^ +at .*$/mg).map((line) => {
+      // Lines that name functions are expected to be of the form
+      // `    at func.name (/path/to/file:NN:NN)`, where `func.name` might
+      // actually be `new func.name` or `func.name [as other.name]` (or both).
+      let match = line.match(/^ +at ([^()]+) \(([^()]+)\)$/);
+      let funcName;
+      let filePath;
+
+      if (match) {
+        funcName = match[1];
+        filePath = match[2];
+      } else {
+        // Anonymous functions (including top-level code) have the form
+        // `    at /path/to/file:NN:NN`.
+        match = line.match(/^ +at ([^()]*)$/);
+        funcName = '(anon)';
+        filePath = match[1];
+      }
+
+      const fileSplit = filePath.match(/\/?[^/]+/g) || ['?'];
+      const splitLen  = fileSplit.length;
+      const fileName  = (splitLen < 2)
+        ? fileSplit[0]
+        : `...${fileSplit[splitLen - 2]}${fileSplit[splitLen - 1]}`;
+
+      return `${funcName} (${fileName})`;
+    });
+  }
+}

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -71,7 +71,9 @@ export default class Response extends CommonBase {
     // possible to encode the full error functor. This will probably best be
     // achieved by making a codec to handle `InfoError` (or perhaps an
     // API-specific subclass thereof.
-    return [this._id, this._result, this._error.message];
+    const error = (this._error === null) ? null : this._error.message;
+
+    return [this._id, this._result, error];
   }
 
   /**
@@ -115,8 +117,7 @@ export default class Response extends CommonBase {
     } else if (error instanceof InfoError) {
       return error;
     } else if (error instanceof Error) {
-      const result = new InfoError('general_error', error.message);
-      result.stack = error.stack;
+      return new InfoError(error, 'general_error', error.message);
     }
 
     const message = (typeof error === 'string')

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -128,21 +128,24 @@ export default class Response extends CommonBase {
 
   /**
    * Makes a cleaned-up stack from an incoming `error` argument. This returns
-   * `null` if `error` doesn't come with a stack.
+   * `null` if given `null`. In other cases were `error` doesn't come with a
+   * stack, this returns an empty array.
    *
    * @param {*} error Error value.
-   * @returns {string|null} Cleaned up error stack, or `null` if there is no
-   *   stack to clean up.
+   * @returns {string|null} Cleaned up error stack, `[]` if this is an error-ish
+   *   value with no stack, or `null` if `error` is `null`.
    */
   static _fixErrorStack(error) {
-    if (!(error instanceof Error)) {
+    if (error === null) {
       return null;
+    } else if (!(error instanceof Error)) {
+      return [];
     }
 
     const stack = error.stack;
 
     if (typeof stack !== 'string') {
-      return null;
+      return [];
     }
 
     // Match on each line of the stack that looks like a function/method call

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -12,6 +12,7 @@ import SplitKey from './SplitKey';
 
 // Register classes with the API.
 Codec.theOne.registerClass(Message);
+Codec.theOne.registerClass(Response);
 Codec.theOne.registerClass(SplitKey);
 
 export { BaseKey, ConnectionError, Message, Response, SplitKey };

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -7,10 +7,11 @@ import { Codec } from 'codec';
 import BaseKey from './BaseKey';
 import ConnectionError from './ConnectionError';
 import Message from './Message';
+import Response from './Response';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
 Codec.theOne.registerClass(Message);
 Codec.theOne.registerClass(SplitKey);
 
-export { BaseKey, ConnectionError, Message, SplitKey };
+export { BaseKey, ConnectionError, Message, Response, SplitKey };

--- a/local-modules/api-common/tests/test_Message.js
+++ b/local-modules/api-common/tests/test_Message.js
@@ -10,64 +10,50 @@ import { Message } from 'api-common';
 describe('api-common/Message', () => {
   describe('constructor(id, target, action, name, args)', () => {
     it('should require integer ids >= 0', () => {
-      assert.throws(() => new Message('this better not work!', 'foo', 'call', 'bar', []));
-      assert.throws(() => new Message(3.7, 'target', 'call', 'method', []));
-      assert.throws(() => new Message(true, 'target', 'call', 'method', []));
-      assert.throws(() => new Message(null, 'target', 'call', 'method', []));
-      assert.throws(() => new Message(undefined, 'target', 'call', 'method', []));
-      assert.throws(() => new Message(-1, 'target', 'call', 'method', []));
+      assert.throws(() => new Message('this better not work!', 'foo', 'bar', []));
+      assert.throws(() => new Message(3.7, 'target', 'method', []));
+      assert.throws(() => new Message(true, 'target', 'method', []));
+      assert.throws(() => new Message(null, 'target', 'method', []));
+      assert.throws(() => new Message(undefined, 'target', 'method', []));
+      assert.throws(() => new Message(-1, 'target', 'method', []));
 
-      assert.doesNotThrow(() => new Message(0, 'target', 'call', 'method', []));
-      assert.doesNotThrow(() => new Message(37, 'target', 'call', 'method', []));
+      assert.doesNotThrow(() => new Message(0, 'target', 'method', []));
+      assert.doesNotThrow(() => new Message(37, 'target', 'method', []));
     });
 
     it('should require target to be a non-empty string', () => {
-      assert.throws(() => new Message(37, 37, 'call', 'bar', []));
-      assert.throws(() => new Message(37, false, 'call', 'bar', []));
-      assert.throws(() => new Message(37, null, 'call', 'bar', []));
-      assert.throws(() => new Message(37, undefined, 'call', 'bar', []));
-      assert.throws(() => new Message(37, '', 'call', 'bar', []));
+      assert.throws(() => new Message(37, 37, 'bar', []));
+      assert.throws(() => new Message(37, false, 'bar', []));
+      assert.throws(() => new Message(37, null, 'bar', []));
+      assert.throws(() => new Message(37, undefined, 'bar', []));
+      assert.throws(() => new Message(37, '', 'bar', []));
 
-      assert.doesNotThrow(() => new Message(0, 'target', 'call', 'method', []));
-    });
-
-    it("should require that action be 'call'", () => {
-      assert.throws(() => new Message(0, 'target', false, 'method', []));
-      assert.throws(() => new Message(0, 'target', 37, 'method', []));
-      assert.throws(() => new Message(0, 'target', null, 'method', []));
-      assert.throws(() => new Message(0, 'target', undefined, 'method', []));
-      assert.throws(() => new Message(0, 'target', '', 'method', []));
-      assert.throws(() => new Message(0, 'target', 'this better not work!', 'method', []));
-
-      assert.doesNotThrow(() => new Message(0, 'target', 'call', 'method', []));
+      assert.doesNotThrow(() => new Message(0, 'target', 'method', []));
     });
 
     it('should require name to be a non-empty string', () => {
-      assert.throws(() => new Message(0, 'target', 'call', false, []));
-      assert.throws(() => new Message(0, 'target', 'call', 37, []));
-      assert.throws(() => new Message(0, 'target', 'call', null, []));
-      assert.throws(() => new Message(0, 'target', 'call', undefined, []));
-      assert.throws(() => new Message(0, 'target', 'call', '', []));
+      assert.throws(() => new Message(0, 'target', false, []));
+      assert.throws(() => new Message(0, 'target', 37, []));
+      assert.throws(() => new Message(0, 'target', null, []));
+      assert.throws(() => new Message(0, 'target', undefined, []));
+      assert.throws(() => new Message(0, 'target', '', []));
 
-      assert.doesNotThrow(() => new Message(0, 'target', 'call', 'method', []));
+      assert.doesNotThrow(() => new Message(0, 'target', 'method', []));
     });
 
-    it('should args to be an array', () => {
-      assert.throws(() => new Message(0, 'target', 'call', 'method', false));
-      assert.throws(() => new Message(0, 'target', 'call', 'method', 37));
-      assert.throws(() => new Message(0, 'target', 'call', 'method', null));
-      assert.throws(() => new Message(0, 'target', 'call', 'method', undefined));
-      assert.throws(() => new Message(0, 'target', 'call', 'method', { }));
+    it('should require args to be an array', () => {
+      assert.throws(() => new Message(0, 'target', 'method', false));
+      assert.throws(() => new Message(0, 'target', 'method', 37));
+      assert.throws(() => new Message(0, 'target', 'method', null));
+      assert.throws(() => new Message(0, 'target', 'method', undefined));
+      assert.throws(() => new Message(0, 'target', 'method', { }));
 
-      assert.doesNotThrow(() => new Message(0, 'target', 'call', 'method', []));
+      assert.doesNotThrow(() => new Message(0, 'target', 'method', []));
     });
 
     it('should return a frozen object', () => {
-      assert.throws(() => {
-        const message = new Message(0, 'target', 'call', 'method', false);
-
-        assert.isFrozen(message);
-      });
+      const message = new Message(0, 'target', 'method', ['args']);
+      assert.isFrozen(message);
     });
   });
 });

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -39,15 +39,15 @@ export default class ApiLog extends Singleton {
    *   the earlier call to `incomingMessage()` for `msg`.
    * @param {Message|null} msg Incoming message, or `null` if there wasn't a
    *   valid message as part of this call.
-   * @param {object} response Response to the message.
+   * @param {Response} response Response to the message.
    */
   fullCall(connectionId, startTime, msg, response) {
     if (response.error) {
       // TODO: Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
-      this._console.error(`[${connectionId}] Error:`, response.error);
-      if (response.errorStack) {
+      this._console.error(`[${connectionId}] Error:`, response.error.message);
+      if (response.errorStack.length !== 0) {
         const stackString = response.errorStack.join('\n  ');
         this._console.info(`Original trace:\n  ${stackString}`);
       }

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -37,7 +37,8 @@ export default class ApiLog extends Singleton {
    * @param {Int} startTime Standard msec timestamp indicating the start time of
    *   the API call being represented here. Should be the value returned from
    *   the earlier call to `incomingMessage()` for `msg`.
-   * @param {object} msg Incoming message.
+   * @param {Message|null} msg Incoming message, or `null` if there wasn't a
+   *   valid message as part of this call.
    * @param {object} response Response to the message.
    */
   fullCall(connectionId, startTime, msg, response) {
@@ -61,7 +62,7 @@ export default class ApiLog extends Singleton {
       endTime:      Date.now(),
       connectionId,
       ok:           !response.error,
-      msg:          msg.toLog()
+      msg:          msg ? msg.toLog() : null
     };
 
     if (details.ok) {

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -262,26 +262,14 @@ export default class Connection extends CommonBase {
    */
   async _actOnMessage(msg) {
     const target = this.getTarget(msg.target);
-    const action = msg.action;
     const name   = msg.name;
     const args   = msg.args;
 
-    switch (action) {
-      case 'call': {
-        activeNow = this;
-        try {
-          return target.call(name, args);
-        } finally {
-          activeNow = null;
-        }
-      }
-
-      // **Note:** Ultimately we might accept `get` and `set`, for example, thus
-      // exposing a bit more of a JavaScript-like interface.
-
-      default: {
-        throw new Error(`Bad action: \`${action}\``);
-      }
+    activeNow = this;
+    try {
+      return target.call(name, args);
+    } finally {
+      activeNow = null;
     }
   }
 

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -194,6 +194,7 @@ export default class Connection extends CommonBase {
       }
     } else if (msg instanceof Error) {
       error = msg;
+      msg = null; // Salient for logging.
     } else {
       // Shouldn't happen because `_decodeMessage()` should only return one of
       // the above two types.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.24.0
+version = 0.25.0


### PR DESCRIPTION
This PR is a round of simplification / clarification / obviousification of the flow of messages and responses across an API boundary. Highlights:

* `Message` no longer has an `action` field. We were only ever using the action `call` at this point. (Earlier versions of the system used a couple other actions too; one of those was removed quite a while ago, and the other was removed in a more recent PR.) At one point, it seemed like the set of actions might expand further, but at this point that seems unlikely.
* Add a new `Response` class to hold the response data for an API call. Previously, responses were naked objects. This class is now where all the smarts live for making error values suitable for both logging and transmission over an API boundary. The code for this all got a bit more resilient in the process.

There is still a bit of work to do to make errors even betterer, but I think this PR lays a pretty good foundation for that future work.