### PR TITLE
Make all the OT classes more similar to each other.

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -644,7 +644,7 @@ export default class BodyClient extends StateMachine {
   _handle_merging_gotApplyDelta(delta, correctedChange) {
     // These are the same variable names as used on the server side. See below
     // for more detail.
-    const dCorrection = correctedChange.delta;
+    const dCorrection = correctedChange.ops;
     const vResultNum  = correctedChange.revNum;
 
     this._log.detail('Correction from server:', correctedChange);
@@ -814,7 +814,7 @@ export default class BodyClient extends StateMachine {
    *   represented in `_snapshot`. This must be used in cases where Quill's
    *   state has progressed ahead of `_snapshot` due to local activity.
    */
-  _updateWithDelta(delta, quillDelta = delta.delta) {
+  _updateWithDelta(delta, quillDelta = delta.ops) {
     const needQuillUpdate = !quillDelta.isEmpty();
 
     if (   (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) !== null)

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -166,15 +166,15 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Validates a `gotApplyDelta` event. This represents a successful result
-   * from the API call `body_applyDelta()`.
+   * Validates a `gotUpdate` event. This represents a successful result
+   * from the API call `body_update()`.
    *
    * @param {BodyOpList} ops The operations (raw delta) that were originally
    *   applied.
    * @param {BodyDelta} correctedChange The correction to the expected
-   *   result as returned from `body_applyDelta()`.
+   *   result as returned from `body_update()`.
    */
-  _check_gotApplyDelta(ops, correctedChange) {
+  _check_gotUpdate(ops, correctedChange) {
     BodyOpList.check(ops);
     BodyDelta.check(correctedChange);
   }
@@ -215,17 +215,6 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Validates a `wantApplyDelta` event. This indicates that it is time to
-   * send collected local changes up to the server.
-   *
-   * @param {BodySnapshot} baseSnapshot The body state at the time of the
-   *   original request.
-   */
-  _check_wantApplyDelta(baseSnapshot) {
-    BodySnapshot.check(baseSnapshot);
-  }
-
-  /**
    * Validates a `wantInput` event. This indicates that it is time to solicit
    * input from the server (in the form of document deltas) and from the local
    * Quill instance (in the form of Quill events), but only if the client isn't
@@ -233,6 +222,17 @@ export default class BodyClient extends StateMachine {
    */
   _check_wantInput() {
     // Nothing to do.
+  }
+
+  /**
+   * Validates a `wantToUpdate` event. This indicates that it is time to
+   * send collected local changes up to the server.
+   *
+   * @param {BodySnapshot} baseSnapshot The body state at the time of the
+   *   original request.
+   */
+  _check_wantToUpdate(baseSnapshot) {
+    BodySnapshot.check(baseSnapshot);
   }
 
   /**
@@ -550,7 +550,7 @@ export default class BodyClient extends StateMachine {
         // that happened in the mean time.
         (async () => {
           await Delay.resolve(PUSH_DELAY_MSEC);
-          this.q_wantApplyDelta(baseSnapshot);
+          this.q_wantToUpdate(baseSnapshot);
         })();
 
         this.s_collecting();
@@ -590,14 +590,14 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * In state `collecting`, handles event `wantApplyDelta`. This means that it
+   * In state `collecting`, handles event `wantToUpdate`. This means that it
    * is time for the collected local changes to be sent up to the server for
    * integration.
    *
    * @param {BodySnapshot} baseSnapshot The body state at the time of the
    *   original request.
    */
-  _handle_collecting_wantApplyDelta(baseSnapshot) {
+  _handle_collecting_wantToUpdate(baseSnapshot) {
     if (this._snapshot.revNum !== baseSnapshot.revNum) {
       // As with the `gotQuillEvent` event, we ignore this event if the doc has
       // changed out from under us.
@@ -624,10 +624,10 @@ export default class BodyClient extends StateMachine {
     (async () => {
       try {
         const value =
-          await this._sessionProxy.body_applyDelta(this._snapshot.revNum, ops);
-        this.q_gotApplyDelta(ops, value);
+          await this._sessionProxy.body_update(this._snapshot.revNum, ops);
+        this.q_gotUpdate(ops, value);
       } catch (e) {
-        this.q_apiError('body_applyDelta', e);
+        this.q_apiError('body_update', e);
       }
     })();
 
@@ -635,15 +635,15 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * In state `merging`, handles event `gotApplyDelta`. This means that a local
+   * In state `merging`, handles event `gotUpdate`. This means that a local
    * change was successfully merged by the server.
    *
    * @param {BodyOpList} ops The operations (raw delta) that were originally
    *   applied.
    * @param {BodyDelta} correctedChange The correction to the expected
-   *   result as returned from `body_applyDelta()`.
+   *   result as returned from `body_update()`.
    */
-  _handle_merging_gotApplyDelta(ops, correctedChange) {
+  _handle_merging_gotUpdate(ops, correctedChange) {
     // These are the same variable names as used on the server side. See below
     // for more detail.
     const dCorrection = correctedChange.ops;

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -620,7 +620,7 @@ export default class BodyClient extends StateMachine {
       return;
     }
 
-    // Send the delta, and handle the response.
+    // Send the change, and handle the response.
     (async () => {
       try {
         const value =

--- a/local-modules/doc-common/AuthorId.js
+++ b/local-modules/doc-common/AuthorId.js
@@ -35,4 +35,23 @@ export default class AuthorId extends UtilityClass {
 
     return value;
   }
+
+  /**
+   * Checks a value which must be of type `AuthorId` or be `null`.
+   *
+   * @param {*} value Value to check.
+   * @returns {string|null} `value`.
+   */
+  static orNull(value) {
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return AuthorId.check(value);
+    } catch (e) {
+      // Higher-fidelity error.
+      throw Errors.bad_value(value, 'AuthorId|orNull');
+    }
+  }
 }

--- a/local-modules/doc-common/BodyChange.js
+++ b/local-modules/doc-common/BodyChange.js
@@ -9,26 +9,24 @@ import BodyDelta from './BodyDelta';
 import Timestamp from './Timestamp';
 
 /**
- * Representation of a change to a document from its immediately-previous
+ * Representation of a change to a document body from its immediately-previous
  * revision, including time, authorship, and revision information in addition to
- * the actual delta. This class is a `BodyDelta` plus additional metadata,
+ * the actual delta. This class is a `BodyDelta` plus additional information,
  * and it in fact derives from `BodyDelta` per se.
  *
- * **Note:** The meaning of the `delta` in an instance of this class is more
+ * **Note:** The semantics of the `delta` in an instance of this class are more
  * specific than that of `BodyDelta` in general, exactly because instances
  * of this class always represent changes from the immediately-previous
  * revision.
  *
- * Instances of this class are immutable, including the deltas. In particular,
- * if a mutable delta is passed to the constructor of this class, it is coerced
- * into immutable form.
+ * Instances of this class are immutable.
  */
 export default class BodyChange extends BodyDelta {
   /**
    * Gets the appropriate first change to a document body (empty delta, no
    * author) for the current moment in time.
    *
-   * @returns {FrozenDelta} An appropriate initial change.
+   * @returns {BodyChange} An appropriate initial change.
    */
   static firstChange() {
     return new BodyChange(0, FrozenDelta.EMPTY, Timestamp.now(), null);

--- a/local-modules/doc-common/BodyChange.js
+++ b/local-modules/doc-common/BodyChange.js
@@ -2,17 +2,16 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { FrozenDelta } from 'doc-common';
-import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
+import AuthorId from './AuthorId';
 import BodyDelta from './BodyDelta';
 import Timestamp from './Timestamp';
 
 /**
  * Representation of a change to a document body from its immediately-previous
  * revision, including time, authorship, and revision information in addition to
- * the actual delta. This class is a `BodyDelta` plus additional information,
- * and it in fact derives from `BodyDelta` per se.
+ * the actual delta. This class is a `BodyDelta` plus additional information.
  *
  * **Note:** The semantics of the `delta` in an instance of this class are more
  * specific than that of `BodyDelta` in general, exactly because instances
@@ -21,7 +20,7 @@ import Timestamp from './Timestamp';
  *
  * Instances of this class are immutable.
  */
-export default class BodyChange extends BodyDelta {
+export default class BodyChange extends CommonBase {
   /**
    * Gets the appropriate first change to a document body (empty delta, no
    * author) for the current moment in time.
@@ -29,34 +28,36 @@ export default class BodyChange extends BodyDelta {
    * @returns {BodyChange} An appropriate initial change.
    */
   static firstChange() {
-    return new BodyChange(0, FrozenDelta.EMPTY, Timestamp.now(), null);
+    return new BodyChange(BodyDelta.EMPTY, Timestamp.now(), null);
   }
 
   /**
    * Constructs an instance.
    *
-   * @param {Int} revNum The revision number of the document produced by this
-   *   change. If this instance represents the first change to a document body,
-   *   then this value will be `0`.
-   * @param {FrozenDelta} delta The body change per se, compared to the
-   *   immediately-previous revision.
+   * @param {BodyDelta} delta The body change per se, compared to the
+   *   immediately-previous revision. **Note:** This includes the resulting
+   *   revision number.
    * @param {Timestamp} timestamp The time of the change, as msec since the Unix
    *   Epoch.
    * @param {string|null} authorId Stable identifier string representing the
    *   author of the change. Allowed to be `null` if the change is authorless.
    */
-  constructor(revNum, delta, timestamp, authorId) {
-    super(revNum, delta,
-      function init() {
-        /** {Timestamp} The time of the change. */
-        this._timestamp = Timestamp.check(timestamp);
+  constructor(delta, timestamp, authorId) {
+    super();
 
-        /**
-         * {string|null} Author ID string, or `null` if the change is
-         * authorless.
-         */
-        this._authorId = TString.orNull(authorId);
-      });
+    /** {BodyDelta} The main content delta. */
+    this._delta = BodyDelta.check(delta);
+
+    /** {Timestamp} The time of the change. */
+    this._timestamp = Timestamp.check(timestamp);
+
+    /**
+     * {string|null} Author ID string, or `null` if the change is
+     * authorless.
+     */
+    this._authorId = AuthorId.orNull(authorId);
+
+    Object.freeze(this);
   }
 
   /**
@@ -65,14 +66,21 @@ export default class BodyChange extends BodyDelta {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [this._revNum, this._delta, this._timestamp, this.authorId];
+    return [this._delta, this._timestamp, this._authorId];
   }
 
   /**
-   * {string|null} The author ID string, or `null` if the change is authorless.
+   * {string|null} The author ID string, or `null` if the change is authorless
+   * (or if the cocept of "author" is meaningless in the larger context of this
+   * instance).
    */
   get authorId() {
     return this._authorId;
+  }
+
+  /** {BodyDelta} The main delta content. */
+  get delta() {
+    return this._delta;
   }
 
   /** {Timestamp} The time of the change. */

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -52,7 +52,9 @@ export default class BodyDelta extends CommonBase {
     /** {Int} The produced revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** {BodyOpList} The actual change, as a raw delta. */
+    /**
+     * {BodyOpList} The actual change, as a list of operations (a raw delta).
+     */
     this._ops = BodyOpList.check(ops);
 
     Object.freeze(this);

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -17,11 +17,11 @@ let EMPTY = null;
  * Delta which can be applied to a `BodySnapshot`, along with associated
  * information, to produce an updated snapshot.
  *
- * Instances of this class are returned from calls to `body_applyDelta()` and
+ * Instances of this class are returned from calls to `body_update()` and
  * `body_deltaAfter()` as defined by the various `doc-server` classes. See those
  * for more details. Note that the meaning of the `delta` value is different
  * depending on which method the result came from. In particular, there is an
- * implied "expected" result from `body_applyDelta()` which this instance's
+ * implied "expected" result from `body_update()` which this instance's
  * `ops` list is with respect to.
  *
  * Instances of this class are immutable.

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -22,7 +22,7 @@ let EMPTY = null;
  * for more details. Note that the meaning of the `delta` value is different
  * depending on which method the result came from. In particular, there is an
  * implied "expected" result from `body_applyDelta()` which this instance's
- * `delta` is with respect to.
+ * `ops` list is with respect to.
  *
  * Instances of this class are immutable.
  */

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { FrozenDelta } from 'doc-common';
 import { CommonBase } from 'util-common';
 
+import BodyOpList from './BodyOpList';
 import RevisionNumber from './RevisionNumber';
 
 /**
@@ -30,7 +30,7 @@ export default class BodyDelta extends CommonBase {
   /** {BodyDelta} Empty instance. */
   static get EMPTY() {
     if (EMPTY === null) {
-      EMPTY = new BodyDelta(0, FrozenDelta.EMPTY);
+      EMPTY = new BodyDelta(0, BodyOpList.EMPTY);
     }
 
     return EMPTY;
@@ -42,7 +42,7 @@ export default class BodyDelta extends CommonBase {
    * @param {Int} revNum The revision number of the document produced by this
    *   instance. If this instance represents the first change to a document,
    *   then this value will be `0`.
-   * @param {FrozenDelta} ops List of operations (raw delta) which can be
+   * @param {BodyOpList} ops List of operations (raw delta) which can be
    *   applied in context to produce the document with the indicated revision
    *   number.
    */
@@ -52,8 +52,8 @@ export default class BodyDelta extends CommonBase {
     /** {Int} The produced revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** {FrozenDelta} The actual change, as a raw delta. */
-    this._ops = FrozenDelta.check(ops);
+    /** {BodyOpList} The actual change, as a raw delta. */
+    this._ops = BodyOpList.check(ops);
 
     Object.freeze(this);
   }
@@ -73,7 +73,7 @@ export default class BodyDelta extends CommonBase {
   }
 
   /**
-   * {FrozenDelta} List of operations (raw delta) used to produce the document
+   * {BodyOpList} List of operations (raw delta) used to produce the document
    * with revision number `revNum`.
    */
   get ops() {

--- a/local-modules/doc-common/BodyOpList.js
+++ b/local-modules/doc-common/BodyOpList.js
@@ -8,27 +8,28 @@ import { TArray } from 'typecheck';
 import { CommonBase, DataUtil, Errors, ObjectUtil } from 'util-common';
 
 /**
- * {FrozenDelta|null} Empty instance. Initialized in the `EMPTY` property
+ * {BodyOpList|null} Empty instance. Initialized in the `EMPTY` property
  * accessor.
  */
 let emptyInstance = null;
 
 /**
- * Always-frozen `Delta`. This is a subclass of `Delta` and mixes in
- * `CommonBase` (the latter for `check()` and `coerce()` functionality). In
- * addition, it contains extra utility functionality beyond what the base
- * `Delta` provides.
+ * Always-frozen list of body OT operations. This is a subclass of Quill's
+ * `Delta` and mixes in `CommonBase` (the latter for `check()` and `coerce()`
+ * functionality). In addition, it contains extra utility functionality beyond
+ * what the base `Delta` provides.
+ *
+ * **Note:** What Quill calls a "delta" and what this project calls a "delta"
+ * differ in one important regard (beyond being different classes).
+ * Specifically, in this project, a "delta" always comes with a revision
+ * number (either implied or explicit). That is why this class is called an
+ * "op list" even though it derives from Quill's `Delta`.
  */
-export default class FrozenDelta extends Delta {
-  /** {string} Name of this class for the sake of API coding. */
-  static get API_TAG() {
-    return 'Delta';
-  }
-
-  /** {FrozenDelta} Empty instance of this class. */
+export default class BodyOpList extends Delta {
+  /** {BodyOpList} Empty instance of this class. */
   static get EMPTY() {
     if (emptyInstance === null) {
-      emptyInstance = new FrozenDelta([]);
+      emptyInstance = new BodyOpList([]);
     }
 
     return emptyInstance;
@@ -41,7 +42,7 @@ export default class FrozenDelta extends Delta {
    * array contents (if any) are not inspected for validity.
    *
    * **Note:** This is a static method exactly because it accepts things other
-   * than instances of `FrozenDelta` per se.
+   * than instances of `BodyOpList` per se.
    *
    * @param {object|array|null|undefined} delta The delta or delta-like value.
    * @returns {boolean} `true` if `delta` is empty or `false` if not.
@@ -57,7 +58,7 @@ export default class FrozenDelta extends Delta {
       return delta.ops.length === 0;
     }
 
-    throw Errors.bad_value(delta, FrozenDelta);
+    throw Errors.bad_value(delta, BodyOpList);
   }
 
   /**
@@ -85,22 +86,22 @@ export default class FrozenDelta extends Delta {
    *   values.
    *
    * @param {object|array|null|undefined} value The value to coerce.
-   * @returns {FrozenDelta} The corresponding instance.
+   * @returns {BodyOpList} The corresponding instance.
    */
   static _impl_coerce(value) {
     // Note: The base class implementation guarantees that we won't get called
     // on an instance of this class.
-    if (FrozenDelta.isEmpty(value)) {
-      return FrozenDelta.EMPTY;
+    if (BodyOpList.isEmpty(value)) {
+      return BodyOpList.EMPTY;
     } else if (value instanceof Delta) {
-      return new FrozenDelta(value.ops);
+      return new BodyOpList(value.ops);
     } else if (Array.isArray(value)) {
-      return new FrozenDelta(value);
+      return new BodyOpList(value);
     } else if (Array.isArray(value.ops)) {
-      return new FrozenDelta(value.ops);
+      return new BodyOpList(value.ops);
     }
 
-    throw Errors.bad_value(value, FrozenDelta);
+    throw Errors.bad_value(value, BodyOpList);
   }
 
   /**
@@ -156,4 +157,4 @@ export default class FrozenDelta extends Delta {
 
 // Add `CommonBase` as a mixin, because the main inheritence is the `Delta`
 // class.
-CommonBase.mixInto(FrozenDelta);
+CommonBase.mixInto(BodyOpList);

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -95,9 +95,9 @@ export default class BodySnapshot extends CommonBase {
   compose(delta) {
     BodyDelta.check(delta);
 
-    const contents = delta.delta.isEmpty()
+    const contents = delta.ops.isEmpty()
       ? this._contents
-      : FrozenDelta.coerce(this._contents.compose(delta.delta));
+      : FrozenDelta.coerce(this._contents.compose(delta.ops));
 
     return new BodySnapshot(delta.revNum, contents);
   }
@@ -120,7 +120,7 @@ export default class BodySnapshot extends CommonBase {
 
     let contents = this._contents;
     for (const d of deltas) {
-      contents = contents.compose(d.delta);
+      contents = contents.compose(d.ops);
     }
 
     const lastDelta = deltas[deltas.length - 1];

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -143,8 +143,8 @@ export default class BodySnapshot extends CommonBase {
 
     const oldContents = this.contents;
     const newContents = newerSnapshot.contents;
-    const delta       = BodyOpList.coerce(oldContents.diff(newContents));
+    const ops         = BodyOpList.coerce(oldContents.diff(newContents));
 
-    return new BodyDelta(newerSnapshot.revNum, delta);
+    return new BodyDelta(newerSnapshot.revNum, ops);
   }
 }

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -6,7 +6,7 @@ import { TArray } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import BodyDelta from './BodyDelta';
-import FrozenDelta from './FrozenDelta';
+import BodyOpList from './BodyOpList';
 import RevisionNumber from './RevisionNumber';
 
 
@@ -26,7 +26,7 @@ export default class BodySnapshot extends CommonBase {
    */
   static get EMPTY() {
     if (emptyInstance === null) {
-      emptyInstance = new BodySnapshot(0, FrozenDelta.EMPTY);
+      emptyInstance = new BodySnapshot(0, BodyOpList.EMPTY);
     }
 
     return emptyInstance;
@@ -37,7 +37,7 @@ export default class BodySnapshot extends CommonBase {
    *
    * @param {RevisionNumber} revNum Revision number of the document.
    * @param {Delta|array|object} contents Document contents. Can be given
-   *   anything that can be coerced into a `FrozenDelta`. Must be a "document"
+   *   anything that can be coerced into a `BodyOpList`. Must be a "document"
    *   (that is, a delta consisting only of `insert` operations).
    */
   constructor(revNum, contents) {
@@ -46,8 +46,8 @@ export default class BodySnapshot extends CommonBase {
     /** {Int} Revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** {FrozenDelta} Document contents. */
-    this._contents = FrozenDelta.coerce(contents);
+    /** {BodyOpList} Document contents. */
+    this._contents = BodyOpList.coerce(contents);
 
     // Explicitly check that the `contents` delta has the form of a "document,"
     // that is, the only operations are `insert`s. For very large documents,
@@ -80,7 +80,7 @@ export default class BodySnapshot extends CommonBase {
     return this._revNum;
   }
 
-  /** {FrozenDelta} The document contents. */
+  /** {BodyOpList} The document contents. */
   get contents() {
     return this._contents;
   }
@@ -97,7 +97,7 @@ export default class BodySnapshot extends CommonBase {
 
     const contents = delta.ops.isEmpty()
       ? this._contents
-      : FrozenDelta.coerce(this._contents.compose(delta.ops));
+      : BodyOpList.coerce(this._contents.compose(delta.ops));
 
     return new BodySnapshot(delta.revNum, contents);
   }
@@ -143,7 +143,7 @@ export default class BodySnapshot extends CommonBase {
 
     const oldContents = this.contents;
     const newContents = newerSnapshot.contents;
-    const delta       = FrozenDelta.coerce(oldContents.diff(newContents));
+    const delta       = BodyOpList.coerce(oldContents.diff(newContents));
 
     return new BodyDelta(newerSnapshot.revNum, delta);
   }

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -16,9 +16,9 @@ import CaretOp from './CaretOp';
 let EMPTY = null;
 
 /**
- * Delta for caret information. Instances of this class can be applied to
- * instances of `Caret` and `CaretSnapshot` to produce updated instances of
- * those classes.
+ * Delta for caret information, consisting of a simple ordered list of
+ * operations. Instances of this class can be applied to instances of `Caret`
+ * and `CaretSnapshot` to produce updated instances of those classes.
  *
  * Instances of this class are immutable.
  */

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -16,9 +16,9 @@ import PropertyOp from './PropertyOp';
 let EMPTY = null;
 
 /**
- * Delta for property (document metadata) information. Instances of this class
- * can be applied to instances of `PropertySnapshot` to produce updated
- * snapshots.
+ * Delta for property (document metadata) information, consisting of a simple
+ * ordered list of operations. Instances of this class can be applied to
+ * instances of `PropertySnapshot` to produce updated snapshots.
  *
  * Instances of this class are immutable.
  */

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -7,13 +7,13 @@ import { Codec } from 'codec';
 import AuthorId from './AuthorId';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
+import BodyOpList from './BodyOpList';
 import BodySnapshot from './BodySnapshot';
 import Caret from './Caret';
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
 import DocumentId from './DocumentId';
-import FrozenDelta from './FrozenDelta';
 import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 import PropertySnapshot from './PropertySnapshot';
@@ -23,12 +23,12 @@ import RevisionNumber from './RevisionNumber';
 // Register classes with the API.
 Codec.theOne.registerClass(BodyChange);
 Codec.theOne.registerClass(BodyDelta);
+Codec.theOne.registerClass(BodyOpList);
 Codec.theOne.registerClass(BodySnapshot);
 Codec.theOne.registerClass(Caret);
 Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretOp);
 Codec.theOne.registerClass(CaretSnapshot);
-Codec.theOne.registerClass(FrozenDelta);
 Codec.theOne.registerClass(PropertyDelta);
 Codec.theOne.registerClass(PropertyOp);
 Codec.theOne.registerClass(PropertySnapshot);
@@ -38,13 +38,13 @@ export {
   AuthorId,
   BodyChange,
   BodyDelta,
+  BodyOpList,
   BodySnapshot,
   Caret,
   CaretDelta,
   CaretOp,
   CaretSnapshot,
   DocumentId,
-  FrozenDelta,
   PropertyDelta,
   PropertyOp,
   PropertySnapshot,

--- a/local-modules/doc-common/tests/test_AuthorId.js
+++ b/local-modules/doc-common/tests/test_AuthorId.js
@@ -8,18 +8,9 @@ import { describe, it } from 'mocha';
 import { AuthorId } from 'doc-common';
 
 describe('doc-common/AuthorId', () => {
-  describe('check', () => {
-    it('should reject null values by default', () => {
+  describe('check()', () => {
+    it('should reject `null`', () => {
       assert.throws(() => AuthorId.check(null));
-    });
-
-    it('should reject null values if nullOk == false', () => {
-      assert.throws(() => AuthorId.check(null, false));
-    });
-
-    it('should accept null values if nullOk == true', () => {
-      assert.doesNotThrow(() => AuthorId.check(null, true));
-      assert.isNull(AuthorId.check(null, true));
     });
 
     it('should reject non-string or empty string values', () => {
@@ -34,7 +25,30 @@ describe('doc-common/AuthorId', () => {
     });
 
     it('should accept 32-character strings comprised of a-zA-Z0-9_-', () => {
-      assert.doesNotThrow(() => AuthorId.check('001122-445566778899AAbb_ddeeff'));
+      const value = '001122-445566778899AAbb_ddeeff';
+      assert.strictEqual(AuthorId.check(value), value);
+    });
+  });
+
+  describe('orNull()', () => {
+    it('should accept `null`', () => {
+      assert.isNull(AuthorId.orNull(null));
+    });
+
+    it('should reject non-string or empty string values', () => {
+      assert.throws(() => AuthorId.orNull(37));
+      assert.throws(() => AuthorId.orNull(''));
+      assert.throws(() => AuthorId.orNull({}));
+      assert.throws(() => AuthorId.orNull(false));
+    });
+
+    it('should reject strings in the wrong format', () => {
+      assert.throws(() => AuthorId.orNull('this better not work!'));
+    });
+
+    it('should accept 32-character strings comprised of a-zA-Z0-9_-', () => {
+      const value = '001122-445566778899AAbb_ddeeff';
+      assert.strictEqual(AuthorId.orNull(value), value);
     });
   });
 });

--- a/local-modules/doc-common/tests/test_BodyOpList.js
+++ b/local-modules/doc-common/tests/test_BodyOpList.js
@@ -7,14 +7,14 @@ import { describe, it } from 'mocha';
 import Delta from 'quill-delta';
 import { inspect } from 'util';
 
-import { FrozenDelta } from 'doc-common';
+import { BodyOpList } from 'doc-common';
 
-describe('doc-common/FrozenDelta', () => {
+describe('doc-common/BodyOpList', () => {
   describe('.EMPTY', () => {
-    const empty = FrozenDelta.EMPTY;
+    const empty = BodyOpList.EMPTY;
 
-    it('should be an instance of `FrozenDelta`', () => {
-      assert.instanceOf(empty, FrozenDelta);
+    it('should be an instance of `BodyOpList`', () => {
+      assert.instanceOf(empty, BodyOpList);
     });
 
     it('should be a frozen object', () => {
@@ -29,8 +29,8 @@ describe('doc-common/FrozenDelta', () => {
       assert.isFrozen(empty.ops);
     });
 
-    it('should be `FrozenDelta.isEmpty()`', () => {
-      assert.isTrue(FrozenDelta.isEmpty(empty));
+    it('should be `BodyOpList.isEmpty()`', () => {
+      assert.isTrue(BodyOpList.isEmpty(empty));
     });
   });
 
@@ -38,8 +38,8 @@ describe('doc-common/FrozenDelta', () => {
     describe('valid empty values', () => {
       const values = [
         new Delta([]),
-        new FrozenDelta([]),
-        FrozenDelta.EMPTY,
+        new BodyOpList([]),
+        BodyOpList.EMPTY,
         null,
         undefined,
         [],
@@ -48,7 +48,7 @@ describe('doc-common/FrozenDelta', () => {
 
       for (const v of values) {
         it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(FrozenDelta.isEmpty(v));
+          assert.isTrue(BodyOpList.isEmpty(v));
         });
       }
     });
@@ -66,18 +66,18 @@ describe('doc-common/FrozenDelta', () => {
         ops1,
         { ops: ops1 },
         new Delta(ops1),
-        new FrozenDelta(ops1),
+        new BodyOpList(ops1),
         ops2,
         { ops: ops2 },
         new Delta(ops2),
-        new FrozenDelta(ops2),
+        new BodyOpList(ops2),
         invalidNonEmptyOps,
         { ops: invalidNonEmptyOps }
       ];
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(FrozenDelta.isEmpty(v));
+          assert.isFalse(BodyOpList.isEmpty(v));
         });
       }
     });
@@ -97,7 +97,7 @@ describe('doc-common/FrozenDelta', () => {
 
       for (const v of values) {
         it(`should throw for: ${inspect(v)}`, () => {
-          assert.throws(() => { FrozenDelta.isEmpty(v); });
+          assert.throws(() => { BodyOpList.isEmpty(v); });
         });
       }
     });
@@ -114,7 +114,7 @@ describe('doc-common/FrozenDelta', () => {
 
       for (const v of values) {
         it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(FrozenDelta.coerce(v).isDocument());
+          assert.isTrue(BodyOpList.coerce(v).isDocument());
         });
       }
     });
@@ -129,7 +129,7 @@ describe('doc-common/FrozenDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(FrozenDelta.coerce(v).isDocument());
+          assert.isFalse(BodyOpList.coerce(v).isDocument());
         });
       }
     });

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -91,28 +91,28 @@ export default class BodyControl extends CommonBase {
   }
 
   /**
-   * Takes a base revision number and delta therefrom, and applies the delta,
-   * including merging of any intermediate revisions. The return value consists
-   * of a new revision number, and a delta to be used to get the new document
-   * state. The delta is with respect to the client's "expected result," that
-   * is to say, what the client would get if the delta were applied with no
-   * intervening changes.
+   * Takes a base revision number and list of operations (raw delta) to apply
+   * therefrom, and applies the operations, including merging of any
+   * intermediate revisions. The return value consists of a "correction" delta
+   * to be used to get the new document state. The correction delta is with
+   * respect to the client's "expected result," that is to say, what the client
+   * would get if the operations were applied with no intervening changes.
    *
-   * As a special case, as long as `baseRevNum` is valid, if `delta` is empty,
+   * As a special case, as long as `baseRevNum` is valid, if `ops` is empty,
    * this method returns a result of the same revision number along with an
    * empty "correction" delta. That is, the return value from passing an empty
-   * delta doesn't provide any information about subsequent revisions of the
-   * document.
+   * list of operations doesn't provide any information about subsequent
+   * revisions of the document.
    *
    * @param {Int} baseRevNum Revision number which `delta` is with respect to.
    * @param {BodyOpList} ops List of operations indicating what has changed with
    *   respect to `baseRevNum`.
-   * @param {string|null} authorId Author of `delta`, or `null` if the change
+   * @param {string|null} authorId Author of the change, or `null` if the change
    *   is to be considered authorless.
    * @returns {BodyDelta} The correction to the implied expected result of
-   *   this operation. The `delta` of this result can be applied to the expected
+   *   this operation. The `ops` of this result can be applied to the expected
    *   result to get the actual result. The promise resolves sometime after the
-   *   delta has been applied to the document.
+   *   change has been applied to the document.
    */
   async applyDelta(baseRevNum, ops, authorId) {
     // Very basic argument validation. Once in the guts of the thing, we will

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -94,7 +94,7 @@ export default class DocSession {
    *   get the actual result.
    */
   async body_update(baseRevNum, ops) {
-    return this._bodyControl.applyDelta(baseRevNum, ops, this._authorId);
+    return this._bodyControl.update(baseRevNum, ops, this._authorId);
   }
 
   /**

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -52,13 +52,13 @@ export default class DocSession {
    *
    * @param {number} baseRevNum Revision number which `delta` is with respect
    *   to.
-   * @param {BodyOpList} delta Delta indicating what has changed with respect
-   *   to `baseRevNum`.
+   * @param {BodyOpList} ops List of operations indicating what has changed with
+   *   respect to `baseRevNum`.
    * @returns {BodyDelta} The correction from the implied expected result to
    *   get the actual result.
    */
-  async body_applyDelta(baseRevNum, delta) {
-    return this._bodyControl.applyDelta(baseRevNum, delta, this._authorId);
+  async body_applyDelta(baseRevNum, ops) {
+    return this._bodyControl.applyDelta(baseRevNum, ops, this._authorId);
   }
 
   /**

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -46,22 +46,6 @@ export default class DocSession {
   }
 
   /**
-   * Applies an update to the body, assigning authorship of the change to the
-   * author represented by this instance. See the equivalent `BodyControl`
-   * method for details.
-   *
-   * @param {number} baseRevNum Revision number which `delta` is with respect
-   *   to.
-   * @param {BodyOpList} ops List of operations indicating what has changed with
-   *   respect to `baseRevNum`.
-   * @returns {BodyDelta} The correction from the implied expected result to
-   *   get the actual result.
-   */
-  async body_applyDelta(baseRevNum, ops) {
-    return this._bodyControl.applyDelta(baseRevNum, ops, this._authorId);
-  }
-
-  /**
    * Returns a particular change to the document. See the equivalent
    * `BodyControl` method for details.
    *
@@ -95,6 +79,22 @@ export default class DocSession {
    */
   async body_snapshot(revNum = null) {
     return this._bodyControl.snapshot(revNum);
+  }
+
+  /**
+   * Applies an update to the body, assigning authorship of the change to the
+   * author represented by this instance. See the equivalent `BodyControl`
+   * method for details.
+   *
+   * @param {number} baseRevNum Revision number which `delta` is with respect
+   *   to.
+   * @param {BodyOpList} ops List of operations indicating what has changed with
+   *   respect to `baseRevNum`.
+   * @returns {BodyDelta} The correction from the implied expected result to
+   *   get the actual result.
+   */
+  async body_update(baseRevNum, ops) {
+    return this._bodyControl.applyDelta(baseRevNum, ops, this._authorId);
   }
 
   /**

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -46,9 +46,9 @@ export default class DocSession {
   }
 
   /**
-   * Applies a delta, assigning authorship of the change to the author
-   * represented by this instance. See the equivalent `BodyControl` method for
-   * details.
+   * Applies an update to the body, assigning authorship of the change to the
+   * author represented by this instance. See the equivalent `BodyControl`
+   * method for details.
    *
    * @param {number} baseRevNum Revision number which `delta` is with respect
    *   to.

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -52,7 +52,7 @@ export default class DocSession {
    *
    * @param {number} baseRevNum Revision number which `delta` is with respect
    *   to.
-   * @param {FrozenDelta} delta Delta indicating what has changed with respect
+   * @param {BodyOpList} delta Delta indicating what has changed with respect
    *   to `baseRevNum`.
    * @returns {BodyDelta} The correction from the implied expected result to
    *   get the actual result.

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Codec } from 'codec';
-import { FrozenDelta } from 'doc-common';
+import { BodyOpList } from 'doc-common';
 import { ProductInfo } from 'env-server';
 import { BaseFile, FileCodec } from 'file-store';
 import { DEFAULT_DOCUMENT } from 'hooks-server';
@@ -19,19 +19,19 @@ import DocServer from './DocServer';
 /** {Logger} Logger to use for this module. */
 const log = new Logger('doc');
 
-/** {FrozenDelta} Default contents when creating a new document. */
-const DEFAULT_TEXT = FrozenDelta.coerce(DEFAULT_DOCUMENT);
+/** {BodyOpList} Default contents when creating a new document. */
+const DEFAULT_TEXT = BodyOpList.coerce(DEFAULT_DOCUMENT);
 
 /**
- * {FrozenDelta} Message used as document to indicate a major validation error.
+ * {BodyOpList} Message used as document to indicate a major validation error.
  */
-const ERROR_NOTE = FrozenDelta.coerce(
+const ERROR_NOTE = BodyOpList.coerce(
   [{ insert: '(Recreated document due to validation error(s).)\n' }]);
 
 /**
- * {FrozenDelta} Message used as document instead of migrating documents from
+ * {BodyOpList} Message used as document instead of migrating documents from
  * old schema versions. */
-const MIGRATION_NOTE = FrozenDelta.coerce(
+const MIGRATION_NOTE = BodyOpList.coerce(
   [{ insert: '(Recreated document due to schema version skew.)\n' }]);
 
 /**

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { FrozenDelta } from 'doc-common';
+import { BodyOpList } from 'doc-common';
 import { EventSource } from 'promise-util';
 import { TString } from 'typecheck';
 import { Errors, Functor, ObjectUtil, UtilityClass } from 'util-common';
@@ -27,7 +27,7 @@ export default class QuillEvents extends UtilityClass {
    */
   static get EMPTY_TEXT_CHANGE_PAYLOAD() {
     return new Functor(
-      QuillEvents.TEXT_CHANGE, FrozenDelta.EMPTY, FrozenDelta.EMPTY, QuillEvents.API);
+      QuillEvents.TEXT_CHANGE, BodyOpList.EMPTY, BodyOpList.EMPTY, QuillEvents.API);
   }
 
   /** {String} Event name for selection change events. */
@@ -73,8 +73,8 @@ export default class QuillEvents extends UtilityClass {
       case QuillEvents.TEXT_CHANGE: {
         const [delta, oldContents, source] = payload.args;
         return new Functor(name,
-          FrozenDelta.coerce(delta),
-          FrozenDelta.coerce(oldContents),
+          BodyOpList.coerce(delta),
+          BodyOpList.coerce(oldContents),
           TString.check(source));
       }
 

--- a/local-modules/util-common/tests/test_StringUtil.js
+++ b/local-modules/util-common/tests/test_StringUtil.js
@@ -76,7 +76,7 @@ describe('util-common/StringUtil', () => {
       assert.equal(asciiLength, utf8Length);
     });
 
-    it('should return a UTF-8 length of 2 for characters `\\u0080 .. \\u07ff', () => {
+    it('should return a UTF-8 length of 2 for characters `[\\u0080..\\u07ff]`', () => {
       let input = '\u0080';
       let utf8Length = StringUtil.utf8LengthForString(input);
 
@@ -88,7 +88,7 @@ describe('util-common/StringUtil', () => {
       assert.equal(utf8Length, 2);
     });
 
-    it('should return a UTF-8 length of 3 for characters `\\u0800 .. \\u7fff', () => {
+    it('should return a UTF-8 length of 3 for characters `[\\u0800..\\u7fff]`', () => {
       let input = '\u0800';
       let utf8Length = StringUtil.utf8LengthForString(input);
 

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -27,7 +27,7 @@ export default class Functor {
    * Constructs an instance.
    *
    * @param {string} name Functor name. This must conform to the "label"
-   *   syntax as defined by {@link TString#label()`}.
+   *   syntax as defined by {@link TString#label()}.
    * @param {...*} args Functor arguments.
    */
   constructor(name, ...args) {


### PR DESCRIPTION
This continues the work of my last PR in making all the various sets of OT classes look more like each other, in terms of names (class names, method names, field names) and semantics.

The most notable change is that the former `FrozenDelta` is now called `BodyOpList`: We have "deltas" for many things other than the document body, and this class is _only_ about the document body. Furthermore, the things we call "deltas" in the rest of the system all have an associated revision number, and this class doesn't. This class is _just_ a list of body content OT operations. Unfortunately, this is the thing that _Quill_ calls a `Delta`, so there's going to be some lingering confusion. (I added some comments to try to help, but that only goes so far.) I suspect there will be a bit more rearranging of things before we're done, and hopefully we'll be able to file down this particular rough edge in the long run.

**Bonus:** Cleaned up a few mismatched quotes that had cropped up in comments and unit test description strings.