### PR TITLE
Make the caret classes (once again) be like the other OT classes.

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -169,8 +169,7 @@ export default class BodyClient extends StateMachine {
    * Validates a `gotUpdate` event. This represents a successful result
    * from the API call `body_update()`.
    *
-   * @param {BodyDelta} delta The operations (raw delta) that were originally
-   *   applied.
+   * @param {BodyDelta} delta The delta that was originally applied.
    * @param {BodyChange} correctedChange The correction to the expected
    *   result as returned from `body_update()`.
    */
@@ -473,12 +472,12 @@ export default class BodyClient extends StateMachine {
    *   document revision.
    */
   _handle_idle_gotDeltaAfter(baseSnapshot, result) {
-    this._log.detail('Delta from server:', result.revNum);
+    this._log.detail('Change from server:', result.revNum);
 
-    // We only take action if the result's base (what `delta` is with regard to)
-    // is the current `_snapshot`. If that _isn't_ the case, then what we have
-    // here is a stale response of one sort or another. For example (and most
-    // likely), it might be the delayed result from an earlier iteration.
+    // We only take action if the result's base (what the change is with regard
+    // to) is the current `_snapshot`. If that _isn't_ the case, then what we
+    // have here is a stale response of one sort or another. For example (and
+    // most likely), it might be the delayed result from an earlier iteration.
     if (this._snapshot.revNum === baseSnapshot.revNum) {
       this._updateWithChange(result);
     }
@@ -494,7 +493,7 @@ export default class BodyClient extends StateMachine {
 
   /**
    * In most states, handles event `gotDeltaAfter`. This will happen when a
-   * server delta comes when we're in the middle of handling a local change. As
+   * server change comes when we're in the middle of handling a local change. As
    * such, it is safe to ignore, because after the local change is integrated,
    * the system will fire off a new `body_deltaAfter()` request.
    *
@@ -578,7 +577,7 @@ export default class BodyClient extends StateMachine {
 
   /**
    * In most states, handles event `gotQuillEvent`. This will happen when a
-   * local delta comes in after we're already in the middle of handling a
+   * local change comes in after we're already in the middle of handling a
    * chain of local changes. As such, it is safe to ignore, because whatever
    * the change was, it will get handled by that pre-existing process.
    *
@@ -637,8 +636,7 @@ export default class BodyClient extends StateMachine {
    * In state `merging`, handles event `gotUpdate`. This means that a local
    * change was successfully merged by the server.
    *
-   * @param {BodyDelta} delta The operations (raw delta) that were originally
-   *   applied.
+   * @param {BodyDelta} delta The delta that was originally applied.
    * @param {BodyChange} correctedChange The correction to the expected
    *   result as returned from `body_update()`.
    */
@@ -799,7 +797,7 @@ export default class BodyClient extends StateMachine {
 
   /**
    * Updates `_snapshot` to be the given revision by applying the indicated
-   * delta to the current revision, and tells the attached Quill instance to
+   * change to the current revision, and tells the attached Quill instance to
    * update itself accordingly.
    *
    * This is only valid to call when the revision of the document that Quill has
@@ -820,9 +818,9 @@ export default class BodyClient extends StateMachine {
 
     if (   (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) !== null)
         && needQuillUpdate) {
-      // It is unsafe to apply the delta as-is, because we know that Quill's
+      // It is unsafe to apply the change as-is, because we know that Quill's
       // revision of the document has diverged.
-      throw Errors.bad_use('Cannot apply delta due to revision skew.');
+      throw Errors.bad_use('Cannot apply change due to revision skew.');
     }
 
     // Update the local snapshot.

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -431,7 +431,7 @@ export default class CaretOverlay {
   _onCaretChange() {
     const oldSnapshot = this._lastCaretSnapshot;
     const newSnapshot = this._caretStore.state;
-    const delta = oldSnapshot.diff(newSnapshot);
+    const delta = oldSnapshot.diff(newSnapshot).delta;
     let updateDisplay = false;
 
     this._lastCaretSnapshot = newSnapshot;

--- a/local-modules/doc-client/CaretStore.js
+++ b/local-modules/doc-client/CaretStore.js
@@ -130,9 +130,9 @@ export default class CaretStore {
         if (snapshot !== null) {
           // We have a snapshot which we can presumably get a delta from, so try
           // to do that.
-          const delta = await sessionProxy.caret_deltaAfter(snapshot.revNum);
-          snapshot = snapshot.compose(delta);
-          docSession.log.detail(`Got caret delta. ${snapshot.carets.length} caret(s).`);
+          const change = await sessionProxy.caret_deltaAfter(snapshot.revNum);
+          snapshot = snapshot.compose(change);
+          docSession.log.detail(`Got caret change. ${snapshot.carets.length} caret(s).`);
         }
       } catch (e) {
         // Assume that the error isn't truly fatal. Most likely, it's because

--- a/local-modules/doc-client/CaretStore.js
+++ b/local-modules/doc-client/CaretStore.js
@@ -130,7 +130,7 @@ export default class CaretStore {
         if (snapshot !== null) {
           // We have a snapshot which we can presumably get a change with
           // respect to, so try to do that.
-          const change = await sessionProxy.caret_deltaAfter(snapshot.revNum);
+          const change = await sessionProxy.caret_getChangeAfter(snapshot.revNum);
           snapshot = snapshot.compose(change);
           docSession.log.detail(`Got caret change. ${snapshot.carets.length} caret(s).`);
         }
@@ -139,7 +139,7 @@ export default class CaretStore {
         // the session got restarted or because the snapshot we have is too old
         // to get a change from. We just `null` out the snapshot and let the
         // next clause try to get it afresh.
-        docSession.log.warn('Trouble with `caret_deltaAfter`:', e);
+        docSession.log.warn('Trouble with `caret_getChangeAfter`:', e);
         snapshot = null;
       }
 

--- a/local-modules/doc-client/CaretStore.js
+++ b/local-modules/doc-client/CaretStore.js
@@ -128,8 +128,8 @@ export default class CaretStore {
 
       try {
         if (snapshot !== null) {
-          // We have a snapshot which we can presumably get a delta from, so try
-          // to do that.
+          // We have a snapshot which we can presumably get a change with
+          // respect to, so try to do that.
           const change = await sessionProxy.caret_deltaAfter(snapshot.revNum);
           snapshot = snapshot.compose(change);
           docSession.log.detail(`Got caret change. ${snapshot.carets.length} caret(s).`);
@@ -137,8 +137,8 @@ export default class CaretStore {
       } catch (e) {
         // Assume that the error isn't truly fatal. Most likely, it's because
         // the session got restarted or because the snapshot we have is too old
-        // to get a delta from. We just `null` out the snapshot and let the next
-        // clause try to get it afresh.
+        // to get a change from. We just `null` out the snapshot and let the
+        // next clause try to get it afresh.
         docSession.log.warn('Trouble with `caret_deltaAfter`:', e);
         snapshot = null;
       }
@@ -147,7 +147,7 @@ export default class CaretStore {
         if (snapshot === null) {
           // We don't yet have a snapshot to base deltas off of, so get one!
           // This can happen either because we've just started a new session or
-          // because the attempt to get a delta failed for some reason. (The
+          // because the attempt to get a change failed for some reason. (The
           // latter is why this section isn't just part of an `else` block to
           // the previous `if`).
           snapshot = await sessionProxy.caret_snapshot();

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -251,7 +251,7 @@ export default class Caret extends CommonBase {
 
     for (const [k, v] of newerCaret._fields) {
       if (!Caret._equalFields(v, fields.get(k))) {
-        ops.push(CaretOp.op_updateField(sessionId, k, v));
+        ops.push(CaretOp.op_setField(sessionId, k, v));
       }
     }
 

--- a/local-modules/doc-common/CaretChange.js
+++ b/local-modules/doc-common/CaretChange.js
@@ -1,0 +1,20 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseChange from './BaseChange';
+import CaretDelta from './CaretDelta';
+
+/**
+ * Change class for representing changes to caret snapshots. The `delta`s passed
+ * to the constructor must be instances of {@link CaretDelta}.
+ */
+export default class CaretChange extends BaseChange {
+  /**
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class.
+   */
+  static get _impl_deltaClass() {
+    return CaretDelta;
+  }
+}

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -66,7 +66,7 @@ export default class CaretOp extends CommonBase {
    *   varies by name.
    * @returns {CaretOp} The corresponding operation.
    */
-  static op_updateField(sessionId, key, value) {
+  static op_setField(sessionId, key, value) {
     TString.check(sessionId);
     Caret.checkField(key, value);
 

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -104,7 +104,7 @@ export default class CaretSnapshot extends CommonBase {
   /**
    * Composes a delta on top of this instance, to produce a new instance.
    *
-   * **Note:** It is an error if `delta` contains an `op_updateField` to a caret
+   * **Note:** It is an error if `delta` contains an `op_setField` to a caret
    * that either does not exist in `this` or was not first introduced with an
    * `op_beginSession`.
    *

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -151,7 +151,7 @@ export default class PropertySnapshot extends CommonBase {
 
   /**
    * Calculates the difference from a given snapshot to this one. The return
-   * value is a delta which can be composed with this instance to produce the
+   * value is a change which can be composed with this instance to produce the
    * snapshot passed in here as an argument. That is, `newerSnapshot ==
    * this.compose(this.diff(newerSnapshot))`.
    *

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -10,6 +10,7 @@ import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
 import BodySnapshot from './BodySnapshot';
 import Caret from './Caret';
+import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
@@ -26,6 +27,7 @@ Codec.theOne.registerClass(BodyChange);
 Codec.theOne.registerClass(BodyDelta);
 Codec.theOne.registerClass(BodySnapshot);
 Codec.theOne.registerClass(Caret);
+Codec.theOne.registerClass(CaretChange);
 Codec.theOne.registerClass(CaretDelta);
 Codec.theOne.registerClass(CaretOp);
 Codec.theOne.registerClass(CaretSnapshot);
@@ -42,6 +44,7 @@ export {
   BodyDelta,
   BodySnapshot,
   Caret,
+  CaretChange,
   CaretDelta,
   CaretOp,
   CaretSnapshot,

--- a/local-modules/doc-common/tests/test_Caret.js
+++ b/local-modules/doc-common/tests/test_Caret.js
@@ -40,35 +40,35 @@ describe('doc-common/Caret', () => {
     });
 
     it('should update `index` given the appropriate op', () => {
-      const op     = CaretOp.op_updateField(caret1.sessionId, 'index', 99999);
+      const op     = CaretOp.op_setField(caret1.sessionId, 'index', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.index, 99999);
     });
 
     it('should update `length` given the appropriate op', () => {
-      const op     = CaretOp.op_updateField(caret1.sessionId, 'length', 99999);
+      const op     = CaretOp.op_setField(caret1.sessionId, 'length', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.length, 99999);
     });
 
     it('should update `color` given the appropriate op', () => {
-      const op     = CaretOp.op_updateField(caret1.sessionId, 'color', '#aabbcc');
+      const op     = CaretOp.op_setField(caret1.sessionId, 'color', '#aabbcc');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.color, '#aabbcc');
     });
 
     it('should update `revNum` given the appropriate op', () => {
-      const op     = CaretOp.op_updateField(caret1.sessionId, 'revNum', 12345);
+      const op     = CaretOp.op_setField(caret1.sessionId, 'revNum', 12345);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.revNum, 12345);
     });
 
     it('should refuse to compose if given a non-matching session ID', () => {
-      const op = CaretOp.op_updateField(caret2.sessionId, 'index', 55);
+      const op = CaretOp.op_setField(caret2.sessionId, 'index', 55);
 
       assert.throws(() => { caret1.compose(new CaretDelta([op])); });
     });
@@ -88,7 +88,7 @@ describe('doc-common/Caret', () => {
 
     it('should result in an `index` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_updateField(older.sessionId, 'index', 99999);
+      const op      = CaretOp.op_setField(older.sessionId, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diff(newer).ops;
 
@@ -111,7 +111,7 @@ describe('doc-common/Caret', () => {
 
     it('should result in an `index` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_updateField(older.sessionId, 'index', 99999);
+      const op      = CaretOp.op_setField(older.sessionId, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diffFields(newer, older.sessionId).ops;
 
@@ -121,7 +121,7 @@ describe('doc-common/Caret', () => {
 
     it('should result in a `length` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_updateField(older.sessionId, 'length', 99999);
+      const op      = CaretOp.op_setField(older.sessionId, 'length', 99999);
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diffFields(newer, older.sessionId).ops;
 
@@ -131,7 +131,7 @@ describe('doc-common/Caret', () => {
 
     it('should result in a `color` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_updateField(older.sessionId, 'color', '#abcdef');
+      const op      = CaretOp.op_setField(older.sessionId, 'color', '#abcdef');
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diffFields(newer, older.sessionId).ops;
 
@@ -163,15 +163,15 @@ describe('doc-common/Caret', () => {
       const c1 = caret1;
       let   c2, op;
 
-      op = CaretOp.op_updateField(c1.sessionId, 'index', 99999);
+      op = CaretOp.op_setField(c1.sessionId, 'index', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_updateField(c1.sessionId, 'length', 99999);
+      op = CaretOp.op_setField(c1.sessionId, 'length', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_updateField(c1.sessionId, 'color', '#999999');
+      op = CaretOp.op_setField(c1.sessionId, 'color', '#999999');
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
     });

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Caret, CaretDelta, CaretOp, CaretSnapshot } from 'doc-common';
+import { Caret, CaretChange, CaretDelta, CaretOp, CaretSnapshot } from 'doc-common';
 
 /**
  * Convenient caret constructor, which takes positional parameters.
@@ -59,11 +59,11 @@ describe('doc-common/CaretSnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('should produce an equal instance when passed an empty delta', () => {
+    it('should produce an equal instance when passed an empty change with the same `revNum`', () => {
       let which = 0;
       function test(snap) {
         which++;
-        const result = snap.compose(CaretDelta.EMPTY);
+        const result = snap.compose(new CaretChange(snap.revNum, CaretDelta.EMPTY));
         assert.deepEqual(result, snap, `#${which}`);
       }
 
@@ -73,10 +73,10 @@ describe('doc-common/CaretSnapshot', () => {
       test(new CaretSnapshot(999, [caret1, caret2, caret3]));
     });
 
-    it('should update `revNum` given the appropriate op', () => {
+    it('should update `revNum` given a change with a different `revNum`', () => {
       const snap     = new CaretSnapshot(1,  [caret1, caret2]);
       const expected = new CaretSnapshot(999,[caret1, caret2]);
-      const result   = snap.compose(new CaretDelta([CaretOp.op_setRevNum(999)]));
+      const result   = snap.compose(new CaretChange(999, []));
 
       assert.isTrue(result.equals(expected));
     });
@@ -84,17 +84,17 @@ describe('doc-common/CaretSnapshot', () => {
     it('should add a new caret given the appropriate op', () => {
       const snap     = new CaretSnapshot(1, []);
       const expected = new CaretSnapshot(1, [caret1]);
-      const delta    = new CaretDelta([CaretOp.op_beginSession(caret1)]);
-      const result   = snap.compose(delta);
+      const change   = new CaretChange(1, [CaretOp.op_beginSession(caret1)]);
+      const result   = snap.compose(change);
 
       assert.isTrue(result.equals(expected));
     });
 
     it('should refuse to update a nonexistent caret', () => {
       const snap  = new CaretSnapshot(1, [caret1]);
-      const delta = new CaretDelta([CaretOp.op_setField('florp', 'index', 1)]);
+      const change = new CaretChange(1, [CaretOp.op_setField('florp', 'index', 1)]);
 
-      assert.throws(() => { snap.compose(delta); });
+      assert.throws(() => { snap.compose(change); });
     });
 
     it('should update a pre-existing caret given an appropriate op', () => {
@@ -103,7 +103,7 @@ describe('doc-common/CaretSnapshot', () => {
       const snap     = new CaretSnapshot(1, [caret1, c1]);
       const expected = new CaretSnapshot(1, [caret1, c2]);
       const op       = CaretOp.op_setField('foo', 'index', 3);
-      const result   = snap.compose(new CaretDelta([op]));
+      const result   = snap.compose(new CaretChange(1, [op]));
 
       assert.isTrue(result.equals(expected));
     });
@@ -111,8 +111,7 @@ describe('doc-common/CaretSnapshot', () => {
     it('should remove a caret given the appropriate op', () => {
       const snap     = new CaretSnapshot(1, [caret1, caret2]);
       const expected = new CaretSnapshot(1, [caret2]);
-      const result =
-        snap.compose(new CaretDelta([CaretOp.op_endSession(caret1.sessionId)]));
+      const result   = snap.compose(new CaretChange(1, [CaretOp.op_endSession(caret1.sessionId)]));
 
       assert.isTrue(result.equals(expected));
     });
@@ -120,17 +119,21 @@ describe('doc-common/CaretSnapshot', () => {
 
   describe('diff()', () => {
     it('should produce an empty diff when passed itself', () => {
-      const snap = new CaretSnapshot(123, [caret1, caret2]);
+      const snap   = new CaretSnapshot(123, [caret1, caret2]);
       const result = snap.diff(snap);
 
-      assert.instanceOf(result, CaretDelta);
-      assert.deepEqual(result.ops, []);
+      assert.instanceOf(result, CaretChange);
+      assert.strictEqual(result.revNum, 123);
+      assert.deepEqual(result.delta, CaretDelta.EMPTY);
     });
 
     it('should result in a `revNum` diff if that in fact changes', () => {
-      const snap1 = new CaretSnapshot(1, [caret1, caret2]);
-      const snap2 = new CaretSnapshot(9, [caret1, caret2]);
+      const snap1  = new CaretSnapshot(1, [caret1, caret2]);
+      const snap2  = new CaretSnapshot(9, [caret1, caret2]);
       const result = snap1.diff(snap2);
+
+      assert.strictEqual(result.revNum, 9);
+      assert.deepEqual(result.delta, CaretDelta.EMPTY);
 
       const composed = new CaretSnapshot(0, []).compose(result);
       const expected = new CaretSnapshot(9, []);
@@ -138,35 +141,35 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should result in a caret removal if that in fact happens', () => {
-      const snap1 = new CaretSnapshot(1, [caret1, caret2]);
-      const snap2 = new CaretSnapshot(1, [caret1]);
+      const snap1  = new CaretSnapshot(4, [caret1, caret2]);
+      const snap2  = new CaretSnapshot(4, [caret1]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, [caret2, caret3]).compose(result);
-      const expected = new CaretSnapshot(0, [caret3]);
+      const composed = new CaretSnapshot(4, [caret2, caret3]).compose(result);
+      const expected = new CaretSnapshot(4, [caret3]);
       assert.isTrue(composed.equals(expected));
     });
 
     it('should result in a caret addition if that in fact happens', () => {
-      const snap1 = new CaretSnapshot(1, [caret1]);
-      const snap2 = new CaretSnapshot(1, [caret1, caret2]);
+      const snap1  = new CaretSnapshot(1, [caret1]);
+      const snap2  = new CaretSnapshot(1, [caret1, caret2]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, []).compose(result);
-      const expected = new CaretSnapshot(0, [caret2]);
+      const composed = new CaretSnapshot(1, []).compose(result);
+      const expected = new CaretSnapshot(1, [caret2]);
       assert.isTrue(composed.equals(expected));
     });
 
     it('should result in a caret update if that in fact happens', () => {
-      const c1 = newCaret('florp', 1, 3, '#444444');
-      const c2 = newCaret('florp', 2, 4, '#555555');
-      const c3 = newCaret('florp', 3, 5, '#666666');
-      const snap1 = new CaretSnapshot(1, [c1]);
-      const snap2 = new CaretSnapshot(1, [c2]);
+      const c1     = newCaret('florp', 1, 3, '#444444');
+      const c2     = newCaret('florp', 2, 4, '#555555');
+      const c3     = newCaret('florp', 3, 5, '#666666');
+      const snap1  = new CaretSnapshot(1, [c1]);
+      const snap2  = new CaretSnapshot(1, [c2]);
       const result = snap1.diff(snap2);
 
-      const composed = new CaretSnapshot(0, [caret1, c3]).compose(result);
-      const expected = new CaretSnapshot(0, [caret1, c2]);
+      const composed = new CaretSnapshot(1, [caret1, c3]).compose(result);
+      const expected = new CaretSnapshot(1, [caret1, c2]);
       assert.isTrue(composed.equals(expected));
     });
   });

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -92,7 +92,7 @@ describe('doc-common/CaretSnapshot', () => {
 
     it('should refuse to update a nonexistent caret', () => {
       const snap  = new CaretSnapshot(1, [caret1]);
-      const delta = new CaretDelta([CaretOp.op_updateField('florp', 'index', 1)]);
+      const delta = new CaretDelta([CaretOp.op_setField('florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(delta); });
     });
@@ -102,7 +102,7 @@ describe('doc-common/CaretSnapshot', () => {
       const c2       = newCaret('foo', 3, 2, '#333333');
       const snap     = new CaretSnapshot(1, [caret1, c1]);
       const expected = new CaretSnapshot(1, [caret1, c2]);
-      const op       = CaretOp.op_updateField('foo', 'index', 3);
+      const op       = CaretOp.op_setField('foo', 'index', 3);
       const result   = snap.compose(new CaretDelta([op]));
 
       assert.isTrue(result.equals(expected));

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -174,8 +174,8 @@ export default class BodyControl extends CommonBase {
    * @param {Int} baseRevNum Revision number for the document.
    * @returns {BodyChange} Delta and associated information. The result's
    *   `revNum` is guaranteed to be at least one more than `baseRevNum` (and
-   *   could possibly be even larger.) The result's `delta` can be applied to
-   *   revision `baseRevNum` to produce revision `revNum` of the document. The
+   *   could possibly be even larger.) The result can be applied to revision
+   *   `baseRevNum` to produce revision `revNum` of the document. The
    *   `timestamp` and `author` of the result will both be `null`.
    */
   async deltaAfter(baseRevNum) {
@@ -261,18 +261,18 @@ export default class BodyControl extends CommonBase {
   }
 
   /**
-   * Takes a base revision number and list of operations (raw delta) to apply
-   * therefrom, and applies the operations, including merging of any
-   * intermediate revisions. The return value consists of a "correction" delta
-   * to be used to get the new document state. The correction delta is with
-   * respect to the client's "expected result," that is to say, what the client
-   * would get if the operations were applied with no intervening changes.
+   * Takes a base revision number and a delta to apply thereto, and applies the
+   * delta, including merging of any intermediate revisions. The return value
+   * consists of a "correction" change to be used to get the new document state.
+   * The correction is with respect to the client's "expected result," that is
+   * to say, what the client would get if the operations were applied with no
+   * intervening changes.
    *
    * As a special case, as long as `baseRevNum` is valid, if `ops` is empty,
    * this method returns a result of the same revision number along with an
-   * empty "correction" delta. That is, the return value from passing an empty
-   * list of operations doesn't provide any information about subsequent
-   * revisions of the document.
+   * empty "correction."" That is, the return value from passing an empty list
+   * of operations doesn't provide any information about subsequent revisions of
+   * the document.
    *
    * @param {Int} baseRevNum Revision number which `delta` is with respect to.
    * @param {BodyDelta} delta List of operations indicating what has changed
@@ -444,13 +444,13 @@ export default class BodyControl extends CommonBase {
   }
 
   /**
-   * Appends a new delta to the document. On success, this returns the revision
+   * Appends a new change to the document. On success, this returns the revision
    * number of the document after the append. On a failure due to `baseRevNum`
    * not being current at the moment of application, this returns `null`. All
    * other errors are reported via thrown errors. See `_applyUpdateTo()` above
    * for further discussion.
    *
-   * **Note:** If the delta is a no-op, then this method throws an error,
+   * **Note:** If the change is a no-op, then this method throws an error,
    * because the calling code should have handled that case without calling this
    * method.
    *

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -178,7 +178,7 @@ export default class BodyControl extends CommonBase {
    *   `baseRevNum` to produce revision `revNum` of the document. The
    *   `timestamp` and `author` of the result will both be `null`.
    */
-  async deltaAfter(baseRevNum) {
+  async getChangeAfter(baseRevNum) {
     RevisionNumber.check(baseRevNum);
 
     for (;;) {
@@ -212,7 +212,7 @@ export default class BodyControl extends CommonBase {
           throw e;
         }
         // It's a timeout, so just fall through and iterate.
-        this._log.info('Storage layer timeout in `deltaAfter`.');
+        this._log.info('Storage layer timeout in `getChangeAfter`.');
       }
     }
   }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -12,7 +12,7 @@ import CaretStorage from './CaretStorage';
 
 /**
  * {Int} How many older caret snapshots should be maintained for potential use
- * as the base for `deltaAfter()`.
+ * as the base for `getChangeAfter()`.
  */
 const MAX_OLD_SNAPSHOTS = 20;
 
@@ -55,7 +55,7 @@ export default class CaretControl extends CommonBase {
 
     /**
      * {array<CaretSnapshot>} Array of older caret snapshots, available for use
-     * for `deltaAfter()`.
+     * for `getChangeAfter()`.
      */
     this._oldSnapshots = [this._snapshot];
 
@@ -81,7 +81,7 @@ export default class CaretControl extends CommonBase {
    *   available.
    * @returns {CaretChange} Change from the base caret revision to a newer one.
    */
-  async deltaAfter(baseRevNum) {
+  async getChangeAfter(baseRevNum) {
     const oldSnapshot = await this.snapshot(baseRevNum);
 
     // Iterate if / as long as the base revision is still the current one. This

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -72,14 +72,14 @@ export default class CaretControl extends CommonBase {
   }
 
   /**
-   * Gets a delta of caret information from the indicated base caret revision.
+   * Gets a change of caret information from the indicated base caret revision.
    * This will throw an error if the indicated caret revision isn't available.
    *
    * @param {Int} baseRevNum Revision number for the caret information which
    *   will form the basis for the result. If `baseRevNum` is the current
    *   revision number, this method will block until a new revision is
    *   available.
-   * @returns {CaretDelta} Delta from the base caret revision to a newer one.
+   * @returns {CaretChange} Change from the base caret revision to a newer one.
    */
   async deltaAfter(baseRevNum) {
     const oldSnapshot = await this.snapshot(baseRevNum);

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -57,8 +57,8 @@ export default class DocSession {
   }
 
   /**
-   * Returns a promise for a snapshot of any revision after the given
-   * `baseRevNum`. See the equivalent `BodyControl` method for details.
+   * Gets a change of the document body from the indicated base revision. See
+   * {@link BodyControl#deltaAfter} for details.
    *
    * @param {Int} baseRevNum Revision number for the document.
    * @returns {BodyChange} Delta and associated information.
@@ -68,8 +68,8 @@ export default class DocSession {
   }
 
   /**
-   * Returns a snapshot of the full document contents. See the equivalent
-   * `BodyControl` method for details.
+   * Returns a snapshot of the full document contents. See
+   * {@link BodyControl#snapshot} for details.
    *
    * @param {Int|null} [revNum = null] Which revision to get. If passed as
    *   `null`, indicates the latest (most recent) revision.
@@ -81,8 +81,8 @@ export default class DocSession {
 
   /**
    * Applies an update to the body, assigning authorship of the change to the
-   * author represented by this instance. See the equivalent `BodyControl`
-   * method for details.
+   * author represented by this instance. See {@link BodyControl#update} for
+   * details.
    *
    * @param {number} baseRevNum Revision number which `delta` is with respect
    *   to.
@@ -96,7 +96,7 @@ export default class DocSession {
   }
 
   /**
-   * Gets a delta of caret information from the indicated base caret revision.
+   * Gets a change of caret information from the indicated base caret revision.
    * This will throw an error if the indicated caret revision isn't available,
    * in which case the client will likely want to use `caret_snapshot()` to get
    * back in synch.

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -58,13 +58,13 @@ export default class DocSession {
 
   /**
    * Gets a change of the document body from the indicated base revision. See
-   * {@link BodyControl#deltaAfter} for details.
+   * {@link BodyControl#getChangeAfter} for details.
    *
    * @param {Int} baseRevNum Revision number for the document.
    * @returns {BodyChange} Delta and associated information.
    */
-  async body_deltaAfter(baseRevNum) {
-    return this._bodyControl.deltaAfter(baseRevNum);
+  async body_getChangeAfter(baseRevNum) {
+    return this._bodyControl.getChangeAfter(baseRevNum);
   }
 
   /**
@@ -117,8 +117,8 @@ export default class DocSession {
    *   Applying this result to a `CaretSnapshot` for `baseRevNum` will produce
    *  an up-to-date snapshot.
    */
-  async caret_deltaAfter(baseRevNum) {
-    return this._caretControl.deltaAfter(baseRevNum);
+  async caret_getChangeAfter(baseRevNum) {
+    return this._caretControl.getChangeAfter(baseRevNum);
   }
 
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.27.0
+version = 0.27.1


### PR DESCRIPTION
Similar to my last PR, this one reworks the caret classes to operate like the body and property ones, in terms of the set of classes and their semantics. Notably:

* There's a new class `CaretChange` which holds full change info (including a revision number).
* `CaretDelta` is now just the content delta (with no associated revision number).
* `CaretSnapshot.compose()` now accepts a change (not a delta).
* `CaretSnapshot.diff()` produces a change (not a delta).