### PR TITLE
Use functor payloads for events.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,15 @@
     "consistent-return": "error",
     "eol-last": "error",
     "eqeqeq": "error",
-    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "indent": [
+      "error",
+      2,
+      {
+        "FunctionDeclaration": { "parameters": 2 },
+        "FunctionExpression": { "parameters": 2 },
+        "SwitchCase": 1
+      }
+    ],
     "keyword-spacing": "error",
     "max-len": [
       "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,11 +4,6 @@
     "es6": true,
     "node": true
   },
-  "ecmaFeatures": {
-    "modules": true,
-    "spread": true,
-    "restParams": true
-  },
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": "2017"

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -133,11 +133,11 @@ taking into account recent additions to the language.
    * @returns ...
    */
   _impl_doSomethingInteresting(arg1, arg2) {
-      return this.mustOverride(arg1, arg2);
+      return this._mustOverride(arg1, arg2);
   }
   ```
 
-  `mustOverride()` is defined by the class `CommonBase` in the `util-common`
+  `_mustOverride()` is defined by the class `CommonBase` in the `util-common`
   local module.
 
 * Utility classes &mdash; Utility classes are classes which only serve as a

--- a/local-modules/api-server/PostConnection.js
+++ b/local-modules/api-server/PostConnection.js
@@ -97,9 +97,9 @@ export default class PostConnection extends Connection {
     this._log.info('Error:', error);
 
     this._res
-    .status(400)
-    .type('application/json')
-    .send(payload);
+      .status(400)
+      .type('application/json')
+      .send(payload);
   }
 
   /**

--- a/local-modules/proppy/Proppy.js
+++ b/local-modules/proppy/Proppy.js
@@ -128,10 +128,7 @@ export default class Proppy extends UtilityClass {
         break;
       }
 
-      match = (
-           /^[ \t]+/.exec(source)
-        || /^#[^\n]*/.exec(source)
-      );
+      match = /^[ \t]+/.exec(source) || /^#[^\n]*/.exec(source);
       if (match) {
         // Whitespace or comment: Skip it. **Note:** Newlines are significant
         // to the grammar, so we don't consume them here.
@@ -150,16 +147,13 @@ export default class Proppy extends UtilityClass {
         continue;
       }
 
-      match = /^[-_.\/a-zA-Z0-9]+/.exec(source);
+      match = /^[-_./a-zA-Z0-9]+/.exec(source);
       if (match) {
         result.push({ type: 'string', value: match[0] });
         continue;
       }
 
-      match = (
-           /^'([^\\']|(\\.))*'/.exec(source)
-        || /^"([^\\"]|(\\.))*"/.exec(source)
-      );
+      match = /^'([^\\']|(\\.))*'/.exec(source) || /^"([^\\"]|(\\.))*"/.exec(source);
       if (match) {
         // Quoted string: Trim the quotes, and parse characters.
         const contents = Proppy._parseQuotedString(match[0].slice(1, -1));

--- a/local-modules/proppy/tests/test_Proppy.js
+++ b/local-modules/proppy/tests/test_Proppy.js
@@ -103,7 +103,7 @@ describe('proppy/Proppy', () => {
       input = '"key\\\'" = "value"';
       _testStringParsing(input, { 'key\'': 'value' });
 
-      input = '"key\\\"" = "value"';
+      input = '"key\\"" = "value"';
       _testStringParsing(input, { 'key"': 'value' });
 
       input = '"key\\n" = "value"';

--- a/local-modules/quill-util/BaseEvent.js
+++ b/local-modules/quill-util/BaseEvent.js
@@ -30,11 +30,6 @@ export default class BaseEvent extends CommonBase {
     this._payload = Functor.check(payload);
   }
 
-  /** {string} Name of the event. */
-  get eventName() {
-    return this._payload.name;
-  }
-
   /** {Functor} Event payload (name and arguments). */
   get payload() {
     return this._payload;
@@ -86,7 +81,7 @@ export default class BaseEvent extends CommonBase {
    */
   earliestOfNow(eventName) {
     for (let e = this; e !== null; e = e.nextNow) {
-      if (e.eventName === eventName) {
+      if (e.payload.name === eventName) {
         return e;
       }
     }
@@ -132,7 +127,7 @@ export default class BaseEvent extends CommonBase {
     let result = null;
 
     for (let e = this; e !== null; e = e.nextNow) {
-      if (e.eventName === eventName) {
+      if (e.payload.name === eventName) {
         result = e;
       }
     }

--- a/local-modules/quill-util/BaseEvent.js
+++ b/local-modules/quill-util/BaseEvent.js
@@ -41,7 +41,7 @@ export default class BaseEvent extends CommonBase {
    * instance, which becomes resolved once it is available.
    */
   get next() {
-    throw this.mustOverride();
+    throw this._mustOverride();
   }
 
   /**
@@ -49,7 +49,7 @@ export default class BaseEvent extends CommonBase {
    * is immediately available, or `null` if there is not yet a next event.
    */
   get nextNow() {
-    throw this.mustOverride();
+    throw this._mustOverride();
   }
 
   /**

--- a/local-modules/quill-util/QuillEvent.js
+++ b/local-modules/quill-util/QuillEvent.js
@@ -9,10 +9,8 @@ import { Errors, Functor } from 'util-common';
 import BaseEvent from './BaseEvent';
 
 /**
- * Event wrapper for a Quill Delta, including reference to the document source,
- * the old contents, and the chain of subsequent events. In addition to the
- * event chain properties, each instance has properties as defined by Quill,
- * with the same names as Quill indicates.
+ * Event wrapper for events coming from Quill, as part of a promise-based event
+ * chain.
  *
  * Instances of this class are always frozen (read-only) to help protect clients
  * from each other (or from inadvertently messing with themselves).
@@ -109,13 +107,10 @@ export default class QuillEvent extends BaseEvent {
    *
    * @param {object} accessKey Key which protects ability to resolve the next
    *   event.
-   * @param {...*} payloadArgs Arguments used to construct the event payload
-   *   functor.
+   * @param {Functor} payload Event payload (name and arguments).
    */
-  constructor(accessKey, ...payloadArgs) {
-    const payload = QuillEvent.fixPayload(new Functor(...payloadArgs));
-
-    super(payload);
+  constructor(accessKey, payload) {
+    super(QuillEvent.fixPayload(payload));
 
     // **Note:** `accessKey` is _not_ exposed as a property. Doing so would
     // cause the security problem that its existence is meant to prevent. That
@@ -148,7 +143,7 @@ export default class QuillEvent extends BaseEvent {
         throw Errors.bad_use('Invalid access.');
       }
 
-      nextNow = new QuillEvent(key, ...args);
+      nextNow = new QuillEvent(key, new Functor(...args));
 
       resolveNext(nextNow);
       return nextNow;

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -6,7 +6,7 @@ import Quill from 'quill';
 
 import { FrozenDelta } from 'doc-common';
 import { TObject } from 'typecheck';
-import { CommonBase } from 'util-common';
+import { CommonBase, Functor } from 'util-common';
 
 import QuillEvent from './QuillEvent';
 
@@ -46,9 +46,8 @@ export default class QuillProm extends Quill {
      * {QuillEvent} The most recent resolved event. It is initialized as defined
      * by the documentation for `currentEvent`.
      */
-    this._currentEvent = new QuillEvent(
-      accessKey, QuillEvent.TEXT_CHANGE,
-      FrozenDelta.EMPTY, FrozenDelta.EMPTY, QuillEvent.API);
+    this._currentEvent = new QuillEvent(accessKey,
+      new Functor(QuillEvent.TEXT_CHANGE, FrozenDelta.EMPTY, FrozenDelta.EMPTY, QuillEvent.API));
 
     // We override `emitter.emit()` to _synchronously_ add an event to the
     // promise chain. We do it this way instead of relying on an event callback

--- a/local-modules/testing-server/Mocks.js
+++ b/local-modules/testing-server/Mocks.js
@@ -10,11 +10,11 @@ import { UtilityClass } from 'util-common';
  */
 export default class Mocks extends UtilityClass {
   static nodeRequest(uri = 'http://www.example.com',
-    method = 'GET',
-    headers = { host: 'example.com' },
-    timeout = 10 * 1000,
-    followRedirects = true,
-    maxRedirects = 10) {
+      method = 'GET',
+      headers = { host: 'example.com' },
+      timeout = 10 * 1000,
+      followRedirects = true,
+      maxRedirects = 10) {
     return { uri, method, headers, timeout, followRedirects, maxRedirects };
   }
 }

--- a/local-modules/testing-server/Mocks.js
+++ b/local-modules/testing-server/Mocks.js
@@ -10,11 +10,11 @@ import { UtilityClass } from 'util-common';
  */
 export default class Mocks extends UtilityClass {
   static nodeRequest(uri = 'http://www.example.com',
-                     method = 'GET',
-                     headers = { host: 'example.com' },
-                     timeout = 10 * 1000,
-                     followRedirects = true,
-                     maxRedirects = 10) {
+    method = 'GET',
+    headers = { host: 'example.com' },
+    timeout = 10 * 1000,
+    followRedirects = true,
+    maxRedirects = 10) {
     return { uri, method, headers, timeout, followRedirects, maxRedirects };
   }
 }

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -68,6 +68,20 @@ export default class TString extends UtilityClass {
   }
 
   /**
+   * Checks a value of type `String`, which must furthermore be a valid
+   * "label-like thing." These are just like identifiers, except that dash (`-`)
+   * is an allowable character throughout.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static label(value) {
+    // This is defined in `CoreTypecheck` so that it can be used by `util-core`
+    // without introducing a circular dependency on this module.
+    return CoreTypecheck.checkLabel(value);
+  }
+
+  /**
    * Checks a value of type `String`, which must furthermore have at least a
    * given number of characters.
    *

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -4,8 +4,24 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
+import { inspect } from 'util';
 
 import { TString } from 'typecheck';
+
+import Assert from 'util-core/tests/Assert';
+
+/** {array<*>} Non-string values to use as test cases. */
+const NON_STRING_CASES = [
+  undefined,
+  null,
+  false,
+  true,
+  37,
+  Symbol('florp'),
+  ['like'],
+  { a: 10 },
+  /** Function. */ () => { /*empty*/ }
+];
 
 describe('typecheck/TString', () => {
   describe('check(value)', () => {
@@ -102,6 +118,129 @@ describe('typecheck/TString', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 4, 8));
+    });
+  });
+
+  describe('checkIdentifier()', () => {
+    it('accepts identifier strings', () => {
+      function test(value) {
+        assert.strictEqual(TString.identifier(value), value);
+      }
+
+      test('a');
+      test('A');
+      test('_');
+      test('blort');
+      test('florp_like');
+      test('x9');
+      test('_0123456789_');
+      test('abcdefghijklmnopqrstuvwxyz');
+      test('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    });
+
+    it('rejects non-identifier strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.identifier(value); },
+          'bad_value',
+          [inspect(value), 'String', 'identifier syntax']);
+      }
+
+      // Needs at least one character.
+      test('');
+
+      // Can't start with a digit.
+      test('0a');
+      test('1a');
+      test('2a');
+      test('3a');
+      test('4a');
+      test('5a');
+      test('6a');
+      test('7a');
+      test('8a');
+      test('9a');
+
+      // Has invalid character.
+      test('a-1');
+      test('a/1');
+      test('a!@#$%^&*');
+    });
+
+    it('rejects non-strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.identifier(value); },
+          'bad_value',
+          [inspect(value), 'String', 'identifier syntax']);
+      }
+
+      for (const v of NON_STRING_CASES) {
+        test(v);
+      }
+    });
+  });
+
+  describe('checkLabel()', () => {
+    it('accepts label strings', () => {
+      function test(value) {
+        assert.strictEqual(TString.label(value), value);
+      }
+
+      test('a');
+      test('A');
+      test('_');
+      test('-');
+      test('blort');
+      test('florp_like');
+      test('florp-like');
+      test('x9');
+      test('_0123456789_');
+      test('-0123456789-');
+      test('abcdefghijklmnopqrstuvwxyz');
+      test('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    });
+
+    it('rejects non-label strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.label(value); },
+          'bad_value',
+          [inspect(value), 'String', 'label syntax']);
+      }
+
+      // Needs at least one character.
+      test('');
+
+      // Can't start with a digit.
+      test('0a');
+      test('1a');
+      test('2a');
+      test('3a');
+      test('4a');
+      test('5a');
+      test('6a');
+      test('7a');
+      test('8a');
+      test('9a');
+
+      // Has invalid character.
+      test('a+1');
+      test('a/1');
+      test('a!@#$%^&*');
+    });
+
+    it('rejects non-strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.label(value); },
+          'bad_value',
+          [inspect(value), 'String', 'label syntax']);
+      }
+
+      for (const v of NON_STRING_CASES) {
+        test(v);
+      }
     });
   });
 

--- a/local-modules/util-core/CoreTypecheck.js
+++ b/local-modules/util-core/CoreTypecheck.js
@@ -28,6 +28,23 @@ export default class CoreTypecheck extends UtilityClass {
   }
 
   /**
+   * Checks that a value is of type `string` and has the usual form of a
+   * "label-like thing" in programming. This is the same as an identifier,
+   * except that dashes are allowed throughout.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static checkLabel(value) {
+    try {
+      return CoreTypecheck.checkString(value, /^[-a-zA-Z_][-a-zA-Z_0-9]*$/);
+    } catch (e) {
+      // More accurate error.
+      throw Errors.bad_value(value, String, 'label syntax');
+    }
+  }
+
+  /**
    * Checks that a value is of type `object`, and is optionally an instance of
    * a particular class. `null` is _not_ considered an object by this check.
    * Functions _are_ considered objects by this check.

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -23,15 +23,13 @@ export default class Functor {
   /**
    * Constructs an instance.
    *
-   * @param {string} name Functor name. This must conform to the usual
-   *   conservative syntax for a programming language "identifier," that is, a
-   *   non-empty string with characters taken from the set `[a-zA-Z_0-9]` and a
-   *   non-numeric first character.
+   * @param {string} name Functor name. This must conform to the "label"
+   *   syntax as defined by {@link TString#label()`}.
    * @param {...*} args Functor arguments.
    */
   constructor(name, ...args) {
     /** {string} Functor name. */
-    this._name = CoreTypecheck.checkIdentifier(name);
+    this._name = CoreTypecheck.checkLabel(name);
 
     /** {array<*>} Functor arguments. */
     this._args = Object.freeze(args);

--- a/local-modules/util-core/tests/Assert.js
+++ b/local-modules/util-core/tests/Assert.js
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+
+import { InfoError, UtilityClass } from 'util-core';
+
+/**
+ * Additional assertion functions for use with this project.
+ */
+export default class Assert extends UtilityClass {
+  /**
+   * Like `assert.throws()`, but specifically to check the details of an
+   * expected `InfoError`.
+   *
+   * @param {function} func Function to call, expected to throw.
+   * @param {string} name Expected error name.
+   * @param {array|null} args Expected error arguments, or `null` if there are
+   *   no expectations.
+   */
+  static throwsInfo(func, name, args = null) {
+    try {
+      func();
+      assert.fail('Did not throw.');
+    } catch (e) {
+      assert.instanceOf(e, InfoError);
+      assert.strictEqual(e.info.name, name);
+      if (args !== null) {
+        assert.deepEqual(e.info.args, args);
+      }
+    }
+  }
+}

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -6,7 +6,9 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import { inspect } from 'util';
 
-import { CoreTypecheck, InfoError } from 'util-core';
+import { CoreTypecheck } from 'util-core';
+
+import Assert from './Assert';
 
 /** {array<string>} Strings to use as test cases. */
 const STRING_CASES = [
@@ -24,30 +26,9 @@ const NON_STRING_CASES = [
   37,
   Symbol('florp'),
   ['like'],
-  { a: 10 }
+  { a: 10 },
+  /** Function. */ () => { /*empty*/ }
 ];
-
-/**
- * Like `assert.throws()`, but specifically to check the details of an
- * expected `InfoError`.
- *
- * @param {function} func Function to call, expected to throw.
- * @param {string} name Expected error name.
- * @param {array|null} args Expected error arguments, or `null` if there are no
- *   expectations.
- */
-function assertThrowsInfo(func, name, args = null) {
-  try {
-    func();
-    assert.fail('Did not throw.');
-  } catch (e) {
-    assert.instanceOf(e, InfoError);
-    assert.strictEqual(e.info.name, name);
-    if (args !== null) {
-      assert.deepEqual(e.info.args, args);
-    }
-  }
-}
 
 describe('util-core/CoreTypecheck', () => {
   describe('checkIdentifier()', () => {
@@ -69,7 +50,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-identifier strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkIdentifier(value); },
           'bad_value',
           [inspect(value), 'String', 'identifier syntax']);
@@ -98,7 +79,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkIdentifier(value); },
           'bad_value',
           [inspect(value), 'String', 'identifier syntax']);
@@ -132,7 +113,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-label strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkLabel(value); },
           'bad_value',
           [inspect(value), 'String', 'label syntax']);
