### PR TITLE
Logging implementation cleanup

### DIFF
--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { inspect } from 'util';
 
 import { SeeAll } from 'see-all';
+import { TString } from 'typecheck';
 
 /**
  * Implementation of the `see-all` logging sink protocol which stores logged
@@ -20,7 +21,7 @@ export default class FileSink {
    */
   constructor(path) {
     /** {string} Path of the file to log to. */
-    this._path = path;
+    this._path = TString.nonEmpty(path);
 
     SeeAll.theOne.add(this);
   }

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import { inspect } from 'util';
 
 import { SeeAll } from 'see-all';
+import { TInt } from 'typecheck';
 
 /**
  * Implementation of the `see-all` logging sink protocol which collects a
@@ -21,10 +22,10 @@ export default class RecentSink {
    *   out of the list.
    */
   constructor(maxAgeMsec) {
-    /** Maximum age. */
-    this._maxAgeMsec = maxAgeMsec;
+    /** {Int} Maximum age. */
+    this._maxAgeMsec = TInt.nonNegative(maxAgeMsec);
 
-    /** The log contents. */
+    /** {array<object>} The log contents. */
     this._log = [];
 
     SeeAll.theOne.add(this);

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -10,7 +10,7 @@ import LogStream from './LogStream';
 const LEVELS = new Set(['debug', 'error', 'warn', 'info', 'detail']);
 
 /**
- * Base class for loggers. Subclasses must implement `_logImpl()`.
+ * Base class for loggers. Subclasses must implement `_impl_log()`.
  */
 export default class BaseLogger extends CommonBase {
   /**
@@ -25,7 +25,7 @@ export default class BaseLogger extends CommonBase {
    */
   log(level, ...message) {
     BaseLogger._validateLevel(level);
-    this._logImpl(level, message);
+    this._impl_log(level, message);
   }
 
   /**
@@ -127,7 +127,7 @@ export default class BaseLogger extends CommonBase {
   withPrefix(...prefix) {
     const result = new BaseLogger();
 
-    result._logImpl = (level, message) => {
+    result._impl_log = (level, message) => {
       this.log(level, ...prefix, ...message);
     };
 
@@ -147,7 +147,7 @@ export default class BaseLogger extends CommonBase {
   withDynamicPrefix(prefixGenerator) {
     const result = new BaseLogger();
 
-    result._logImpl = (level, message) => {
+    result._impl_log = (level, message) => {
       const prefix = prefixGenerator();
       this.log(level, ...prefix, ...message);
     };
@@ -156,13 +156,14 @@ export default class BaseLogger extends CommonBase {
   }
 
   /**
-   * Actual logging implementation.
+   * Actual logging implementation. Subclasses must override this to do
+   * something appropriate.
    *
    * @abstract
    * @param {string} level Severity level. Guaranteed to be a valid level.
    * @param {array} message Array of arguments to log.
    */
-  _logImpl(level, message) {
+  _impl_log(level, message) {
     this._mustOverride(level, message);
   }
 

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -2,6 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from 'typecheck';
+
+import Logger from './Logger';
+
 /**
  * Adaptor which provides a writable stream on top of a logger at a particular
  * severity level.
@@ -17,11 +21,11 @@ export default class LogStream {
    * @param {string} level Severity level to log at.
    */
   constructor(logger, level) {
-    /** Underlying logger to use. */
-    this._logger = logger;
+    /** {Logger} Underlying logger to use. */
+    this._logger = Logger.check(logger);
 
-    /** Severity level. */
-    this._level = level;
+    /** {string} Severity level. */
+    this._level = TString.check(level);
   }
 
   /**

--- a/local-modules/see-all/Logger.js
+++ b/local-modules/see-all/Logger.js
@@ -64,7 +64,7 @@ export default class Logger extends BaseLogger {
    * @param {string} level Severity level. Guaranteed to be a valid level.
    * @param {array} message Array of arguments to log.
    */
-  _logImpl(level, message) {
+  _impl_log(level, message) {
     if ((level === 'detail') && !this._enableDetail) {
       // This tag isn't listed as one to log at the `detail` level. (That is,
       // it's being squelched.)

--- a/local-modules/see-all/Logger.js
+++ b/local-modules/see-all/Logger.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TBoolean, TString } from 'typecheck';
+
 import BaseLogger from './BaseLogger';
 import AllSinks from './AllSinks';
 
@@ -49,11 +51,11 @@ export default class Logger extends BaseLogger {
   constructor(tag, enableDetail = false) {
     super();
 
-    /** The module / subsystem tag. */
-    this._tag = tag;
+    /** {string} The module / subsystem tag. */
+    this._tag = TString.nonEmpty(tag);
 
-    /** Whether logging is enabled for the `detail` level. */
-    this._enableDetail = enableDetail;
+    /** {boolean} Whether logging is enabled for the `detail` level. */
+    this._enableDetail = TBoolean.check(enableDetail);
 
     Object.freeze(this);
   }


### PR DESCRIPTION
The logging implementation is some of the oldest code in the system, so it's unsurprising that it never got updated to hew to the conventions that evolved as the project has progressed. This PR addresses a couple of the issues.