### PR TITLE
New event classes

### DIFF
--- a/local-modules/promise-util/ChainedEvent.js
+++ b/local-modules/promise-util/ChainedEvent.js
@@ -1,0 +1,285 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase, Errors, Functor } from 'util-common';
+
+import EventSource from './EventSource';
+
+/**
+ * Promise-chained event. Each instance becomes chained to the next event which
+ * gets emitted by the same source. The chain is available both synchronously
+ * and asynchronously. In the synchronous case, it is possible to run into the
+ * end of the chain, represented by `null`. In the asynchronous case, the
+ * properties and accessors return promises that only become resolved once an
+ * appropriate event has been emitted by the source.
+ */
+export default class ChainedEvent extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {EventSource} source Source of this event.
+   * @param {Functor} payload Event payload (name and arguments).
+   */
+  constructor(source, payload) {
+    super();
+
+    /**
+     * {EventSource} Source of this event. This is used to validate the chaining
+     * of events.
+     *
+     * **Note:** It is important to _not_ reveal this value as a
+     * publicly-accessible property, because that would violate the intended
+     * design whereby access to an event does _not_ convey permission to emit
+     * new events on the associated chain.
+     */
+    this._source = EventSource.check(source);
+
+    /** {Functor} Event payload (name and arguments). */
+    this._payload = Functor.check(payload);
+
+    /**
+     * {ChainedEvent|null} Next event in the chain after this one, or `null` if
+     * there is as yet no next event.
+     */
+    this._nextNow = null;
+
+    /**
+     * {Promise<ChainedEvent>|null} Promise for the next event in the chain
+     * after this one, or `null` if there are no pending requests for same.
+     */
+    this._nextProm = null;
+
+    /**
+     * {function|null} Resolver for `_nextProm`. Set to non-`null` whenever
+     * `_nextProm` is also non-`null`.
+     */
+    this._nextResolver = null;
+
+    Object.seal(this);
+  }
+
+  /** {Functor} Event payload (name and arguments). */
+  get payload() {
+    return this._payload;
+  }
+
+  /**
+   * {Promise<ChainedEvent>} Promise for the next event in the chain after this
+   * instance, which becomes resolved once it is available.
+   */
+  get next() {
+    if (this._nextNow !== null) {
+      return Promise.resolve(this._nextNow);
+    }
+
+    // This event is currently at the tail of the chain, so the result will be
+    // an unresolved promise.
+
+    if (this._nextProm === null) {
+      // First time `next` has been called; need to set up the promise and
+      // resolver.
+      this._nextProm = new Promise((res, rej_unused) => {
+        this._nextResolver = res;
+      });
+    }
+
+    return this._nextProm;
+  }
+
+  /**
+   * {ChainedEvent|null} The next event in the chain after this instance if it
+   * is immediately available, or `null` if there is not yet a next event.
+   */
+  get nextNow() {
+    return this._nextNow;
+  }
+
+  /**
+   * Gets the earliest event of the indicated name in the event chain, starting
+   * at (and possibly including) this instance. This method only returns once a
+   * matching event is available.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent} The earliest event with the indidated name,
+   *   starting at this instance.
+   */
+  async earliestOf(eventName) {
+    for (let e = this; /*e*/; e = await e.next) {
+      const resultNow = e.earliestOfNow(eventName);
+      if (resultNow !== null) {
+        return resultNow;
+      }
+    }
+  }
+
+  /**
+   * Gets the earliest immediately-available event of the indicated name in the
+   * event chain, starting at (and possibly including) this instance. If no
+   * matching event is immediately available, this method returns `null`.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent|null} The earliest immediately-available event with
+   *   the indidated name, starting at this instance; or `null` if there is no
+   *   such event.
+   */
+  earliestOfNow(eventName) {
+    for (let e = this; e !== null; e = e.nextNow) {
+      if (e.payload.name === eventName) {
+        return e;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the latest (most recent) event of the indicated name in the event
+   * chain, starting at (and possibly including) this instance. This method only
+   * returns once a matching event is available.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent|null} The latest immediately-available event with
+   *   the indidated name, starting at this instance; or `null` if there is no
+   *   such event.
+   */
+  async latestOf(eventName) {
+    const resultNow = this.latestOfNow(eventName);
+
+    if (resultNow !== null) {
+      return resultNow;
+    } else {
+      // Wait for at least one matching event, and then get the instantaneously-
+      // latest (because there could have been more than one).
+      const next = await this.nextOf(eventName);
+      return next.latestOfNow(eventName);
+    }
+  }
+
+  /**
+   * Gets the latest (most recent) immediately-available event of the indicated
+   * name in the event chain, starting at (and possibly including) this
+   * instance. If no matching event is immediately available, this method
+   * returns `null`.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent|null} The latest immediately-available event with
+   *   the indidated name, starting at this instance; or `null` if there is no
+   *   such event.
+   */
+  latestOfNow(eventName) {
+    let result = null;
+
+    for (let e = this; e !== null; e = e.nextNow) {
+      if (e.payload.name === eventName) {
+        result = e;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Gets the next event of the indicated name after this instance, whenever it
+   * becomes resolved.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent} The next event with the indidated name, once it has
+   *   become resolved.
+   */
+  async nextOf(eventName) {
+    return (await this.next).earliestOf(eventName);
+  }
+
+  /**
+   * Gets the next event of the indicated name after this instance, if it is
+   * immediately available.
+   *
+   * @param {string} eventName Event name of interest.
+   * @returns {ChainedEvent|null} The next event with the indidated name that
+   *   has already been resolved, or `null` if there is no such event.
+   */
+  nextOfNow(eventName) {
+    const nextNow = this.nextNow;
+    return (nextNow === null) ? null : nextNow.earliestOfNow(eventName);
+  }
+
+  /**
+   * Constructs a new event which is set up to be at the head of an event chain
+   * which continues with _this_ instance's next event, but with a different
+   * event payload. Put another way, this constructs a replacement event for
+   * this instance, but with the same chaining.
+   *
+   * @param {Functor} payload Event payload (name and arguments).
+   * @returns {ChainedEvent} New event instance with the given `payload`, and
+   *   whose `next` and `nextNow` behave the same as this instance's properties
+   *   of the same names.
+   */
+  withNewPayload(payload) {
+    const result = new ChainedEvent(this._source, payload);
+
+    if (this._nextNow) {
+      // This instance already knows its next event, so set up the result with
+      // the same one.
+      result._resolveNext(this._nextNow);
+    } else {
+      // This instance is at the tail of the event chain. Wait for its `next`,
+      // and propagate that to the result.
+      (async () => {
+        result._resolveNext(await this.next);
+      })();
+    }
+
+    return result;
+  }
+
+  /**
+   * Constructs a new event which &mdash; from its perspective &mdash; is
+   * "pushed" onto the head of the event chain that continues with this
+   * instance. That is, the constructed event's `next` and `nextNow` immediately
+   * point at this instance.
+   *
+   * @param {Functor} [payload = new Functor('none')] Event payload (name and
+   *   arguments).
+   * @returns {ChainedEvent} New event instance with `payload` properties, and
+   *   whose `next` and `nextNow` refer to this instance.
+   */
+  withPushedHead(payload = new Functor('none')) {
+    const result = new ChainedEvent(this._source, payload);
+
+    result._resolveNext(this);
+    return result;
+  }
+
+  /**
+   * Resolves (hooks up) the given event as next event in the chain from this
+   * instance. The event must have the same `source` as this one.
+   *
+   * **Note:** This method is marked "private" but is in effect "protected." It
+   * is called by {@link EventSource}.
+   *
+   * @param {ChainedEvent} event Event to hook up.
+   */
+  _resolveNext(event) {
+    ChainedEvent.check(event);
+    if (this._source !== event._source) {
+      throw Errors.bad_use('Mismatched `event` source.');
+    }
+
+    if (this._nextNow !== null) {
+      throw Errors.bad_use('Can only call `_resolveNext()` once.');
+    }
+
+    this._nextNow = event;
+
+    if (this._nextResolver !== null) {
+      // There have already been one or more calls to `.next`, so we need to
+      // resolve the promise that those calls returned. After that, there is no
+      // longer a need to keep the promise and resolver around, so `null` them
+      // out.
+      this._nextResolver(event);
+      this._nextResolver = null;
+      this._nextProm     = null;
+    }
+  }
+}

--- a/local-modules/promise-util/EventSource.js
+++ b/local-modules/promise-util/EventSource.js
@@ -1,0 +1,93 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase, Functor } from 'util-common';
+
+import ChainedEvent from './ChainedEvent';
+
+/**
+ * Event source for a chain of {@link ChainedEvent} instances. It is instances
+ * of this class which are able to add new events to a chain, that is, this
+ * class represents the authority to emit events on a particular chain (as
+ * opposed to it being functionality exposed on `ChainedEvent` itself).
+ *
+ * **Note:** This class does _not_ remember any events ever emitted by itself
+ * other than the most recent, because doing otherwise would cause a garbage
+ * accumulation issue. (Imagine a single instance of this class being actively
+ * used during a session which lasts for, say, a month.)
+ */
+export default class EventSource extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {ChainedEvent} Current (Latest / most recent) event emitted by this
+     * instance. If this instance has never emitted, this is an initial "stub"
+     * which is suitable for `await`ing in {@link #currentEvent}. (This
+     * arrangement makes the logic in {@link #emit} particularly simple.)
+     */
+    this._currentEvent = new ChainedEvent(this, new Functor('chain_head'));
+
+    /**
+     * {boolean} Whether or not this instance has ever emitted an event. Used
+     * to determine how to treat `_currentEvent` in {@link #currentEvent}.
+     */
+    this._everEmitted = false;
+
+    Object.seal(this);
+  }
+
+  /**
+   * {Promise<ChainedEvent>} Promise for the current (Latest / most recent)
+   * event emitted by this instance. This is an immediately-resolved promise in
+   * all cases _except_ when this instance has never emitted an event. In the
+   * latter case, it becomes resolved as soon as the first event is emitted.
+   *
+   * **Note:** Because of the chained nature of events, this property provides
+   * access to all subsequent events emitted by this source.
+   */
+  get currentEvent() {
+    if (this._everEmitted) {
+      // `_currentEvent` is in fact a truly emitted event.
+      return this._currentEvent;
+    } else {
+      // `_currentEvent` is just the initial stub that was made during
+      // construction of this instance. _Its_ chained `next` event will be the
+      // first actual event coming from this instance.
+      return this._currentEvent.next;
+    }
+  }
+
+  /**
+   * {ChainedEvent|null} Current (Latest / most recent) event emitted by this
+   * instance, or `null` if this instance has never emitted an event.
+   *
+   * **Note:** Because of the chained nature of events, this property (when
+   * non-`null`) provides access to all subsequent events emitted by this
+   * source.
+   */
+  get currentEventNow() {
+    return this._everEmitted ? this._currentEvent : null;
+  }
+
+  /**
+   * Emits an event with the given payload.
+   *
+   * @param {Functor} payload The event payload.
+   * @returns {ChainedEvent} The emitted event.
+   */
+  emit(payload) {
+    const event = new ChainedEvent(this, payload);
+
+    this._currentEvent._resolveNext(event);
+
+    this._currentEvent = event;
+    this._everEmitted  = true;
+
+    return event;
+  }
+}

--- a/local-modules/promise-util/main.js
+++ b/local-modules/promise-util/main.js
@@ -3,8 +3,10 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import CallPiler from './CallPiler';
+import ChainedEvent from './ChainedEvent';
 import Condition from './Condition';
 import Delay from './Delay';
+import EventSource from './EventSource';
 import Mutex from './Mutex';
 
-export { CallPiler, Condition, Delay, Mutex };
+export { CallPiler, ChainedEvent, Condition, Delay, EventSource, Mutex };

--- a/local-modules/promise-util/tests/test_ChainedEvent.js
+++ b/local-modules/promise-util/tests/test_ChainedEvent.js
@@ -1,0 +1,137 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ChainedEvent, Delay, EventSource } from 'promise-util';
+import { Functor } from 'util-common';
+
+describe('promise-util/ChainedEvent', () => {
+  describe('constructor()', () => {
+    it('should work', async () => {
+      const source = new EventSource();
+      new ChainedEvent(source, new Functor('blort'));
+    });
+  });
+
+  describe('.next', () => {
+    it('should be an unresolved promise if there is no next event', async () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+
+      const race = await Promise.race([event.next, Delay.resolve(10, 123)]);
+      assert.strictEqual(race, 123);
+    });
+
+    it('should eventually resolve to the chained event', async () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+
+      const next = event.next;
+      await Delay.resolve(10);
+      source.emit(new Functor('florp'));
+      const got = await next;
+      assert.strictEqual(got.payload.name, 'florp');
+    });
+  });
+
+  describe('.nextNow', () => {
+    it('should be `null` if there is no next events', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+
+      assert.isNull(event.nextNow);
+    });
+
+    it('should be the next event once emitted', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+
+      source.emit(new Functor('florp'));
+      assert.strictEqual(event.nextNow.payload.name, 'florp');
+    });
+  });
+
+  describe('withNewPayload()', () => {
+    it('should produce an instance with the indicated payload', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+      const expect = new Functor('florp');
+
+      const result = event.withNewPayload(expect);
+      assert.strictEqual(result.payload, expect);
+    });
+
+    it('should produce an instance whose `nextNow` tracks the original', async () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+      const result = event.withNewPayload(new Functor('florp'));
+
+      assert.isNull(result.nextNow);
+      source.emit(new Functor('like'));
+      assert.strictEqual(event.nextNow.payload.name, 'like');
+
+      // The result is allowed to (and expected to) asynchronously update
+      // `nextNow`. We can only count on it being set after `next` resolves.
+      await result.next;
+
+      assert.strictEqual(result.nextNow.payload.name, 'like');
+    });
+
+    it('should produce an instance whose `next` tracks the original', async () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort'));
+      const result = event.withNewPayload(new Functor('florp'));
+
+      const race = await Promise.race([result.next, Delay.resolve(10, 123)]);
+      assert.strictEqual(race, 123);
+
+      source.emit(new Functor('like'));
+      const eventNext  = await event.next;
+      const resultNext = await result.next;
+      assert.strictEqual(eventNext.payload.name, 'like');
+      assert.strictEqual(resultNext.payload.name, 'like');
+    });
+  });
+
+  describe('withPushedHead()', () => {
+    it('should produce a result with the default payload', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const result = event.withPushedHead();
+
+      assert.strictEqual(result.payload.name, 'none');
+      assert.strictEqual(result.payload.args.length, 0);
+    });
+  });
+
+  describe('withPushedHead(payload)', () => {
+    it('should produce a result with the indicated payload', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const expect = new Functor('florp', 'x');
+      const result = event.withPushedHead(expect);
+
+      assert.strictEqual(result.payload, expect);
+    });
+
+    it('should produce a result with `next` bound a promise to the original event', async () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const result = event.withPushedHead(new Functor('florp'));
+
+      const next = await result.next;
+      assert.strictEqual(next, event);
+    });
+
+    it('should produce a result with `nextNow` bound to the original event', () => {
+      const source = new EventSource();
+      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const result = event.withPushedHead(new Functor('florp'));
+
+      assert.strictEqual(result.nextNow, event);
+    });
+  });
+});

