### PR TITLE
Make `BodyDelta` be more like our other delta classes.

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -675,7 +675,7 @@ export default class BodyClient extends StateMachine {
     // state to Quill's current state) composed with the correction to that
     // delta which when applied brings the client's state into alignment with
     // the server's state.
-    const correctedDelta = BodyDelta.coerce(delta.compose(dCorrection));
+    const correctedDelta = delta.compose(dCorrection);
 
     if (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) === null) {
       // Thanfully, the local user hasn't made any other changes while we
@@ -791,7 +791,7 @@ export default class BodyClient extends StateMachine {
     // Remember that we consumed all these changes.
     this._currentEvent = change;
 
-    return BodyDelta.coerce(delta);
+    return delta;
   }
 
   /**

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -827,7 +827,7 @@ export default class BodyClient extends StateMachine {
 
     // Tell Quill if necessary.
     if (needQuillUpdate) {
-      this._quill.updateContents(quillDelta, CLIENT_SOURCE);
+      this._quill.updateContents(quillDelta.toQuillForm(), CLIENT_SOURCE);
     }
   }
 
@@ -839,7 +839,7 @@ export default class BodyClient extends StateMachine {
    */
   _updateWithSnapshot(snapshot) {
     this._snapshot = snapshot;
-    this._quill.setContents(snapshot.contents, CLIENT_SOURCE);
+    this._quill.setContents(snapshot.contents.toQuillForm(), CLIENT_SOURCE);
   }
 
   /**

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -725,8 +725,7 @@ export default class BodyClient extends StateMachine {
 
     // `false` indicates that `dMore` should be taken to have been applied
     // second (lost any insert races or similar).
-    const dIntegratedCorrection =
-      BodyDelta.coerce(dMore.transform(dCorrection, false));
+    const dIntegratedCorrection = dMore.transform(dCorrection, false);
     this._updateWithChange(
       new BodyChange(vResultNum, correctedDelta), dIntegratedCorrection);
 

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -30,61 +30,6 @@ export default class BodyDelta extends Delta {
   }
 
   /**
-   * Main coercion implementation, per the superclass documentation. In this
-   * case, the following is how it proceeds:
-   *
-   * * If `value` is a `Delta`, returns an instance with the same list of
-   *   ops.
-   * * If `value` is an array, returns an instance with `value` as the list
-   *   of ops.
-   * * Throws a `bad_value` error for any other value.
-   *
-   * In general, this method will return the unique instance `EMPTY` when
-   * possible.
-   *
-   * Unlike the `Delta` constructor:
-   *
-   * * The result is always deeply frozen.
-   * * This method will throw an error instead of silently accepting invalid
-   *   values.
-   * * This does not accept arbitrary objects that just happen to have an `ops`
-   *   field.
-   *
-   * @param {object|array|null|undefined} value The value to coerce.
-   * @returns {BodyDelta} The corresponding instance.
-   */
-  static _impl_coerce(value) {
-    // **Note:** The base class implementation guarantees that we won't get
-    // called on an instance of this class.
-
-    let ops;
-    if (Array.isArray(value)) {
-      ops = value;
-    } else if (value instanceof Delta) {
-      ops = value.ops;
-    } else {
-      // Invalid argument. Diagnose further.
-      if ((typeof value === 'object') && value.constructor && (value.constructor.name === 'Delta')) {
-        // The version of `Delta` used by Quill is different than the one we
-        // specified in our `package.json`. Even though it will often happen to
-        // work if we just let it slide (e.g. by snarfing `ops` out of the
-        // object and running with it), we don't want to end up shipping two
-        // versions of `Delta` to the client; so, instead of just blithely
-        // accepting this possibility, we reject it here and report an error
-        // which makes it easy to figure out what happened. Should you find
-        // yourself looking at this error, the right thing to do is look at
-        // Quill's `package.json` and update the `quill-delta` dependency here
-        // to what you find there.
-        throw Errors.bad_use('Divergent versions of `quill-delta` package.');
-      } else {
-        throw Errors.bad_value(value, BodyDelta);
-      }
-    }
-
-    return (ops.length === 0) ? BodyDelta.EMPTY : new BodyDelta(ops);
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {array<object>} ops The transformation operations of this instance.

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -4,7 +4,7 @@
 
 import Delta from 'quill-delta';
 
-import { TArray, TBoolean } from 'typecheck';
+import { TArray, TBoolean, TObject } from 'typecheck';
 import { CommonBase, DataUtil, Errors, ObjectUtil } from 'util-common';
 
 /**
@@ -14,12 +14,20 @@ import { CommonBase, DataUtil, Errors, ObjectUtil } from 'util-common';
 let EMPTY = null;
 
 /**
- * Always-frozen list of body OT operations. This is a subclass of Quill's
- * `Delta` and mixes in `CommonBase` (the latter for `check()` and `coerce()`
- * functionality). In addition, it contains extra utility functionality beyond
- * what the base `Delta` provides.
+ * Always-frozen list of body OT operations. This uses Quill's `Delta` class to
+ * implement the "interesting" OT functionality, however this class does _not_
+ * inherit from that class, because while the method names have the same names
+ * and high-level semantics, the _types_ of the arguments and results are not
+ * actually the same. The methods `toQuillForm()` and `fromQuillForm()` can be
+ * used to convert back and forth as needed.
+ *
+ * **Note:** As of this writing, there are no actual differences between the
+ * operations of an instance of this class and those of a Quill `Delta`.
+ * However, there is a very good chance that this will stop being the case in
+ * the near future, once the operations of this class become more strongly
+ * typed (and verified).
  */
-export default class BodyDelta extends Delta {
+export default class BodyDelta extends CommonBase {
   /** {BodyDelta} Empty instance of this class. */
   static get EMPTY() {
     if (EMPTY === null) {
@@ -30,6 +38,36 @@ export default class BodyDelta extends Delta {
   }
 
   /**
+   * Given a Quill `Delta` instance, returns an instance of this class with the
+   * same operations.
+   *
+   * @param {Delta} quillDelta Quill `Delta` instance.
+   * @returns {BodyDelta} Equivalent instance of this class.
+   */
+  static fromQuillForm(quillDelta) {
+    try {
+      TObject.check(quillDelta, Delta);
+    } catch (e) {
+      if ((typeof quillDelta === 'object') && (quillDelta.constructor.name === 'Delta')) {
+        // The version of `Delta` used by Quill is different than the one we
+        // specified in our `package.json`. Even though it will often happen
+        // to work if we just let it slide (e.g. by snarfing `ops` out of the
+        // object and running with it), we don't want to end up shipping two
+        // versions of `Delta` to the client; so, instead of just blithely
+        // accepting this possibility, we reject it here and report an error
+        // which makes it easy to figure out what happened. Should you find
+        // yourself looking at this error, the right thing to do is look at
+        // Quill's `package.json` and update the `quill-delta` dependency in
+        // the this module to what you find there.
+        throw Errors.bad_use('Divergent versions of `quill-delta` package.');
+      }
+      throw e;
+    }
+
+    return new BodyDelta(quillDelta.ops);
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {array<object>} ops The transformation operations of this instance.
@@ -37,11 +75,20 @@ export default class BodyDelta extends Delta {
    *   of the given value.
    */
   constructor(ops) {
-    // **TODO:** The contents of `ops` should be validated.
-    TArray.check(ops);
+    super();
 
-    super(DataUtil.deepFreeze(ops));
+    /**
+     * {array} Array of operations. **TODO:** The contents of `ops` should be
+     * validated.
+     */
+    this._ops = DataUtil.deepFreeze(TArray.check(ops));
+
     Object.freeze(this);
+  }
+
+  /** {array} Array of operations. Always a deep-frozen value. */
+  get ops() {
+    return this._ops;
   }
 
   /**
@@ -55,11 +102,11 @@ export default class BodyDelta extends Delta {
     BodyDelta.check(other);
 
     // Use Quill's implementation.
-    const quillThis   = new Delta(this.ops);
-    const quillOther  = new Delta(other.ops);
+    const quillThis   = this.toQuillForm();
+    const quillOther  = other.toQuillForm();
     const quillResult = quillThis.compose(quillOther);
 
-    return new BodyDelta(quillResult.ops);
+    return BodyDelta.fromQuillForm(quillResult);
   }
 
   /**
@@ -84,11 +131,11 @@ export default class BodyDelta extends Delta {
     }
 
     // Use Quill's implementation.
-    const quillThis   = new Delta(this.ops);
-    const quillNewer  = new Delta(newerDelta.ops);
+    const quillThis   = this.toQuillForm();
+    const quillNewer  = newerDelta.toQuillForm();
     const quillResult = quillThis.diff(quillNewer);
 
-    return new BodyDelta(quillResult.ops);
+    return BodyDelta.fromQuillForm(quillResult);
   }
 
   /**
@@ -185,14 +232,10 @@ export default class BodyDelta extends Delta {
     TBoolean.check(thisIsFirst);
 
     // Use Quill's implementation.
-    const quillThis   = new Delta(this.ops);
-    const quillOther  = new Delta(other.ops);
+    const quillThis   = this.toQuillForm();
+    const quillOther  = other.toQuillForm();
     const quillResult = quillThis.transform(quillOther, thisIsFirst);
 
-    return new BodyDelta(quillResult.ops);
+    return BodyDelta.fromQuillForm(quillResult);
   }
 }
-
-// Add `CommonBase` as a mixin, because the main inheritence is the `Delta`
-// class.
-CommonBase.mixInto(BodyDelta);

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -164,8 +164,8 @@ export default class BodyDelta extends CommonBase {
    * **Note:** Generally speaking, instances for which `isDocument()` is true
    * can _also_ be used as non-document deltas.
    *
-   * @returns {boolean} `true` if this instance is a document delta or `false`
-   * if not.
+   * @returns {boolean} `true` if this instance can be treated as a document
+   *   delta or `false` if not.
    */
   isDocument() {
     for (const op of this.ops) {

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -150,6 +150,15 @@ export default class BodyDelta extends Delta {
   }
 
   /**
+   * Produces a Quill `Delta` (per se) with the same contents as this instance.
+   *
+   * @returns {Delta} A Quill `Delta` with the same contents as `this`.
+   */
+  toQuillForm() {
+    return new Delta(this.ops);
+  }
+
+  /**
    * Computes the transformation of a delta with respect to this one, such that
    * the result can be composed on top of this instance to produce a sensible
    * combined result. For example, given a document delta and two different

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -6,7 +6,6 @@ import { TArray } from 'typecheck';
 
 import BaseSnapshot from './BaseSnapshot';
 import BodyChange from './BodyChange';
-import BodyDelta from './BodyDelta';
 
 
 /**
@@ -39,7 +38,7 @@ export default class BodySnapshot extends BaseSnapshot {
 
     const contents = change.delta.isEmpty()
       ? this.contents
-      : BodyDelta.coerce(this.contents.compose(change.delta));
+      : this.contents.compose(change.delta);
 
     return new BodySnapshot(change.revNum, contents);
   }
@@ -85,7 +84,7 @@ export default class BodySnapshot extends BaseSnapshot {
 
     const oldContents = this.contents;
     const newContents = newerSnapshot.contents;
-    const delta       = BodyDelta.coerce(oldContents.diff(newContents));
+    const delta       = oldContents.diff(newContents);
 
     return new BodyChange(newerSnapshot.revNum, delta);
   }

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -77,10 +77,12 @@ export default class CaretDelta extends CommonBase {
   /**
    * Returns `true` iff this instance has the form of a "document," or put
    * another way, iff it is valid to compose with an empty snapshot. For this
-   * class, to be a document, `ops` must consist only of `op_beginSession`
-   * instances, and no two ops may refer to the same session ID.
+   * class, to be considered a document `ops` must consist only of
+   * `op_beginSession` instances, and no two ops may refer to the same session
+   * ID.
    *
-   * @returns {boolean} `true` if this instance is a document or `false` if not.
+   * @returns {boolean} `true` if this instance can be used as a document or
+   *   `false` if not.
    */
   isDocument() {
     const ids = new Set();

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -77,10 +77,12 @@ export default class PropertyDelta extends CommonBase {
   /**
    * Returns `true` iff this instance has the form of a "document," or put
    * another way, iff it is valid to compose with an empty snapshot. For this
-   * class, to be a document, `ops` must consist only of `op_setProperty`
-   * instances, and no two ops may refer to the same property name.
+   * class, to be considered a document `ops` must consist only of
+   * `op_setProperty` instances, and no two ops may refer to the same property
+   * name.
    *
-   * @returns {boolean} `true` if this instance is a document or `false` if not.
+   * @returns {boolean} `true` if this instance can be used as a document or
+   *   `false` if not.
    */
   isDocument() {
     const names = new Set();

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -144,6 +144,105 @@ describe('doc-common/BodyDelta', () => {
     });
   });
 
+  describe('compose()', () => {
+    it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
+      const result = BodyDelta.EMPTY.compose(BodyDelta.EMPTY);
+      assert.instanceOf(result, BodyDelta);
+      assert.deepEqual(result.ops, []);
+    });
+
+    it('should reject calls when `other` is not an instance of the class', () => {
+      const delta = BodyDelta.EMPTY;
+      const other = 'blort';
+      assert.throws(() => delta.compose(other));
+    });
+  });
+
+  describe('diff()', () => {
+    it('should return an empty result from `EMPTY.diff(EMPTY)`', () => {
+      const result = BodyDelta.EMPTY.diff(BodyDelta.EMPTY);
+      assert.instanceOf(result, BodyDelta);
+      assert.deepEqual(result.ops, []);
+    });
+
+    it('should reject calls when `this` is not a document', () => {
+      const delta = new BodyDelta([{ retain: 10 }]);
+      const other = BodyDelta.EMPTY;
+      assert.throws(() => delta.diff(other));
+    });
+
+    it('should reject calls when `other` is not a document', () => {
+      const delta = BodyDelta.EMPTY;
+      const other = new BodyDelta([{ retain: 10 }]);
+      assert.throws(() => delta.diff(other));
+    });
+
+    it('should reject calls when `other` is not an instance of the class', () => {
+      const delta = BodyDelta.EMPTY;
+      const other = 'blort';
+      assert.throws(() => delta.diff(other));
+    });
+  });
+
+  describe('compose() / diff()', () => {
+    // These tests take composition triples `origDoc + change = newDoc` and test
+    // `compose()` and `diff()` in various combinations.
+    function test(label, origDoc, change, newDoc) {
+      origDoc = new BodyDelta(origDoc);
+      change  = new BodyDelta(change);
+      newDoc  = new BodyDelta(newDoc);
+
+      describe(label, () => {
+        it('should produce the expected composition', () => {
+          const result = origDoc.compose(change);
+          assert.instanceOf(result, BodyDelta);
+          assert.deepEqual(result.ops, newDoc.ops);
+        });
+
+        it('should produce the expected diff', () => {
+          const result = origDoc.diff(newDoc);
+          assert.instanceOf(result, BodyDelta);
+          assert.deepEqual(result.ops, change.ops);
+        });
+
+        it('should produce the new doc when composing the orig doc with the diff', () => {
+          const diff   = origDoc.diff(newDoc);
+          const result = origDoc.compose(diff);
+          assert.instanceOf(result, BodyDelta);
+          assert.deepEqual(result.ops, newDoc.ops);
+        });
+      });
+    }
+
+    test('full replacement',
+      [{ insert: '111' }],
+      [{ insert: '222' }, { delete: 3 }],
+      [{ insert: '222' }]);
+    test('insert at start',
+      [{ insert: '111' }],
+      [{ insert: '222' }],
+      [{ insert: '222111' }]);
+    test('append at end',
+      [{ insert: '111' }],
+      [{ retain: 3 }, { insert: '222' }],
+      [{ insert: '111222' }]);
+    test('surround',
+      [{ insert: '111' }],
+      [{ insert: '222' }, { retain: 3 }, { insert: '333' }],
+      [{ insert: '222111333' }]);
+    test('replace one middle bit',
+      [{ insert: 'Drink more Slurm.' }],
+      [{ retain: 6 }, { insert: 'LESS' }, { delete: 4 }],
+      [{ insert: 'Drink LESS Slurm.' }]);
+    test('replace two middle bits',
+      [{ insert: '[[hello]] [[goodbye]]' }],
+      [
+        { retain: 2 }, { insert: 'YO' }, { delete: 5 }, { retain: 5 },
+        { insert: 'LATER' }, { delete: 7 }
+      ],
+      [{ insert: '[[YO]] [[LATER]]' }]);
+  });
+
   describe('isDocument()', () => {
     describe('`true` cases', () => {
       const values = [
@@ -205,6 +304,65 @@ describe('doc-common/BodyDelta', () => {
           assert.isFalse(delta.isEmpty());
         });
       }
+    });
+  });
+
+  describe('transform()', () => {
+    it('should return an empty result from `EMPTY.transform(EMPTY, *)`', () => {
+      const result1 = BodyDelta.EMPTY.transform(BodyDelta.EMPTY, false);
+      assert.instanceOf(result1, BodyDelta);
+      assert.deepEqual(result1.ops, []);
+
+      const result2 = BodyDelta.EMPTY.transform(BodyDelta.EMPTY, true);
+      assert.instanceOf(result2, BodyDelta);
+      assert.deepEqual(result2.ops, []);
+    });
+
+    it('should reject calls when `other` is not an instance of the class', () => {
+      const delta = BodyDelta.EMPTY;
+      const other = 'blort';
+      assert.throws(() => delta.transform(other, true));
+    });
+
+    it('should reject calls when `thisIsFirst` is not a boolean', () => {
+      const delta = BodyDelta.EMPTY;
+      assert.throws(() => delta.transform(delta, 'blort'));
+    });
+
+    it('should produce the expected transformations', () => {
+      function test(d1, d2, expectedTrue, expectedFalse = expectedTrue) {
+        d1 = new BodyDelta(d1);
+        d2 = new BodyDelta(d2);
+
+        const xformTrue  = d1.transform(d2, true);
+        const xformFalse = d1.transform(d2, false);
+
+        assert.deepEqual(xformTrue.ops,  expectedTrue);
+        assert.deepEqual(xformFalse.ops, expectedFalse);
+      }
+
+      test(
+        [{ insert: 'blort' }],
+        [{ insert: 'blort' }],
+        [{ retain: 5 }, { insert: 'blort' }],
+        [{ insert: 'blort' }]);
+      test(
+        [{ delete: 10 }],
+        [{ delete: 10 }],
+        []);
+      test(
+        [{ delete: 10 }],
+        [{ delete: 10 }, { insert: 'florp' }],
+        [{ insert: 'florp' }]);
+      test(
+        [{ insert: '111' }],
+        [{ insert: '222' }],
+        [{ retain: 3 }, { insert: '222' }],
+        [{ insert: '222' }]);
+      test(
+        [{ retain: 10 }, { insert: '111' }],
+        [{ retain: 20 }, { insert: '222' }],
+        [{ retain: 23 }, { insert: '222' }]);
     });
   });
 });

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -4,7 +4,6 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
-import Delta from 'quill-delta';
 import { inspect } from 'util';
 
 import { BodyDelta } from 'doc-common';
@@ -31,74 +30,6 @@ describe('doc-common/BodyDelta', () => {
 
     it('should be `.isEmpty()`', () => {
       assert.isTrue(EMPTY.isEmpty());
-    });
-  });
-
-  describe('coerce()', () => {
-    describe('instances of the actual class', () => {
-      const values = [
-        BodyDelta.EMPTY,
-        new BodyDelta([]),
-        new BodyDelta([{ insert: '123' }])
-      ];
-
-      for (const v of values) {
-        it(`should yield the same value for: ${inspect(v)}`, () => {
-          const result = BodyDelta.coerce(v);
-          assert.strictEqual(result, v);
-        });
-      }
-    });
-
-    describe('valid empty arguments', () => {
-      const values = [
-        [],
-        new Delta([])
-      ];
-
-      for (const v of values) {
-        it(`should yield \`EMPTY\` for: ${inspect(v)}`, () => {
-          const result = BodyDelta.coerce(v);
-          assert.strictEqual(result, BodyDelta.EMPTY);
-        });
-      }
-    });
-
-    describe('valid non-empty arguments', () => {
-      const values = [
-        [{ insert: 'x' }],
-        [{ delete: 123 }],
-        [{ retain: 123 }],
-        [{ insert: 'x', attributes: { bold: true } }],
-        [{ insert: 'florp' }, { insert: 'x', attributes: { bold: true } }],
-        new Delta([{ insert: 'x' }])
-      ];
-
-      for (const v of values) {
-        it(`should succeed for: ${inspect(v)}`, () => {
-          const result = BodyDelta.coerce(v);
-          assert.instanceOf(result, BodyDelta);
-        });
-      }
-    });
-
-    describe('invalid arguments', () => {
-      const values = [
-        { ops: [] },
-        null,
-        undefined,
-        false,
-        123,
-        'florp',
-        /xyz/,
-        new Map()
-      ];
-
-      for (const v of values) {
-        it(`should fail for: ${inspect(v)}`, () => {
-          assert.throws(() => BodyDelta.coerce(v));
-        });
-      }
     });
   });
 

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -4,6 +4,7 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
+import Delta from 'quill-delta';
 import { inspect } from 'util';
 
 import { BodyDelta } from 'doc-common';
@@ -235,6 +236,21 @@ describe('doc-common/BodyDelta', () => {
           assert.isFalse(delta.isEmpty());
         });
       }
+    });
+  });
+
+  describe('toQuillForm()', () => {
+    it('should produce `Delta` instances with strict-equal ops', () => {
+      function test(ops) {
+        const delta  = new BodyDelta(ops);
+        const result = delta.toQuillForm();
+        assert.instanceOf(result, Delta);
+        assert.strictEqual(result.ops, delta.ops);
+      }
+
+      test([]);
+      test([{ insert: 'blort' }]);
+      test([{ retain: 123 }]);
     });
   });
 

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -34,6 +34,30 @@ describe('doc-common/BodyDelta', () => {
     });
   });
 
