### PR TITLE
I heard you liked to change changes.

### DIFF
--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -164,6 +164,52 @@ export default class BaseChange extends CommonBase {
   }
 
   /**
+   * Returns an instance just like this one except with the author set as given.
+   *
+   * @param {string} authorId The new author ID.
+   * @returns {BaseChange} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withAuthorId(authorId) {
+    return new this.constructor(this._revNum, this._delta, this._timestamp, authorId);
+  }
+
+  /**
+   * Returns an instance just like this one except with the delta set as given.
+   *
+   * @param {object} delta The new delta.
+   * @returns {BaseChange} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withDelta(delta) {
+    return new this.constructor(this._revNum, delta, this._timestamp, this._authorId);
+  }
+
+  /**
+   * Returns an instance just like this one except with the revision number set
+   * as given.
+   *
+   * @param {Int} revNum The new revision number.
+   * @returns {BaseChange} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withRevNum(revNum) {
+    return new this.constructor(revNum, this._delta, this._timestamp, this._authorId);
+  }
+
+  /**
+   * Returns an instance just like this one except with the timestamp set as
+   * given.
+   *
+   * @param {Timestamp} timestamp The new timestamp.
+   * @returns {BaseChange} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withTimestamp(timestamp) {
+    return new this.constructor(this._revNum, this._delta, timestamp, this._authorId);
+  }
+
+  /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class. Subclasses must be fill this in.
    *

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -38,6 +38,16 @@ const USECS_PER_SEC = 1000000;
  * of the year 2002 and a maximum around the start of the year 2050.
  */
 export default class Timestamp extends CommonBase {
+  /** {Timestamp} The maximum valid timestamp. */
+  static get MAX_VALUE() {
+    return new Timestamp(MAX_SECS - 1, USECS_PER_SEC - 1);
+  }
+
+  /** {Timestamp} The minimum valid timestamp. */
+  static get MIN_VALUE() {
+    return new Timestamp(MIN_SECS, 0);
+  }
+
   /**
    * Constructs an instance from a millisecond-granularity time value, such as
    * might have been returned from `Date.now()`.

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -47,7 +47,7 @@ describe('doc-common/BodyChange', () => {
       test(0,   new BodyDelta([{ retain: 100 }]));
       test(123, BodyDelta.EMPTY);
       test(909, new BodyDelta([{ insert: 'x' }]), null);
-      test(909, new BodyDelta([{ insert: 'x' }]), Timestamp.now());
+      test(909, new BodyDelta([{ insert: 'x' }]), Timestamp.MIN_VALUE);
       test(242, BodyDelta.EMPTY,                  null, null);
       test(242, BodyDelta.EMPTY,                  null, 'florp9019');
     });

--- a/local-modules/doc-common/tests/test_Timestamp.js
+++ b/local-modules/doc-common/tests/test_Timestamp.js
@@ -14,6 +14,34 @@ const SEC_2010_JAN_01 = Math.floor(new Date(2010, 1, 1, 0, 0, 0, 0).valueOf() / 
 const SEC_2040_JAN_01 = Math.floor(new Date(2040, 1, 1, 0, 0, 0, 0).valueOf() / 1000);
 
 describe('doc-common/Timestamp', () => {
+  describe('.MAX_VALUE', () => {
+    it('should be an instance of the class', () => {
+      assert.instanceOf(Timestamp.MAX_VALUE, Timestamp);
+    });
+
+    it('should be larger than `MIN_VALUE`', () => {
+      assert.strictEqual(Timestamp.MAX_VALUE.compareTo(Timestamp.MIN_VALUE), 1);
+    });
+
+    it('should have the largest allowed `usecs`', () => {
+      assert.strictEqual(Timestamp.MAX_VALUE.usecs, 999999);
+    });
+  });
+
+  describe('.MIN_VALUE', () => {
+    it('should be an instance of the class', () => {
+      assert.instanceOf(Timestamp.MIN_VALUE, Timestamp);
+    });
+
+    it('should be smaller than `MAX_VALUE`', () => {
+      assert.strictEqual(Timestamp.MIN_VALUE.compareTo(Timestamp.MAX_VALUE), -1);
+    });
+
+    it('should have `0` for `usecs`', () => {
+      assert.strictEqual(Timestamp.MIN_VALUE.usecs, 0);
+    });
+  });
+
   describe('check()', () => {
     it('should reject `null`', () => {
       assert.throws(() => Timestamp.check(null));


### PR DESCRIPTION
This PR adds a full complement of `with*()` methods to `BaseChange`.

**Bonus:** Expose the minimum and maximum allowed `Timestamp` values, mostly so that we don't have to use `Timestamp.now()` in tests (which is a somewhat fragile dependency).