--- a/local-modules/promise-util/tests/test_EventSource.js
+++ b/local-modules/promise-util/tests/test_EventSource.js
@@ -1,0 +1,75 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Delay, EventSource } from 'promise-util';
+import { Functor } from 'util-common';
+
+describe('promise-util/EventSource', () => {
+  describe('constructor()', () => {
+    it('should work', async () => {
+      new EventSource();
+    });
+  });
+
+  describe('.currentEvent', () => {
+    it('should be an unresolved promise if no events have ever been emitted', async () => {
+      const source = new EventSource();
+      const currentEvent = source.currentEvent;
+
+      const race = await Promise.race([currentEvent, Delay.resolve(10, 123)]);
+      assert.strictEqual(race, 123);
+    });
+
+    it('should eventually resolve to the first emitted event if no events have ever been emitted', async () => {
+      const source = new EventSource();
+      const currentEvent = source.currentEvent;
+
+      await Delay.resolve(100);
+      source.emit(new Functor('blort'));
+      const got = await currentEvent;
+      assert.strictEqual(got.payload.name, 'blort');
+    });
+
+    it('should resolve to the most recently emitted event', async () => {
+      const source = new EventSource();
+      source.emit(new Functor('blort'));
+      source.emit(new Functor('florp'));
+      const ce1 = source.currentEvent;
+      source.emit(new Functor('like'));
+      const ce2 = source.currentEvent;
+
+      const got1 = await ce1;
+      const got2 = await ce2;
+      assert.strictEqual(got1.payload.name, 'florp');
+      assert.strictEqual(got2.payload.name, 'like');
+    });
+  });
+
+  describe('.currentEventNow', () => {
+    it('should be `null` if no events have ever been emitted', () => {
+      const source = new EventSource();
+      assert.isNull(source.currentEventNow);
+    });
+
+    it('should be the most recently emitted event if there were ever any emitted events', () => {
+      const source = new EventSource();
+
+      source.emit(new Functor('blort'));
+      source.emit(new Functor('florp'));
+      assert.strictEqual(source.currentEventNow.payload.name, 'florp');
+      source.emit(new Functor('like'));
+      assert.strictEqual(source.currentEventNow.payload.name, 'like');
+    });
+  });
+
+  describe('emit()', () => {
+    it('should work', () => {
+      const source = new EventSource();
+      source.emit(new Functor('blort'));
+    });
+  });
+});

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -3,8 +3,9 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
-import Logger from './Logger';
+import BaseLogger from './BaseLogger';
 
 /**
  * Adaptor which provides a writable stream on top of a logger at a particular
@@ -13,16 +14,18 @@ import Logger from './Logger';
  * **Note:** This implements just the basic functionality, _not_ including any
  * events or flow control.
  */