+  describe('fromQuillForm()', () => {
+    it('should return an instance with equal `ops`', () => {
+      const ops        = [{ insert: 'foo' }, { retain: 10 }, { insert: 'bar' }];
+      const quillDelta = new Delta(ops);
+      const result     = BodyDelta.fromQuillForm(quillDelta);
+
+      assert.deepEqual(result.ops, ops);
+    });
+
+    it('should reject non-quill-delta arguments', () => {
+      function test(v) {
+        assert.throws(() => { BodyDelta.fromQuillForm(v); });
+      }
+
+      test(null);
+      test(undefined);
+      test(false);
+      test('blort');
+      test({ insert: '123' });
+      test([{ insert: '123' }]);
+      test(new BodyDelta([{ insert: '123' }]));
+    });
+  });
+
   describe('constructor()', () => {
     describe('valid arguments', () => {
       // This one is not a valid `ops` array, but per docs, the constructor

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -648,7 +648,7 @@ export default class BodyControl extends CommonBase {
       }
     }
 
-    return BodyDelta.coerce(result);
+    return result;
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -575,7 +575,7 @@ export default class BodyControl extends CommonBase {
 
     // The `true` argument indicates that `dServer` should be taken to have been
     // applied first (won any insert races or similar).
-    const dNext = BodyDelta.coerce(dServer.transform(dClient, true));
+    const dNext = dServer.transform(dClient, true);
 
     if (dNext.isEmpty()) {
       // It turns out that nothing changed. **Note:** It is unclear whether this

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -73,8 +73,8 @@ export default class QuillEvents extends UtilityClass {
       case QuillEvents.TEXT_CHANGE: {
         const [delta, oldContents, source] = payload.args;
         return new Functor(name,
-          BodyDelta.coerce(delta),
-          BodyDelta.coerce(oldContents),
+          new BodyDelta(delta.ops),
+          new BodyDelta(oldContents.ops),
           TString.check(source));
       }
 

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Delta from 'quill-delta';
-
 import { BodyDelta } from 'doc-common';
 import { EventSource } from 'promise-util';
 import { TString } from 'typecheck';

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -74,24 +74,9 @@ export default class QuillEvents extends UtilityClass {
     switch (name) {
       case QuillEvents.TEXT_CHANGE: {
         const [delta, oldContents, source] = payload.args;
-
-        if (!(delta instanceof Delta)) {
-          // The version of `Delta` used by Quill is different than the one we
-          // specified in our `package.json`. Even though it will often happen
-          // to work if we just let it slide (e.g. by snarfing `ops` out of the
-          // object and running with it), we don't want to end up shipping two
-          // versions of `Delta` to the client; so, instead of just blithely
-          // accepting this possibility, we reject it here and report an error
-          // which makes it easy to figure out what happened. Should you find
-          // yourself looking at this error, the right thing to do is look at
-          // Quill's `package.json` and update the `quill-delta` dependency in
-          // the `doc-common` module to what you find there.
-          throw Errors.bad_use('Divergent versions of `quill-delta` package.');
-        }
-
         return new Functor(name,
-          new BodyDelta(delta.ops),
-          new BodyDelta(oldContents.ops),
+          BodyDelta.fromQuillForm(delta),
+          BodyDelta.fromQuillForm(oldContents),
           TString.check(source));
       }
 


### PR DESCRIPTION
This PR addresses the main prerequisite required before extracting a common base class out of the three OT `*Delta` classes. Specifically, `BodyDelta` _used to_ inherit from Quill's `Delta`, but that had become an increasing source of tension as our own delta classes evolve away from Quill's simplistic structure.

At this point, the main thing that has been fixed (with regard to the previous status quo) is that the expected argument types of and the type produced by the various OT methods have been aligned with what our code "ought to" expect. (Briefly, we stopped having to use Quill-specific adapter crap in the middle of our core logic.) At some point, though, we will almost certainly diverge further, specifically because Quill's and our respective ideas of what an OT "operation" should look and behave like are different; and we are now in a position to make that divergence happen without too much additional strife.

