### PR TITLE
In service of a trivial `PropertyChange` class.

### DIFF
--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -81,9 +81,10 @@ export default class BaseChange extends CommonBase {
    * @param {Int} revNum The revision number of the document produced by this
    *   instance (when composed as contextually appropriate). If this instance
    *   represents the first change to a document, then this value will be `0`.
-   * @param {object} delta The document change per se, compared to the
-   *   implied base revision. This must be an object of type `deltaClass` as
-   *   defined by the subclass.
+   * @param {object|array} delta The document change per se, compared to the
+   *   implied base revision. This must be either an object of type `deltaClass`
+   *   as defined by the subclass or an array which can be passed to the
+   *   `deltaClass` constructor to produce a valid delta.
    * @param {Timestamp|null} [timestamp = null] The time of the change, or
    *   `null` if the change doesn't have an associated moment of time.
    * @param {string|null} [authorId = null] Stable identifier string
@@ -97,7 +98,9 @@ export default class BaseChange extends CommonBase {
     this._revNum = RevisionNumber.check(revNum);
 
     /** {object} The main content delta. */
-    this._delta = this.constructor.deltaClass.check(delta);
+    this._delta = Array.isArray(delta)
+      ? new this.constructor.deltaClass(delta)
+      : this.constructor.deltaClass.check(delta);
 
     /** {Timestamp|null} The time of the change. */
     this._timestamp = Timestamp.orNull(timestamp);

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -1,0 +1,172 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TFunction, TObject } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+import AuthorId from './AuthorId';
+import RevisionNumber from './RevisionNumber';
+import Timestamp from './Timestamp';
+
+/**
+ * Base class for representation of a change to document content. A change
+ * consists of four parts:
+ *
+ * * the revision number (of the document or document part) produced by the
+ *   change when applied in context.
+ *
+ * * a delta (instructions for change), which describes the details of the
+ *   change from the document's contextually-defined previous state. The context
+ *   is sometimes (but not always) the immediately-previous revision of the
+ *   document. The other typical context is an _expected_ document based on
+ *   an attempt to apply an update.
+ *
+ * * an optional timestamp, which specifies the moment in time when the change
+ *   was created (e.g. by an end user). This is only present if there is a
+ *   single specific moment in time at which the change was made. As a
+ *   counter-example, instances of this class which are created by composing
+ *   multiple other changes will not typically have a timestamp.
+ *
+ * * an optional ID of the author, which identifies the entity who created the
+ *   change. As with the timestamp, this is only present if there is a single
+ *   unique author of a change. As a counter-example, some changes are created
+ *   "spontaneously" by the system (e.g. the empty first change to a document)
+ *   and as such have no author.
+ *
+ * Instances of (subclasses of) this class are both consumed and produced by the
+ * various "snapshot" classes.
+ *
+ * Instances of this class are immutable.
+ */
+export default class BaseChange extends CommonBase {
+  /**
+   * {BaseChange} Representation of the empty (and authorless and timeless)
+   * first change to a document.
+   */
+  static get FIRST() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._FIRST) {
+      this._FIRST = new this(0, this.deltaClass.EMPTY);
+    }
+
+    return this._FIRST;
+  }
+
+  /**
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class.
+   */
+  static get deltaClass() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._deltaClass) {
+      // Call the `_impl` and verify the result.
+      const clazz = TFunction.checkClass(this._impl_deltaClass);
+
+      TObject.check(clazz.EMPTY, clazz);
+      TFunction.checkCallable(clazz.check);
+      this._deltaClass = clazz;
+    }
+
+    return this._deltaClass;
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {Int} revNum The revision number of the document produced by this
+   *   instance (when composed as contextually appropriate). If this instance
+   *   represents the first change to a document, then this value will be `0`.
+   * @param {object} delta The document change per se, compared to the
+   *   implied base revision. This must be an object of type `deltaClass` as
+   *   defined by the subclass.
+   * @param {Timestamp|null} [timestamp = null] The time of the change, or
+   *   `null` if the change doesn't have an associated moment of time.
+   * @param {string|null} [authorId = null] Stable identifier string
+   *   representing the author of the change. Allowed to be `null` if the change
+   *   is authorless.
+   */
+  constructor(revNum, delta, timestamp = null, authorId = null) {
+    super();
+
+    /** {Int} The produced revision number. */
+    this._revNum = RevisionNumber.check(revNum);
+
+    /** {object} The main content delta. */
+    this._delta = this.constructor.deltaClass.check(delta);
+
+    /** {Timestamp|null} The time of the change. */
+    this._timestamp = Timestamp.orNull(timestamp);
+
+    /**
+     * {string|null} Author ID string, or `null` if the change is
+     * authorless.
+     */
+    this._authorId = AuthorId.orNull(authorId);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {string|null} The author ID string, or `null` if the change is authorless
+   * (or if the concept of "author" is meaningless in the larger context of this
+   * instance).
+   */
+  get authorId() {
+    return this._authorId;
+  }
+
+  /**
+   * {object} The main delta content. This is an instance of `deltaClass` as
+   * defined by the subclass.
+   */
+  get delta() {
+    return this._delta;
+  }
+
+  /** {Int} The produced revision number. */
+  get revNum() {
+    return this._revNum;
+  }
+
+  /**
+   * {Timestamp|null} The time of the change, or `null` if the change has no
+   * specific associated moment in time.
+   */
+  get timestamp() {
+    return this._timestamp;
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    const result = [this._revNum, this._delta, this._timestamp, this._authorId];
+
+    // Trim off one or two trailing `null`s, if possible.
+    for (let i = 3; i >= 2; i--) {
+      if (result[i] !== null) {
+        break;
+      }
+      result.pop();
+    }
+
+    return result;
+  }
+
+  /**
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class. Subclasses must be fill this in.
+   *
+   * @abstract
+   */
+  static get _impl_deltaClass() {
+    return this._mustOverride();
+  }
+}

