### PR TITLE
Clean up `BodyDelta`.

### DIFF
--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -30,32 +30,6 @@ export default class BodyDelta extends Delta {
   }
 
   /**
-   * Returns `true` iff the given delta or delta-like value is empty. This
-   * accepts the same set of values as `coerce()`, see which. Anything else is
-   * considered to be an error, except that when not given a `Delta` per se the
-   * array contents (if any) are not inspected for validity.
-   *
-   * **Note:** This is a static method exactly because it accepts things other
-   * than instances of `BodyDelta` per se.
-   *
-   * @param {object|array|null|undefined} delta The delta or delta-like value.
-   * @returns {boolean} `true` if `delta` is empty or `false` if not.
-   */
-  static isEmpty(delta) {
-    if (delta instanceof Delta) {
-      return (delta.ops.length === 0);
-    } else if ((delta === null) || (delta === undefined)) {
-      return true;
-    } else if (Array.isArray(delta)) {
-      return delta.length === 0;
-    } else if ((typeof delta === 'object') && Array.isArray(delta.ops)) {
-      return delta.ops.length === 0;
-    }
-
-    throw Errors.bad_value(delta, BodyDelta);
-  }
-
-  /**
    * Main coercion implementation, per the superclass documentation. In this
    * case, the following is how it proceeds:
    *
@@ -113,15 +87,6 @@ export default class BodyDelta extends Delta {
   }
 
   /**
-   * Converts this instance for API transmission.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toApi() {
-    return [this.ops];
-  }
-
-  /**
    * Returns `true` iff this instance has the form of a "document." In Quill
    * terms, a "document" is a delta that consists _only_ of `insert` operations.
    *
@@ -145,6 +110,15 @@ export default class BodyDelta extends Delta {
    */
   isEmpty() {
     return this.ops.length === 0;
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this.ops];
   }
 }
 

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -85,14 +85,13 @@ export default class BodyDelta extends Delta {
   static _impl_coerce(value) {
     // Note: The base class implementation guarantees that we won't get called
     // on an instance of this class.
-    if (BodyDelta.isEmpty(value)) {
+    if ((value === null) || (value === undefined)) {
       return BodyDelta.EMPTY;
-    } else if (value instanceof Delta) {
-      return new BodyDelta(value.ops);
     } else if (Array.isArray(value)) {
-      return new BodyDelta(value);
-    } else if (Array.isArray(value.ops)) {
-      return new BodyDelta(value.ops);
+      return (value.length === 0) ? BodyDelta.EMPTY : new BodyDelta(value);
+    } else if ((value instanceof Delta) || Array.isArray(value.ops)) {
+      const ops = value.ops;
+      return (ops.length === 0) ? BodyDelta.EMPTY : new BodyDelta(ops);
     }
 
     throw Errors.bad_value(value, BodyDelta);

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -34,63 +34,55 @@ describe('doc-common/BodyDelta', () => {
     });
   });
 
-  describe('static isEmpty()', () => {
-    describe('valid empty values', () => {
+  describe('coerce()', () => {
+    describe('valid empty arguments', () => {
       const values = [
-        new Delta([]),
-        new BodyDelta([]),
-        BodyDelta.EMPTY,
         null,
         undefined,
         [],
+        new Delta([]),
         { ops: [] }
       ];
 
       for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(BodyDelta.isEmpty(v));
+        it(`should yield \`EMPTY\` for: ${inspect(v)}`, () => {
+          const result = BodyDelta.coerce(v);
+          assert.strictEqual(result, BodyDelta.EMPTY);
         });
       }
     });
 
-    describe('valid non-empty values', () => {
-      const ops1 = [{ insert: 'x' }];
-      const ops2 = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
-
+    describe('valid non-empty arguments', () => {
       const values = [
-        ops1,
-        { ops: ops1 },
-        new Delta(ops1),
-        new BodyDelta(ops1),
-        ops2,
-        { ops: ops2 },
-        new Delta(ops2),
-        new BodyDelta(ops2)
+        [{ insert: 'x' }],
+        [{ delete: 123 }],
+        [{ retain: 123 }],
+        [{ insert: 'x', attributes: { bold: true } }],
+        [{ insert: 'florp' }, { insert: 'x', attributes: { bold: true } }],
+        new Delta([{ insert: 'x' }]),
+        { ops: [{ retain: 123 }] }
       ];
 
       for (const v of values) {
-        it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(BodyDelta.isEmpty(v));
+        it(`should succeed for: ${inspect(v)}`, () => {
+          const result = BodyDelta.coerce(v);
+          assert.instanceOf(result, BodyDelta);
         });
       }
     });
 
-    describe('non-delta-like values', () => {
+    describe('invalid arguments', () => {
       const values = [
-        37,
-        true,
         false,
-        '',
-        'this better not work!',
-        {},
-        () => true,
-        /blort/,
-        Symbol.for('foo')
+        123,
+        'florp',
+        /xyz/,
+        new Map()
       ];
 
       for (const v of values) {
-        it(`should throw for: ${inspect(v)}`, () => {
-          assert.throws(() => { BodyDelta.isEmpty(v); });
+        it(`should fail for: ${inspect(v)}`, () => {
+          assert.throws(() => BodyDelta.coerce(v));
         });
       }
     });

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -103,7 +103,37 @@ describe('doc-common/BodyDelta', () => {
     });
   });
 
-  describe('isDocument(doc)', () => {
+  describe('isEmpty()', () => {
+    describe('valid empty values', () => {
+      const values = [
+        new BodyDelta([]),
+        BodyDelta.EMPTY,
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(v.isEmpty());
+        });
+      }
+    });
+
+    describe('valid non-empty values', () => {
+      const values = [
+        [{ insert: 'x' }],
+        [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }],
+        [{ retain: 100 }]
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${inspect(v)}`, () => {
+          const delta = new BodyDelta(v);
+          assert.isFalse(delta.isEmpty());
+        });
+      }
+    });
+  });
+
+  describe('isDocument()', () => {
     describe('`true` cases', () => {
       const values = [
         [],

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -57,11 +57,6 @@ describe('doc-common/BodyDelta', () => {
       const ops1 = [{ insert: 'x' }];
       const ops2 = [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }];
 
-      // This one is not a valid `ops` array, but per docs, `isEmpty()` doesn't
-      // inspect the contents of `ops` arrays and so using this value should
-      // succeed.
-      const invalidNonEmptyOps = [null, undefined, /blort/, 1, 2, 3];
-
       const values = [
         ops1,
         { ops: ops1 },
@@ -70,9 +65,7 @@ describe('doc-common/BodyDelta', () => {
         ops2,
         { ops: ops2 },
         new Delta(ops2),
-        new BodyDelta(ops2),
-        invalidNonEmptyOps,
-        { ops: invalidNonEmptyOps }
+        new BodyDelta(ops2)
       ];
 
       for (const v of values) {
@@ -98,6 +91,48 @@ describe('doc-common/BodyDelta', () => {
       for (const v of values) {
         it(`should throw for: ${inspect(v)}`, () => {
           assert.throws(() => { BodyDelta.isEmpty(v); });
+        });
+      }
+    });
+  });
+
+  describe('constructor()', () => {
+    describe('valid arguments', () => {
+      // This one is not a valid `ops` array, but per docs, the constructor
+      // doesn't inspect the contents of `ops` arrays and so using this value
+      // should succeed (for some values of the terms "should" and "succeed").
+      const invalidNonEmptyOps = [null, undefined, ['x'], { a: 10 }, 1, 2, 3];
+
+      const values = [
+        [],
+        [{ insert: 'x' }],
+        [{ delete: 123 }],
+        [{ retain: 123 }],
+        [{ insert: 'x', attributes: { bold: true } }],
+        [{ insert: 'florp' }, { insert: 'x', attributes: { bold: true } }],
+        invalidNonEmptyOps
+      ];
+
+      for (const v of values) {
+        it(`should succeed for: ${inspect(v)}`, () => {
+          new BodyDelta(v);
+        });
+      }
+    });
+
+    describe('invalid arguments', () => {
+      const values = [
+        null,
+        undefined,
+        123,
+        'florp',
+        { insert: 123 },
+        new Map()
+      ];
+
+      for (const v of values) {
+        it(`should fail for: ${inspect(v)}`, () => {
+          assert.throws(() => new BodyDelta(v));
         });
       }
     });

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -11,30 +11,30 @@ import { BodyDelta } from 'doc-common';
 
 describe('doc-common/BodyDelta', () => {
   describe('.EMPTY', () => {
-    const empty = BodyDelta.EMPTY;
+    const EMPTY = BodyDelta.EMPTY;
 
     it('should be an instance of `BodyDelta`', () => {
-      assert.instanceOf(empty, BodyDelta);
+      assert.instanceOf(EMPTY, BodyDelta);
     });
 
     it('should be a frozen object', () => {
-      assert.isFrozen(empty);
+      assert.isFrozen(EMPTY);
     });
 
     it('should have an empty `ops`', () => {
-      assert.strictEqual(empty.ops.length, 0);
+      assert.strictEqual(EMPTY.ops.length, 0);
     });
 
     it('should have a frozen `ops`', () => {
-      assert.isFrozen(empty.ops);
+      assert.isFrozen(EMPTY.ops);
     });
 
-    it('should be `BodyDelta.isEmpty()`', () => {
-      assert.isTrue(BodyDelta.isEmpty(empty));
+    it('should be `.isEmpty()`', () => {
+      assert.isTrue(EMPTY.isEmpty());
     });
   });
 
-  describe('isEmpty()', () => {
+  describe('static isEmpty()', () => {
     describe('valid empty values', () => {
       const values = [
         new Delta([]),
@@ -114,7 +114,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(BodyDelta.coerce(v).isDocument());
+          assert.isTrue(new BodyDelta(v).isDocument());
         });
       }
     });
@@ -122,6 +122,8 @@ describe('doc-common/BodyDelta', () => {
     describe('`false` cases', () => {
       const values = [
         [{ retain: 37 }],
+        [{ delete: 914 }],
+        [{ retain: 37, attributes: { bold: true } }],
         [{ insert: 'line 1' }, { retain: 9 }],
         [{ insert: 'line 1' }, { retain: 14 }, { insert: '\n' }],
         [{ insert: 'line 1' }, { insert: '\n' }, { retain: 23 }, { insert: 'line 2' }]
@@ -129,7 +131,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(BodyDelta.coerce(v).isDocument());
+          assert.isFalse(new BodyDelta(v).isDocument());
         });
       }
     });


### PR DESCRIPTION
This is a bit of "pre-factoring" work to make `BodyDelta` more like what we ultimately want `CaretDelta` and `PropertyDelta` to also look like.