### PR TITLE
Clean up a couple error-related bits. 

### DIFF
--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -1,0 +1,40 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+import { InfoError } from 'util-common';
+
+/**
+ * Error which can be encoded and decoded across an API boundary.
+ *
+ * **Note:** We intentionally exclude stack trace info from the encoded form,
+ * because that can be security-sensitive.
+ */
+export default class CodableError extends InfoError {
+  /** {string} Name of this class for the sake of API coding. */
+  static get API_TAG() {
+    return 'Error';
+  }
+
+  /**
+   * Constructs an instance. Arguments are the same as for `InfoError` except
+   * that an initial "cause" argument is not allowed.
+   *
+   * @param {...*} args Constructor arguments. These are the same as for
+   *   `InfoError` except that an initial "cause" argument is not allowed.
+   */
+  constructor(...args) {
+    TString.check(args[0]); // Ensures it's a functor name and not a cause.
+    super(...args);
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this.name, ...(this.args)];
+  }
+}

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -3,12 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray, TInt, TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 /**
  * The main "envelope" of a message being sent from client to server to requrest
  * action.
  */
-export default class Message {
+export default class Message extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -19,6 +20,8 @@ export default class Message {
    * @param {array<*>} args Arguments to include with the message.
    */
   constructor(id, target, name, args) {
+    super();
+
     /** {Int} Message ID. */
     this._id = TInt.nonNegative(id);
 

--- a/local-modules/api-common/main.js
+++ b/local-modules/api-common/main.js
@@ -5,14 +5,16 @@
 import { Codec } from 'codec';
 
 import BaseKey from './BaseKey';
+import CodableError from './CodableError';
 import ConnectionError from './ConnectionError';
 import Message from './Message';
 import Response from './Response';
 import SplitKey from './SplitKey';
 
 // Register classes with the API.
+Codec.theOne.registerClass(CodableError);
 Codec.theOne.registerClass(Message);
 Codec.theOne.registerClass(Response);
 Codec.theOne.registerClass(SplitKey);
 
-export { BaseKey, ConnectionError, Message, Response, SplitKey };
+export { BaseKey, CodableError, ConnectionError, Message, Response, SplitKey };

--- a/local-modules/doc-common/FrozenDelta.js
+++ b/local-modules/doc-common/FrozenDelta.js
@@ -20,6 +20,11 @@ let emptyInstance = null;
  * `Delta` provides.
  */
 export default class FrozenDelta extends Delta {
+  /** {string} Name of this class for the sake of API coding. */
+  static get API_TAG() {
+    return 'Delta';
+  }
+
   /** {FrozenDelta} Empty instance of this class. */
   static get EMPTY() {
     if (emptyInstance === null) {
@@ -111,11 +116,6 @@ export default class FrozenDelta extends Delta {
 
     super(DataUtil.deepFreeze(ops));
     Object.freeze(this);
-  }
-
-  /** Name of this class in the API. */
-  static get API_TAG() {
-    return 'Delta';
   }
 
   /**

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -242,7 +242,7 @@ export default class LocalFile extends BaseFile {
        * @returns {Iterator<string, FrozenBuffer>} Iterator over all storage.
        */
       allStorage() {
-        return outerThis._filterStorage(LocalFile._isInternalStorageId);
+        return outerThis._filterStorage(LocalFile._isExternalStorageId);
       },
 
       /**
@@ -633,7 +633,20 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
-   * Indicates whether the given storage ID is an internal-use one.
+   * Indicates whether the given storage ID is a regular for-external-use one.
+   * This is the opposite of `_isInternalStorageId()`.
+   *
+   * @param {string} storageId The storage ID.
+   * @returns {boolean} `true` iff `storageId` is only for the internal use of
+   *   this module.
+   */
+  static _isExternalStorageId(storageId) {
+    return !LocalFile._isInternalStorageId(storageId);
+  }
+
+  /**
+   * Indicates whether the given storage ID is an internal-use one. This is the
+   * opposite of `_isExternalStorageId()`.
    *
    * @param {string} storageId The storage ID.
    * @returns {boolean} `true` iff `storageId` is only for the internal use of

--- a/local-modules/util-common/InfoError.js
+++ b/local-modules/util-common/InfoError.js
@@ -110,6 +110,13 @@ export default class InfoError extends Error {
     /** {array<*>} The detail arguments. */
     this._args = detailsArgs;
 
+    if (this._cause !== null) {
+      // Append the cause's stack to this instance's. **TODO:** Figure out if
+      // we can do this lazily, which would mean somehow both overriding
+      // `.stack` _and_ being able to get its originally-set value.
+      this.stack += `\ncaused by:\n${this._cause.stack}`;
+    }
+
     Object.freeze(this);
   }
 
@@ -135,21 +142,5 @@ export default class InfoError extends Error {
    */
   get args() {
     return this._args;
-  }
-
-  /**
-   * Gets the string form of this instance. This includes the `cause`, if any.
-   *
-   * @returns {string} The string form.
-   */
-  toString() {
-    const thisTrace = super.toString();
-    const cause = this._cause;
-
-    if (cause === null) {
-      return thisTrace;
-    } else {
-      return `${thisTrace}${cause.toString()}`;
-    }
   }
 }


### PR DESCRIPTION
This is a follow-on from my last PR, aiming to smooth out a couple of the rough edges. Errors now stringify a bit better, and are also transmitted across an API boundary with a bit better fidelity.

**Bonus:** Fixed a bug in the `deleteAll` file op, which manifested as a problem in document reinitialization after a validation error.