### PR TITLE
Consistent snapshot construction.

### DIFF
--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -46,7 +46,7 @@ export default class CaretOp extends CommonBase {
    * @returns {CaretOp} The corresponding operation.
    */
   static op_endSession(sessionId) {
-    TString.check(sessionId);
+    TString.nonEmpty(sessionId);
 
     return new CaretOp(new Functor(CaretOp.END_SESSION, sessionId));
   }
@@ -61,7 +61,7 @@ export default class CaretOp extends CommonBase {
    * @returns {CaretOp} The corresponding operation.
    */
   static op_setField(sessionId, key, value) {
-    TString.check(sessionId);
+    TString.nonEmpty(sessionId);
     Caret.checkField(key, value);
 
     return new CaretOp(new Functor(CaretOp.SET_FIELD, sessionId, key, value));
@@ -111,11 +111,6 @@ export default class CaretOp extends CommonBase {
       case CaretOp.SET_FIELD: {
         const [sessionId, key, value] = payload.args;
         return Object.freeze({ opName, sessionId, key, value });
-      }
-
-      case CaretOp.SET_REV_NUM: {
-        const [revNum] = payload.args;
-        return Object.freeze({ opName, revNum });
       }
 
       default: {

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -6,7 +6,6 @@ import { TString } from 'typecheck';
 import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
 
 import Caret from './Caret';
-import RevisionNumber from './RevisionNumber';
 
 /**
  * Operation which can be applied to a `Caret` or `CaretSnapshot`.
@@ -25,11 +24,6 @@ export default class CaretOp extends CommonBase {
   /** {string} Operation name for "set field" operations. */
   static get SET_FIELD() {
     return 'set_field';
-  }
-
-  /** {string} Operation name for "set revision number" operations. */
-  static get SET_REV_NUM() {
-    return 'set_rev_num';
   }
 
   /**
@@ -71,18 +65,6 @@ export default class CaretOp extends CommonBase {
     Caret.checkField(key, value);
 
     return new CaretOp(new Functor(CaretOp.SET_FIELD, sessionId, key, value));
-  }
-
-  /**
-   * Constructs a new "set revision number" operation.
-   *
-   * @param {Int} revNum The new revision number.
-   * @returns {CaretOp} The corresponding operation.
-   */
-  static op_setRevNum(revNum) {
-    RevisionNumber.check(revNum);
-
-    return new CaretOp(new Functor(CaretOp.SET_REV_NUM, revNum));
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
-import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
+import { CommonBase, Errors, Functor } from 'util-common';
 
 import Caret from './Caret';
 
@@ -133,21 +133,7 @@ export default class CaretOp extends CommonBase {
       return false;
     }
 
-    const p1 = this._payload;
-    const p2 = other._payload;
-
-    // **TODO:** This should just be `Functor.equals()`, except that method
-    // needs to be able to use `equals()` on elements.
-
-    if (p1.name !== p2.name) {
-      return false;
-    }
-
-    if (DataUtil.equalData(p1.args, p2.args)) {
-      return true;
-    }
-
-    return (p1.name === CaretOp.BEGIN_SESSION) && p1.args[0].equals(p2.args[0]);
+    return this._payload.equals(other._payload);
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
-import { CommonBase, Errors, Functor } from 'util-common';
+import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
 
 import Caret from './Caret';
 import RevisionNumber from './RevisionNumber';
@@ -140,6 +140,37 @@ export default class CaretOp extends CommonBase {
         throw Errors.wtf(`Weird operation name: ${opName}`);
       }
     }
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality of content.
+   *
+   * @param {*} other Value to compare to.
+   * @returns {boolean} `true` iff `other` is also an instance of this class,
+   *   and `this` and `other` have equal contents.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    } else if (!(other instanceof CaretOp)) {
+      return false;
+    }
+
+    const p1 = this._payload;
+    const p2 = other._payload;
+
+    // **TODO:** This should just be `Functor.equals()`, except that method
+    // needs to be able to use `equals()` on elements.
+
+    if (p1.name !== p2.name) {
+      return false;
+    }
+
+    if (DataUtil.equalData(p1.args, p2.args)) {
+      return true;
+    }
+
+    return (p1.name === CaretOp.BEGIN_SESSION) && p1.args[0].equals(p2.args[0]);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -45,7 +45,8 @@ export default class CaretSnapshot extends CommonBase {
   constructor(revNum, delta) {
     RevisionNumber.check(revNum);
 
-    if (Array.isArray(delta)) {
+    if (   Array.isArray(delta)
+        && ((delta.length === 0) || (delta[0] instanceof CaretOp))) {
       delta = new CaretDelta(delta);
     } else if (delta[Symbol.iterator]) {
       // FIXME: Remove this clause after conversion of call sites.

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -43,25 +43,18 @@ export default class CaretSnapshot extends CommonBase {
    *   include in the instance.
    */
   constructor(revNum, delta) {
-    RevisionNumber.check(revNum);
-
-    if (   Array.isArray(delta)
-        && ((delta.length === 0) || (delta[0] instanceof CaretOp))) {
+    if (Array.isArray(delta)) {
+      // Convert the given array into a proper delta instance. (This does type
+      // checking of the argument.)
       delta = new CaretDelta(delta);
-    } else if (delta[Symbol.iterator]) {
-      // FIXME: Remove this clause after conversion of call sites.
-      TIterable.check(delta);
-      const ops = [];
-      for (const caret of delta) {
-        ops.push(CaretOp.op_beginSession(caret));
-      }
-      delta = new CaretDelta(ops);
+    } else {
+      CaretDelta.check(delta);
     }
 
     super();
 
     /** {Int} The caret information revision number. */
-    this._revNum = revNum;
+    this._revNum = RevisionNumber.check(revNum);
 
     /**
      * {Map<string, CaretOp>} Map of session ID to an `op_beginSession` which

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TIterable, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import Caret from './Caret';

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -107,11 +107,7 @@ export default class PropertyOp extends CommonBase {
       return false;
     }
 
-    const p1 = this._payload;
-    const p2 = other._payload;
-
-    return (p1.name === p2.name)
-      && DataUtil.equalData(p1.args, p2.args);
+    return this._payload.equals(other._payload);
   }
 
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -59,7 +59,7 @@ export default class PropertySnapshot extends CommonBase {
      */
     this._properties = new Map();
 
-    // Fill in the instance variables.
+    // Fill in `_properties`.
     for (const op of delta.ops) {
       const opProps = op.props;
 

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -46,6 +46,8 @@ export default class PropertySnapshot extends CommonBase {
       // Convert the given array into a proper delta instance. (This does type
       // checking of the argument.)
       delta = new PropertyDelta(delta);
+    } else {
+      PropertyDelta.check(delta);
     }
 
     super();

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -57,7 +57,7 @@ export default class PropertySnapshot extends CommonBase {
 
     /**
      * {Map<string, PropertyOp>} Map of name to corresponding property, in the
-     * form of a "set property" instance.
+     * form of an `op_setProperty`.
      */
     this._properties = new Map();
 
@@ -92,7 +92,7 @@ export default class PropertySnapshot extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
-    return [PropertySnapshot.EMPTY.diff(this)];
+    return [this._revNum, [...this._properties.values()]];
   }
 
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -8,6 +8,7 @@ import { CommonBase, Errors } from 'util-common';
 import PropertyChange from './PropertyChange';
 import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
+import RevisionNumber from './RevisionNumber';
 
 /**
  * {PropertySnapshot|null} Empty instance. Initialized in the `EMPTY` property
@@ -26,7 +27,7 @@ export default class PropertySnapshot extends CommonBase {
    */
   static get EMPTY() {
     if (EMPTY === null) {
-      EMPTY = new PropertySnapshot([]);
+      EMPTY = new PropertySnapshot(0, []);
     }
 
     return EMPTY;
@@ -35,22 +36,22 @@ export default class PropertySnapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {PropertyChange|array<PropertyOp>} change A from-empty change or
-   *   array of ops representing all the properties and the current revision
-   *   number. In the case of an array, the instance will have a revision number
-   *   of `0`.
+   * @param {Int} revNum Revision number of the caret information.
+   * @param {PropertyDelta|array<PropertyOp>} delta A from-empty delta (or
+   *   array of ops which can be used to construct same), representing all the
+   *   properties to include in the instance.
    */
-  constructor(change) {
-    if (Array.isArray(change)) {
-      // Convert the given array into a proper change instance. (This does type
+  constructor(revNum, delta) {
+    if (Array.isArray(delta)) {
+      // Convert the given array into a proper delta instance. (This does type
       // checking of the argument.)
-      change = new PropertyChange(0, change);
+      delta = new PropertyDelta(delta);
     }
 
     super();
 
     /** {Int} The property information revision number. */
-    this._revNum = change.revNum;
+    this._revNum = RevisionNumber.check(revNum);
 
     /**
      * {Map<string, PropertyOp>} Map of name to corresponding property, in the
@@ -59,7 +60,7 @@ export default class PropertySnapshot extends CommonBase {
     this._properties = new Map();
 
     // Fill in the instance variables.
-    for (const op of change.delta.ops) {
+    for (const op of delta.ops) {
       const opProps = op.props;
 
       switch (opProps.opName) {
@@ -145,8 +146,7 @@ export default class PropertySnapshot extends CommonBase {
       }
     }
 
-    return new PropertySnapshot(
-      new PropertyChange(change.revNum, [...newProps.values()]));
+    return new PropertySnapshot(change.revNum, [...newProps.values()]);
   }
 
   /**

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -51,8 +51,6 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       test([]);
-      test([]);
-      test([PropertyOp.op_setProperty('x', 'y')]);
       test([PropertyOp.op_setProperty('x', 'y')]);
       test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_setProperty('z', 'pdq')]);
     });

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -4,6 +4,7 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
+import { inspect } from 'util';
 
 import { PropertyChange, PropertyDelta, PropertyOp, PropertySnapshot } from 'doc-common';
 import { DataUtil, Functor } from 'util-common';
@@ -21,7 +22,7 @@ describe('doc-common/PropertySnapshot', () => {
   describe('constructor()', () => {
     it('should accept an array of valid ops', () => {
       function test(value) {
-        new PropertySnapshot(value);
+        new PropertySnapshot(0, value);
       }
 
       test([]);
@@ -32,22 +33,32 @@ describe('doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should accept a valid change', () => {
-      function test(revNum, ops) {
-        const change = new PropertyChange(revNum, ops);
-        new PropertySnapshot(change);
+    it('should accept valid revision numbers', () => {
+      function test(value) {
+        new PropertySnapshot(value, PropertyDelta.EMPTY);
       }
 
-      test(0,   []);
-      test(123, []);
-      test(0,   [PropertyOp.op_setProperty('x', 'y')]);
-      test(123, [PropertyOp.op_setProperty('x', 'y')]);
-      test(37,  [PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_setProperty('z', 'pdq')]);
+      test(0);
+      test(1);
+      test(999999);
+    });
+
+    it('should accept a valid delta', () => {
+      function test(ops) {
+        const delta = new PropertyDelta(ops);
+        new PropertySnapshot(0, delta);
+      }
+
+      test([]);
+      test([]);
+      test([PropertyOp.op_setProperty('x', 'y')]);
+      test([PropertyOp.op_setProperty('x', 'y')]);
+      test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_setProperty('z', 'pdq')]);
     });
 
     it('should reject an array that is not all valid ops', () => {
       function test(value) {
-        assert.throws(() => { new PropertySnapshot(value); });
+        assert.throws(() => { new PropertySnapshot(0, value); });
       }
 
       test([1]);
@@ -62,15 +73,30 @@ describe('doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should reject a change with disallowed ops', () => {
+    it('should reject a delta with disallowed ops', () => {
       function test(ops) {
-        const change = new PropertyChange(0, ops);
-        assert.throws(() => { new PropertySnapshot(change); });
+        const delta = new PropertyDelta(ops);
+        assert.throws(() => { new PropertySnapshot(0, delta); });
       }
 
       // Deletes aren't allowed.
       test([PropertyOp.op_deleteProperty('x')]);
       test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_deleteProperty('x')]);
+    });
+
+    it('should reject invalid revision numbers', () => {
+      function test(value) {
+        assert.throws(() => { new PropertySnapshot(value, PropertyDelta.EMPTY); });
+      }
+
+      test(-1);
+      test(1.5);
+      test(null);
+      test(false);
+      test(undefined);
+      test([]);
+      test([789]);
+      test({ a: 10 });
     });
   });
 
@@ -86,17 +112,16 @@ describe('doc-common/PropertySnapshot', () => {
 
       test(PropertySnapshot.EMPTY);
 
-      test(new PropertySnapshot(new PropertyChange(123, PropertyDelta.EMPTY)));
-      test(new PropertySnapshot(new PropertyChange(0,   [PropertyOp.op_setProperty('foo', 'bar')])));
-      test(new PropertySnapshot(new PropertyChange(37,  [PropertyOp.op_setProperty('foo', 'bar')])));
-      test(new PropertySnapshot(
-        new PropertyChange(37,
-          [PropertyOp.op_setProperty('foo', 'bar'), PropertyOp.op_setProperty('baz', 914)])));
+      test(new PropertySnapshot(123, PropertyDelta.EMPTY));
+      test(new PropertySnapshot(0,   [PropertyOp.op_setProperty('foo', 'bar')]));
+      test(new PropertySnapshot(37,  [PropertyOp.op_setProperty('foo', 'bar')]));
+      test(new PropertySnapshot(37,
+        [PropertyOp.op_setProperty('foo', 'bar'), PropertyOp.op_setProperty('baz', 914)]));
     });
 
     it('should update `revNum` given a change with a different `revNum`', () => {
-      const snap     = new PropertySnapshot(new PropertyChange(123, PropertyDelta.EMPTY));
-      const expected = new PropertySnapshot(new PropertyChange(456, PropertyDelta.EMPTY));
+      const snap     = new PropertySnapshot(123, PropertyDelta.EMPTY);
+      const expected = new PropertySnapshot(456, PropertyDelta.EMPTY);
       const result   = snap.compose(new PropertyChange(456, PropertyDelta.EMPTY));
 
       assert.strictEqual(result.revNum, 456);
@@ -105,8 +130,8 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should add a new property given the appropriate op', () => {
       const op       = PropertyOp.op_setProperty('florp', 'like');
-      const snap     = new PropertySnapshot([]);
-      const expected = new PropertySnapshot([op]);
+      const snap     = new PropertySnapshot(0, []);
+      const expected = new PropertySnapshot(0, [op]);
       const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
@@ -116,8 +141,8 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should update a pre-existing property given an appropriate op', () => {
       const op       = PropertyOp.op_setProperty('florp', 'like');
-      const snap     = new PropertySnapshot([PropertyOp.op_setProperty('florp', 'unlike')]);
-      const expected = new PropertySnapshot([op]);
+      const snap     = new PropertySnapshot(0, [PropertyOp.op_setProperty('florp', 'unlike')]);
+      const expected = new PropertySnapshot(0, [op]);
       const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
@@ -126,7 +151,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should remove a property given the appropriate op', () => {
-      const snap   = new PropertySnapshot([PropertyOp.op_setProperty('florp', 'like')]);
+      const snap   = new PropertySnapshot(0, [PropertyOp.op_setProperty('florp', 'like')]);
       const change = new PropertyChange(0, [PropertyOp.op_deleteProperty('florp')]);
       const result = snap.compose(change);
 
@@ -137,8 +162,8 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('diff()', () => {
     it('should produce an empty diff when passed itself', () => {
-      const snap = new PropertySnapshot(new PropertyChange(914,
-        [PropertyOp.op_setProperty('a', 10), PropertyOp.op_setProperty('b', 20)]));
+      const snap = new PropertySnapshot(914,
+        [PropertyOp.op_setProperty('a', 10), PropertyOp.op_setProperty('b', 20)]);
       const result = snap.diff(snap);
 
       assert.instanceOf(result, PropertyChange);
@@ -147,25 +172,23 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should result in a `revNum` diff if that in fact changes', () => {
-      const snap1 = new PropertySnapshot(
-        new PropertyChange(123, [PropertyOp.op_setProperty('a', 10)]));
-      const snap2 = new PropertySnapshot(
-        new PropertyChange(456, [PropertyOp.op_setProperty('a', 10)]));
+      const snap1 = new PropertySnapshot(123, [PropertyOp.op_setProperty('a', 10)]);
+      const snap2 = new PropertySnapshot(456, [PropertyOp.op_setProperty('a', 10)]);
       const result = snap1.diff(snap2);
 
-      const composed = new PropertySnapshot([]).compose(result);
-      const expected = new PropertySnapshot(new PropertyChange(456, PropertyDelta.EMPTY));
+      const composed = new PropertySnapshot(0, []).compose(result);
+      const expected = new PropertySnapshot(456, PropertyDelta.EMPTY);
       assert.strictEqual(composed.revNum, 456);
       assert.isTrue(composed.equals(expected));
     });
 
     it('should result in a property removal if that in fact happens', () => {
-      const snap1 = new PropertySnapshot([
+      const snap1 = new PropertySnapshot(0, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('c', 30)
       ]);
-      const snap2 = new PropertySnapshot([
+      const snap2 = new PropertySnapshot(0, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('c', 30)
       ]);
@@ -178,53 +201,49 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('equals()', () => {
     it('should return `true` when passed itself', () => {
-      let snap;
+      function test(...args) {
+        const snap = new PropertySnapshot(...args);
+        assert.isTrue(snap.equals(snap), inspect(snap));
+      }
 
-      snap = PropertySnapshot.EMPTY;
-      assert.isTrue(snap.equals(snap));
-
-      snap = new PropertySnapshot(new PropertyChange(37, PropertyDelta.EMPTY));
-      assert.isTrue(snap.equals(snap));
-
-      snap = new PropertySnapshot([
+      test(0, []);
+      test(0, PropertyDelta.EMPTY);
+      test(37, []);
+      test(37, PropertyDelta.EMPTY);
+      test(914, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('c', 30)
       ]);
-      assert.isTrue(snap.equals(snap));
     });
 
     it('should return `true` when passed an identically-constructed value', () => {
-      let snap1, snap2;
+      function test(...args) {
+        const snap1 = new PropertySnapshot(...args);
+        const snap2 = new PropertySnapshot(...args);
+        const label = inspect(snap1);
+        assert.isTrue(snap1.equals(snap2), label);
+        assert.isTrue(snap2.equals(snap1), label);
+      }
 
-      snap1 = PropertySnapshot.EMPTY;
-      snap2 = new PropertySnapshot([]);
-      assert.isTrue(snap1.equals(snap2));
-
-      snap1 = new PropertySnapshot(new PropertyChange(37, PropertyDelta.EMPTY));
-      snap2 = new PropertySnapshot(new PropertyChange(37, PropertyDelta.EMPTY));
-      assert.isTrue(snap1.equals(snap2));
-
-      snap1 = new PropertySnapshot([
+      test(0, []);
+      test(0, PropertyDelta.EMPTY);
+      test(37, []);
+      test(37, PropertyDelta.EMPTY);
+      test(914, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('c', 30)
       ]);
-      snap2 = new PropertySnapshot([
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
-      ]);
-      assert.isTrue(snap1.equals(snap2));
     });
 
     it('should return `true` when identical construction ops are passed in different orders', () => {
-      const snap1 = new PropertySnapshot([
+      const snap1 = new PropertySnapshot(321, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('c', 30)
       ]);
-      const snap2 = new PropertySnapshot([
+      const snap2 = new PropertySnapshot(321, [
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('c', 30),
@@ -234,36 +253,36 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return `true` when equal property values are not also `===`', () => {
-      const snap1 = new PropertySnapshot([
+      const snap1 = new PropertySnapshot(37, [
         PropertyOp.op_setProperty('a', [1, 2]),
         PropertyOp.op_setProperty('b', { b: 20 }),
         PropertyOp.op_setProperty('c', new Functor('x', [1, 2, 3]))
       ]);
-      const snap2 = new PropertySnapshot([
+      const snap2 = new PropertySnapshot(37, [
         PropertyOp.op_setProperty('a', [1, 2]),
         PropertyOp.op_setProperty('b', { b: 20 }),
         PropertyOp.op_setProperty('c', new Functor('x', [1, 2, 3]))
       ]);
 
       assert.isTrue(snap1.equals(snap2));
+      assert.isTrue(snap2.equals(snap1));
     });
 
     it('should return `false` when `revNum`s differ', () => {
-      const snap1 = new PropertySnapshot(
-        new PropertyChange(123, [PropertyOp.op_setProperty('a', 10)]));
-      const snap2 = new PropertySnapshot(
-        new PropertyChange(456, [PropertyOp.op_setProperty('a', 10)]));
+      const snap1 = new PropertySnapshot(123, [PropertyOp.op_setProperty('a', 10)]);
+      const snap2 = new PropertySnapshot(456, [PropertyOp.op_setProperty('a', 10)]);
 
       assert.isFalse(snap1.equals(snap2));
+      assert.isFalse(snap2.equals(snap1));
     });
 
     it('should return `false` when a property value differs', () => {
-      const snap1 = new PropertySnapshot([
+      const snap1 = new PropertySnapshot(9, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 20),
         PropertyOp.op_setProperty('c', 30)
       ]);
-      const snap2 = new PropertySnapshot([
+      const snap2 = new PropertySnapshot(9, [
         PropertyOp.op_setProperty('a', 10),
         PropertyOp.op_setProperty('b', 22222),
         PropertyOp.op_setProperty('c', 30)
@@ -288,14 +307,14 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('get()', () => {
     it('should return the value associated with an existing property', () => {
-      const snap = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
 
       assert.strictEqual(snap.get('blort'), 'zorch');
     });
 
     it('should always return a deep-frozen value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
-      const snap = new PropertySnapshot([PropertyOp.op_setProperty('blort', value)]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', value)]);
 
       const result = snap.get('blort');
       assert.isTrue(DataUtil.isDeepFrozen(result));
@@ -303,7 +322,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should throw an error when given a name that is not bound as a property', () => {
-      const snap = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
 
       assert.throws(() => { snap.get('x'); });
     });
@@ -311,7 +330,7 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('has()', () => {
     it('should return `true` for an existing property', () => {
-      const snap = new PropertySnapshot([
+      const snap = new PropertySnapshot(1, [
         PropertyOp.op_setProperty('blort', 'zorch'),
         PropertyOp.op_setProperty('florp', 'like')
       ]);
@@ -321,7 +340,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return `false` for a non-existent property', () => {
-      const snap = new PropertySnapshot([
+      const snap = new PropertySnapshot(1, [
         PropertyOp.op_setProperty('blort', 'zorch'),
         PropertyOp.op_setProperty('florp', 'like')
       ]);
@@ -353,14 +372,14 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('withProperty()', () => {
     it('should return `this` if the exact property is already in the snapshot', () => {
-      const snap = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
 
       assert.strictEqual(snap.withProperty('blort', 'zorch'), snap);
     });
 
     it('should return an appropriately-constructed instance given a new property', () => {
-      const snap     = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
-      const expected = new PropertySnapshot([
+      const snap     = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const expected = new PropertySnapshot(1, [
         PropertyOp.op_setProperty('blort', 'zorch'),
         PropertyOp.op_setProperty('florp', 'like')
       ]);
@@ -369,8 +388,8 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given an updated property', () => {
-      const snap     = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
-      const expected = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'like')]);
+      const snap     = new PropertySnapshot(2, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const expected = new PropertySnapshot(2, [PropertyOp.op_setProperty('blort', 'like')]);
 
       assert.isTrue(snap.withProperty('blort', 'like').equals(expected));
     });
@@ -378,15 +397,15 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('withRevNum()', () => {
     it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
-      const snap = new PropertySnapshot(new PropertyChange(123, PropertyDelta.EMPTY));
+      const snap = new PropertySnapshot(123, PropertyDelta.EMPTY);
 
       assert.strictEqual(snap.withRevNum(123), snap);
     });
 
     it('should return an appropriately-constructed instance given a different `revNum`', () => {
       const delta    = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
-      const snap     = new PropertySnapshot(new PropertyChange(123, delta));
-      const expected = new PropertySnapshot(new PropertyChange(456, delta));
+      const snap     = new PropertySnapshot(123, delta);
+      const expected = new PropertySnapshot(456, delta);
 
       assert.deepEqual(snap.withRevNum(456), expected);
     });
@@ -394,18 +413,18 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('withoutProperty()', () => {
     it('should return `this` if there is no matching property', () => {
-      const snap = new PropertySnapshot([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
 
       assert.strictEqual(snap.withoutProperty('x'), snap);
       assert.strictEqual(snap.withoutProperty('y'), snap);
     });
 
     it('should return an appropriately-constructed instance if there is a matching property', () => {
-      const snap = new PropertySnapshot([
+      const snap = new PropertySnapshot(2, [
         PropertyOp.op_setProperty('blort', 'zorch'),
         PropertyOp.op_setProperty('florp', 'like')
       ]);
-      const expected = new PropertySnapshot([
+      const expected = new PropertySnapshot(2, [
         PropertyOp.op_setProperty('florp', 'like')
       ]);
 

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -16,6 +16,7 @@ describe('doc-common/PropertySnapshot', () => {
 
       assert.strictEqual(EMPTY.revNum, 0);
       assert.strictEqual(EMPTY.properties.size, 0);
+      assert.isFrozen(EMPTY);
     });
   });
 
@@ -54,6 +55,11 @@ describe('doc-common/PropertySnapshot', () => {
       test([PropertyOp.op_setProperty('x', 'y')]);
       test([PropertyOp.op_setProperty('x', 'y')]);
       test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_setProperty('z', 'pdq')]);
+    });
+
+    it('should produce a frozen instance', () => {
+      const snap = new PropertySnapshot(0, [PropertyOp.op_setProperty('x', 'y')]);
+      assert.isFrozen(snap);
     });
 
     it('should reject an array that is not all valid ops', () => {

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -251,7 +251,7 @@ export default class BodyControl extends CommonBase {
 
     const contents = (base === null)
       ? this._composeRevisions(BodyDelta.EMPTY, 0,               revNum + 1)
-      : this._composeRevisions(base.contents,     base.revNum + 1, revNum + 1);
+      : this._composeRevisions(base.contents,   base.revNum + 1, revNum + 1);
     const result = new BodySnapshot(revNum, await contents);
 
     this._log.detail('Made snapshot for revision:', revNum);

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -294,7 +294,7 @@ export default class BodyControl extends CommonBase {
     // Snapshot of the base revision. This call validates `baseRevNum`.
     const base = await this.snapshot(baseRevNum);
 
-    // Check for an empty `ops`. If it is, we don't bother trying to apply it.
+    // Check for an empty `delta`. If it is, we don't bother trying to apply it.
     // See method header comment for more info.
     if (delta.isEmpty()) {
       return new BodyChange(baseRevNum, BodyDelta.EMPTY);

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -5,6 +5,7 @@
 import { inspect } from 'util';
 
 import CoreTypecheck from './CoreTypecheck';
+import DataUtil from './DataUtil';
 
 /**
  * Functor data value. A "functor," generally speaking, is a thing that looks
@@ -115,7 +116,8 @@ export default class Functor {
    * only considered to be equal to other direct instances of this class. (This
    * class is not meant to be subclassed.) Given two instances of this class,
    * their names must be strictly equal, their argument array lengths must be
-   * the same, and corresponding arguments must be strictly equal.
+   * the same, and corresponding arguments must be either strictly equal or
+   * equal as defined by `DataUtil.equalData()`.
    *
    * @param {*} other Value to compare to.
    * @returns {boolean} `true` if `other` is equal to this instance, or `false`
@@ -137,7 +139,9 @@ export default class Functor {
     }
 
     for (let i = 0; i < thisArgs.length; i++) {
-      if (thisArgs[i] !== otherArgs[i]) {
+      const arg1 = thisArgs[i];
+      const arg2 = otherArgs[i];
+      if ((arg1 !== arg2) && !DataUtil.equalData(arg1, arg2)) {
         return false;
       }
     }

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -115,9 +115,16 @@ export default class Functor {
    * Compares this to another value for equality. Instances of this class are
    * only considered to be equal to other direct instances of this class. (This
    * class is not meant to be subclassed.) Given two instances of this class,
-   * their names must be strictly equal, their argument array lengths must be
-   * the same, and corresponding arguments must be either strictly equal or
-   * equal as defined by `DataUtil.equalData()`.
+   * in order to be considered equal, the following must hold:
+   *
+   * * Their names must be strictly equal.
+   * * Their argument array lengths must be the same.
+   * * Each pair of corresponding arguments must be equal, by one of the
+   *   following tests (performed in order):
+   *   * The arguments must be strictly equal.
+   *   * The arguments must be equal as defined by `DataUtil.equalData()`.
+   *   * The argument of this instance must define a `.equal()` method which
+   *     returns `true` when passed the argument of the other instance.
    *
    * @param {*} other Value to compare to.
    * @returns {boolean} `true` if `other` is equal to this instance, or `false`
@@ -142,7 +149,9 @@ export default class Functor {
       const arg1 = thisArgs[i];
       const arg2 = otherArgs[i];
       if ((arg1 !== arg2) && !DataUtil.equalData(arg1, arg2)) {
-        return false;
+        if ((typeof arg1.equals !== 'function') || !arg1.equals(arg2)) {
+          return false;
+        }
       }
     }
 

--- a/local-modules/util-core/tests/test_Functor.js
+++ b/local-modules/util-core/tests/test_Functor.js
@@ -99,10 +99,26 @@ describe('util-core/Functor', () => {
       assert.isTrue(ftor.equals(ftor));
     });
 
-    it('should return `true` when compared to a samely-constructed instance', () => {
-      const arrayArg = ['a', 'b'];
-      const ftor1 = new Functor('blort', 10, arrayArg);
-      const ftor2 = new Functor('blort', 10, arrayArg);
+    it('should return `true` when the name and all arguments are `===`', () => {
+      function test(...args) {
+        const ftor1 = new Functor('blort', ...args);
+        const ftor2 = new Functor('blort', ...args);
+        assert.isTrue(ftor1.equals(ftor2));
+      }
+
+      test();
+      test(1);
+      test('x', true, undefined);
+      test([]);
+      test([1, 2, 3]);
+      test({ a: 10, b: 20 }, 'foo');
+      test(/florp/);
+      test(new Set(['x', 'y']));
+    });
+
+    it('should return `true` when the name is `===` and all arguments are `equalData()`', () => {
+      const ftor1 = new Functor('blort', 10, ['x', ['y']], { a: 123 }, new Functor('z'));
+      const ftor2 = new Functor('blort', 10, ['x', ['y']], { a: 123 }, new Functor('z'));
       assert.isTrue(ftor1.equals(ftor2));
     });
 
@@ -119,9 +135,9 @@ describe('util-core/Functor', () => {
       assert.isFalse(ftor2.equals(ftor1));
     });
 
-    it('should return `false` when an argument is not strict-equal', () => {
-      const ftor1 = new Functor('blort', 10, ['a']);
-      const ftor2 = new Functor('blort', 10, ['a']);
+    it('should return `false` when an argument is not `===` or `equalData()`', () => {
+      const ftor1 = new Functor('blort', 10, new Set(['a', 'b']));
+      const ftor2 = new Functor('blort', 10, new Set(['a', 'b']));
       assert.isFalse(ftor1.equals(ftor2));
     });
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.27.1
+version = 0.27.2


### PR DESCRIPTION
The main point of this PR is to make snapshot construction be isomorphic between all three OT classes. They now all take a pair of arguments `(revNum, delta)`. In service of that end goal, I also did the following:

* Reworked the `CaretSnapshot` innards to use `CaretOp` instances instead of plain `Caret`s as what it stores in its internal map. This makes a few methods more straightforward and also makes the code a bit more parallel with `PropertySnapshot`.
* Expanded `Functor.equals()` so that it covered a couple additional cases that help simplify other code. In particular, it now knows how to check structured data for equality (not just `===`ity) and will call through to an object's `.equals()` method (if defined) as a last resort.