### PR TITLE
Frozen data stuff.

### DIFF
--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -7,7 +7,7 @@
 import crypto from 'crypto';
 
 import { TString } from 'typecheck';
-import { DataUtil, Random } from 'util-common';
+import { Random } from 'util-common';
 
 import BaseKey from './BaseKey';
 
@@ -101,8 +101,8 @@ export default class SplitKey extends BaseKey {
 
     const hash = crypto.createHash('sha256');
 
-    hash.update(DataUtil.bufferFromHex(challenge));
-    hash.update(DataUtil.bufferFromHex(this._secret));
+    hash.update(Buffer.from(challenge, 'hex'));
+    hash.update(Buffer.from(this._secret, 'hex'));
 
     return hash.digest('hex');
   }

--- a/local-modules/api-common/tests/test_BaseKey.js
+++ b/local-modules/api-common/tests/test_BaseKey.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseKey } from 'api-common';
-import { DataUtil, Random } from 'util-common';
+import { Random } from 'util-common';
 
 const VALID_ID = '12345678';
 
@@ -16,7 +16,7 @@ class FakeKey extends BaseKey {
   }
 
   _impl_challengeResponseFor(challenge) {
-    const bytes = DataUtil.bufferFromHex(challenge);
+    const bytes = Buffer.from(challenge, 'hex');
 
     for (let i = 0; i < bytes.length; i++) {
       bytes[i] ^= 0x0e;

--- a/local-modules/util-common/DataUtil.js
+++ b/local-modules/util-common/DataUtil.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from 'typecheck';
 import { ObjectUtil, UtilityClass } from 'util-common-base';
 
 /**
@@ -88,18 +87,5 @@ export default class DataUtil extends UtilityClass {
         throw new Error(`Cannot deep-freeze non-data value: ${value}`);
       }
     }
-  }
-
-  /**
-   * Parses an even-length string of hex digits (lower case), producing a
-   * `Buffer`.
-   *
-   * @param {string} hex String of hex digits.
-   * @returns {Buffer} Buffer of parsed bytes.
-   */
-  static bufferFromHex(hex) {
-    TString.hexBytes(hex);
-
-    return Buffer.from(hex, 'hex');
   }
 }

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -28,8 +28,8 @@ describe('util-common/DataUtil', () => {
       function test(value) {
         const popsicle = DataUtil.deepFreeze(value);
         const deepPopsicle = DataUtil.deepFreeze(popsicle);
-        assert.strictEqual(deepPopsicle, popsicle);
-        assert.deepEqual(deepPopsicle, value);
+        assert.strictEqual(deepPopsicle, popsicle, 'Frozen strict-equals re-frozen.');
+        assert.deepEqual(deepPopsicle, value, 'Re-frozen deep-equals original.');
       }
 
       test({});
@@ -71,6 +71,14 @@ describe('util-common/DataUtil', () => {
       test([1, 2, 'foo', 'bar']);
       test([[[[[[[[[['hello']]]]]]]]]]);
       test({ x: [[[[[123]]]]], y: [37, [37], [[37]], [[[37]]]], z: [{ x: 10 }] });
+    });
+
+    it('should not freeze the originally passed value', () => {
+      const orig = [1, 2, 3];
+      const popsicle = DataUtil.deepFreeze(orig);
+
+      assert.isFrozen(popsicle);
+      assert.isNotFrozen(orig);
     });
   });
 

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -28,6 +28,7 @@ describe('util-common/DataUtil', () => {
       function test(value) {
         const popsicle = DataUtil.deepFreeze(value);
         const deepPopsicle = DataUtil.deepFreeze(popsicle);
+        assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.strictEqual(deepPopsicle, popsicle, 'Frozen strict-equals re-frozen.');
         assert.deepEqual(deepPopsicle, value, 'Re-frozen deep-equals original.');
       }
@@ -41,27 +42,9 @@ describe('util-common/DataUtil', () => {
     });
 
     it('should return a deep-frozen object if passed one that isn\'t already deep-frozen', () => {
-      // Good enough recursive frozen check for testing, but not good enough to
-      // be in the main class.
-      function isDeepFrozen(value) {
-        if (!Object.isFrozen(value)) {
-          return false;
-        } else if (typeof value !== 'object') {
-          return true;
-        }
-
-        for (const v of Object.values(value)) {
-          if (!isDeepFrozen(v)) {
-            return false;
-          }
-        }
-
-        return true;
-      }
-
       function test(value) {
         const popsicle = DataUtil.deepFreeze(value);
-        assert.isTrue(isDeepFrozen(popsicle), value);
+        assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.deepEqual(popsicle, value);
       }
 
@@ -77,7 +60,7 @@ describe('util-common/DataUtil', () => {
       const orig = [1, 2, 3];
       const popsicle = DataUtil.deepFreeze(orig);
 
-      assert.isFrozen(popsicle);
+      assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.isNotFrozen(orig);
     });
 
@@ -88,7 +71,7 @@ describe('util-common/DataUtil', () => {
 
       const popsicle = DataUtil.deepFreeze(orig);
 
-      assert.isFrozen(popsicle);
+      assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.deepEqual(popsicle, orig);
     });
 
@@ -99,7 +82,7 @@ describe('util-common/DataUtil', () => {
 
       const popsicle = DataUtil.deepFreeze(orig);
 
-      assert.isFrozen(popsicle);
+      assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.deepEqual(popsicle, orig);
     });
 
@@ -110,7 +93,7 @@ describe('util-common/DataUtil', () => {
 
       const popsicle = DataUtil.deepFreeze(orig);
 
-      assert.isFrozen(popsicle);
+      assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.deepEqual(popsicle, orig);
     });
 
@@ -119,7 +102,7 @@ describe('util-common/DataUtil', () => {
 
       const popsicle = DataUtil.deepFreeze(orig);
 
-      assert.isFrozen(popsicle);
+      assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.deepEqual(popsicle, orig);
     });
 

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -80,6 +80,48 @@ describe('util-common/DataUtil', () => {
       assert.isFrozen(popsicle);
       assert.isNotFrozen(orig);
     });
+
+    it('should work on arrays with holes', () => {
+      const orig = [1, 2, 3];
+      orig[37]   = ['florp'];
+      orig[914]  = [[['like']]];
+
+      const popsicle = DataUtil.deepFreeze(orig);
+
+      assert.isFrozen(popsicle);
+      assert.deepEqual(popsicle, orig);
+    });
+
+    it('should work on arrays with additional string-named properties', () => {
+      const orig = [1, 2, 3];
+      orig.florp = ['florp'];
+      orig.like  = [[['like']]];
+
+      const popsicle = DataUtil.deepFreeze(orig);
+
+      assert.isFrozen(popsicle);
+      assert.deepEqual(popsicle, orig);
+    });
+
+    it('should work on arrays with additional symbol-named properties', () => {
+      const orig = [1, 2, 3];
+      orig[Symbol('florp')] = ['florp'];
+      orig[Symbol('like')] = [[['like']]];
+
+      const popsicle = DataUtil.deepFreeze(orig);
+
+      assert.isFrozen(popsicle);
+      assert.deepEqual(popsicle, orig);
+    });
+
+    it('should work on objects with symbol-named properties', () => {
+      const orig = { a: 10, [Symbol('b')]: 20 };
+
+      const popsicle = DataUtil.deepFreeze(orig);
+
+      assert.isFrozen(popsicle);
+      assert.deepEqual(popsicle, orig);
+    });
   });
 
   describe('bufferFromHex()', () => {

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -155,26 +155,4 @@ describe('util-common/DataUtil', () => {
       test({ a: 10, b: { c: { d: synthetic } } });
     });
   });
-
-  describe('bufferFromHex()', () => {
-    it('should throw an Error if passed an odd-lengthed string', () => {
-      assert.throws(() => DataUtil.bufferFromHex('aabbc'));
-    });
-
-    it('should throw an error if pass a string that isn\'t solely hex bytes', () => {
-      assert.throws(() => DataUtil.bufferFromHex('this better not work!'));
-    });
-
-    it('should return a buffer when passed a valid hex string', () => {
-      const bytes = DataUtil.bufferFromHex('deadbeef');
-
-      assert.isTrue(Buffer.isBuffer(bytes));
-
-      assert.strictEqual(bytes.length, 4);
-      assert.strictEqual(bytes[0], 0xde);
-      assert.strictEqual(bytes[1], 0xad);
-      assert.strictEqual(bytes[2], 0xbe);
-      assert.strictEqual(bytes[3], 0xef);
-    });
-  });
 });

--- a/local-modules/util-common/tests/test_DataUtil.js
+++ b/local-modules/util-common/tests/test_DataUtil.js
@@ -122,6 +122,38 @@ describe('util-common/DataUtil', () => {
       assert.isFrozen(popsicle);
       assert.deepEqual(popsicle, orig);
     });
+
+    it('should fail if given a function or a composite that contains same', () => {
+      function test(value) {
+        assert.throws(() => { DataUtil.deepFreeze(value); });
+      }
+
+      test(test); // Because `test` is indeed a function!
+      test(() => 123);
+      test([1, 2, 3, test]);
+      test([1, 2, 3, [[[[[test]]]]]]);
+      test({ a: 10, b: test });
+      test({ a: 10, b: { c: { d: test } } });
+    });
+
+    it('should fail if given a non-simple object or a composite that contains same', () => {
+      function test(value) {
+        assert.throws(() => { DataUtil.deepFreeze(value); });
+      }
+
+      const instance = new Number(10);
+      const synthetic = {
+        a: 10,
+        get x() { return 20; }
+      };
+
+      test(instance);
+      test(synthetic);
+      test([instance]);
+      test([1, 2, 3, [[[[[synthetic]]]]]]);
+      test({ a: 10, b: instance });
+      test({ a: 10, b: { c: { d: synthetic } } });
+    });
   });
 
   describe('bufferFromHex()', () => {


### PR DESCRIPTION
This PR fixes a bug in `DataUtil.deepFreeze()`, adds a companion `isDeepFrozen()` method, and adds a bunch of tests for the whole shmegegge.

**Bonus:** Removed `bufferFromHex()` which wasn't pulling its weight.