### PR TITLE
Introduce functors, and use them in `InfoError`.

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -259,7 +259,7 @@ export default class ApiClient {
       delete this._callbacks[id];
       if (error) {
         this._log.detail(`Reject ${id}:`, error);
-        callback.reject(new InfoError('remote_error', this.connectionId, error.message));
+        callback.reject(new InfoError('remote_error', this.connectionId, error));
       } else {
         this._log.detail(`Resolve ${id}:`, result);
         callback.resolve(result);

--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -2,8 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from 'typecheck';
-import { InfoError } from 'util-common';
+import { Functor, InfoError } from 'util-common';
 
 /**
  * Error which can be encoded and decoded across an API boundary.
@@ -21,12 +20,10 @@ export default class CodableError extends InfoError {
    * Constructs an instance. Arguments are the same as for `InfoError` except
    * that an initial "cause" argument is not allowed.
    *
-   * @param {...*} args Constructor arguments. These are the same as for
-   *   `InfoError` except that an initial "cause" argument is not allowed.
+   * @param {Functor} info Error info.
    */
-  constructor(...args) {
-    TString.check(args[0]); // Ensures it's a functor name and not a cause.
-    super(...args);
+  constructor(info) {
+    super(Functor.check(info));
   }
 
   /**
@@ -35,6 +32,6 @@ export default class CodableError extends InfoError {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this.name, ...(this.args)];
+    return [this.info];
   }
 }

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -5,7 +5,7 @@
 import util from 'util';
 
 import { TInt } from 'typecheck';
-import { CommonBase, InfoError } from 'util-common';
+import { CommonBase, Functor, InfoError } from 'util-common';
 
 import CodableError from './CodableError';
 
@@ -114,10 +114,10 @@ export default class Response extends CommonBase {
     } else if (error instanceof InfoError) {
       // Adopt the functor of the error. Lose the cause (if any), exact class
       // identity, and stack.
-      return new CodableError(error.name, ...(error.args));
+      return new CodableError(error.info);
     } else if (error instanceof Error) {
       // Adopt the message. Lose the rest of the info.
-      return new CodableError('general_error', error.message);
+      return new CodableError(new Functor('general_error', error.message));
     }
 
     const message = (typeof error === 'string')

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -44,6 +44,7 @@ export default class Registry extends CommonBase {
 
     // Register all the special codecs.
     this.registerCodec(SpecialCodecs.ARRAY);
+    this.registerCodec(SpecialCodecs.FUNCTOR);
     this.registerCodec(SpecialCodecs.SIMPLE_OBJECT);
     this.registerCodec(SpecialCodecs.selfRepresentative('boolean'));
     this.registerCodec(SpecialCodecs.selfRepresentative('null'));

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { UtilityClass } from 'util-common';
+import { Functor, UtilityClass } from 'util-common';
 
 import ItemCodec from './ItemCodec';
 
@@ -72,6 +72,38 @@ export default class SpecialCodecs extends UtilityClass {
     }
 
     return true;
+  }
+
+  /** {ItemCodec} Codec used for coding functors. */
+  static get FUNCTOR() {
+    return new ItemCodec('f', Functor, null,
+      this._functorEncode, this._functorDecode);
+  }
+
+  /**
+   * Decodes a functor.
+   *
+   * @param {array<*>} payload Construction payload as previously produced by
+   *   `_functorEncode()`.
+   * @param {function} subDecode Function to call to decode component values
+   *   inside `payload`, as needed.
+   * @returns {Functor} Decoded functor.
+   */
+  static _functorDecode(payload, subDecode) {
+    const decodedArgs = payload.map(subDecode);
+    return new Functor(...decodedArgs);
+  }
+
+  /**
+   * Encodes a functor.
+   *
+   * @param {Functor} value Functor to encode.
+   * @param {function} subEncode Function to call to encode component values
+   *   inside `value`, as needed.
+   * @returns {array<*>} Encoded form.
+   */
+  static _functorEncode(value, subEncode) {
+    return [value.name, ...(value.args)].map(subEncode);
   }
 
   /** {ItemCodec} Codec used for coding simple objects. */

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SeeAll } from 'see-all';
-import { Singleton } from 'util-common';
+import { InfoError, Singleton } from 'util-common';
 
 /**
  * Implementation of the `see-all` logging sink protocol for use in a web

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SeeAll } from 'see-all';
-import { InfoError, Singleton } from 'util-common';
+import { Singleton } from 'util-common';
 
 /**
  * Implementation of the `see-all` logging sink protocol for use in a web

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -2,14 +2,16 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Errors, ObjectUtil, UtilityClass } from 'util-core';
+import { CoreTypecheck, Errors, ObjectUtil, UtilityClass } from 'util-core';
 
 /**
  * Type checker for type `Object`.
  */
 export default class TObject extends UtilityClass {
   /**
-   * Checks a value of type `Object`.
+   * Checks that a value is of type `Object`, and is optionally an instance of
+   * a particular class. `null` is _not_ considered an object by this check.
+   * Functions _are_ considered objects by this check.
    *
    * @param {*} value Value to check.
    * @param {object|null} [clazz = null] Class (constructor) that `value` must
@@ -17,13 +19,9 @@ export default class TObject extends UtilityClass {
    * @returns {object} `value`.
    */
   static check(value, clazz = null) {
-    if (typeof value !== 'object') {
-      throw Errors.bad_value(value, Object);
-    } else if ((clazz !== null) && !(value instanceof clazz)) {
-      throw Errors.bad_value(value, `class ${clazz.name}`);
-    }
-
-    return value;
+    // This is defined in `CoreTypecheck` so that it can be used by `util-core`
+    // without introducing a circular dependency on this module.
+    return CoreTypecheck.checkObject(value, clazz);
   }
 
   /**

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -11,20 +11,47 @@ describe('typecheck/TObject', () => {
   describe('check(value)', () => {
     it('should return the provided value when passed an object', () => {
       const value = { a: 1, b: 2 };
+      const func  = () => 123;
 
       assert.strictEqual(TObject.check(value), value);
+      assert.strictEqual(TObject.check(func),  func);
     });
 
     it('should throw an Error when passed anything other than an object', () => {
-      assert.throws(() => TObject.check('this better not work'));
+      assert.throws(() => TObject.check(null));
+      assert.throws(() => TObject.check(undefined));
       assert.throws(() => TObject.check(54));
       assert.throws(() => TObject.check(true));
-      assert.throws(() => TObject.check(() => true));
-      assert.throws(() => TObject.check(undefined));
+      assert.throws(() => TObject.check('this better not work'));
     });
   });
 
-  describe('withExactKeys(value, keys)', () => {
+  describe('check(value, clazz)', () => {
+    it('should accept a value of the given class', () => {
+      function test(value, clazz) {
+        assert.strictEqual(TObject.check(value, clazz), value);
+      }
+
+      test({ a: 10 }, Object);
+
+      test(['x'],     Array);
+      test(['x'],     Object);
+
+      test(() => 123, Function);
+      test(() => 123, Object);
+    });
+
+    it('should throw an Error when passed a value not of the given class', () => {
+      assert.throws(() => TObject.check(new Boolean(true), String));
+    });
+
+    it('should throw an Error when passed anything other than an object', () => {
+      assert.throws(() => TObject.check(null, Object));
+      assert.throws(() => TObject.check(54,   Object));
+    });
+  });
+
+  describe('withExactKeys()', () => {
     it('should allow an object with exactly the provided keys', () => {
       const value = { 'a': 1, 'b': 2, 'c': 3 };
 

--- a/local-modules/util-common/ColorSelector.js
+++ b/local-modules/util-common/ColorSelector.js
@@ -4,6 +4,8 @@
 
 import ColorUtil from './ColorUtil';
 
+import { CommonBase } from 'util-core';
+
 /**
  * Generator of an unending progression of colors. The original
  * task for which it was created was to make background colors for chat bubbles
@@ -18,7 +20,7 @@ import ColorUtil from './ColorUtil';
  * The V component of each color is 87.5% which puts all of the colors in the
  * pastel range.
  */
-export default class ColorSelector {
+export default class ColorSelector extends CommonBase {
   /**
    * Constructs a new ColorSelector object.
    *
@@ -29,6 +31,8 @@ export default class ColorSelector {
    *   on each iteration.
    */
   constructor(seed = 0, stride = 53) {
+    super();
+
     /**
      * {number} The current hue angle in degrees; the H component of an HSL
      * color.

--- a/local-modules/util-common/FrozenBuffer.js
+++ b/local-modules/util-common/FrozenBuffer.js
@@ -7,9 +7,7 @@
 import crypto from 'crypto';
 
 import { TBuffer, TInt } from 'typecheck';
-import { Errors } from 'util-core';
-
-import CommonBase from './CommonBase';
+import { CommonBase, Errors } from 'util-core';
 
 /** {string} Node's name for the hashing algorithm to use. */
 const NODE_HASH_NAME = 'sha256';

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CommonBase } from 'util-core';
+
 /**
  * Iterable over object properties. Instances walk over all properties of the
  * objects they are given, whether enumerable or not. The values yielded by
@@ -10,7 +12,7 @@
  * either a string or a symbol) and `target` to the target object (either the
  * top-level object or an element in its prototype chain).
  */
-export default class PropertyIterable {
+export default class PropertyIterable extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -22,6 +24,8 @@ export default class PropertyIterable {
    *   selected.
    */
   constructor(object, filter = null) {
+    super();
+
     /** The object to iterate over. */
     this._object = object;
 

--- a/local-modules/util-common/Singleton.js
+++ b/local-modules/util-common/Singleton.js
@@ -2,9 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { ObjectUtil } from 'util-core';
-
-import CommonBase from './CommonBase';
+import { CommonBase, ObjectUtil } from 'util-core';
 
 /**
  * Base class for singletons (classes for which there is ever but a single

--- a/local-modules/util-common/main.js
+++ b/local-modules/util-common/main.js
@@ -4,7 +4,6 @@
 
 import ColorSelector from './ColorSelector';
 import ColorUtil from './ColorUtil';
-import CommonBase from './CommonBase';
 import DeferredLoader from './DeferredLoader';
 import FrozenBuffer from './FrozenBuffer';
 import IterableUtil from './IterableUtil';
@@ -18,7 +17,6 @@ import WebsocketCodes from './WebsocketCodes';
 export {
   ColorSelector,
   ColorUtil,
-  CommonBase,
   DeferredLoader,
   FrozenBuffer,
   IterableUtil,

--- a/local-modules/util-common/tests/test_JsonUtil.js
+++ b/local-modules/util-common/tests/test_JsonUtil.js
@@ -5,7 +5,6 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { TObject } from 'typecheck';
 import { JsonUtil } from 'util-common';
 
 describe('util-common/JsonUtil', () => {
@@ -26,9 +25,9 @@ describe('util-common/JsonUtil', () => {
       const jsonString = '{ "a": 1, "b": 2, "c": 3 }';
       const object = JsonUtil.parseFrozen(jsonString);
 
-      assert.doesNotThrow(() => TObject.check(object));
-      assert.doesNotThrow(() => TObject.withExactKeys(object, ['a', 'b', 'c']));
-      assert.throws(() => object['a'] = 'this better not work!');
+      assert.isFrozen(object);
+      assert.isObject(object);
+      assert.hasAllKeys(object, ['a', 'b', 'c']);
     });
   });
 });

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -2,8 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
-import { Errors, InfoError } from 'util-core';
+import CoreTypecheck from './CoreTypecheck';
+import Errors from './Errors';
+import InfoError from './InfoError';
 
 /**
  * Base class which provides a couple conveniences beyond what baseline
@@ -45,7 +46,7 @@ export default class CommonBase {
   static check(value) {
     // **Note:** In the context of static methods, `this` refers to the class
     // that was called upon.
-    return TObject.check(value, this);
+    return CoreTypecheck.checkObject(value, this);
   }
 
   /**

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -4,7 +4,6 @@
 
 import CoreTypecheck from './CoreTypecheck';
 import Errors from './Errors';
-import InfoError from './InfoError';
 
 /**
  * Base class which provides a couple conveniences beyond what baseline
@@ -180,7 +179,3 @@ export default class CommonBase {
     throw Errors.wtf('Must override.');
   }
 }
-
-// Mix this class into `InfoError`. We do it here to avoid a circular
-// dependency. See also class header comment in `InfoError`.
-CommonBase.mixInto(InfoError);

--- a/local-modules/util-core/CoreTypecheck.js
+++ b/local-modules/util-core/CoreTypecheck.js
@@ -28,6 +28,33 @@ export default class CoreTypecheck extends UtilityClass {
   }
 
   /**
+   * Checks that a value is of type `object`, and is optionally an instance of
+   * a particular class. `null` is _not_ considered an object by this check.
+   * Functions _are_ considered objects by this check.
+   *
+   * @param {*} value Value to check.
+   * @param {object|null} [clazz = null] Class (constructor) that `value` must
+   *   be an instance of, or `null` if there is no class requirement.
+   * @returns {object} `value`.
+   */
+  static checkObject(value, clazz = null) {
+    if (clazz !== null) {
+      if (!(value instanceof clazz)) {
+        throw Errors.bad_value(value, `class ${clazz.name}`);
+      }
+    } else if (value === null) {
+      throw Errors.bad_value(value, Object);
+    } else {
+      const type = typeof value;
+      if ((type !== 'object') && (type !== 'function')) {
+        throw Errors.bad_value(value, Object);
+      }
+    }
+
+    return value;
+  }
+
+  /**
    * Checks that a value is of type `string`.
    *
    * @param {*} value Value in question.

--- a/local-modules/util-core/DataUtil.js
+++ b/local-modules/util-core/DataUtil.js
@@ -42,12 +42,18 @@ export default class DataUtil extends UtilityClass {
         const proto = Object.getPrototypeOf(value);
         let cloneBase; // Empty object to start from when cloning.
 
-        if (proto === Object.prototype) {
-          cloneBase = {};
-        } else if (proto === Array.prototype) {
-          cloneBase = [];
-        } else {
-          throw new Error(`Cannot deep-freeze non-data object: ${value}`);
+        switch (proto) {
+          case Object.prototype: {
+            cloneBase = {};
+            break;
+          }
+          case Array.prototype: {
+            cloneBase = [];
+            break;
+          }
+          default: {
+            throw new Error(`Cannot deep-freeze non-data object: ${value}`);
+          }
         }
 
         let newObj = null;  // Becomes non-`null` with the first change.

--- a/local-modules/util-core/DataUtil.js
+++ b/local-modules/util-core/DataUtil.js
@@ -2,17 +2,29 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import Functor from './Functor';
 import ObjectUtil from './ObjectUtil';
 import UtilityClass from './UtilityClass';
 
 /**
  * "Data value" helper utilities. A "data value" is defined as any JavaScript
- * value or object which has no behavior. This includes anything that can be
- * encoded as JSON without loss of fidelity and also includes things such as
- * `undefined`, symbols, and "odd-shaped" arrays (ones with holes or extra
- * properties). It notably does _not_ include functions, objects with synthetic
- * properties, or objects with a prototype other than `Object.prototype` or
- * `Array.prototype`.
+ * value or object which has no behavior. This includes:
+ *
+ * * Anything that can be encoded as JSON without loss of fidelity.
+ * * Symbols.
+ * * `undefined` and `null`.
+ * * "Odd-shaped" arrays (ones with holes or extra properties).
+ * * By special dispensation, instances of the class `Functor` (defined in this
+ *   module).
+ *
+ * This does _not_ include:
+ *
+ * * Functions.
+ * * Objects with synthetic properties.
+ * * Objects with a prototype other than `Object.prototype`, `Array.prototype`,
+ *   or `Functor.prototype`.
+ * * Any composite value with an element that is not a data value, per these
+ *   rules.
  */
 export default class DataUtil extends UtilityClass {
   /**
@@ -39,10 +51,9 @@ export default class DataUtil extends UtilityClass {
           return value;
         }
 
-        const proto = Object.getPrototypeOf(value);
         let cloneBase; // Empty object to start from when cloning.
 
-        switch (proto) {
+        switch (Object.getPrototypeOf(value)) {
           case Object.prototype: {
             cloneBase = {};
             break;
@@ -50,6 +61,13 @@ export default class DataUtil extends UtilityClass {
           case Array.prototype: {
             cloneBase = [];
             break;
+          }
+          case Functor.prototype: {
+            // Handle functors directly here.
+            const args = value.args;
+            return DataUtil.isDeepFrozen(args)
+              ? value
+              : new Functor(value.name, ...(DataUtil.deepFreeze(args)));
           }
           default: {
             throw new Error(`Cannot deep-freeze non-data object: ${value}`);
@@ -132,26 +150,34 @@ export default class DataUtil extends UtilityClass {
       return false;
     }
 
-    const proto = Object.getPrototypeOf(value);
-    if ((proto !== Object.prototype) && (proto !== Array.prototype)) {
-      return false;
-    }
+    switch (Object.getPrototypeOf(value)) {
+      case Object.prototype:
+      case Array.prototype: {
+        // We have a frozen composite of one of the acceptable standard types
+        // (either array or simple object). We still need to check the
+        // properties / elements.
 
-    // At this point, we know we have a frozen composite of an acceptable type
-    // (either array or simple object). We still need to check the properties /
-    // elements.
+        for (const k of Object.getOwnPropertyNames(value)) {
+          const prop = Object.getOwnPropertyDescriptor(value, k);
+          const v = prop.value;
+          if ((v === undefined) && !ObjectUtil.hasOwnProperty(prop, 'value')) {
+            // This is a synthetic property.
+            return false;
+          } else if (!DataUtil.isDeepFrozen(v)) {
+            return false;
+          }
+        }
 
-    for (const k of Object.getOwnPropertyNames(value)) {
-      const prop = Object.getOwnPropertyDescriptor(value, k);
-      const v = prop.value;
-      if ((v === undefined) && !ObjectUtil.hasOwnProperty(prop, 'value')) {
-        // This is a synthetic property.
-        return false;
-      } else if (!DataUtil.isDeepFrozen(v)) {
+        return true;
+      }
+
+      case Functor.prototype: {
+        return DataUtil.isDeepFrozen(value.args);
+      }
+
+      default: {
         return false;
       }
     }
-
-    return true;
   }
 }

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -1,0 +1,135 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import util from 'util';
+
+import CoreTypecheck from './CoreTypecheck';
+
+/**
+ * Functor data value. A "functor," generally speaking, is a thing that looks
+ * like a function call. In this case, it consists of a string name and a
+ * list of zero or more positional argument values. Instances are immutable.
+ *
+ * When rendered as a string, instances of this class look like function calls,
+ * e.g., `someName(1, 2, 'foo')`.
+ */
+export default class Functor {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} name Functor name. This must conform to the usual
+   *   conservative syntax for a programming language "identifier," that is, a
+   *   non-empty string with characters taken from the set `[a-zA-Z_0-9]` and a
+   *   non-numeric first character.
+   * @param {...*} args Functor arguments.
+   */
+  constructor(name, ...args) {
+    /** {string} Functor name. */
+    this._name = CoreTypecheck.checkIdentifier(name);
+
+    /** {array<*>} Functor arguments. */
+    this._args = Object.freeze(args);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {array<*>} Array of arguments. It is a frozen (immutable) value, though its
+   * contents might not also be frozen.
+   */
+  get args() {
+    return this._args;
+  }
+
+  /** {string} The functor name. */
+  get name() {
+    return this._name;
+  }
+
+  /**
+   * Custom inspector function, as called by `util.inspect`.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [util.inspect.custom](depth, opts) {
+    if (depth < 0) {
+      return `${this._name}(${this._args.length === 0 ? '' : '...'})`;
+    }
+
+    const result = [this._name, '('];
+
+    if (depth < 0) {
+      // Minimal expansion if we're at the depth limit.
+      if (this._args.length !== 0) {
+        result.push('...');
+      }
+    } else {
+      // Set up the inspection opts so that recursive calls respect the topmost
+      // requested depth.
+      const subOpts = (opts.depth === null)
+        ? opts
+        : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+      let first = true;
+      for (const a of this._args) {
+        if (first) {
+          first = false;
+        } else {
+          result.push(', ');
+        }
+        result.push(util.inspect(a, subOpts));
+      }
+    }
+
+    result.push(')');
+    return result.join('');
+  }
+
+  /**
+   * Compares this to another value for equality. Instances of this class are
+   * only considered to be equal to other direct instances of this class. (This
+   * class is not meant to be subclassed.) Given two instances of this class,
+   * their names must be strictly equal, their argument array lengths must be
+   * the same, and corresponding arguments must be strictly equal.
+   *
+   * @param {*} other Value to compare to.
+   * @returns {boolean} `true` if `other` is equal to this instance, or `false`
+   *   if not.
+   */
+  equals(other) {
+    if (this === other) {
+      // Easy out.
+      return true;
+    } else if (!(other instanceof Functor) || (other.constructor !== Functor)) {
+      return false;
+    }
+
+    const thisArgs = this._args;
+    const otherArgs = other._args;
+
+    if ((this._name !== other._name) || (thisArgs.length !== otherArgs.length)) {
+      return false;
+    }
+
+    for (let i = 0; i < thisArgs.length; i++) {
+      if (thisArgs[i] !== otherArgs[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Get the string form of this instance. This uses `util.inspect()` on the
+   * elements of the `args` array.
+   *
+   * @returns {string} The string form of this instance.
+   */
+  toString() {
+    return util.inspect(this, { breakLength: Infinity });
+  }
+}

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -54,6 +54,22 @@ export default class Functor {
   }
 
   /**
+   * Same as calling the custom inspector function via its symbol-bound method.
+   *
+   * _This_ method exists because, as of this writing, the browser polyfill for
+   * `util.inspect` doesn't find `util.inspect.custom` methods. **TODO:**
+   * Occasionally check to see if this workaround is still needed, and remove it
+   * if it is finally unnecessary.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  inspect(depth, opts) {
+    return this[util.inspect.custom](depth, opts);
+  }
+
+  /**
    * Custom inspector function, as called by `util.inspect`.
    *
    * @param {Int} depth Current inspection depth.

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -4,6 +4,7 @@
 
 import util from 'util';
 
+//import CommonBase from './CommonBase';
 import CoreTypecheck from './CoreTypecheck';
 
 /**
@@ -13,6 +14,11 @@ import CoreTypecheck from './CoreTypecheck';
  *
  * When rendered as a string, instances of this class look like function calls,
  * e.g., `someName(1, 2, 'foo')`.
+ *
+ * **Note:** This class mixes in `CommonBase`, so that it gets the static
+ * `check()` method and friends. However, because `CommonBase` uses this class,
+ * we can't just mix it in here (as this class is the one that gets initialized
+ * first). Instead, this happens during module initialization.
  */
 export default class Functor {
   /**

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -21,7 +21,7 @@ import DataUtil from './DataUtil';
  * **Note:** This class mixes in `CommonBase`, so that it gets the static
  * `check()` method and friends. However, because `CommonBase` uses this class,
  * we can't just mix it in here (as this class is the one that gets initialized
- * first). Instead, `CommonBase` does that during _its_ initialization.
+ * first). Instead, this happens during module initialization.
  */
 export default class InfoError extends Error {
   /**

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -70,7 +70,7 @@ export default class InfoError extends Error {
    * set `[a-zA-Z_0-9]` and a non-numeric first character.
    *
    * @param {Error|string} firstArg _Either_ the causal `Error` or the detail
-   *   schema name
+   *   schema name.
    * @param {...*} args Additional arguments, as described above.
    */
   constructor(firstArg, ...args) {

--- a/local-modules/util-core/main.js
+++ b/local-modules/util-core/main.js
@@ -5,9 +5,19 @@
 import CoreTypecheck from './CoreTypecheck';
 import DataUtil from './DataUtil';
 import Errors from './Errors';
+import Functor from './Functor';
 import InfoError from './InfoError';
 import ObjectUtil from './ObjectUtil';
 import URL from './URL';
 import UtilityClass from './UtilityClass';
 
-export { CoreTypecheck, DataUtil, Errors, InfoError, ObjectUtil, URL, UtilityClass };
+export {
+  CoreTypecheck,
+  DataUtil,
+  Errors,
+  Functor,
+  InfoError,
+  ObjectUtil,
+  URL,
+  UtilityClass
+};

--- a/local-modules/util-core/main.js
+++ b/local-modules/util-core/main.js
@@ -12,6 +12,13 @@ import ObjectUtil from './ObjectUtil';
 import URL from './URL';
 import UtilityClass from './UtilityClass';
 
+// Mix this class into `Functor` and `InfoError`. We do these here to avoid
+// circular dependencies: `CommonBase` uses `Errors` which uses `InfoError`
+// which uses `Functor`. `Functor` and `InfoError` both want to get the
+// `CommonBase` methods.
+CommonBase.mixInto(Functor);
+CommonBase.mixInto(InfoError);
+
 export {
   CommonBase,
   CoreTypecheck,

--- a/local-modules/util-core/main.js
+++ b/local-modules/util-core/main.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import CommonBase from './CommonBase';
 import CoreTypecheck from './CoreTypecheck';
 import DataUtil from './DataUtil';
 import Errors from './Errors';
@@ -12,6 +13,7 @@ import URL from './URL';
 import UtilityClass from './UtilityClass';
 
 export {
+  CommonBase,
   CoreTypecheck,
   DataUtil,
   Errors,

--- a/local-modules/util-core/tests/test_CommonBase.js
+++ b/local-modules/util-core/tests/test_CommonBase.js
@@ -22,7 +22,7 @@ class CommonBaseSubclass extends CommonBase {
   }
 }
 
-describe('util-common/CommonBase', () => {
+describe('util-core/CommonBase', () => {
   describe('mixInto(class)', () => {
     it('should add its properties to the supplied class', () => {
       assert.notProperty(NearlyEmptyClass, 'coerce');
@@ -39,6 +39,7 @@ describe('util-common/CommonBase', () => {
       const subclass = new CommonBaseSubclass();
 
       assert.strictEqual(CommonBase.check(base), base);
+      assert.strictEqual(CommonBase.check(subclass), subclass);
       assert.strictEqual(CommonBaseSubclass.check(subclass), subclass);
     });
 

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -42,9 +42,9 @@ function assertThrowsInfo(func, name, args = null) {
     assert.fail('Did not throw.');
   } catch (e) {
     assert.instanceOf(e, InfoError);
-    assert.strictEqual(e.name, name);
+    assert.strictEqual(e.info.name, name);
     if (args !== null) {
-      assert.deepEqual(e.args, args);
+      assert.deepEqual(e.info.args, args);
     }
   }
 }

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -110,6 +110,90 @@ describe('util-core/CoreTypecheck', () => {
     });
   });
 
+  describe('checkObject(value)', () => {
+    it('accepts objects', () => {
+      function test(value) {
+        assert.strictEqual(CoreTypecheck.checkObject(value), value);
+      }
+
+      test({});
+      test({ a: 10, b: 20, c: 30, });
+      test([]);
+      test(['blort']);
+      test(new Set());
+      test(() => 914);
+      test(function () { return 37; });
+    });
+
+    it('rejects non-objects', () => {
+      function test(value) {
+        assertThrowsInfo(
+          () => { CoreTypecheck.checkObject(value); },
+          'bad_value',
+          [inspect(value), 'Object']);
+      }
+
+      test(null);
+      test(undefined);
+      test(false);
+      test(123);
+      test('blort');
+    });
+  });
+
+  describe('checkObject(value, clazz)', () => {
+    it('accepts objects of the given class', () => {
+      function test(value, clazz) {
+        assert.strictEqual(CoreTypecheck.checkObject(value, clazz), value);
+      }
+
+      test({},                       Object);
+      test({ a: 10, b: 20, c: 30, }, Object);
+      test([1, 2, 3],                Object);
+      test(new Set(),                Object);
+      test(new Boolean(false),       Object);
+      test(() => 914,                Object);
+
+      test([],        Array);
+      test(['blort'], Array);
+
+      test(new Boolean(false), Boolean);
+      test(new Number(123),    Number);
+      test(new Set(),          Set);
+
+      test(() => 914,                  Function);
+      test(function () { return 37; }, Function);
+    });
+
+    it('rejects objects of the wrong class', () => {
+      function test(value, clazz) {
+        assertThrowsInfo(
+          () => { CoreTypecheck.checkObject(value, clazz); },
+          'bad_value',
+          [inspect(value), `class ${clazz.name}`]);
+      }
+
+      test({},        Boolean);
+      test([],        Number);
+      test(new Set(), Array);
+    });
+
+    it('rejects non-objects', () => {
+      function test(value, clazz) {
+        assertThrowsInfo(
+          () => { CoreTypecheck.checkObject(value, clazz); },
+          'bad_value',
+          [inspect(value), `class ${clazz.name}`]);
+      }
+
+      test(null,      Object);
+      test(undefined, Number);
+      test(false,     Boolean);
+      test(123,       Number);
+      test('blort',   Set);
+    });
+  });
+
   describe('checkString(value)', () => {
     it('accepts strings', () => {
       function test(value) {

--- a/local-modules/util-core/tests/test_Functor.js
+++ b/local-modules/util-core/tests/test_Functor.js
@@ -1,0 +1,154 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { Functor } from 'util-core';
+
+describe('util-core/Functor', () => {
+  describe('constructor()', () => {
+    it('should accept valid names', () => {
+      function test(name) {
+        const result = new Functor(name);
+        assert.instanceOf(result, Functor, name);
+      }
+
+      test('a');
+      test('A');
+      test('_');
+      test('a1');
+      test('_0123456789');
+      test('abcde_fghij_klmno_pqrst_uvwxy_z');
+      test('ABCDE_FGHIJ_KLMNO_PQRST_UVWXY_Z');
+    });
+
+    it('should accept various amounts and types of arguments', () => {
+      function test(...args) {
+        const result = new Functor('blort', ...args);
+        assert.instanceOf(result, Functor, inspect(args));
+      }
+
+      test();
+      test(1);
+      test('a', true, null, undefined);
+      test(new Functor('x', 11, 22));
+      test(new Boolean(true));
+      test(new Map());
+      test([[[[[[[10]]]]]]], { a: { b: { c: 20 } } });
+      test(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
+    });
+
+    it('should reject invalid names', () => {
+      function test(name) {
+        assert.throws(() => { new Functor(name); });
+      }
+
+      test('');
+      test('1');
+      test('x%');
+      test(123);
+      test(null);
+    });
+  });
+
+  describe('.args', () => {
+    it('should be a frozen array', () => {
+      const ftor = new Functor('blort', 'a', ['b'], { c: 30 });
+      assert.isArray(ftor.args);
+      assert.isFrozen(ftor.args);
+    });
+
+    it('should report the constructed args', () => {
+      function test(...args) {
+        const result = new Functor('blort', ...args);
+        const resultArgs = result.args;
+
+        assert.strictEqual(resultArgs.length, args.length);
+        for (let i = 0; i < args.length; i++) {
+          assert.strictEqual(resultArgs[i], args[i], inspect(args[i]));
+        }
+      }
+
+      test();
+      test(1, 2, 3);
+      test([[[['a']]]], new Map(), new Set());
+    });
+  });
+
+  describe('.name', () => {
+    it('should report the constructed name', () => {
+      function test(name) {
+        const result = new Functor(name);
+        assert.strictEqual(result.name, name);
+      }
+
+      test('blort');
+      test('florp_like');
+      test('SIDEWAYS_TIMELINE');
+    });
+  });
+
+  describe('equals()', () => {
+    it('should return `true` when compared to itself', () => {
+      const ftor = new Functor('blort', 10);
+      assert.isTrue(ftor.equals(ftor));
+    });
+
+    it('should return `true` when compared to a samely-constructed instance', () => {
+      const arrayArg = ['a', 'b'];
+      const ftor1 = new Functor('blort', 10, arrayArg);
+      const ftor2 = new Functor('blort', 10, arrayArg);
+      assert.isTrue(ftor1.equals(ftor2));
+    });
+
+    it('should return `false` when the names do not match', () => {
+      const ftor1 = new Functor('blort', 10);
+      const ftor2 = new Functor('florp', 10);
+      assert.isFalse(ftor1.equals(ftor2));
+    });
+
+    it('should return `false` when argument counts do not match', () => {
+      const ftor1 = new Functor('blort', 10);
+      const ftor2 = new Functor('blort', 10, 20);
+      assert.isFalse(ftor1.equals(ftor2));
+      assert.isFalse(ftor2.equals(ftor1));
+    });
+
+    it('should return `false` when an argument is not strict-equal', () => {
+      const ftor1 = new Functor('blort', 10, ['a']);
+      const ftor2 = new Functor('blort', 10, ['a']);
+      assert.isFalse(ftor1.equals(ftor2));
+    });
+
+    it('should return `false` when compared to a non-functor', () => {
+      const ftor = new Functor('blort', 10);
+
+      function test(value) {
+        assert.isFalse(ftor.equals(value), inspect(value));
+      }
+
+      test(undefined);
+      test(null);
+      test('blort');
+      test(['blort', 10]);
+      test({ blort: 10 });
+    });
+  });
+
+  describe('toString()', () => {
+    it('should produce expected strings in various cases', () => {
+      function test(expect, name, ...args) {
+        const result = new Functor(name, ...args);
+        assert.strictEqual(result.toString(), expect);
+      }
+
+      test('blort()',               'blort');
+      test('blort(1)',              'blort', 1);
+      test('florp(1, \'foo\')',     'florp', 1, 'foo');
+      test('florp([ 1, \'foo\' ])', 'florp', [1, 'foo']);
+    });
+  });
+});

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.25.0
+version = 0.26.0


### PR DESCRIPTION
This PR introduces a new general composite data type, and uses it to simplify `InfoError`. Ultimately, it will be used to simplify a couple other areas of the code.

Specifically, there are a bunch of places in the code where we cart around a pair consisting of a string name and an arbitrary list of associated data values. The canonical example of this (in the world at large) is the name of a method along with the arguments to pass to that method. Since this has the general "shape" of a function call, these things have traditionally gotten the name "functor," which is exactly what I named it here.

`InfoError` uses a name and value list to represent the information about an error, and so it made a good first target for "functorization." A later PRs will use them for API messages. Other possibilities for use (less sure about how well they'll pan out) include all of: transaction operations, OT operations, state machine events, and other kinds of events (e.g. the sort produced by UI components). And there's probably other potential uses in our code that I haven't yet noticed.