-export default class LogStream {
+export default class LogStream extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Logger} logger Underlying logger to use.
+   * @param {BaseLogger} logger Underlying logger to use.
    * @param {string} level Severity level to log at.
    */
   constructor(logger, level) {
-    /** {Logger} Underlying logger to use. */
-    this._logger = Logger.check(logger);
+    super();
+
+    /** {BaseLogger} Underlying logger to use. */
+    this._logger = BaseLogger.check(logger);
 
     /** {string} Severity level. */
     this._level = TString.check(level);

--- a/local-modules/see-all/main.js
+++ b/local-modules/see-all/main.js
@@ -2,7 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import BaseLogger from './BaseLogger';
 import Logger from './Logger';
+import LogStream from './LogStream';
 import SeeAll from './SeeAll';
 
-export { Logger, SeeAll };
+export { BaseLogger, Logger, LogStream, SeeAll };

--- a/local-modules/see-all/tests/MockLogger.js
+++ b/local-modules/see-all/tests/MockLogger.js
@@ -1,0 +1,32 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseLogger } from 'see-all';
+
+/**
+ * Mock logger, which provides a convenient record of how it was called.
+ */
+export default class MockLogger extends BaseLogger {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /** {array<array>} Array of logged items. */
+    this.record = [];
+  }
+
+  /**
+   * Actual logging implementation. Subclasses must override this to do
+   * something appropriate.
+   *
+   * @abstract
+   * @param {string} level Severity level. Guaranteed to be a valid level.
+   * @param {array} message Array of arguments to log.
+   */
+  _impl_log(level, message) {
+    this.record.push([level, ...message]);
+  }
+}

