### PR TITLE
A little more cleanup

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -94,9 +94,6 @@ export default class BodyClient extends StateMachine {
     /** {DocSession} Server session control / manager. */
     this._docSession = DocSession.check(docSession);
 
-    /** {ApiClient} API interface. */
-    this._apiClient = docSession.apiClient;
-
     /** {Logger} Logger specific to this client's session. */
     this._log = docSession.log;
 
@@ -340,7 +337,7 @@ export default class BodyClient extends StateMachine {
     // won't become open synchronously, the API client code allows us to start
     // sending messages over it immediately. (They'll just get queued up as
     // necessary.)
-    this._apiClient.open();
+    this._docSession.apiClient.open();
 
     // Perform a challenge-response to authorize access to the document.
     try {

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -130,10 +130,10 @@ export default class BodyClient extends StateMachine {
     this._pendingDeltaAfter = false;
 
     /**
-     * {boolean} Is there currently a pending (as-yet unfulfilled) request for a
-     * new local change via the Quill document event promise chain?
+     * {boolean} Is there currently a pending (as-yet unfulfilled) `await` on
+     * the Quill event promise chain?
      */
-    this._pendingQuillChange = false;
+    this._pendingQuillAwait = false;
 
     /**
      * {array<Int>} Timestamps of every transition into the `errorWait` state
@@ -288,11 +288,11 @@ export default class BodyClient extends StateMachine {
    * changes that were in-flight when the connection became problematic.
    */
   _handle_errorWait_start() {
-    this._snapshot           = null;
-    this._sessionProxy       = null;
-    this._currentEvent       = null;
-    this._pendingDeltaAfter  = false;
-    this._pendingQuillChange = false;
+    this._snapshot          = null;
+    this._sessionProxy      = null;
+    this._currentEvent      = null;
+    this._pendingDeltaAfter = false;
+    this._pendingQuillAwait = false;
 
     // After this, it's just like starting from the `detached` state.
     this.s_detached();
@@ -426,14 +426,14 @@ export default class BodyClient extends StateMachine {
     // for same. (Otherwise, we would unnecessarily build up redundant promise
     // resolver functions when changes are coming in from the server while the
     // local user is idle.)
-    if (!this._pendingQuillChange) {
-      this._pendingQuillChange = true;
+    if (!this._pendingQuillAwait) {
+      this._pendingQuillAwait = true;
 
       // **Note:** As of this writing, Quill will never reject (report an error
       // on) a document change promise.
       (async () => {
         await this._currentEvent.next;
-        this._pendingQuillChange = false;
+        this._pendingQuillAwait = false;
         this.q_gotQuillEvent(baseSnapshot);
       })();
     }

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TFunction } from 'typecheck';
 import { CommonBase } from 'util-core';
 
 /**
@@ -58,7 +59,7 @@ export default class PropertyIterable extends CommonBase {
   onlyMethods() {
     // **Note:** If `value` is defined, the property is guaranteed not to be
     // synthetic.
-    return this.filter(desc => (typeof desc.value === 'function'));
+    return this.filter(desc => TFunction.isCallable(desc.value));
   }
 
   /**

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -5,15 +5,14 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { TObject } from 'typecheck';
 import { PropertyIterable } from 'util-common';
 
 const TEST_OBJECT = {
   a: 1,
   b: 2,
-  functionItem: assert,
+  functionItem: () => true,
   classItem: PropertyIterable,
-  objectItem: {}
+  objectItem: { a: 1 }
 };
 
 describe('util-common/PropertyIterable', () => {
@@ -22,18 +21,18 @@ describe('util-common/PropertyIterable', () => {
       const iter = new PropertyIterable(TEST_OBJECT);
       const expectedProperties = ['a', 'b', 'functionItem', 'classItem', 'objectItem'];
 
-      assert.doesNotThrow(() => _testIterator(iter, expectedProperties));
+      testIteratable(iter, expectedProperties);
     });
   });
 
   describe('iterating soley over methods', () => {
-    it('should return just function elements of the object', () => {
+    it('should return just callable function elements of the object', () => {
       const iter = new PropertyIterable(TEST_OBJECT);
       const methodIter = iter.onlyMethods();
-      const expectedProperties = ['functionItem', 'classItem'];
-      const unexpectedProperties = ['a', 'b', 'objectItem'];
+      const expectedProperties = ['functionItem'];
+      const unexpectedProperties = ['a', 'b', 'classItem', 'objectItem'];
 
-      assert.doesNotThrow(() => _testIterator(methodIter, expectedProperties, unexpectedProperties));
+      testIteratable(methodIter, expectedProperties, unexpectedProperties);
     });
   });
 
@@ -43,11 +42,9 @@ describe('util-common/PropertyIterable', () => {
       const nonObjectIter = iter.skipObject();
       const expectedProperties = ['a', 'b', 'objectItem', 'functionItem', 'classItem'];
 
-      assert.doesNotThrow(() => _testIterator(nonObjectIter, expectedProperties));
+      const result = testIteratable(nonObjectIter, expectedProperties);
 
-      const result = _testIterator(nonObjectIter, expectedProperties);
-
-      TObject.withExactKeys(result, expectedProperties);
+      assert.hasAllKeys(result, expectedProperties);
     });
   });
 
@@ -64,27 +61,25 @@ describe('util-common/PropertyIterable', () => {
  * was specifically checked.
  *
  * @param {PropertyIterable} iter The iterator we are testing.
- * @param {array<string>|null} [expectedProperties=[]] A list of property
- *   names. The iterator must return _at least_ all of the properties in this
- *   list.
- * @param {array<string>|null} [unexpectedProperties=[]] A list of property
- *   names. The iterator must not return any of the properties in this list.
- * @returns {array<string>} An array of property names returned by the iterator.
+ * @param {array<string>} [expectedProperties = []] List of property names. The
+ *   iterator must return _at least_ all of the properties in this list.
+ * @param {array<string>} [unexpectedProperties = []] List of property names.
+ *   The iterator must not return any of the properties in this list.
+ * @returns {array<string>} List of property names returned by the iterator.
  */
-function _testIterator(iter, expectedProperties = [], unexpectedProperties = []) {
+function testIteratable(iter, expectedProperties = [], unexpectedProperties = []) {
   const result = {};
 
   for (const property of iter) {
     result[property.name] = true;
   }
 
-  for (const requiredProperty of expectedProperties) {
-    assert.isDefined(result[requiredProperty]);
-    assert.isTrue(result[requiredProperty]);
+  if (expectedProperties.length !== 0) {
+    assert.containsAllKeys(result, expectedProperties);
   }
 
-  for (const unexpectedProperty of unexpectedProperties) {
-    assert.isUndefined(result[unexpectedProperty]);
+  if (unexpectedProperties.length !== 0) {
+    assert.doesNotHaveAnyKeys(result, unexpectedProperties);
   }
 
   return result;

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -49,7 +49,20 @@ describe('util-common/PropertyIterable', () => {
   });
 
   describe('iterating solely over non-synthetic properties', () => {
-    it('should iterate solely over non-synthetic properties');
+    it('should iterate solely over non-synthetic properties', () => {
+      const obj = {
+        yes1: 'x',
+        yes2: 'y',
+        get no1() { return 10; },
+        get no2() { return 20; },
+        set no2(x) { /*empty*/ },
+        set no3(x) { /*empty*/ }
+      };
+      const iter = new PropertyIterable(obj).skipSynthetic();
+      const expectedProperties = ['yes1', 'yes2'];
+
+      testIteratable(iter, expectedProperties);
+    });
   });
 });
 
@@ -61,7 +74,7 @@ describe('util-common/PropertyIterable', () => {
  * was specifically checked.
  *
  * @param {PropertyIterable} iter The iterator we are testing.
- * @param {array<string>} [expectedProperties = []] List of property names. The
+ * @param {array<string>} expectedProperties List of property names. The
  *   iterator must return _at least_ all of the properties in this list.
  * @param {array<string>} [unexpectedProperties = []] List of property names.
  *   The iterator must not return any of the properties in this list.

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -80,7 +80,7 @@ describe('util-common/PropertyIterable', () => {
  *   The iterator must not return any of the properties in this list.
  * @returns {array<string>} List of property names returned by the iterator.
  */
-function testIteratable(iter, expectedProperties = [], unexpectedProperties = []) {
+function testIteratable(iter, expectedProperties, unexpectedProperties = []) {
   const result = {};
 
   for (const property of iter) {


### PR DESCRIPTION
* A couple more renames in `BodyClient` to match current semantics.
* Tighten up `PropertyIterable.onlyMethods()`; and clean up and expand the test cases just a bit.