### PR TITLE
Extract `BaseSnapshot`.

### DIFF
--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -64,11 +64,14 @@ export default class BaseChange extends CommonBase {
     // instance.
 
     if (!this._deltaClass) {
-      // Call the `_impl` and verify the result.
+      // Call the `_impl` and verify the result (via duck-typing, because there
+      // is no `BaseDelta` base class).
       const clazz = TFunction.checkClass(this._impl_deltaClass);
 
       TObject.check(clazz.EMPTY, clazz);
       TFunction.checkCallable(clazz.check);
+      TFunction.checkCallable(clazz.prototype.equals);
+      TFunction.checkCallable(clazz.prototype.isDocument);
       this._deltaClass = clazz;
     }
 

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -10,7 +10,8 @@ import RevisionNumber from './RevisionNumber';
 
 /**
  * Base class for snapshots of (parts of) documents. Every snapshot consists of
- * a revision number and a from-empty delta.
+ * a revision number and a from-empty delta. Instances of this class are always
+ * frozen.
  */
 export default class BaseSnapshot extends CommonBase {
   /**
@@ -60,6 +61,8 @@ export default class BaseSnapshot extends CommonBase {
   /**
    * Constructs an instance.
    *
+   * **Note:** Subclasses are responsible for freezing the constructed instance.
+   *
    * @param {RevisionNumber} revNum Revision number of the document.
    * @param {object|array} contents The document contents per se, in the form of
    *   a document delta (that is, a from-empty delta). This must be either an
@@ -86,8 +89,6 @@ export default class BaseSnapshot extends CommonBase {
     if (!this._contents.isDocument()) {
       throw Errors.bad_value(contents, this.constructor.deltaClass, 'document');
     }
-
-    Object.freeze(this);
   }
 
   /** {BaseDelta} The document contents as a from-empty delta. */
@@ -105,6 +106,8 @@ export default class BaseSnapshot extends CommonBase {
    * to be considered equal, they must be instances of the same exact class,
    * their revision numbers must be the same, and their contents must be
    * `.equals()`.
+   *
+   * Subclasses may override this method if this behavior isn't right for them.
    *
    * @param {*} other Instance to compare to.
    * @returns {boolean} `true` if `this` and `other` are equal, or `false` if

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -133,6 +133,36 @@ export default class BaseSnapshot extends CommonBase {
   }
 
   /**
+   * Returns an instance just like this one except with the content set as
+   * given. This will return `this` if `content` is strictly equal (`===`) to
+   * `this.content`.
+   *
+   * @param {object} contents The new contents.
+   * @returns {BaseSnapshot} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withContents(contents) {
+    return (contents === this._contents)
+      ? this
+      : new this.constructor(this._revNum, contents);
+  }
+
+  /**
+   * Returns an instance just like this one except with the revision number set
+   * as given. This will return `this` if `revNum` is the same as what this
+   * instance already has.
+   *
+   * @param {Int} revNum The new revision number.
+   * @returns {BaseSnapshot} An appropriately-constructed instance. This will be
+   *   a direct instance of the same class as `this`.
+   */
+  withRevNum(revNum) {
+    return (revNum === this._revNum)
+      ? this
+      : new this.constructor(revNum, this._contents);
+  }
+
+  /**
    * {class} Class (constructor function) of change objects to be used with
    * instances of this class. Subclasses must be fill this in.
    *

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -1,0 +1,141 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TObject } from 'typecheck';
+import { CommonBase, Errors } from 'util-common';
+
+import BaseChange from './BaseChange';
+import RevisionNumber from './RevisionNumber';
+
+/**
+ * Base class for snapshots of (parts of) documents. Every snapshot consists of
+ * a revision number and a from-empty delta.
+ */
+export default class BaseSnapshot extends CommonBase {
+  /**
+   * {BaseSnapshot} Empty instance of this class. It has an empty delta and
+   * revision number `0`.
+   */
+  static get EMPTY() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._EMPTY) {
+      this._EMPTY = new this(0, this.deltaClass.EMPTY);
+    }
+
+    return this._EMPTY;
+  }
+
+  /**
+   * {class} Class (constructor function) of change objects to be used with
+   * instances of this class.
+   */
+  static get changeClass() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._changeClass) {
+      // Call the `_impl` and verify the result.
+      const clazz = this._impl_changeClass;
+
+      TObject.check(clazz.prototype, BaseChange);
+      this._changeClass = clazz;
+    }
+
+    return this._changeClass;
+  }
+
+  /**
+   * {class} Class (constructor function) of delta objects to be used with
+   * instances of this class.
+   */
+  static get deltaClass() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+    return this.changeClass.deltaClass;
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {RevisionNumber} revNum Revision number of the document.
+   * @param {object|array} contents The document contents per se, in the form of
+   *   a document delta (that is, a from-empty delta). This must be either an
+   *   object of type `deltaClass` as defined by the subclass or an array which
+   *   can be passed to the `deltaClass` constructor to produce a valid delta.
+   */
+  constructor(revNum, contents) {
+    super();
+
+    /** {Int} Revision number. */
+    this._revNum = RevisionNumber.check(revNum);
+
+    /** {object} Document contents. */
+    this._contents = Array.isArray(contents)
+      ? new this.constructor.deltaClass(contents)
+      : this.constructor.deltaClass.check(contents);
+
+    // Explicitly check that the `contents` delta has the form of a "document,"
+    // as defined by the subclass's `deltaClass`.
+    //
+    // **TODO:** This might turn out to be a prohibitively slow operation, so it
+    // is probably a good idea to evaluate how expensive this is in practice,
+    // and figure out a better tactic if need be.
+    if (!this._contents.isDocument()) {
+      throw Errors.bad_value(contents, this.constructor.deltaClass, 'document');
+    }
+
+    Object.freeze(this);
+  }
+
+  /** {BaseDelta} The document contents as a from-empty delta. */
+  get contents() {
+    return this._contents;
+  }
+
+  /** {RevisionNumber} The revision number. */
+  get revNum() {
+    return this._revNum;
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality. For two instances
+   * to be considered equal, they must be instances of the same exact class,
+   * their revision numbers must be the same, and their contents must be
+   * `.equals()`.
+   *
+   * @param {*} other Instance to compare to.
+   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
+   *   not.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    }
+
+    return (this.constructor === other.constructor)
+      && (this._revNum === other._revNum)
+      && this._contents.equals(other._contents);
+  }
+
+  /**
+   * Converts this instance for API transmission.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toApi() {
+    return [this._revNum, this._contents];
+  }
+
+  /**
+   * {class} Class (constructor function) of change objects to be used with
+   * instances of this class. Subclasses must be fill this in.
+   *
+   * @abstract
+   */
+  static get _impl_changeClass() {
+    return this._mustOverride();
+  }
+}

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -116,6 +116,10 @@ export default class BaseSnapshot extends CommonBase {
   equals(other) {
     if (this === other) {
       return true;
+    } else if (!(other instanceof BaseSnapshot)) {
+      // **Note:** This handles non-objects and `null`s, making the final
+      // `return` expression pretty straightforward.
+      return false;
     }
 
     return (this.constructor === other.constructor)

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -79,11 +79,29 @@ export default class BodyDelta extends Delta {
    *   of the given value.
    */
   constructor(ops) {
-    // TODO: Should consider validating the contents of `ops`.
+    // **TODO:** The contents of `ops` should be validated.
     TArray.check(ops);
 
     super(DataUtil.deepFreeze(ops));
     Object.freeze(this);
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality. To be considered
+   * equal, `other` must be an instance of this class with an `ops` which is
+   * `DataUtil.equalData()` to this instance's `ops`.
+   *
+   * @param {*} other Instance to compare to.
+   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
+   *   not.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    }
+
+    return (other instanceof BodyDelta)
+      && DataUtil.equalData(this._ops, other._ops);
   }
 
   /**

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -105,8 +105,9 @@ export default class BodyDelta extends Delta {
   }
 
   /**
-   * Returns `true` iff this instance has the form of a "document." In Quill
-   * terms, a "document" is a delta that consists _only_ of `insert` operations.
+   * Returns `true` iff this instance has the form of a "document," or put
+   * another way, iff it is valid to compose with an empty snapshot. In Quill
+   * terms, a document is a delta that consists _only_ of `insert` operations.
    *
    * @returns {boolean} `true` if this instance is a document or `false` if not.
    */

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -14,6 +14,20 @@ import BodyDelta from './BodyDelta';
  */
 export default class BodySnapshot extends BaseSnapshot {
   /**
+   * Constructs an instance.
+   *
+   * @param {RevisionNumber} revNum Revision number of the document.
+   * @param {object|array} contents The document contents per se, in the form of
+   *   a document delta (that is, a from-empty delta). This must be either a
+   *   `BodyDelta` or an array which can be passed to the `BodyDelta`
+   *   constructor to produce a valid delta.
+   */
+  constructor(revNum, contents) {
+    super(revNum, contents);
+    Object.freeze(this);
+  }
+
+  /**
    * Composes a change on top of this instance, to produce a new instance.
    *
    * @param {BodyChange} change Change to compose on top of this instance.

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -3,82 +3,16 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray } from 'typecheck';
-import { CommonBase, Errors } from 'util-common';
 
+import BaseSnapshot from './BaseSnapshot';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
-import RevisionNumber from './RevisionNumber';
 
 
 /**
- * {BodySnapshot|null} Empty instance. Initialized in the `EMPTY` property
- * accessor.
+ * Snapshot of main document body contents.
  */
-let emptyInstance = null;
-
-/**
- * Snapshot of document contents, with other associated information.
- */
-export default class BodySnapshot extends CommonBase {
-  /**
-   * {BodySnapshot} Empty instance of this class. It has an empty delta and
-   * revision number `0`.
-   */
-  static get EMPTY() {
-    if (emptyInstance === null) {
-      emptyInstance = new BodySnapshot(0, BodyDelta.EMPTY);
-    }
-
-    return emptyInstance;
-  }
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {RevisionNumber} revNum Revision number of the document.
-   * @param {object|array} contents The document contents per se, in the form of
-   *   a document delta (that is, a from-empty delta). This must be either a
-   *   `BodyDelta` or an array which can be passed to the `BodyDelta`
-   *   constructor to produce a valid delta.
-   */
-  constructor(revNum, contents) {
-    super();
-
-    /** {Int} Revision number. */
-    this._revNum = RevisionNumber.check(revNum);
-
-    /** {object} Document contents. */
-    this._contents = Array.isArray(contents)
-      ? new BodyDelta(contents)
-      : BodyDelta.check(contents);
-
-    // Explicitly check that the `contents` delta has the form of a "document,"
-    // that is, the only operations are `insert`s. For very large documents,
-    // this might turn out to be a prohibitively slow operation, so...
-    //
-    // **TODO:** Evaluate how expensive this is in practice, and figure out a
-    // better tactic if need be.
-    //
-    // **TODO:** There is more to being valid than just being `isDocument()`,
-    // i.e. the ops themselves have to be valid in the contents of this project.
-    // That validity should also be enforced.
-    if (!this._contents.isDocument()) {
-      throw Errors.bad_value(contents, BodyDelta, 'isDocument()');
-    }
-
-    Object.freeze(this);
-  }
-
-  /** {BodyDelta} The document contents as a from-empty delta. */
-  get contents() {
-    return this._contents;
-  }
-
-  /** {RevisionNumber} The revision number. */
-  get revNum() {
-    return this._revNum;
-  }
-
+export default class BodySnapshot extends BaseSnapshot {
   /**
    * Composes a change on top of this instance, to produce a new instance.
    *
@@ -90,8 +24,8 @@ export default class BodySnapshot extends CommonBase {
     BodyChange.check(change);
 
     const contents = change.delta.isEmpty()
-      ? this._contents
-      : BodyDelta.coerce(this._contents.compose(change.delta));
+      ? this.contents
+      : BodyDelta.coerce(this.contents.compose(change.delta));
 
     return new BodySnapshot(change.revNum, contents);
   }
@@ -112,7 +46,7 @@ export default class BodySnapshot extends CommonBase {
       return this;
     }
 
-    let contents = this._contents;
+    let contents = this.contents;
     for (const c of changes) {
       contents = contents.compose(c.delta);
     }
@@ -143,11 +77,10 @@ export default class BodySnapshot extends CommonBase {
   }
 
   /**
-   * Converts this instance for API transmission.
-   *
-   * @returns {array} Reconstruction arguments.
+   * {class} Class (constructor function) of change objects to be used with
+   * instances of this class.
    */
-  toApi() {
-    return [this._revNum, this._contents];
+  static get _impl_changeClass() {
+    return BodyChange;
   }
 }

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -60,7 +60,7 @@ export default class BodySnapshot extends CommonBase {
     // i.e. the ops themselves have to be valid in the contents of this project.
     // That validity should also be enforced.
     if (!this._contents.isDocument()) {
-      throw Errors.bad_value(contents, 'document delta');
+      throw Errors.bad_value(contents, BodyDelta, 'isDocument()');
     }
 
     Object.freeze(this);

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -36,9 +36,10 @@ export default class BodySnapshot extends CommonBase {
    * Constructs an instance.
    *
    * @param {RevisionNumber} revNum Revision number of the document.
-   * @param {Delta|array|object} contents Document contents. Can be given
-   *   anything that can be coerced into a `BodyDelta`. Must be a "document"
-   *   (that is, a delta consisting only of `insert` operations).
+   * @param {object|array} contents The document contents per se, in the form of
+   *   a document delta (that is, a from-empty delta). This must be either a
+   *   `BodyDelta` or an array which can be passed to the `BodyDelta`
+   *   constructor to produce a valid delta.
    */
   constructor(revNum, contents) {
     super();
@@ -46,8 +47,10 @@ export default class BodySnapshot extends CommonBase {
     /** {Int} Revision number. */
     this._revNum = RevisionNumber.check(revNum);
 
-    /** {BodyDelta} Document contents. */
-    this._contents = BodyDelta.coerce(contents);
+    /** {object} Document contents. */
+    this._contents = Array.isArray(contents)
+      ? new BodyDelta(contents)
+      : BodyDelta.check(contents);
 
     // Explicitly check that the `contents` delta has the form of a "document,"
     // that is, the only operations are `insert`s. For very large documents,

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -75,6 +75,41 @@ export default class CaretDelta extends CommonBase {
   }
 
   /**
+   * Returns `true` iff this instance has the form of a "document," or put
+   * another way, iff it is valid to compose with an empty snapshot. For this
+   * class, to be a document, `ops` must consist only of `op_beginSession`
+   * instances, and no two ops may refer to the same session ID.
+   *
+   * @returns {boolean} `true` if this instance is a document or `false` if not.
+   */
+  isDocument() {
+    const ids = new Set();
+
+    for (const op of this.ops) {
+      const opProps = op.props;
+
+      switch (opProps.opName) {
+        case CaretOp.BEGIN_SESSION: {
+          const sessionId = opProps.caret.sessionId;
+
+          if (ids.has(sessionId)) {
+            return false;
+          }
+
+          ids.add(sessionId);
+          break;
+        }
+
+        default: {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Converts this instance for API transmission.
    *
    * @returns {array} Reconstruction arguments.

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -5,7 +5,7 @@
 import { inspect } from 'util';
 
 import { TArray } from 'typecheck';
-import { CommonBase } from 'util-common';
+import { CommonBase, DataUtil } from 'util-common';
 
 import CaretOp from './CaretOp';
 
@@ -49,20 +49,38 @@ export default class CaretDelta extends CommonBase {
   }
 
   /**
+   * {array<CaretOp>} Array of operations to be applied. This is guaranteed to
+   * be a frozen (immutable) value.
+   */
+  get ops() {
+    return this._ops;
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality. To be considered
+   * equal, `other` must be an instance of this class with an `ops` which is
+   * `DataUtil.equalData()` to this instance's `ops`.
+   *
+   * @param {*} other Instance to compare to.
+   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
+   *   not.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    }
+
+    return (other instanceof CaretDelta)
+      && DataUtil.equalData(this._ops, other._ops);
+  }
+
+  /**
    * Converts this instance for API transmission.
    *
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
     return [this._ops];
-  }
-
-  /**
-   * {array<CaretOp>} Array of operations to be applied. This is guaranteed to
-   * be a frozen (immutable) value.
-   */
-  get ops() {
-    return this._ops;
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -51,6 +51,12 @@ export default class CaretSnapshot extends CommonBase {
       CaretDelta.check(delta);
     }
 
+    // We know we have a valid delta, but we furthermore need it to be a
+    // _document_ (from-empty) delta.
+    if (!delta.isDocument()) {
+      throw Errors.bad_value(delta, CaretDelta, 'isDocument()');
+    }
+
     super();
 
     /** {Int} The caret information revision number. */
@@ -68,18 +74,13 @@ export default class CaretSnapshot extends CommonBase {
 
       switch (opProps.opName) {
         case CaretOp.BEGIN_SESSION: {
-          const sessionId = opProps.caret.sessionId;
-
-          if (this._carets.has(sessionId)) {
-            throw Errors.bad_use(`Duplicate caret: ${sessionId}`);
-          }
-
-          this._carets.set(sessionId, op);
+          this._carets.set(opProps.caret.sessionId, op);
           break;
         }
 
         default: {
-          throw Errors.bad_value(op, 'CaretSnapshot construction op');
+          // Should have been prevented by the `isDocument()` check.
+          throw Errors.wtf('Weird op');
         }
       }
     }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -262,22 +262,6 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Constructs an instance just like this one, except with a different
-   * caret revision number. If the given revision number is the same as what
-   * this instance already stores, this method returns `this`.
-   *
-   * @param {Int} revNum The new caret revision number.
-   * @returns {CaretSnapshot} An appropriately-constructed instance.
-   */
-  withRevNum(revNum) {
-    // This type checks `revNum`, which is why it's not just run when we need
-    // to call `compose()`.
-    const change = new CaretChange(revNum, CaretDelta.EMPTY);
-
-    return (revNum === this.revNum) ? this : this.compose(change);
-  }
-
-  /**
    * Constructs an instance just like this one, except without any reference to
    * the session indicated by the given caret. If there is no session for the
    * given caret, this method returns `this`.

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -3,64 +3,30 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
-import { CommonBase, Errors } from 'util-common';
+import { Errors } from 'util-common';
 
+import BaseSnapshot from './BaseSnapshot';
 import Caret from './Caret';
 import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
-import RevisionNumber from './RevisionNumber';
 
-/**
- * {CaretSnapshot|null} Empty instance. Initialized in the `EMPTY` property
- * accessor.
- */
-let EMPTY = null;
 
 /**
  * Snapshot of information about all active sessions on a particular document.
  * Instances of this class are always frozen (immutable).
  */
-export default class CaretSnapshot extends CommonBase {
-  /**
-   * {CaretSnapshot} Empty instance of this class. It has no carets and a
-   * revision number of `0`.
-   */
-  static get EMPTY() {
-    if (EMPTY === null) {
-      EMPTY = new CaretSnapshot(0, []);
-    }
-
-    return EMPTY;
-  }
-
+export default class CaretSnapshot extends BaseSnapshot {
   /**
    * Constructs an instance.
    *
    * @param {Int} revNum Revision number of the caret information.
-   * @param {CaretDelta|array<CaretOp>} delta A from-empty delta (or array of
+   * @param {CaretDelta|array<CaretOp>} contents A from-empty delta (or array of
    *   ops which can be used to construct same), representing all the carets to
    *   include in the instance.
    */
-  constructor(revNum, delta) {
-    if (Array.isArray(delta)) {
-      // Convert the given array into a proper delta instance. (This does type
-      // checking of the argument.)
-      delta = new CaretDelta(delta);
-    } else {
-      CaretDelta.check(delta);
-    }
-
-    // We know we have a valid delta, but we furthermore need it to be a
-    // _document_ (from-empty) delta.
-    if (!delta.isDocument()) {
-      throw Errors.bad_value(delta, CaretDelta, 'isDocument()');
-    }
-
-    super();
-
-    /** {Int} The caret information revision number. */
-    this._revNum = RevisionNumber.check(revNum);
+  constructor(revNum, contents) {
+    super(revNum, contents);
 
     /**
      * {Map<string, CaretOp>} Map of session ID to an `op_beginSession` which
@@ -69,7 +35,7 @@ export default class CaretSnapshot extends CommonBase {
     this._carets = new Map();
 
     // Fill in `_carets`.
-    for (const op of delta.ops) {
+    for (const op of this.contents.ops) {
       const opProps = op.props;
 
       switch (opProps.opName) {
@@ -89,11 +55,6 @@ export default class CaretSnapshot extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {CaretDelta} The caret state as a from-empty delta. */
-  get contents() {
-    return new CaretDelta([...this._carets.values()]);
-  }
-
   /**
    * {array<Caret>} Array of active carets. It is guaranteed to be a frozen
    * (immutable) value.
@@ -106,11 +67,6 @@ export default class CaretSnapshot extends CommonBase {
     }
 
     return Object.freeze(result);
-  }
-
-  /** {Int} The caret information revision number. */
-  get revNum() {
-    return this._revNum;
   }
 
   /**
@@ -259,7 +215,7 @@ export default class CaretSnapshot extends CommonBase {
     const thisCarets  = this._carets;
     const otherCarets = other._carets;
 
-    if (   (this._revNum    !== other._revNum)
+    if (   (this.revNum     !== other.revNum)
         || (thisCarets.size !== otherCarets.size)) {
       return false;
     }
@@ -286,15 +242,6 @@ export default class CaretSnapshot extends CommonBase {
   }
 
   /**
-   * Converts this instance for API transmission.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toApi() {
-    return [this._revNum, this.contents.ops];
-  }
-
-  /**
    * Constructs an instance just like this one, except with an additional or
    * updated reference to the indicated caret. If the given caret (including all
    * fields) is already represented in this instance, this method returns
@@ -311,7 +258,7 @@ export default class CaretSnapshot extends CommonBase {
 
     return op.equals(this._carets.get(sessionId))
       ? this
-      : this.compose(new CaretChange(this._revNum, [op]));
+      : this.compose(new CaretChange(this.revNum, [op]));
   }
 
   /**
@@ -327,7 +274,7 @@ export default class CaretSnapshot extends CommonBase {
     // to call `compose()`.
     const change = new CaretChange(revNum, CaretDelta.EMPTY);
 
-    return (revNum === this._revNum) ? this : this.compose(change);
+    return (revNum === this.revNum) ? this : this.compose(change);
   }
 
   /**
@@ -360,7 +307,15 @@ export default class CaretSnapshot extends CommonBase {
     const op = CaretOp.op_endSession(sessionId);
 
     return this._carets.has(sessionId)
-      ? this.compose(new CaretChange(this._revNum, [op]))
+      ? this.compose(new CaretChange(this.revNum, [op]))
       : this;
+  }
+
+  /**
+   * {class} Class (constructor function) of change objects to be used with
+   * instances of this class.
+   */
+  static get _impl_changeClass() {
+    return CaretChange;
   }
 }

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -75,6 +75,41 @@ export default class PropertyDelta extends CommonBase {
   }
 
   /**
+   * Returns `true` iff this instance has the form of a "document," or put
+   * another way, iff it is valid to compose with an empty snapshot. For this
+   * class, to be a document, `ops` must consist only of `op_setProperty`
+   * instances, and no two ops may refer to the same property name.
+   *
+   * @returns {boolean} `true` if this instance is a document or `false` if not.
+   */
+  isDocument() {
+    const names = new Set();
+
+    for (const op of this.ops) {
+      const opProps = op.props;
+
+      switch (opProps.opName) {
+        case PropertyOp.SET_PROPERTY: {
+          const sessionId = opProps.name;
+
+          if (names.has(sessionId)) {
+            return false;
+          }
+
+          names.add(sessionId);
+          break;
+        }
+
+        default: {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Converts this instance for API transmission.
    *
    * @returns {array} Reconstruction arguments.

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -5,7 +5,7 @@
 import { inspect } from 'util';
 
 import { TArray } from 'typecheck';
-import { CommonBase } from 'util-common';
+import { CommonBase, DataUtil } from 'util-common';
 
 import PropertyOp from './PropertyOp';
 
@@ -49,20 +49,38 @@ export default class PropertyDelta extends CommonBase {
   }
 
   /**
+   * {array<PropertyOp>} Array of operations to be applied. This is guaranteed
+   * to be a frozen (immutable) value.
+   */
+  get ops() {
+    return this._ops;
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality. To be considered
+   * equal, `other` must be an instance of this class with an `ops` which is
+   * `DataUtil.equalData()` to this instance's `ops`.
+   *
+   * @param {*} other Instance to compare to.
+   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
+   *   not.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    }
+
+    return (other instanceof PropertyDelta)
+      && DataUtil.equalData(this._ops, other._ops);
+  }
+
+  /**
    * Converts this instance for API transmission.
    *
    * @returns {array} Reconstruction arguments.
    */
   toApi() {
     return [this._ops];
-  }
-
-  /**
-   * {array<PropertyOp>} Array of operations to be applied. This is guaranteed
-   * to be a frozen (immutable) value.
-   */
-  get ops() {
-    return this._ops;
   }
 
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -50,6 +50,12 @@ export default class PropertySnapshot extends CommonBase {
       PropertyDelta.check(delta);
     }
 
+    // We know we have a valid delta, but we furthermore need it to be a
+    // _document_ (from-empty) delta.
+    if (!delta.isDocument()) {
+      throw Errors.bad_value(delta, PropertyDelta, 'isDocument()');
+    }
+
     super();
 
     /** {Int} The property information revision number. */
@@ -67,17 +73,13 @@ export default class PropertySnapshot extends CommonBase {
 
       switch (opProps.opName) {
         case PropertyOp.SET_PROPERTY: {
-          const name = opProps.name;
-          if (this._properties.has(name)) {
-            throw Errors.bad_use(`Duplicate property name: ${name}`);
-          }
-
-          this._properties.set(name, op);
+          this._properties.set(opProps.name, op);
           break;
         }
 
         default: {
-          throw Errors.bad_value(op, 'PropertySnapshot construction op');
+          // Should have been prevented by the `isDocument()` check.
+          throw Errors.wtf('Weird op');
         }
       }
     }

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -7,7 +7,6 @@ import { Errors } from 'util-common';
 
 import BaseSnapshot from './BaseSnapshot';
 import PropertyChange from './PropertyChange';
-import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 
 /**
@@ -225,22 +224,6 @@ export default class PropertySnapshot extends BaseSnapshot {
     return op.equals(this._properties.get(name))
       ? this
       : this.compose(new PropertyChange(this._revNum, [op]));
-  }
-
-  /**
-   * Constructs an instance just like this one, except with a different
-   * caret revision number. If the given revision number is the same as what
-   * this instance already stores, this method returns `this`.
-   *
-   * @param {Int} revNum The new caret revision number.
-   * @returns {PropertySnapshot} An appropriately-constructed instance.
-   */
-  withRevNum(revNum) {
-    // This type checks `revNum`, which is why it's not just run when we need
-    // to call `compose()`.
-    const change = new PropertyChange(revNum, PropertyDelta.EMPTY);
-
-    return (revNum === this.revNum) ? this : this.compose(change);
   }
 
   /**

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -6,6 +6,7 @@ import { Codec } from 'codec';
 
 import AuthorId from './AuthorId';
 import BaseChange from './BaseChange';
+import BaseSnapshot from './BaseSnapshot';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
 import BodySnapshot from './BodySnapshot';
@@ -40,6 +41,7 @@ Codec.theOne.registerClass(Timestamp);
 export {
   AuthorId,
   BaseChange,
+  BaseSnapshot,
   BodyChange,
   BodyDelta,
   BodySnapshot,

--- a/local-modules/doc-common/package.json
+++ b/local-modules/doc-common/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
 
   "dependencies": {
-    "quill-delta": "^3.4.3",
+    "quill-delta": "3.6.1",
 
     "codec": "local",
     "hooks-common": "local",

--- a/local-modules/doc-common/tests/MockChange.js
+++ b/local-modules/doc-common/tests/MockChange.js
@@ -1,0 +1,16 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseChange } from 'doc-common';
+
+import MockDelta from './MockDelta';
+
+/**
+ * Mock subclass of `BaseChange` for testing.
+ */
+export default class MockChange extends BaseChange {
+  static get _impl_deltaClass() {
+    return MockDelta;
+  }
+}

--- a/local-modules/doc-common/tests/MockDelta.js
+++ b/local-modules/doc-common/tests/MockDelta.js
@@ -1,0 +1,37 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase, DataUtil, Errors } from 'util-common';
+
+/**
+ * Mock "delta" class for testing.
+ */
+export default class MockDelta extends CommonBase {
+  static get EMPTY() {
+    if (!this._EMPTY) {
+      this._EMPTY = new MockDelta();
+    }
+    return this._EMPTY;
+  }
+
+  constructor(ops = []) {
+    super();
+
+    if (!(Array.isArray(ops) && (ops.length <= 3))) {
+      throw Errors.bad_value(ops, 'length 0..3 array');
+    }
+
+    this.ops = ops;
+    Object.freeze(this);
+  }
+
+  isDocument() {
+    return this.ops[0] !== 'not_document';
+  }
+
+  equals(other) {
+    return (other instanceof MockDelta)
+      && DataUtil.equalData(this.ops, other.ops);
+  }
+}

--- a/local-modules/doc-common/tests/test_BaseChange.js
+++ b/local-modules/doc-common/tests/test_BaseChange.js
@@ -29,6 +29,14 @@ class MockDelta extends CommonBase {
 
     this.got = got;
   }
+
+  isDocument() {
+    return true;
+  }
+
+  equals(other) {
+    return this === other;
+  }
 }
 
 /**

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -1,0 +1,227 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { BaseSnapshot } from 'doc-common';
+
+import MockChange from './MockChange';
+import MockDelta from './MockDelta';
+
+/**
+ * Mock subclass of `BaseSnapshot` for testing.
+ */
+class MockSnapshot extends BaseSnapshot {
+  constructor(revNum, contents) {
+    super(revNum, contents);
+    Object.freeze(this);
+  }
+
+  static get _impl_changeClass() {
+    return MockChange;
+  }
+}
+
+describe('doc-common/BaseSnapshot', () => {
+  describe('.EMPTY', () => {
+    it('should be an empty instance', () => {
+      const EMPTY = MockSnapshot.EMPTY;
+
+      assert.strictEqual(EMPTY.revNum, 0);
+      assert.strictEqual(EMPTY.contents, MockDelta.EMPTY);
+      assert.isFrozen(EMPTY);
+    });
+  });
+
+  describe('constructor()', () => {
+    it('should accept an array of ops for the contents', () => {
+      function test(value) {
+        new MockSnapshot(0, value);
+      }
+
+      test([]);
+      test(['x']);
+      test(['x', 2, 3]);
+    });
+
+    it('should accept valid revision numbers', () => {
+      function test(value) {
+        new MockSnapshot(value, MockDelta.EMPTY);
+      }
+
+      test(0);
+      test(1);
+      test(999999);
+    });
+
+    it('should accept a valid delta', () => {
+      function test(ops) {
+        const delta = new MockDelta(ops);
+        new MockSnapshot(0, delta);
+      }
+
+      test([]);
+      test(['x']);
+      test(['x', 2, 3]);
+    });
+
+    it('should produce a frozen instance', () => {
+      const snap = new MockSnapshot(0, ['blort']);
+      assert.isFrozen(snap);
+    });
+
+    it('should reject an invalid array', () => {
+      // The `MockDelta` contructor requires the `ops` array to have three or
+      // fewer elements.
+      const badArray1 = [1, 2, 3, 4];
+
+      // This will become a valid delta for which `isDocument()` is `false`.
+      const badArray2 = ['not_document'];
+
+      assert.throws(() => { new MockSnapshot(0, badArray1); });
+      assert.throws(() => { new MockSnapshot(0, badArray2); });
+    });
+
+    it('should reject a non-document delta', () => {
+      // This is a valid delta for which `isDocument()` is `false`.
+      const badDelta = new MockDelta(['not_document']);
+
+      assert.throws(() => { new MockSnapshot(0, badDelta); });
+    });
+
+    it('should reject invalid revision numbers', () => {
+      function test(value) {
+        assert.throws(() => { new MockSnapshot(value, MockDelta.EMPTY); });
+      }
+
+      test(-1);
+      test(1.5);
+      test(null);
+      test(false);
+      test(undefined);
+      test([]);
+      test([789]);
+      test({ a: 10 });
+    });
+  });
+
+  describe('equals()', () => {
+    it('should return `true` when passed itself', () => {
+      function test(...args) {
+        const snap = new MockSnapshot(...args);
+        assert.isTrue(snap.equals(snap), inspect(snap));
+      }
+
+      test(0, []);
+      test(0, MockDelta.EMPTY);
+      test(37, []);
+      test(37, MockDelta.EMPTY);
+      test(914, ['a', 'b', 'c']);
+    });
+
+    it('should return `true` when passed an identically-constructed value', () => {
+      function test(...args) {
+        const snap1 = new MockSnapshot(...args);
+        const snap2 = new MockSnapshot(...args);
+        const label = inspect(snap1);
+        assert.isTrue(snap1.equals(snap2), label);
+        assert.isTrue(snap2.equals(snap1), label);
+      }
+
+      test(0, []);
+      test(0, MockDelta.EMPTY);
+      test(37, []);
+      test(37, MockDelta.EMPTY);
+      test(914, ['a', 'b', 'c']);
+    });
+
+    it('should return `true` when equal property values are not also `===`', () => {
+      // This validates that the base class calls `.equals()` on the delta.
+      const snap1 = new MockSnapshot(37, [1, 2, 3]);
+      const snap2 = new MockSnapshot(37, [1, 2, 3]);
+
+      assert.isTrue(snap1.equals(snap2));
+      assert.isTrue(snap2.equals(snap1));
+    });
+
+    it('should return `false` when `revNum`s differ', () => {
+      const snap1 = new MockSnapshot(123, MockDelta.EMPTY);
+      const snap2 = new MockSnapshot(456, MockDelta.EMPTY);
+
+      assert.isFalse(snap1.equals(snap2));
+      assert.isFalse(snap2.equals(snap1));
+    });
+
+    it('should return `false` when deltas are not equal', () => {
+      const snap1 = new MockSnapshot(123, [1]);
+      const snap2 = new MockSnapshot(123, [2, 3]);
+
+      assert.isFalse(snap1.equals(snap2));
+      assert.isFalse(snap2.equals(snap1));
+    });
+
+    it('should return `false` when passed a non-snapshot', () => {
+      const snap = MockSnapshot.EMPTY;
+
+      assert.isFalse(snap.equals(undefined));
+      assert.isFalse(snap.equals(null));
+      assert.isFalse(snap.equals(false));
+      assert.isFalse(snap.equals(true));
+      assert.isFalse(snap.equals(914));
+      assert.isFalse(snap.equals(['not', 'a', 'snapshot']));
+      assert.isFalse(snap.equals(new Map()));
+    });
+  });
+
+  describe('withContents()', () => {
+    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+      const snap = new MockSnapshot(123, MockDelta.EMPTY);
+
+      assert.strictEqual(snap.withContents(MockDelta.EMPTY), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a different `contents`', () => {
+      const delta  = new MockDelta(['yo']);
+      const snap   = new MockSnapshot(123, [3]);
+      const result = snap.withContents(delta);
+
+      assert.strictEqual(result.revNum,   123);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `contents`', () => {
+      const snap = new MockSnapshot(123, []);
+
+      assert.throws(() => snap.withContents('blortch'));
+      assert.throws(() => snap.withContents(['array', 'is', 'too', 'long']));
+    });
+  });
+
+  describe('withRevNum()', () => {
+    it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
+      const snap = new MockSnapshot(123, MockDelta.EMPTY);
+
+      assert.strictEqual(snap.withRevNum(123), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a different `revNum`', () => {
+      const delta  = new MockDelta([1, 2]);
+      const snap   = new MockSnapshot(123, delta);
+      const result = snap.withRevNum(456);
+
+      assert.strictEqual(result.revNum,   456);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `revNum`', () => {
+      const snap = new MockSnapshot(123, []);
+
+      assert.throws(() => snap.withRevNum('blortch'));
+      assert.throws(() => snap.withRevNum(-1));
+      assert.throws(() => snap.withRevNum(22.7));
+    });
+  });
+});

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -35,13 +35,25 @@ describe('doc-common/BodyDelta', () => {
   });
 
   describe('coerce()', () => {
+    describe('instances of the actual class', () => {
+      const values = [
+        BodyDelta.EMPTY,
+        new BodyDelta([]),
+        new BodyDelta([{ insert: '123' }])
+      ];
+
+      for (const v of values) {
+        it(`should yield the same value for: ${inspect(v)}`, () => {
+          const result = BodyDelta.coerce(v);
+          assert.strictEqual(result, v);
+        });
+      }
+    });
+
     describe('valid empty arguments', () => {
       const values = [
-        null,
-        undefined,
         [],
-        new Delta([]),
-        { ops: [] }
+        new Delta([])
       ];
 
       for (const v of values) {
@@ -59,8 +71,7 @@ describe('doc-common/BodyDelta', () => {
         [{ retain: 123 }],
         [{ insert: 'x', attributes: { bold: true } }],
         [{ insert: 'florp' }, { insert: 'x', attributes: { bold: true } }],
-        new Delta([{ insert: 'x' }]),
-        { ops: [{ retain: 123 }] }
+        new Delta([{ insert: 'x' }])
       ];
 
       for (const v of values) {
@@ -73,6 +84,9 @@ describe('doc-common/BodyDelta', () => {
 
     describe('invalid arguments', () => {
       const values = [
+        { ops: [] },
+        null,
+        undefined,
         false,
         123,
         'florp',
@@ -130,36 +144,6 @@ describe('doc-common/BodyDelta', () => {
     });
   });
 
-  describe('isEmpty()', () => {
-    describe('valid empty values', () => {
-      const values = [
-        new BodyDelta([]),
-        BodyDelta.EMPTY,
-      ];
-
-      for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(v.isEmpty());
-        });
-      }
-    });
-
-    describe('valid non-empty values', () => {
-      const values = [
-        [{ insert: 'x' }],
-        [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }],
-        [{ retain: 100 }]
-      ];
-
-      for (const v of values) {
-        it(`should return \`false\` for: ${inspect(v)}`, () => {
-          const delta = new BodyDelta(v);
-          assert.isFalse(delta.isEmpty());
-        });
-      }
-    });
-  });
-
   describe('isDocument()', () => {
     describe('`true` cases', () => {
       const values = [
@@ -189,6 +173,36 @@ describe('doc-common/BodyDelta', () => {
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
           assert.isFalse(new BodyDelta(v).isDocument());
+        });
+      }
+    });
+  });
+
+  describe('isEmpty()', () => {
+    describe('valid empty values', () => {
+      const values = [
+        new BodyDelta([]),
+        BodyDelta.EMPTY,
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(v.isEmpty());
+        });
+      }
+    });
+
+    describe('valid non-empty values', () => {
+      const values = [
+        [{ insert: 'x' }],
+        [{ insert: 'line 1' }, { insert: '\n' }, { insert: 'line 2' }],
+        [{ retain: 100 }]
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${inspect(v)}`, () => {
+          const delta = new BodyDelta(v);
+          assert.isFalse(delta.isEmpty());
         });
       }
     });

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -198,7 +198,7 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should refuse to update a nonexistent caret', () => {
-      const snap  = new CaretSnapshot(1, [op1]);
+      const snap   = new CaretSnapshot(1, [op1]);
       const change = new CaretChange(1, [CaretOp.op_setField('florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(change); });

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -447,6 +447,29 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
+  describe('withContents()', () => {
+    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+      const snap = new CaretSnapshot(123, CaretDelta.EMPTY);
+
+      assert.strictEqual(snap.withContents(CaretDelta.EMPTY), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a different `contents`', () => {
+      const delta  = new CaretDelta([op1, op2, op3]);
+      const snap   = new CaretSnapshot(111, [op1]);
+      const result = snap.withContents(delta);
+
+      assert.strictEqual(result.revNum,   111);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `contents`', () => {
+      const snap = new CaretSnapshot(123, []);
+
+      assert.throws(() => snap.withContents('blortch'));
+    });
+  });
+
   describe('withRevNum()', () => {
     it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
       const snap = new CaretSnapshot(1, [op1]);
@@ -455,10 +478,18 @@ describe('doc-common/CaretSnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `revNum`', () => {
-      const snap     = new CaretSnapshot(1, [op1, op2]);
-      const expected = new CaretSnapshot(2, [op1, op2]);
+      const delta  = new CaretDelta([op1, op2]);
+      const snap   = new CaretSnapshot(1, delta);
+      const result = snap.withRevNum(2);
 
-      assert.isTrue(snap.withRevNum(2).equals(expected));
+      assert.strictEqual(result.revNum,   2);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `revNum`', () => {
+      const snap = new CaretSnapshot(1, [op1, op2]);
+
+      assert.throws(() => snap.withRevNum('blortch'));
     });
   });
 

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -75,6 +75,10 @@ describe('doc-common/PropertySnapshot', () => {
         PropertyOp.op_setProperty('x', 'y'),
         PropertyOp.op_deleteProperty('x') // Deletes aren't allowed.
       ]);
+      test([
+        PropertyOp.op_setProperty('x', 'y'),
+        PropertyOp.op_setProperty('x', 'z') // Duplicate names aren't allowed.
+      ]);
     });
 
     it('should reject a delta with disallowed ops', () => {
@@ -85,7 +89,15 @@ describe('doc-common/PropertySnapshot', () => {
 
       // Deletes aren't allowed.
       test([PropertyOp.op_deleteProperty('x')]);
-      test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_deleteProperty('x')]);
+      test([
+        PropertyOp.op_setProperty('x', 'y'),
+        PropertyOp.op_deleteProperty('x')]);
+
+      // Duplicate names aren't allowed.
+      test([
+        PropertyOp.op_setProperty('x', 'y'),
+        PropertyOp.op_setProperty('x', 'z')
+      ]);
     });
 
     it('should reject invalid revision numbers', () => {

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -386,6 +386,29 @@ describe('doc-common/PropertySnapshot', () => {
     });
   });
 
+  describe('withContents()', () => {
+    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+      const snap = new PropertySnapshot(123, PropertyDelta.EMPTY);
+
+      assert.strictEqual(snap.withContents(PropertyDelta.EMPTY), snap);
+    });
+
+    it('should return an appropriately-constructed instance given a different `contents`', () => {
+      const delta  = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap   = new PropertySnapshot(123, []);
+      const result = snap.withContents(delta);
+
+      assert.strictEqual(result.revNum,   123);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `contents`', () => {
+      const snap = new PropertySnapshot(123, []);
+
+      assert.throws(() => snap.withContents('blortch'));
+    });
+  });
+
   describe('withProperty()', () => {
     it('should return `this` if the exact property is already in the snapshot', () => {
       const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
@@ -419,11 +442,18 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `revNum`', () => {
-      const delta    = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
-      const snap     = new PropertySnapshot(123, delta);
-      const expected = new PropertySnapshot(456, delta);
+      const delta  = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap   = new PropertySnapshot(123, delta);
+      const result = snap.withRevNum(456);
 
-      assert.deepEqual(snap.withRevNum(456), expected);
+      assert.strictEqual(result.revNum,   456);
+      assert.strictEqual(result.contents, delta);
+    });
+
+    it('should reject an invalid `revNum`', () => {
+      const snap = new PropertySnapshot(123, []);
+
+      assert.throws(() => snap.withRevNum('blortch'));
     });
   });
 

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -20,18 +20,18 @@ import DocServer from './DocServer';
 const log = new Logger('doc');
 
 /** {BodyDelta} Default contents when creating a new document. */
-const DEFAULT_TEXT = BodyDelta.coerce(DEFAULT_DOCUMENT);
+const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
 
 /**
  * {BodyDelta} Message used as document to indicate a major validation error.
  */
-const ERROR_NOTE = BodyDelta.coerce(
+const ERROR_NOTE = new BodyDelta(
   [{ insert: '(Recreated document due to validation error(s).)\n' }]);
 
 /**
  * {BodyDelta} Message used as document instead of migrating documents from
  * old schema versions. */
-const MIGRATION_NOTE = BodyDelta.coerce(
+const MIGRATION_NOTE = new BodyDelta(
   [{ insert: '(Recreated document due to schema version skew.)\n' }]);
 
 /**


### PR DESCRIPTION
This PR extracts a common base class out of `BodySnapshot`, `CaretSnapshot`, and `PropertySnapshot`. There's a bit more refactoring that could be done, but I think this is a reasonable first cut.

In the process I also tweaked the three delta classes to be more similar to each other, which will make factoring a base class out of _those_ a bit easier when the time comes (which will be soon).

**Special Bonus:** I discovered that we were including two versions of `quill-delta` in our client bundle. This has been fixed, and I added code to detect when it happens again (because it will). See the big ole comment where the detection happens for a bit more color.