--- a/local-modules/see-all/tests/test_LogStream.js
+++ b/local-modules/see-all/tests/test_LogStream.js
@@ -2,8 +2,103 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
+import { Delay } from 'promise-util';
+import { LogStream } from 'see-all';
+
+import MockLogger from './MockLogger';
+
 describe('see-all/LogStream', () => {
-  it('needs a way to be tested');
+  describe('write(string)', () => {
+    it('should call through to the underlying logger', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'info');
+
+      ls.write('florp');
+      ls.write('plorple\n');
+      assert.deepEqual(logger.record, [['info', 'florp'], ['info', 'plorple\n']]);
+    });
+  });
+
+  describe('write(string, encoding)', () => {
+    it('should not pay attention to the `encoding` argument', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'debug');
+
+      ls.write('florp', 'not-actually-a-valid-encoding');
+      assert.deepEqual(logger.record, [['debug', 'florp']]);
+    });
+  });
+
+  describe('write(string, encoding, callback)', () => {
+    it('should call the callback', async () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'info');
+      let gotCallback = false;
+
+      ls.write('florp', null, () => { gotCallback = true; });
+
+      // We expect the callback to be called asynchronously, so we have to wait
+      // a moment.
+      await Delay.resolve(10);
+      assert.isTrue(gotCallback);
+    });
+  });
+
+  describe('write(buffer)', () => {
+    it('should call through to the underlying logger', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'error');
+
+      ls.write(Buffer.from('😅', 'utf8'));
+      assert.deepEqual(logger.record, [['error', '😅']]);
+    });
+  });
+
+  describe('write(buffer, encoding)', () => {
+    it('should not pay attention to the `encoding` argument', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'warn');
+
+      ls.write(Buffer.from('😅', 'utf8'), 'ascii');
+      assert.deepEqual(logger.record, [['warn', '😅']]);
+    });
+  });
+
+  describe('end(string)', () => {
+    it('should call through to the underlying logger', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'info');
+
+      ls.end('zorch');
+      assert.deepEqual(logger.record, [['info', 'zorch']]);
+    });
+  });
+
+  describe('end(string, encoding)', () => {
+    it('should not pay attention to the `encoding` argument', () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'debug');
+
+      ls.end('splat', 'not-actually-a-valid-encoding');
+      assert.deepEqual(logger.record, [['debug', 'splat']]);
+    });
+  });
+
+  describe('end(string, encoding, callback)', () => {
+    it('should *not* call the callback', async () => {
+      const logger = new MockLogger();
+      const ls = new LogStream(logger, 'info');
+      let gotCallback = false;
+
+      ls.end('foo', null, () => { gotCallback = true; });
+
+      // If the callback is going to be called, it won't be immediately. So
+      // wait a moment.
+      await Delay.resolve(100);
+      assert.isFalse(gotCallback);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a pair of classes to `promise-util` for generating and holding events. This is meant to ultimately replace the more ad-hoc code in `doc-client`, but that replacement will wait for another day (or at least another PR).

**Bonus:** Wrote tests for `LogStream`.