### PR TITLE
`doc-client` naming cleanup.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -108,7 +108,7 @@ export default class TopControl {
    */
   _recoverySetup() {
     (async () => {
-      await this._editorComplex.docClient.when_unrecoverableError();
+      await this._editorComplex.bodyClient.when_unrecoverableError();
       this._recoverIfPossible();
     })();
   }

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -103,7 +103,7 @@ export default class TopControl {
   }
 
   /**
-   * Hooks things up so that this instance gets notified if/when the `DocClient`
+   * Hooks things up so that this instance gets notified if/when the editor
    * aborts due to error. Should that happen, a recovery attempt is initiated.
    */
   _recoverySetup() {

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -76,7 +76,7 @@ const CLIENT_SOURCE = 'doc-client';
  * just wait until it comes back with a result, instead of having to set up a
  * low-duration timeout to repeatedly ask for new changes.
  */
-export default class DocClient extends StateMachine {
+export default class BodyClient extends StateMachine {
   /**
    * Constructs an instance. It is initially in state `detached`. The
    * constructed instance expects to be the primary non-human controller of the

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -377,7 +377,7 @@ export default class BodyClient extends StateMachine {
     // Save the result as the current (latest known) revision of the document,
     // and tell Quill about it.
     const firstEvent = this._quill.currentEvent;
-    this._updateDocWithSnapshot(snapshot);
+    this._updateWithSnapshot(snapshot);
 
     // The above action should have caused the Quill instance to make a change
     // which shows up on its event chain. Grab it, and verify that indeed it's
@@ -485,7 +485,7 @@ export default class BodyClient extends StateMachine {
     // here is a stale response of one sort or another. For example (and most
     // likely), it might be the delayed result from an earlier iteration.
     if (this._snapshot.revNum === baseSnapshot.revNum) {
-      this._updateDocWithDelta(result);
+      this._updateWithDelta(result);
     }
 
     // Fire off the next iteration of requesting server changes, after a short
@@ -670,7 +670,7 @@ export default class BodyClient extends StateMachine {
       // And note that Quill doesn't need to be updated here (that is, its delta
       // is empty) because what we are integrating into the client document is
       // exactly what Quill handed to us.
-      this._updateDocWithDelta(
+      this._updateWithDelta(
         new BodyDelta(vResultNum, delta), FrozenDelta.EMPTY);
       this._becomeIdle();
       return;
@@ -689,7 +689,7 @@ export default class BodyClient extends StateMachine {
       // Thanfully, the local user hasn't made any other changes while we
       // were waiting for the server to get back to us, which means we can
       // cleanly apply the correction on top of Quill's current state.
-      this._updateDocWithDelta(
+      this._updateWithDelta(
         new BodyDelta(vResultNum, correctedDelta), dCorrection);
       this._becomeIdle();
       return;
@@ -735,7 +735,7 @@ export default class BodyClient extends StateMachine {
     // second (lost any insert races or similar).
     const dIntegratedCorrection =
       FrozenDelta.coerce(dMore.transform(dCorrection, false));
-    this._updateDocWithDelta(
+    this._updateWithDelta(
       new BodyDelta(vResultNum, correctedDelta), dIntegratedCorrection);
 
     // (3)
@@ -820,7 +820,7 @@ export default class BodyClient extends StateMachine {
    *   represented in `_snapshot`. This must be used in cases where Quill's
    *   state has progressed ahead of `_snapshot` due to local activity.
    */
-  _updateDocWithDelta(delta, quillDelta = delta.delta) {
+  _updateWithDelta(delta, quillDelta = delta.delta) {
     const needQuillUpdate = !quillDelta.isEmpty();
 
     if (   (this._currentEvent.nextOfNow(QuillEvent.TEXT_CHANGE) !== null)
@@ -845,7 +845,7 @@ export default class BodyClient extends StateMachine {
    *
    * @param {BodySnapshot} snapshot New snapshot.
    */
-  _updateDocWithSnapshot(snapshot) {
+  _updateWithSnapshot(snapshot) {
     this._snapshot = snapshot;
     this._quill.setContents(snapshot.contents, CLIENT_SOURCE);
   }

--- a/local-modules/doc-client/DocClient.js
+++ b/local-modules/doc-client/DocClient.js
@@ -231,11 +231,12 @@ export default class DocClient extends StateMachine {
   }
 
   /**
-   * Validates a `wantChanges` event. This indicates that it is time to
-   * request a new change from the server, but only if the client isn't in the
-   * middle of doing something else.
+   * Validates a `wantInput` event. This indicates that it is time to solicit
+   * input from the server (in the form of document deltas) and from the local
+   * Quill instance (in the form of Quill events), but only if the client isn't
+   * in the middle of doing something else.
    */
-  _check_wantChanges() {
+  _check_wantInput() {
     // Nothing to do.
   }
 
@@ -411,12 +412,12 @@ export default class DocClient extends StateMachine {
   }
 
   /**
-   * In state `idle`, handles event `wantChanges`. This can happen as a chained
+   * In state `idle`, handles event `wantInput`. This can happen as a chained
    * event (during startup or at the end of handling the integration of changes)
    * or due to a delay timeout. This will make requests both to the server and
    * to the local Quill instance.
    */
-  _handle_idle_wantChanges() {
+  _handle_idle_wantInput() {
     // We grab the current revision of the doc, so we can refer back to it when
     // a response comes. That is, `_doc` might have changed out from
     // under us between when this event is handled and when the promises used
@@ -460,11 +461,11 @@ export default class DocClient extends StateMachine {
   }
 
   /**
-   * In any state but `idle`, handles event `wantChanges`. We ignore the event,
+   * In any state but `idle`, handles event `wantInput`. We ignore the event,
    * because the client is in the middle of doing something else. When it's done
-   * with whatever it may be, it will send a new `wantChanges` event.
+   * with whatever it may be, it will send a new `wantInput` event.
    */
-  _handle_any_wantChanges() {
+  _handle_any_wantInput() {
     // Nothing to do. Stay in the same state.
   }
 
@@ -492,7 +493,7 @@ export default class DocClient extends StateMachine {
     // despite any particularly active editing by other clients.
     (async () => {
       await Delay.resolve(PULL_DELAY_MSEC);
-      this.q_wantChanges();
+      this.q_wantInput();
     })();
   }
 
@@ -663,7 +664,7 @@ export default class DocClient extends StateMachine {
       //
       // In particular, if there happened to be any local changes made (coming
       // from Quill) while the server request was in flight, they will be picked
-      // up promptly due to the handling of the `wantChanges` event which will
+      // up promptly due to the handling of the `wantInput` event which will
       // get fired off immediately.
       //
       // And note that Quill doesn't need to be updated here (that is, its delta
@@ -850,11 +851,11 @@ export default class DocClient extends StateMachine {
   }
 
   /**
-   * Sets up the state machine to idle while waiting for changes.
+   * Sets up the state machine to idle while waiting for input.
    */
   _becomeIdle() {
     this.s_idle();
-    this.q_wantChanges();
+    this.q_wantInput();
   }
 
   /**

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -86,7 +86,7 @@ export default class EditorComplex extends CommonBase {
      * {BodyClient|null} Document body client instance (API-to-editor hookup).
      * Set in `_initSession()`.
      */
-    this._docClient = null;
+    this._bodyClient = null;
 
     // The rest of the initialization has to happen asynchronously. In
     // particular, there is no avoiding the asynchrony in `_domSetup()`, and
@@ -134,8 +134,8 @@ export default class EditorComplex extends CommonBase {
   }
 
   /** {BodyClient} The document body client instance. */
-  get docClient() {
-    return this._docClient;
+  get bodyClient() {
+    return this._bodyClient;
   }
 
   /** {DocSession} The session control instance. */
@@ -196,13 +196,13 @@ export default class EditorComplex extends CommonBase {
   _initSession(sessionKey, fromConstructor) {
     this._sessionKey = SplitKey.check(sessionKey);
     this._docSession = new DocSession(this._sessionKey);
-    this._docClient  = new BodyClient(this._bodyQuill, this._docSession);
+    this._bodyClient  = new BodyClient(this._bodyQuill, this._docSession);
 
-    this._docClient.start();
+    this._bodyClient.start();
 
     // Log a note once everything is all set up.
     (async () => {
-      await this._docClient.when_idle();
+      await this._bodyClient.when_idle();
       if (fromConstructor) {
         log.info('Initialization complete!');
       } else {

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -12,7 +12,7 @@ import { DomUtil } from 'util-client';
 import { CommonBase, Errors } from 'util-common';
 
 import CaretOverlay from './CaretOverlay';
-import DocClient from './DocClient';
+import BodyClient from './BodyClient';
 import DocSession from './DocSession';
 
 /** {Logger} Logger for this module. */
@@ -83,8 +83,8 @@ export default class EditorComplex extends CommonBase {
     this._docSession = null;
 
     /**
-     * {DocClient|null} Document client instance (API-to-editor hookup). Set in
-     * `_initSession()`.
+     * {BodyClient|null} Document body client instance (API-to-editor hookup).
+     * Set in `_initSession()`.
      */
     this._docClient = null;
 
@@ -92,7 +92,7 @@ export default class EditorComplex extends CommonBase {
     // particular, there is no avoiding the asynchrony in `_domSetup()`, and
     // that setup needs to be complete before we construct the Quill and
     // author overlay instances. And _all_ of this needs to be done before we
-    // make a `DocClient` (which gets done by `_initSession()`).
+    // make a `BodyClient` (which gets done by `_initSession()`).
     (async () => {
       // Do all of the DOM setup for the instance.
       const [titleNode, quillNode, authorOverlayNode] =
@@ -133,7 +133,7 @@ export default class EditorComplex extends CommonBase {
     return this._caretOverlay;
   }
 
-  /** {DocClient} The document client instance. */
+  /** {BodyClient} The document body client instance. */
   get docClient() {
     return this._docClient;
   }
@@ -196,7 +196,7 @@ export default class EditorComplex extends CommonBase {
   _initSession(sessionKey, fromConstructor) {
     this._sessionKey = SplitKey.check(sessionKey);
     this._docSession = new DocSession(this._sessionKey);
-    this._docClient  = new DocClient(this._bodyQuill, this._docSession);
+    this._docClient  = new BodyClient(this._bodyQuill, this._docSession);
 
     this._docClient.start();
 

--- a/local-modules/doc-client/main.js
+++ b/local-modules/doc-client/main.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import DocClient from './DocClient';
+import BodyClient from './BodyClient';
 import DocSession from './DocSession';
 import EditorComplex from './EditorComplex';
 
-export { DocClient, DocSession, EditorComplex };
+export { BodyClient, DocSession, EditorComplex };


### PR DESCRIPTION
This PR pays down a bit of naming tech debt in `doc-client`. The meanings of various classes and variables had drifted over time, and the names hadn't tracked the changes in semantics.
