### PR TITLE
Mostly logging cleanup

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -376,7 +376,7 @@ export default class ApiClient extends CommonBase {
       default: {
         // Whatever this state is, it's not documented as part of the websocket
         // spec!
-        this._log.wtf(`Weird state: ${wsState}`);
+        this._log.wtf('Weird state:', wsState);
       }
     }
 

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -81,7 +81,7 @@ export default class TargetMap extends CommonBase {
     if (result) {
       // We have already initiated authorization on this target. Return the
       // promise from the original initiation.
-      log.info(`Already authing: ${id}`);
+      log.info('Already authing:', id);
       return result;
     }
 
@@ -93,17 +93,17 @@ export default class TargetMap extends CommonBase {
         const challenge = await meta.makeChallenge(id);
         const response  = key.challengeResponseFor(challenge);
 
-        log.info(`Got challenge: ${id} ${challenge}`);
+        log.info('Got challenge:', id, challenge);
         await meta.authWithChallengeResponse(challenge, response);
 
         // Successful auth.
-        log.info(`Authed: ${id}`);
+        log.info('Authed:', id);
         this._pendingAuths.delete(id); // It's no longer pending.
         return this._addTarget(id);
       } catch (error) {
         // Trouble along the way. Clean out the pending auth, and propagate the
         // error.
-        log.error(`Auth failed: ${id}`);
+        log.error('Auth failed:', id);
         this._pendingAuths.delete(id);
         throw error;
       }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -55,10 +55,10 @@ export default class TargetMap {
    *   complete.
    */
   async authorizeTarget(key) {
-    const id = key.id;
-    const api = this._apiClient;
-    const log = api.log;
-    const meta = api.meta;
+    const id        = key.id;
+    const apiClient = this._apiClient;
+    const log       = apiClient.log;
+    const meta      = apiClient.meta;
     let result;
 
     result = this._targets.get(id);
@@ -81,7 +81,7 @@ export default class TargetMap {
     result = (async () => {
       try {
         const challenge = await meta.makeChallenge(id);
-        const response = key.challengeResponseFor(challenge);
+        const response  = key.challengeResponseFor(challenge);
 
         log.info(`Got challenge: ${id} ${challenge}`);
         await meta.authWithChallengeResponse(challenge, response);
@@ -137,7 +137,7 @@ export default class TargetMap {
    * as well as when a connection gets reset.
    */
   reset() {
-    this._targets = new Map();
+    this._targets      = new Map();
     this._pendingAuths = new Map();
 
     // Set up the standard initial map contents.

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TString } from 'typecheck';
 import { CommonBase, Errors, URL } from 'util-common';
 
@@ -101,6 +103,34 @@ export default class BaseKey extends CommonBase {
    */
   _impl_challengeResponseFor(challenge) {
     return this._mustOverride(challenge);
+  }
+
+  /**
+   * Same as calling the custom inspector function via its symbol-bound method.
+   *
+   * _This_ method exists because, as of this writing, the browser polyfill for
+   * `util.inspect()` doesn't find `util.inspect.custom` methods. **TODO:**
+   * Occasionally check to see if this workaround is still needed, and remove it
+   * if it is finally unnecessary.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  inspect(depth, opts) {
+    return this[inspect.custom](depth, opts);
+  }
+
+  /**
+   * Custom inspector function, as called by `util.inspect()`. This is done to
+   * prevent inadvertent logging of the secret values.
+   *
+   * @param {Int} depth_unused Current inspection depth.
+   * @param {object} opts_unused Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth_unused, opts_unused) {
+    return this.toString();
   }
 
   /**

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -88,7 +88,7 @@ export default class Connection extends CommonBase {
     // to this instance/connection.
     this._context.addEvergreen('meta', new MetaHandler(this));
 
-    this._log.info(`Open via <${this._baseUrl}>.`);
+    this._log.info('Open via:', this._baseUrl);
   }
 
   /** {string} The base URL. */

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -212,7 +212,7 @@ export default class Context extends CommonBase {
     // <https://tc39.github.io/ecma262/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind>.
     for (const [key, value] of map) {
       if (value.wasIdleAsOf(idleLimit)) {
-        log.info(`Removed: ${key}`);
+        log.info('Removed:', key);
         map.delete(key);
       }
     }

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -69,7 +69,7 @@ export default class MetaHandler {
     // except without auth control.
     this._connection.context.removeControl(id);
 
-    this._log.info(`Authed challenge: ${id} ${challenge}`);
+    this._log.info('Authed challenge:', id, challenge);
   }
 
   /**
@@ -120,14 +120,14 @@ export default class MetaHandler {
       if (this._activeChallenges.delete(challenge)) {
         // `delete` returns `true` to indicate that the value was found. In this
         // case, it means that it expired.
-        this._log.info(`Challenge expired: ${id} ${challenge}`);
+        this._log.info('Challenge expired:', id, challenge);
       }
     })();
 
     // **Note:** It's probably okay to log the expected response, but may be
     // worth thinking a bit more about. (Attention: Security professionals!)
-    this._log.info(`New challenge: ${id} ${challenge}`);
-    this._log.info(`  => ${response}`);
+    this._log.info('New challenge:', id, challenge);
+    this._log.info('  => ', response);
 
     return challenge;
   }

--- a/local-modules/api-server/WsConnection.js
+++ b/local-modules/api-server/WsConnection.js
@@ -38,9 +38,9 @@ export default class WsConnection extends Connection {
    */
   _handleClose(code, msg) {
     const codeStr = WebsocketCodes.close(code);
-    const msgStr = msg ? `: ${msg}` : '';
+    const msgArgs = msg ? ['/', msg] : [];
 
-    this._log.info(`Close: ${codeStr}${msgStr}`);
+    this._log.info('Close:', codeStr, ...msgArgs);
     this.close();
   }
 

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -77,7 +77,7 @@ export default class Application {
   start() {
     const port = Hooks.theOne.listenPort;
     this._app.listen(port, () => {
-      log.info(`Now listening on port ${port}.`);
+      log.info('Listening on port:', port);
     });
   }
 

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -158,7 +158,7 @@ export default class Application {
       }
       for (const t of rootTokens) {
         context.addEvergreen(t, this._rootAccess);
-        log.info(`Accept root: ${t}`);
+        log.info('Accept root:', t);
       }
       this._rootTokens = rootTokens;
     }

--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -63,10 +63,10 @@ export default class RootAccess {
     this._context.add(key, session);
 
     log.info('Newly-authorized access.');
-    log.info(`  author:  ${authorId}`);
-    log.info(`  doc:     ${docId}`);
-    log.info(`  key id:  ${key.id}`); // The ID is safe to log (not security-sensitive).
-    log.info(`  key url: ${key.url}`);
+    log.info('  author:  ', authorId);
+    log.info('  doc:     ', docId);
+    log.info('  key id:  ', key.id); // The ID is safe to log (not security-sensitive).
+    log.info('  key url: ', key.url);
 
     return key;
   }

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -308,7 +308,7 @@ export default class ClientBundle extends Singleton {
       // The `test()` skips `.` and `..`.
       if (/^[a-z]/.test(name)) {
         const fullPath = `/${name}`;
-        log.info(`Bundle updated: ${name}`);
+        log.info('Bundle updated:', name);
         this._currentBundles.set(name, this._fs.readFileSync(fullPath));
         this._fs.unlinkSync(fullPath);
         any = true;

--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -213,7 +213,7 @@ export default class DevMode extends Singleton {
 
     if (toPath === null) {
       // This file has no mapping into the target directory.
-      log.info(`Unmapped: ${fromPath}`);
+      log.info('Unmapped:', fromPath);
       return null;
     }
 
@@ -227,15 +227,15 @@ export default class DevMode extends Singleton {
 
     if (bestFromPath === null) {
       // The file was deleted.
-      log.info(`Removed: ${logPath}`);
+      log.info('Removed:', logPath);
     } else if (fromPath === bestFromPath) {
       // The file that changed is the "most overlaid" one. That is, if `foo.js`
       // has an overlay, and we just noticed that the base (non-overlay) version
       // of `foo.js` changed, then we _don't_ report it as changed.
-      log.info(`Updated: ${logPath}`);
+      log.info('Updated:', logPath);
     } else {
       // It's an underlay file.
-      log.info(`Ignored: ${logPath}`);
+      log.info('Ignored:',  logPath);
       return null;
     }
 
@@ -274,7 +274,7 @@ export default class DevMode extends Singleton {
         // which is no big deal. This has been observed to happen when
         // development is done semi-remotely, e.g. `rsync`ing files from a
         // laptop to a machine in a dev-production environment.
-        log.info(`Already removed: ${toPath}`);
+        log.info('Already removed:', toPath);
       }
     } else {
       // The source file changed.

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -250,7 +250,7 @@ export default class CaretOverlay {
       // The remaining elements of `oldSessions` are sessions which have gone
       // away.
       for (const s of oldSessions) {
-        docSession.log.info(`Session ended: ${s}`);
+        docSession.log.info('Session ended:', s);
         this._endSession(s);
       }
 

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -358,7 +358,7 @@ export default class DocClient extends StateMachine {
 
     try {
       const info = await infoPromise;
-      this._log.info(`Session info: ${info}`);
+      this._log.info('Session info:', info);
     } catch (e) {
       this.q_apiError('getLogInfo', e);
       return;
@@ -475,7 +475,7 @@ export default class DocClient extends StateMachine {
    *   document revision.
    */
   _handle_idle_gotDeltaAfter(baseDoc, result) {
-    this._log.detail(`Delta from server: ${result.revNum}`);
+    this._log.detail('Delta from server:', result.revNum);
 
     // We only take action if the result's base (what `delta` is with regard to)
     // is the current `_doc`. If that _isn't_ the case, then what we have here
@@ -648,7 +648,7 @@ export default class DocClient extends StateMachine {
     const dCorrection = correctedChange.delta;
     const vResultNum  = correctedChange.revNum;
 
-    this._log.detail(`Correction from server: r${vResultNum}`, dCorrection);
+    this._log.detail('Correction from server:', correctedChange);
 
     if (dCorrection.isEmpty()) {
       // There is no change from what we expected. This means that no other

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -173,7 +173,7 @@ export default class EditorComplex extends CommonBase {
    * @param {SplitKey} sessionKey New session key to use.
    */
   connectNewSession(sessionKey) {
-    log.info(`Hooking up new session: ${sessionKey}`);
+    log.info('Hooking up new session:', sessionKey);
     this._initSession(sessionKey, false);
   }
 

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -173,7 +173,7 @@ export default class EditorComplex extends CommonBase {
    * @param {SplitKey} sessionKey New session key to use.
    */
   connectNewSession(sessionKey) {
-    log.info('Hooking up new session:', sessionKey);
+    log.info('Hooking up new session:', sessionKey.toString());
     this._initSession(sessionKey, false);
   }
 

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -335,7 +335,7 @@ export default class BodyControl extends CommonBase {
       : this._composeRevisions(base.contents,     base.revNum + 1, revNum + 1);
     const result = new BodySnapshot(revNum, await contents);
 
-    this._log.detail(`Made snapshot for revision ${revNum}.`);
+    this._log.detail('Made snapshot for revision:', revNum);
 
     this._snapshots.set(revNum, result);
     return result;
@@ -434,7 +434,7 @@ export default class BodyControl extends CommonBase {
 
     // In a valid doc, the loop body won't end up executing at all.
     for (const storagePath of transactionResult.data.keys()) {
-      this._log.info(`Corrupt document: Extra change at path: ${storagePath}`);
+      this._log.info('Corrupt document. Extra change at path:', storagePath);
       return BodyControl.STATUS_ERROR;
     }
 
@@ -485,7 +485,7 @@ export default class BodyControl extends CommonBase {
       if ((e instanceof InfoError) && (e.name === 'path_not_empty')) {
         // This happens if and when we lose an append race, which will regularly
         // occur if there are simultaneous editors.
-        this._log.info(`Lost append race for revision ${revNum}.`);
+        this._log.info('Lost append race for revision:', revNum);
         return null;
       } else {
         // No other errors are expected, so just rethrow.

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -298,7 +298,7 @@ export default class CaretControl extends CommonBase {
       this._oldSnapshots.shift();
     }
 
-    this._log.info(`Updated carets: Caret revision ${newRevNum}.`);
+    this._log.info('Updated caret revision:', newRevNum);
 
     return newRevNum;
   }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -148,7 +148,7 @@ export default class CaretStorage extends CommonBase {
         const newSnapshot = snapshot.withoutSession(sessionId);
         if (newSnapshot !== snapshot) {
           snapshot = newSnapshot;
-          this._log.detail(`Integrated caret removal: ${sessionId}`);
+          this._log.detail('Integrated caret removal:', sessionId);
         }
       }
     }
@@ -158,7 +158,7 @@ export default class CaretStorage extends CommonBase {
       const newSnapshot = snapshot.withCaret(carets.caretForSession(sessionId));
       if (newSnapshot !== snapshot) {
         snapshot = newSnapshot;
-        this._log.detail(`Integrated caret update: ${sessionId}`);
+        this._log.detail('Integrated caret update:', sessionId);
       }
     }
 
@@ -247,7 +247,7 @@ export default class CaretStorage extends CommonBase {
 
     for (const sessionId of currentSessionIds) {
       if (!this._carets.hasSession(sessionId)) {
-        this._log.info(`New remote caret: ${sessionId}`);
+        this._log.info('New remote caret:', sessionId);
         ops.push(fc.op_readPath(Paths.forCaret(sessionId)));
       }
     }
@@ -279,7 +279,7 @@ export default class CaretStorage extends CommonBase {
 
     for (const sessionId of this._remoteSessionIds()) {
       if (!currentSessionIds.has(sessionId)) {
-        this._log.info(`Remote caret has gone away: ${sessionId}`);
+        this._log.info('Remote caret has gone away:', sessionId);
         carets = carets.withoutSession(sessionId);
       }
     }
@@ -299,7 +299,7 @@ export default class CaretStorage extends CommonBase {
     let caretData;
 
     for (const p of paths) {
-      this._log.info(`Remote caret changed: ${Paths.sessionFromCaretPath(p)}`);
+      this._log.info('Remote caret changed:', Paths.sessionFromCaretPath(p));
       ops.push(fc.op_readPath(p));
     }
 
@@ -369,14 +369,14 @@ export default class CaretStorage extends CommonBase {
       }
 
       if (caret) {
-        this._log.detail(`Updating caret: ${sessionId}`);
+        this._log.detail('Updating caret:', sessionId);
         ops.push(fc.op_writePath(path, caret));
         if (!storedCaret) {
           // First time this session is being stored.
           setUpdates.push(sessionId);
         }
       } else {
-        this._log.detail(`Deleting caret: ${sessionId}`);
+        this._log.detail('Deleting caret:', sessionId);
         ops.push(fc.op_deletePath(path));
         setUpdates.push(sessionId);
       }

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -139,7 +139,7 @@ export default class DocServer extends Singleton {
   _complexReaper(docId) {
     return () => {
       this._complexes.delete(docId);
-      log.info(`Reaped idle file complex: ${docId}`);
+      log.info('Reaped idle file complex:', docId);
     };
   }
 
@@ -197,7 +197,7 @@ export default class DocServer extends Singleton {
         log.error(`Trouble reaping session ${sessionId}.`, e);
       }
 
-      log.info(`Reaped idle session: ${sessionId}`);
+      log.info('Reaped idle session:', sessionId);
     };
   }
 }

--- a/local-modules/env-server/PidFile.js
+++ b/local-modules/env-server/PidFile.js
@@ -35,7 +35,7 @@ export default class PidFile extends Singleton {
     // Write the PID file.
     fs.writeFileSync(this._pidPath, `${process.pid}\n`);
 
-    log.info(`PID: ${process.pid}`);
+    log.info('PID:', process.pid);
   }
 
   /**
@@ -45,7 +45,7 @@ export default class PidFile extends Singleton {
    * @param {string} id Signal ID.
    */
   _handleSignal(id) {
-    log.info(`Received signal: ${id}`);
+    log.info('Received signal:', id);
     this._erasePid();
     process.kill(process.pid, id);
   }
@@ -56,7 +56,7 @@ export default class PidFile extends Singleton {
   _erasePid() {
     try {
       fs.unlinkSync(this._pidPath);
-      log.info(`Removed PID file.`);
+      log.info('Removed PID file.');
     } catch (e) {
       // Ignore errors. We're about to exit anyway.
     }

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -126,7 +126,7 @@ export default class LocalFile extends BaseFile {
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withPrefix(`[${fileId}]`);
 
-    this._log.info(`Path: ${this._storageDir}`);
+    this._log.info('Path:', this._storageDir);
   }
 
   /**
@@ -316,10 +316,10 @@ export default class LocalFile extends BaseFile {
 
       for (const [storageId, value] of updatedStorage) {
         if (value === null) {
-          this._log.detail(`Transaction deleted: ${storageId}`);
+          this._log.detail('Transaction deleted:', storageId);
           this._storage.delete(storageId);
         } else {
-          this._log.detail(`Transaction wrote: ${storageId}`);
+          this._log.detail('Transaction wrote:', storageId);
           this._storage.set(storageId, value);
         }
 
@@ -406,7 +406,7 @@ export default class LocalFile extends BaseFile {
       for (let i = 0; i < paths.length; i++) {
         const storagePath = paths[i];
         storage.set(storagePath, FrozenBuffer.coerce(bufs[i]));
-        this._log.info(`Read: ${storagePath}`);
+        this._log.info('Read:', storagePath);
       }
 
       paths    = [];
@@ -435,7 +435,7 @@ export default class LocalFile extends BaseFile {
     try {
       const revNumBuffer = storage.get(REVISION_NUMBER_ID);
       revNum = this._revNumCodec.decodeJsonBuffer(revNumBuffer);
-      this._log.info(`Starting revision number: ${revNum}`);
+      this._log.info('Starting revision number:', revNum);
     } catch (e) {
       // In case of failure, use the size of the storage map as a good enough
       // value for `revNum`. This case probably won't happen in practice except
@@ -443,7 +443,7 @@ export default class LocalFile extends BaseFile {
       // be fine in that the primary required guarantee is monotonic increase
       // within any given process (and not really across processes).
       revNum = storage.size;
-      this._log.info(`Starting with "fake" revision number: ${revNum}`);
+      this._log.info('Starting with "fake" revision number:', revNum);
     }
 
     // Only set the instance variables after all the reading is done and the
@@ -582,10 +582,10 @@ export default class LocalFile extends BaseFile {
       const fsPath = this._fsPathForStorageId(storageId);
       if (data === null) {
         afsResults.push(afs.unlink(fsPath));
-        this._log.info(`Deleted: ${storageId}`);
+        this._log.info('Deleted:', storageId);
       } else {
         afsResults.push(afs.writeFile(fsPath, data.toBuffer()));
-        this._log.info(`Wrote: ${storageId}`);
+        this._log.info('Wrote:', storageId);
       }
 
       if (afsResults.length >= MAX_PARALLEL_FS_CALLS) {
@@ -600,7 +600,7 @@ export default class LocalFile extends BaseFile {
       this._log.detail('Completed FS ops.');
     }
 
-    this._log.info(`Finished writing storage. Revision number: ${revNum}`);
+    this._log.info('Finished writing storage. Revision number:', revNum);
     return true;
   }
 

--- a/local-modules/file-store-local/LocalFileStore.js
+++ b/local-modules/file-store-local/LocalFileStore.js
@@ -37,7 +37,7 @@ export default class LocalFileStore extends BaseFileStore {
      */
     this._ensuredDir = false;
 
-    log.info(`File storage directory: ${this._dir}`);
+    log.info('File storage directory:', this._dir);
   }
 
   /**

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -420,15 +420,15 @@ export default class Transactor extends CommonBase {
   _logAboutWaiting(message) {
     if (this._waitSatisfied) {
       if (this._waitCount === 1) {
-        this._log.info(`No waiting required. ${message}`);
+        this._log.info('No waiting required.', message);
       } else {
-        this._log.info(`Done waiting. ${message}`);
+        this._log.info('Done waiting.', message);
       }
     } else {
       if (this._waitCount === 1) {
-        this._log.info(`Waiting. ${message}`);
+        this._log.info('Waiting.', message);
       } else {
-        this._log.info(`Wait #${this._waitCount}. ${message}`);
+        this._log.info(`Wait #${this._waitCount}.`, message);
       }
     }
   }

--- a/local-modules/state-machine/StateMachine.js
+++ b/local-modules/state-machine/StateMachine.js
@@ -168,14 +168,14 @@ export default class StateMachine {
           return;
         }
 
-        this._log.detail(`New state: ${name}`);
+        this._log.detail('New state:', name);
         this._stateName = name;
 
         // Trigger the awaiter for the state, if any.
         const condition = this._stateConditions.get(name);
         if (condition) {
           condition.onOff();
-          this._log.detail(`Triggered awaiter for state: ${name}`);
+          this._log.detail('Triggered awaiter for state:', name);
 
           // Remove the condition, because in general, these kinds of state
           // awaiters are used only ephemerally.
@@ -185,10 +185,10 @@ export default class StateMachine {
 
       this[`when_${name}`] = () => {
         if (this._stateName === name) {
-          this._log.detail(`Immediately-resolved awaiter for state: ${name}`);
+          this._log.detail('Immediately-resolved awaiter for state:', name);
           return Promise.resolve(true);
         } else {
-          this._log.detail(`Awaiter added for state: ${name}`);
+          this._log.detail('Awaiter added for state:', name);
           let condition = this._stateConditions.get(name);
           if (!condition) {
             condition = new Condition();
@@ -247,7 +247,7 @@ export default class StateMachine {
     // Log the state name and event details (if not squelched), and occasional
     // count of how many events have been handled so far.
 
-    log.detail(`In state: ${stateName}`);
+    log.detail('In state:', stateName);
     log.detail('Dispatching:', event);
 
     // Dispatch the event. In case of exception, enqueue an `error` event.

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -15,20 +15,29 @@ export default class CommonBase {
   /**
    * Adds the instance and static methods defined on this class to another
    * class, that is, treat this class as a "mixin" and apply it to the given
-   * class.
+   * class. If the given class already defines any of the methods, the original
+   * definitions take precedence.
    *
    * @param {class} clazz Class to mix into.
    */
   static mixInto(clazz) {
-    clazz.check         = this.check;
-    clazz.coerce        = this.coerce;
-    clazz.coerceOrNull  = this.coerceOrNull;
-    clazz._mustOverride = this._mustOverride;
+    for (const k of [
+      'check', 'coerce', 'coerceOrNull', '_impl_coerce', '_impl_coerceOrNull',
+      '_mustOverride'
+    ]) {
+      if (!clazz[k]) {
+        clazz[k] = this[k];
+      }
+    }
 
     const thisProto  = this.prototype;
     const clazzProto = clazz.prototype;
 
-    clazzProto._mustOverride = thisProto._mustOverride;
+    for (const k of ['_mustOverride']) {
+      if (!clazzProto[k]) {
+        clazzProto[k] = thisProto[k];
+      }
+    }
   }
 
   /**

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -4,7 +4,6 @@
 
 import { inspect } from 'util';
 
-//import CommonBase from './CommonBase';
 import CoreTypecheck from './CoreTypecheck';
 
 /**

--- a/server/main.js
+++ b/server/main.js
@@ -106,7 +106,7 @@ function run() {
   // A little spew to identify us.
   const info = ProductInfo.theOne.INFO;
   for (const k of Object.keys(info)) {
-    log.info(`${k} = ${info[k]}`);
+    log.info(k, '=', info[k]);
   }
 
   if (devMode) {


### PR DESCRIPTION
This PR is a cleanup pass over all our `log.<type>(...)` statements, switching them to pass separate arguments instead of using template concatenation, where possible. This both avoids extra work _and_ enables better rendering in the browser console.

**Bonus:** Cleaned up the method call plumbing in `api-client`.