--- a/local-modules/doc-common/BodyChange.js
+++ b/local-modules/doc-common/BodyChange.js
@@ -2,125 +2,19 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CommonBase } from 'util-common';
-
-import AuthorId from './AuthorId';
+import BaseChange from './BaseChange';
 import BodyDelta from './BodyDelta';
-import RevisionNumber from './RevisionNumber';
-import Timestamp from './Timestamp';
 
 /**
- * {BodyChange|null} Representation of the empty (and authorless and timeless)
- * first change to a document. Initialized in the static getter of the same
- * name.
+ * Change class for representing changes to a document body. The `delta`s passed
+ * to the constructor must be instances of {@link BodyDelta}.
  */
-let FIRST = null;
-
-/**
- * Representation of a change to a document body from its immediately-previous
- * revision, including time, authorship, and revision information in addition to
- * the actual delta. This class is a `BodyDelta` plus additional information.
- *
- * Instances of this class are returned from calls to `body_update()` and
- * `body_deltaAfter()` as defined by the various `doc-server` classes. See those
- * for more details. Note that the meaning of the `delta` value is different
- * depending on which method the result came from. In particular, there is an
- * implied "expected" result from `body_update()` which this instance's
- * `delta` is with respect to.
- *
- * Instances of this class are immutable.
- */
-export default class BodyChange extends CommonBase {
+export default class BodyChange extends BaseChange {
   /**
-   * {BodyChange} Representation of the empty (and authorless and timeless)
-   * first change to a document.
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class.
    */
-  static get FIRST() {
-    if (FIRST === null) {
-      FIRST = new BodyChange(0, BodyDelta.EMPTY);
-    }
-
-    return FIRST;
-  }
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {Int} revNum The revision number of the document produced by this
-   *   instance (when composed as contextually appropriate). If this instance
-   *   represents the first change to a document, then this value will be `0`.
-   * @param {BodyDelta} delta The body change per se, compared to the
-   *   implied base revision.
-   * @param {Timestamp|null} [timestamp = null] The time of the change, or
-   *   `null` if the change doesn't have an associated moment of time.
-   * @param {string|null} [authorId = null] Stable identifier string
-   *   representing the author of the change. Allowed to be `null` if the change
-   *   is authorless.
-   */
-  constructor(revNum, delta, timestamp = null, authorId = null) {
-    super();
-
-    /** {Int} The produced revision number. */
-    this._revNum = RevisionNumber.check(revNum);
-
-    /** {BodyDelta} The main content delta. */
-    this._delta = BodyDelta.check(delta);
-
-    /** {Timestamp|null} The time of the change. */
-    this._timestamp = Timestamp.orNull(timestamp);
-
-    /**
-     * {string|null} Author ID string, or `null` if the change is
-     * authorless.
-     */
-    this._authorId = AuthorId.orNull(authorId);
-
-    Object.freeze(this);
-  }
-
-  /**
-   * Converts this instance for API transmission.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toApi() {
-    const result = [this._revNum, this._delta, this._timestamp, this._authorId];
-
-    // Trim off one or two trailing `null`s, if possible.
-    for (let i = 3; i >= 2; i--) {
-      if (result[i] !== null) {
-        break;
-      }
-      result.pop();
-    }
-
-    return result;
-  }
-
-  /**
-   * {string|null} The author ID string, or `null` if the change is authorless
-   * (or if the cocept of "author" is meaningless in the larger context of this
-   * instance).
-   */
-  get authorId() {
-    return this._authorId;
-  }
-
-  /** {BodyDelta} The main delta content. */
-  get delta() {
-    return this._delta;
-  }
-
-  /** {Int} The produced revision number. */
-  get revNum() {
-    return this._revNum;
-  }
-
-  /**
-   * {Timestamp|null} The time of the change, or `null` if the change has no
-   * specific associated moment in time.
-   */
-  get timestamp() {
-    return this._timestamp;
+  static get _impl_deltaClass() {
+    return BodyDelta;
   }
 }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -79,7 +79,7 @@ export default class CaretOp extends CommonBase {
    * @param {Int} revNum The new revision number.
    * @returns {CaretOp} The corresponding operation.
    */
-  static op_updateRevNum(revNum) {
+  static op_setRevNum(revNum) {
     RevisionNumber.check(revNum);
 
     return new CaretOp(new Functor(CaretOp.SET_REV_NUM, revNum));

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -184,7 +184,7 @@ export default class CaretSnapshot extends CommonBase {
     // Add an op for the revision number, if needed.
 
     if (this._revNum !== newerSnapshot._revNum) {
-      caretOps.push(CaretOp.op_updateRevNum(newerSnapshot._revNum));
+      caretOps.push(CaretOp.op_setRevNum(newerSnapshot._revNum));
     }
 
     // Find carets that are new or updated from `this` when going to

--- a/local-modules/doc-common/PropertyChange.js
+++ b/local-modules/doc-common/PropertyChange.js
@@ -1,0 +1,21 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseChange from './BaseChange';
+import PropertyDelta from './PropertyDelta';
+
+/**
+ * Change class for representing changes to one or more document properties
+ * (that is, the structured document metadata). The `delta`s passed to the
+ * constructor must be instances of {@link PropertyDelta}.
+ */
+export default class PropertyChange extends BaseChange {
+  /**
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class.
+   */
+  static get _impl_deltaClass() {
+    return PropertyDelta;
+  }
+}

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -5,8 +5,6 @@
 import { TString } from 'typecheck';
 import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
 
-import RevisionNumber from './RevisionNumber';
-
 /**
  * Operation which can be applied to a `Property` or `PropertySnapshot`.
  */
@@ -19,11 +17,6 @@ export default class PropertyOp extends CommonBase {
   /** {string} Operation name for "set property" operations. */
   static get SET_PROPERTY() {
     return 'set_property';
-  }
-
-  /** {string} Operation name for "set revision number" operations. */
-  static get SET_REV_NUM() {
-    return 'set_rev_num';
   }
 
   /**
@@ -49,21 +42,8 @@ export default class PropertyOp extends CommonBase {
    */
   static op_setProperty(name, value) {
     TString.identifier(name);
-    value = DataUtil.deepFreeze(value);
 
     return new PropertyOp(new Functor(PropertyOp.SET_PROPERTY, name, value));
-  }
-
-  /**
-   * Constructs a new "set revision number" operation.
-   *
-   * @param {Int} revNum The new revision number.
-   * @returns {PropertyOp} The corresponding operation.
-   */
-  static op_updateRevNum(revNum) {
-    RevisionNumber.check(revNum);
-
-    return new PropertyOp(new Functor(PropertyOp.SET_REV_NUM, revNum));
   }
 
   /**
@@ -76,7 +56,7 @@ export default class PropertyOp extends CommonBase {
     super();
 
     /** {Functor} payload The operation payload (name and arguments). */
-    this._payload = Functor.check(payload);
+    this._payload = DataUtil.deepFreeze(Functor.check(payload));
 
     Object.freeze(this);
   }
@@ -105,11 +85,6 @@ export default class PropertyOp extends CommonBase {
       case PropertyOp.SET_PROPERTY: {
         const [name, value] = payload.args;
         return Object.freeze({ opName, name, value });
-      }
-
-      case PropertyOp.SET_REV_NUM: {
-        const [revNum] = payload.args;
-        return Object.freeze({ opName, revNum });
       }
 
       default: {

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -44,7 +44,7 @@ export default class PropertySnapshot extends CommonBase {
     if (Array.isArray(change)) {
       // Convert the given array into a proper change instance. (This does type
       // checking of the argument.)
-      change = new PropertyChange(0, new PropertyDelta(change));
+      change = new PropertyChange(0, change);
     }
 
     super();
@@ -146,7 +146,7 @@ export default class PropertySnapshot extends CommonBase {
     }
 
     return new PropertySnapshot(
-      new PropertyChange(change.revNum, new PropertyDelta([...newProps.values()])));
+      new PropertyChange(change.revNum, [...newProps.values()]));
   }
 
   /**
@@ -189,7 +189,7 @@ export default class PropertySnapshot extends CommonBase {
     }
 
     // Build the result.
-    return new PropertyChange(newerSnapshot.revNum, new PropertyDelta(ops));
+    return new PropertyChange(newerSnapshot.revNum, ops);
   }
 
   /**
@@ -269,7 +269,7 @@ export default class PropertySnapshot extends CommonBase {
 
     return op.equals(this._properties.get(name))
       ? this
-      : this.compose(new PropertyChange(this._revNum, new PropertyDelta([op])));
+      : this.compose(new PropertyChange(this._revNum, [op]));
   }
 
   /**
@@ -301,7 +301,7 @@ export default class PropertySnapshot extends CommonBase {
     const op = PropertyOp.op_deleteProperty(name); // This type checks.
 
     return this._properties.has(name)
-      ? this.compose(new PropertyChange(this._revNum, new PropertyDelta([op])))
+      ? this.compose(new PropertyChange(this._revNum, [op]))
       : this;
   }
 }

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -2,9 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TArray, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
+import PropertyChange from './PropertyChange';
 import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 
@@ -34,20 +35,22 @@ export default class PropertySnapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {PropertyDelta|array<PropertyOp>} delta A from-empty delta or array
-   *   of ops representing all the properties and the current revision number.
-   *   If there is no revision number operation, then the instance will have a
-   *   revision number of `0`.
+   * @param {PropertyChange|array<PropertyOp>} change A from-empty change or
+   *   array of ops representing all the properties and the current revision
+   *   number. In the case of an array, the instance will have a revision number
+   *   of `0`.
    */
-  constructor(delta) {
-    const ops = (delta instanceof PropertyDelta)
-      ? delta.ops
-      : TArray.check(delta, PropertyOp.check);
+  constructor(change) {
+    if (Array.isArray(change)) {
+      // Convert the given array into a proper change instance. (This does type
+      // checking of the argument.)
+      change = new PropertyChange(0, new PropertyDelta(change));
+    }
 
     super();
 
     /** {Int} The property information revision number. */
-    this._revNum = -1;
+    this._revNum = change.revNum;
 
     /**
      * {Map<string, PropertyOp>} Map of name to corresponding property, in the
@@ -56,7 +59,7 @@ export default class PropertySnapshot extends CommonBase {
     this._properties = new Map();
 
     // Fill in the instance variables.
-    for (const op of ops) {
+    for (const op of change.delta.ops) {
       const opProps = op.props;
 
       switch (opProps.opName) {
@@ -70,26 +73,10 @@ export default class PropertySnapshot extends CommonBase {
           break;
         }
 
-        case PropertyOp.SET_REV_NUM: {
-          if (this._revNum !== -1) {
-            throw Errors.bad_use('Duplicate `set_rev_num` op.');
-          }
-
-          this._revNum = opProps.revNum;
-          break;
-        }
-
         default: {
           throw Errors.bad_value(op, 'PropertySnapshot construction op');
         }
       }
-    }
-
-    if (this._revNum === -1) {
-      // Default value if it was never set. (We don't just initialize it to `0`,
-      // because that would make it impossible to error out in some cases of
-      // duplicate ops.
-      this._revNum = 0;
     }
 
     Object.freeze(this._properties);
@@ -127,19 +114,18 @@ export default class PropertySnapshot extends CommonBase {
   }
 
   /**
-   * Composes a delta on top of this instance, to produce a new instance.
+   * Composes a change on top of this instance, to produce a new instance.
    *
-   * @param {PropertyDelta} delta Delta to compose on top of this instance.
+   * @param {PropertyChange} change Change to compose on top of this instance.
    * @returns {PropertySnapshot} New instance consisting of the composition of
-   *   this instance with `delta`.
+   *   this instance with `change`.
    */
-  compose(delta) {
-    PropertyDelta.check(delta);
+  compose(change) {
+    PropertyChange.check(change);
 
     const newProps = new Map(this._properties.entries());
-    let   revNum   = this._revNum;
 
-    for (const op of delta.ops) {
+    for (const op of change.delta.ops) {
       const opProps = op.props;
 
       switch (opProps.opName) {
@@ -153,21 +139,14 @@ export default class PropertySnapshot extends CommonBase {
           break;
         }
 
-        case PropertyOp.SET_REV_NUM: {
-          revNum = opProps.revNum;
-          break;
-        }
-
         default: {
           throw Errors.wtf(`Weird op name: ${opProps.opName}`);
         }
       }
     }
 
-    return new PropertySnapshot([
-      PropertyOp.op_updateRevNum(revNum),
-      ...newProps.values()
-    ]);
+    return new PropertySnapshot(
+      new PropertyChange(change.revNum, new PropertyDelta([...newProps.values()])));
   }
 
   /**
@@ -183,7 +162,7 @@ export default class PropertySnapshot extends CommonBase {
    *
    * @param {PropertySnapshot} newerSnapshot Snapshot to take the difference
    *   from.
-   * @returns {PropertyDelta} Delta which represents the difference between
+   * @returns {PropertyChange} Change which represents the difference between
    *   `newerSnapshot` and this instance.
    */
   diff(newerSnapshot) {
@@ -191,11 +170,6 @@ export default class PropertySnapshot extends CommonBase {
 
     const newerProps = newerSnapshot._properties;
     const ops        = [];
-
-    // Add an op for the revision number, if needed.
-    if (this._revNum !== newerSnapshot._revNum) {
-      ops.push(PropertyOp.op_updateRevNum(newerSnapshot._revNum));
-    }
 
     // Find properties that are new or updated from `this` when going to
     // `newerSnapshot`.
@@ -215,7 +189,7 @@ export default class PropertySnapshot extends CommonBase {
     }
 
     // Build the result.
-    return new PropertyDelta(ops);
+    return new PropertyChange(newerSnapshot.revNum, new PropertyDelta(ops));
   }
 
   /**
@@ -295,7 +269,7 @@ export default class PropertySnapshot extends CommonBase {
 
     return op.equals(this._properties.get(name))
       ? this
-      : this.compose(new PropertyDelta([op]));
+      : this.compose(new PropertyChange(this._revNum, new PropertyDelta([op])));
   }
 
   /**
@@ -307,11 +281,11 @@ export default class PropertySnapshot extends CommonBase {
    * @returns {PropertySnapshot} An appropriately-constructed instance.
    */
   withRevNum(revNum) {
-    const op = PropertyOp.op_updateRevNum(revNum); // This type checks.
+    // This type checks `revNum`, which is why it's not just run when we need
+    // to call `compose()`.
+    const change = new PropertyChange(revNum, PropertyDelta.EMPTY);
 
-    return (revNum === this._revNum)
-      ? this
-      : this.compose(new PropertyDelta([op]));
+    return (revNum === this._revNum) ? this : this.compose(change);
   }
 
   /**
@@ -327,7 +301,7 @@ export default class PropertySnapshot extends CommonBase {
     const op = PropertyOp.op_deleteProperty(name); // This type checks.
 
     return this._properties.has(name)
-      ? this.compose(new PropertyDelta([op]))
+      ? this.compose(new PropertyChange(this._revNum, new PropertyDelta([op])))
       : this;
   }
 }

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -14,6 +14,7 @@ import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
 import DocumentId from './DocumentId';
+import PropertyChange from './PropertyChange';
 import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 import PropertySnapshot from './PropertySnapshot';
@@ -28,6 +29,7 @@ Codec.theOne.registerClass(Caret);
 Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretOp);
 Codec.theOne.registerClass(CaretSnapshot);
+Codec.theOne.registerClass(PropertyChange);
 Codec.theOne.registerClass(PropertyDelta);
 Codec.theOne.registerClass(PropertyOp);
 Codec.theOne.registerClass(PropertySnapshot);
@@ -44,6 +46,7 @@ export {
   CaretOp,
   CaretSnapshot,
   DocumentId,
+  PropertyChange,
   PropertyDelta,
   PropertyOp,
   PropertySnapshot,

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -5,6 +5,7 @@
 import { Codec } from 'codec';
 
 import AuthorId from './AuthorId';
+import BaseChange from './BaseChange';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
 import BodySnapshot from './BodySnapshot';
@@ -34,6 +35,7 @@ Codec.theOne.registerClass(Timestamp);
 
 export {
   AuthorId,
+  BaseChange,
   BodyChange,
   BodyDelta,
   BodySnapshot,

--- a/local-modules/doc-common/tests/test_BaseChange.js
+++ b/local-modules/doc-common/tests/test_BaseChange.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 import Delta from 'quill-delta';
 
 import { BaseChange, Timestamp } from 'doc-common';
-import { CommonBase } from 'util-common';
+import { CommonBase, Errors } from 'util-common';
 
 /**
  * Mock "delta" class for testing.
@@ -18,6 +18,16 @@ class MockDelta extends CommonBase {
       this._EMPTY = new MockDelta();
     }
     return this._EMPTY;
+  }
+
+  constructor(got = null) {
+    super();
+
+    if ((got !== null) && (got.length !== 3)) {
+      throw Errors.bad_value(got, 'length 3 arrray');
+    }
+
+    this.got = got;
   }
 }
 
@@ -75,6 +85,13 @@ describe('doc-common/BaseChange', () => {
       test(242, MockDelta.EMPTY, null, 'florp9019');
     });
 
+    it('should accept an array for the `delta`, which should get passed to the delta constructor', () => {
+      const array  = ['valid', 'length 3', '(see the MockDelta constructor)'];
+      const result = new MockChange(0, array);
+
+      assert.strictEqual(result.delta.got, array);
+    });
+
     it('should reject invalid arguments', () => {
       function test(...args) {
         assert.throws(() => new MockChange(...args));
@@ -94,7 +111,7 @@ describe('doc-common/BaseChange', () => {
       test(0, false);
       test(0, new Map());
       test(0, { ops: [] });
-      test(0, []);
+      test(0, ['invalid']);
       test(0, new Delta()); // Needs to be a `MockDelta`.
 
       // Invalid `timestamp`.

--- a/local-modules/doc-common/tests/test_BaseChange.js
+++ b/local-modules/doc-common/tests/test_BaseChange.js
@@ -1,0 +1,114 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import Delta from 'quill-delta';
+
+import { BaseChange, Timestamp } from 'doc-common';
+import { CommonBase } from 'util-common';
+
+/**
+ * Mock "delta" class for testing.
+ */
+class MockDelta extends CommonBase {
+  static get EMPTY() {
+    if (!this._EMPTY) {
+      this._EMPTY = new MockDelta();
+    }
+    return this._EMPTY;
+  }
+}
+
+/**
+ * Subclass of `BaseChange` used to do the testing.
+ */
+class MockChange extends BaseChange {
+  static get _impl_deltaClass() {
+    return MockDelta;
+  }
+}
+
+describe('doc-common/BaseChange', () => {
+  describe('.FIRST', () => {
+    const first = MockChange.FIRST;
+
+    it('should be an instance of the subclass', () => {
+      assert.instanceOf(first, MockChange);
+    });
+
+    it('should be a frozen object', () => {
+      assert.isFrozen(first);
+    });
+
+    it('should have the expected properties', () => {
+      assert.deepEqual(first.delta, MockDelta.EMPTY);
+      assert.strictEqual(first.revNum, 0);
+      assert.isNull(first.authorId);
+      assert.isNull(first.timestamp);
+    });
+  });
+
+  describe('constructor()', () => {
+    it('should produce a frozen instance', () => {
+      const result = new MockChange(0, MockDelta.EMPTY);
+      assert.isFrozen(result);
+    });
+
+    it('should accept valid arguments, which should be reflected in the accessors', () => {
+      function test(...args) {
+        const [revNum, delta, timestamp = null, authorId = null] = args;
+        const result = new MockChange(...args);
+        assert.strictEqual(result.revNum, revNum);
+        assert.strictEqual(result.delta, delta);
+        assert.strictEqual(result.timestamp, timestamp);
+        assert.strictEqual(result.authorId, authorId);
+      }
+
+      test(0,   MockDelta.EMPTY);
+      test(123, MockDelta.EMPTY);
+      test(0,   new MockDelta());
+      test(909, new MockDelta(), null);
+      test(909, new MockDelta(), Timestamp.now());
+      test(242, MockDelta.EMPTY, null, null);
+      test(242, MockDelta.EMPTY, null, 'florp9019');
+    });
+
+    it('should reject invalid arguments', () => {
+      function test(...args) {
+        assert.throws(() => new MockChange(...args));
+      }
+
+      // Invalid `revNum`.
+      test(-1,    MockDelta.EMPTY);
+      test(1.5,   MockDelta.EMPTY);
+      test('1',   MockDelta.EMPTY);
+      test([1],   MockDelta.EMPTY);
+      test(null,  MockDelta.EMPTY);
+      test(false, MockDelta.EMPTY);
+
+      // Invalid 'delta'.
+      test(0, null);
+      test(0, undefined);
+      test(0, false);
+      test(0, new Map());
+      test(0, { ops: [] });
+      test(0, []);
+      test(0, new Delta()); // Needs to be a `MockDelta`.
+
+      // Invalid `timestamp`.
+      test(0, MockDelta.EMPTY, false);
+      test(0, MockDelta.EMPTY, 0);
+      test(0, MockDelta.EMPTY, []);
+      test(0, MockDelta.EMPTY, new Date());
+      test(0, MockDelta.EMPTY, Date.now());
+
+      // Invalid `authorId`.
+      test(0, MockDelta.EMPTY, null, false);
+      test(0, MockDelta.EMPTY, null, 123);
+      test(0, MockDelta.EMPTY, null, [123]);
+      test(0, MockDelta.EMPTY, null, new Map());
+    });
+  });
+});

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -52,6 +52,13 @@ describe('doc-common/BodyChange', () => {
       test(242, BodyDelta.EMPTY,                  null, 'florp9019');
     });
 
+    it('should accept an array for the `delta`, which should get passed to the `BodyDelta` constructor', () => {
+      const ops    = [{ retain: 100 }];
+      const result = new BodyChange(0, ops);
+
+      assert.deepEqual(result.delta.ops, ops);
+    });
+
     it('should reject invalid arguments', () => {
       function test(...args) {
         assert.throws(() => new BodyChange(...args));
@@ -71,7 +78,6 @@ describe('doc-common/BodyChange', () => {
       test(0, false);
       test(0, new Map());
       test(0, { ops: [] });
-      test(0, []);
       test(0, new Delta()); // Needs to be a `BodyDelta`.
 
       // Invalid `timestamp`.

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -1,0 +1,91 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import Delta from 'quill-delta';
+
+import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
+
+describe('doc-common/BodyChange', () => {
+  describe('.FIRST', () => {
+    const first = BodyChange.FIRST;
+
+    it('should be an instance of `BodyChange`', () => {
+      assert.instanceOf(first, BodyChange);
+    });
+
+    it('should be a frozen object', () => {
+      assert.isFrozen(first);
+    });
+
+    it('should have the expected properties', () => {
+      assert.deepEqual(first.delta, BodyDelta.EMPTY);
+      assert.strictEqual(first.revNum, 0);
+      assert.isNull(first.authorId);
+      assert.isNull(first.timestamp);
+    });
+  });
+
+  describe('constructor()', () => {
+    it('should produce a frozen instance', () => {
+      const result = new BodyChange(0, BodyDelta.EMPTY);
+      assert.isFrozen(result);
+    });
+
+    it('should accept valid arguments, which should be reflected in the accessors', () => {
+      function test(...args) {
+        const [revNum, delta, timestamp = null, authorId = null] = args;
+        const result = new BodyChange(...args);
+        assert.strictEqual(result.revNum, revNum);
+        assert.strictEqual(result.delta, delta);
+        assert.strictEqual(result.timestamp, timestamp);
+        assert.strictEqual(result.authorId, authorId);
+      }
+
+      test(0,   new BodyDelta([{ retain: 100 }]));
+      test(123, BodyDelta.EMPTY);
+      test(909, new BodyDelta([{ insert: 'x' }]), null);
+      test(909, new BodyDelta([{ insert: 'x' }]), Timestamp.now());
+      test(242, BodyDelta.EMPTY,                  null, null);
+      test(242, BodyDelta.EMPTY,                  null, 'florp9019');
+    });
+
+    it('should reject invalid arguments', () => {
+      function test(...args) {
+        assert.throws(() => new BodyChange(...args));
+      }
+
+      // Invalid `revNum`.
+      test(-1,    BodyDelta.EMPTY);
+      test(1.5,   BodyDelta.EMPTY);
+      test('1',   BodyDelta.EMPTY);
+      test([1],   BodyDelta.EMPTY);
+      test(null,  BodyDelta.EMPTY);
+      test(false, BodyDelta.EMPTY);
+
+      // Invalid 'delta'.
+      test(0, null);
+      test(0, undefined);
+      test(0, false);
+      test(0, new Map());
+      test(0, { ops: [] });
+      test(0, []);
+      test(0, new Delta()); // Needs to be a `BodyDelta`.
+
+      // Invalid `timestamp`.
+      test(0, BodyDelta.EMPTY, false);
+      test(0, BodyDelta.EMPTY, 0);
+      test(0, BodyDelta.EMPTY, []);
+      test(0, BodyDelta.EMPTY, new Date());
+      test(0, BodyDelta.EMPTY, Date.now());
+
+      // Invalid `authorId`.
+      test(0, BodyDelta.EMPTY, null, false);
+      test(0, BodyDelta.EMPTY, null, 123);
+      test(0, BodyDelta.EMPTY, null, [123]);
+      test(0, BodyDelta.EMPTY, null, new Map());
+    });
+  });
+});

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -76,7 +76,7 @@ describe('doc-common/CaretSnapshot', () => {
     it('should update `revNum` given the appropriate op', () => {
       const snap     = new CaretSnapshot(1,  [caret1, caret2]);
       const expected = new CaretSnapshot(999,[caret1, caret2]);
-      const result   = snap.compose(new CaretDelta([CaretOp.op_updateRevNum(999)]));
+      const result   = snap.compose(new CaretDelta([CaretOp.op_setRevNum(999)]));
 
       assert.isTrue(result.equals(expected));
     });

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -34,8 +34,7 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should accept a valid change', () => {
       function test(revNum, ops) {
-        const delta  = new PropertyDelta(ops);
-        const change = new PropertyChange(revNum, delta);
+        const change = new PropertyChange(revNum, ops);
         new PropertySnapshot(change);
       }
 
@@ -65,7 +64,7 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should reject a change with disallowed ops', () => {
       function test(ops) {
-        const change = new PropertyChange(0, new PropertyDelta(ops));
+        const change = new PropertyChange(0, ops);
         assert.throws(() => { new PropertySnapshot(change); });
       }
 
@@ -88,11 +87,11 @@ describe('doc-common/PropertySnapshot', () => {
       test(PropertySnapshot.EMPTY);
 
       test(new PropertySnapshot(new PropertyChange(123, PropertyDelta.EMPTY)));
-      test(new PropertySnapshot(new PropertyChange(0,   new PropertyDelta([PropertyOp.op_setProperty('foo', 'bar')]))));
-      test(new PropertySnapshot(new PropertyChange(37,  new PropertyDelta([PropertyOp.op_setProperty('foo', 'bar')]))));
+      test(new PropertySnapshot(new PropertyChange(0,   [PropertyOp.op_setProperty('foo', 'bar')])));
+      test(new PropertySnapshot(new PropertyChange(37,  [PropertyOp.op_setProperty('foo', 'bar')])));
       test(new PropertySnapshot(
         new PropertyChange(37,
-          new PropertyDelta([PropertyOp.op_setProperty('foo', 'bar'), PropertyOp.op_setProperty('baz', 914)]))));
+          [PropertyOp.op_setProperty('foo', 'bar'), PropertyOp.op_setProperty('baz', 914)])));
     });
 
     it('should update `revNum` given a change with a different `revNum`', () => {
@@ -108,7 +107,7 @@ describe('doc-common/PropertySnapshot', () => {
       const op       = PropertyOp.op_setProperty('florp', 'like');
       const snap     = new PropertySnapshot([]);
       const expected = new PropertySnapshot([op]);
-      const change   = new PropertyChange(0, new PropertyDelta([op]));
+      const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
       assert.strictEqual(result.get('florp'), 'like');
@@ -119,7 +118,7 @@ describe('doc-common/PropertySnapshot', () => {
       const op       = PropertyOp.op_setProperty('florp', 'like');
       const snap     = new PropertySnapshot([PropertyOp.op_setProperty('florp', 'unlike')]);
       const expected = new PropertySnapshot([op]);
-      const change   = new PropertyChange(0, new PropertyDelta([op]));
+      const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
       assert.strictEqual(result.get('florp'), 'like');
@@ -127,10 +126,9 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should remove a property given the appropriate op', () => {
-      const snap     = new PropertySnapshot([PropertyOp.op_setProperty('florp', 'like')]);
-      const delta    = new PropertyDelta([PropertyOp.op_deleteProperty('florp')]);
-      const change   = new PropertyChange(0, delta);
-      const result   = snap.compose(change);
+      const snap   = new PropertySnapshot([PropertyOp.op_setProperty('florp', 'like')]);
+      const change = new PropertyChange(0, [PropertyOp.op_deleteProperty('florp')]);
+      const result = snap.compose(change);
 
       assert.isFalse(result.has('florp'));
       assert.isTrue(result.equals(PropertySnapshot.EMPTY));
@@ -140,7 +138,7 @@ describe('doc-common/PropertySnapshot', () => {
   describe('diff()', () => {
     it('should produce an empty diff when passed itself', () => {
       const snap = new PropertySnapshot(new PropertyChange(914,
-        new PropertyDelta([PropertyOp.op_setProperty('a', 10), PropertyOp.op_setProperty('b', 20)])));
+        [PropertyOp.op_setProperty('a', 10), PropertyOp.op_setProperty('b', 20)]));
       const result = snap.diff(snap);
 
       assert.instanceOf(result, PropertyChange);
@@ -150,9 +148,9 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should result in a `revNum` diff if that in fact changes', () => {
       const snap1 = new PropertySnapshot(
-        new PropertyChange(123, new PropertyDelta([PropertyOp.op_setProperty('a', 10)])));
+        new PropertyChange(123, [PropertyOp.op_setProperty('a', 10)]));
       const snap2 = new PropertySnapshot(
-        new PropertyChange(456, new PropertyDelta([PropertyOp.op_setProperty('a', 10)])));
+        new PropertyChange(456, [PropertyOp.op_setProperty('a', 10)]));
       const result = snap1.diff(snap2);
 
       const composed = new PropertySnapshot([]).compose(result);
@@ -252,9 +250,9 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should return `false` when `revNum`s differ', () => {
       const snap1 = new PropertySnapshot(
-        new PropertyChange(123, new PropertyDelta([PropertyOp.op_setProperty('a', 10)])));
+        new PropertyChange(123, [PropertyOp.op_setProperty('a', 10)]));
       const snap2 = new PropertySnapshot(
-        new PropertyChange(456, new PropertyDelta([PropertyOp.op_setProperty('a', 10)])));
+        new PropertyChange(456, [PropertyOp.op_setProperty('a', 10)]));
 
       assert.isFalse(snap1.equals(snap2));
     });

--- a/local-modules/util-common/tests/test_ColorSelector.js
+++ b/local-modules/util-common/tests/test_ColorSelector.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { ColorSelector } from 'util-common';
 
 describe('ColorSelector', () => {
-  describe('.constructor()', () => {
+  describe('constructor()', () => {
     it('should default to a hue angle of pure red if given no seed', () => {
       const selector = new ColorSelector();
       const hsl = selector.nextColorHSL();
@@ -46,7 +46,7 @@ describe('ColorSelector', () => {
       assert.equal(colorA.hue, colorB.hue - 37);
     });
 
-    describe('.nextCssColor()', () => {
+    describe('nextCssColor()', () => {
       it('should return a valid hex string representation of the RGB value of a given color', () => {
         const selector = new ColorSelector();
         const hex = selector.nextCssColor();


### PR DESCRIPTION
This PR follows up my previous one, with one of the promised refactorings. Specifically, `BaseChange` gets extracted out of `BodyChange`, leaving the latter a quite trivial class. And with that, it becomes equally trivial to add a new subclass of `BaseChange` for properties. The main churn in this PR is adjusting the rest of the property classes to behave more similarly to the body classes.

Coming soon: carets!

**Bonus:** Fixed a couple unit test labels to match the dominant style.