@@ -161,7 +142,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkLabel(value); },
           'bad_value',
           [inspect(value), 'String', 'label syntax']);
@@ -190,7 +171,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-objects', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value); },
           'bad_value',
           [inspect(value), 'Object']);
@@ -230,7 +211,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects objects of the wrong class', () => {
       function test(value, clazz) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value, clazz); },
           'bad_value',
           [inspect(value), `class ${clazz.name}`]);
@@ -243,7 +224,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-objects', () => {
       function test(value, clazz) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value, clazz); },
           'bad_value',
           [inspect(value), `class ${clazz.name}`]);
@@ -270,7 +251,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value); },
           'bad_value',
           [inspect(value), 'String']);
@@ -294,7 +275,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects strings that do not match the regex', () => {
       function test(value, regex) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value, regex); },
           'bad_value',
           [inspect(value), 'String', regex.toString()]);
@@ -306,7 +287,7 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-strings', () => {
       function test(value) {
-        assertThrowsInfo(
+        Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value, /./); },
           'bad_value',
           [inspect(value), 'String', '/./']);
@@ -320,7 +301,7 @@ describe('util-core/CoreTypecheck', () => {
     it('rejects a non-`RegExp` second argument', () => {
       const notRegex = 'not-a-regex';
 
-      assertThrowsInfo(
+      Assert.throwsInfo(
         () => { CoreTypecheck.checkString('x', notRegex); },
         'bad_value',
         [inspect(notRegex), 'RegExp']);

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -50,7 +50,7 @@ function assertThrowsInfo(func, name, args = null) {
 }
 
 describe('util-core/CoreTypecheck', () => {
-  describe('checkIdentifier(value)', () => {
+  describe('checkIdentifier()', () => {
     it('accepts identifier strings', () => {
       function test(value) {
         assert.strictEqual(CoreTypecheck.checkIdentifier(value), value);
@@ -102,6 +102,69 @@ describe('util-core/CoreTypecheck', () => {
           () => { CoreTypecheck.checkIdentifier(value); },
           'bad_value',
           [inspect(value), 'String', 'identifier syntax']);
+      }
+
+      for (const v of NON_STRING_CASES) {
+        test(v);
+      }
+    });
+  });
+
+  describe('checkLabel()', () => {
+    it('accepts label strings', () => {
+      function test(value) {
+        assert.strictEqual(CoreTypecheck.checkLabel(value), value);
+      }
+
+      test('a');
+      test('A');
+      test('_');
+      test('-');
+      test('blort');
+      test('florp_like');
+      test('florp-like');
+      test('x9');
+      test('_0123456789_');
+      test('-0123456789-');
+      test('abcdefghijklmnopqrstuvwxyz');
+      test('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    });
+
+    it('rejects non-label strings', () => {
+      function test(value) {
+        assertThrowsInfo(
+          () => { CoreTypecheck.checkLabel(value); },
+          'bad_value',
+          [inspect(value), 'String', 'label syntax']);
+      }
+
+      // Needs at least one character.
+      test('');
+
+      // Can't start with a digit.
+      test('0a');
+      test('1a');
+      test('2a');
+      test('3a');
+      test('4a');
+      test('5a');
+      test('6a');
+      test('7a');
+      test('8a');
+      test('9a');
+
+      // Has invalid character.
+      test('a+1');
+      test('a/1');
+      test('a!@#$%^&*');
+    });
+
+    it('rejects non-strings', () => {
+      function test(value) {
+        assertThrowsInfo(
+          () => { CoreTypecheck.checkLabel(value); },
+          'bad_value',
+          [inspect(value), 'String', 'label syntax']);
       }
 
       for (const v of NON_STRING_CASES) {

--- a/local-modules/util-core/tests/test_Functor.js
+++ b/local-modules/util-core/tests/test_Functor.js
@@ -19,10 +19,12 @@ describe('util-core/Functor', () => {
       test('a');
       test('A');
       test('_');
+      test('-');
       test('a1');
-      test('_0123456789');
+      test('_0123456789_');
+      test('-0123456789-');
       test('abcde_fghij_klmno_pqrst_uvwxy_z');
-      test('ABCDE_FGHIJ_KLMNO_PQRST_UVWXY_Z');
+      test('ABCDE-FGHIJ-KLMNO-PQRST-UVWXY-Z');
     });
 
     it('should accept various amounts and types of arguments', () => {
@@ -86,7 +88,7 @@ describe('util-core/Functor', () => {
       }
 
       test('blort');
-      test('florp_like');
+      test('florp-like');
       test('SIDEWAYS_TIMELINE');
     });
   });


### PR DESCRIPTION
This PR is the first step (of probably three or four PRs total) of a major cleanup of how our event chaining mechanism works. What we're doing here is getting the base class `BaseEvent` to hold complete events (in the form of a functor) and not just the event name. The part of `QuillEvent` where it gives event parameters names (which are "natively" positional) is split out, which as a bit of a happy side effect causes the client code to get a little bit simpler and less buggy (the latter being an edge-ish case that _probably_ never happened, but I'm not 100% sure).

Later PRs will rework of the event chaining mechanism and (I hope) make it more straightforward to define something like an "event set schema" (or maybe more generally a "functor set schema") to replace the ad-hoc `static` methods that I added to `QuillProm`.

**Bonus:** Tried switching us to ESLint 4.0, and proactively cleaned up some of the new complaints it will be giving us. I didn't actually check in the version bump, though, because it looks like there's at least one bug in it which we run across in our code.