### PR TITLE
`BaseDelta` and mostly-related changes.

### DIFF
--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -225,7 +225,7 @@ export default class BaseChange extends CommonBase {
 
   /**
    * {class} Class (constructor function) of delta objects to be used with
-   * instances of this class. Subclasses must be fill this in.
+   * instances of this class. Subclasses must fill this in.
    *
    * @abstract
    */

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -2,10 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TFunction, TObject } from 'typecheck';
+import { TObject } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import AuthorId from './AuthorId';
+import BaseDelta from './BaseDelta';
 import RevisionNumber from './RevisionNumber';
 import Timestamp from './Timestamp';
 
@@ -64,14 +65,10 @@ export default class BaseChange extends CommonBase {
     // instance.
 
     if (!this._deltaClass) {
-      // Call the `_impl` and verify the result (via duck-typing, because there
-      // is no `BaseDelta` base class).
-      const clazz = TFunction.checkClass(this._impl_deltaClass);
+      // Call the `_impl` and verify the result.
+      const clazz = this._impl_deltaClass;
 
-      TObject.check(clazz.EMPTY, clazz);
-      TFunction.checkCallable(clazz.check);
-      TFunction.checkCallable(clazz.prototype.equals);
-      TFunction.checkCallable(clazz.prototype.isDocument);
+      TObject.check(clazz.prototype, BaseDelta);
       this._deltaClass = clazz;
     }
 
@@ -153,7 +150,7 @@ export default class BaseChange extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    const result = [this._revNum, this._delta, this._timestamp, this._authorId];
+    const result = [this._revNum, this._delta.ops, this._timestamp, this._authorId];
 
     // Trim off one or two trailing `null`s, if possible.
     for (let i = 3; i >= 2; i--) {

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -85,6 +85,8 @@ export default class BaseDelta extends CommonBase {
 
     /** {array<object>} Array of operations. */
     this._ops = this.constructor.checkOpArray(ops);
+
+    Object.freeze(this);
   }
 
   /**
@@ -148,6 +150,16 @@ export default class BaseDelta extends CommonBase {
     const result = this._impl_isDocument();
 
     return TBoolean.check(result);
+  }
+
+  /**
+   * Returns `true` iff this instance is empty. An empty instance is defined as
+   * one whose `ops` array has no elements.
+   *
+   * @returns {boolean} `true` if this instance is empty, or `false` if not.
+   */
+  isEmpty() {
+    return this._ops.length === 0;
   }
 
   /**

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -105,6 +105,8 @@ export default class BaseDelta extends CommonBase {
    * * The two instance's `ops` arrays must be the same length.
    * * Corresponding `ops` elements must be `.equals()`.
    *
+   * Subclasses may override this method if this behavior isn't right for them.
+   *
    * @param {*} other Instance to compare to.
    * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
    *   not.

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -1,0 +1,200 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { inspect } from 'util';
+
+import { TBoolean } from 'typecheck';
+import { CommonBase, Errors } from 'util-common';
+
+
+/**
+ * Delta for caret information, consisting of a simple ordered list of
+ * operations. Instances of this class can be applied to instances of `Caret`
+ * and `CaretSnapshot` to produce updated instances of those classes.
+ *
+ * Instances of this class are immutable.
+ */
+export default class BaseDelta extends CommonBase {
+  /**
+   * {BaseDelta} Empty instance of this class, that is, an instance whose `ops`
+   * is an empty array (`[]`). This is a direct instance of whatever class this
+   * is accessed on (and not just a `BaseDelta` per se).
+   */
+  static get EMPTY() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._EMPTY) {
+      this._EMPTY = new this([]);
+    }
+
+    return this._EMPTY;
+  }
+
+  /**
+   * Checks the given value to see if it is a valid array of operations for use
+   * with this class. This does _not_ check to see if the array is frozen.
+   *
+   * @param {*} value The alleged operation.
+   * @returns {array<object>} `value` if it is indeed valid.
+   * @throws {Error} if `value` is not valid.
+   */
+  static checkOpArray(value) {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._opPredicate) {
+      // Call the `_impl` and construct the predicate based on what we get back.
+      const classOrPredicate = this._impl_opClassOrPredicate;
+      if (classOrPredicate.prototype instanceof CommonBase) {
+        // It's a class as generally defined by this project.
+        this._opPredicate = (v => v instanceof classOrPredicate);
+      } else {
+        // Assume it's a plain predicate function.
+        this._opPredicate = classOrPredicate;
+      }
+    }
+
+    if (!Array.isArray(value)) {
+      throw Errors.bad_value(value, Array, `${this.name} operation`);
+    }
+
+    for (const op of value) {
+      if (!this._opPredicate(op)) {
+        throw Errors.bad_value(op, `${this.name} operation`);
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {array<object>} ops Array of operations. Each operation must be an
+   *   instance of {@link opClass}. If not passed as a frozen array, the
+   *   constructed instance will instead store a frozen clone of this value.
+   */
+  constructor(ops) {
+    super();
+
+    if (!Object.isFrozen(ops)) {
+      ops = Object.freeze(ops.slice());
+    }
+
+    /** {array<object>} Array of operations. */
+    this._ops = this.constructor.checkOpArray(ops);
+  }
+
+  /**
+   * {array<object>} Array of operations to be applied. This is guaranteed to
+   * be a frozen (immutable) value.
+   */
+  get ops() {
+    return this._ops;
+  }
+
+  /**
+   * Compares this to another possible-instance, for equality. To be considered
+   * equal:
+   *
+   * * `other` must be an instance of the same direct class as `this`.
+   * * The two instance's `ops` arrays must be the same length.
+   * * Corresponding `ops` elements must be `.equals()`.
+   *
+   * @param {*} other Instance to compare to.
+   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
+   *   not.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    } else if (!(other instanceof BaseDelta)) {
+      // **Note:** This handles non-objects and `null`s, making the final
+      // `return` expression pretty straightforward.
+      return false;
+    }
+
+    const thisOps  = this._ops;
+    const otherOps = other._ops;
+
+    if (   (this.constructor !== other.constructor)
+        || (thisOps.length !== otherOps.length)) {
+      return false;
+    }
+
+    for (let i = 0; i < thisOps.length; i++) {
+      if (!thisOps[i].equals(otherOps[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns `true` iff this instance has the form of a "document," or put
+   * another way, iff it is valid to compose with an instance which represents
+   * an empty snapshot. The details of what makes an instance a document vary
+   * from subclass to subclass.
+   *
+   * @returns {boolean} `true` if this instance can be used as a document or
+   *   `false` if not.
+   */
+  isDocument() {
+    // **TODO:** Consider caching the results of this call, if it turns out to
+    // be common for it to be called many times on the same object.
+    const result = this._impl_isDocument();
+
+    return TBoolean.check(result);
+  }
+
+  /**
+   * Converts this instance to codec reconstruction arguments.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toCodecArgs() {
+    return [this._ops];
+  }
+
+  /**
+   * Gets a human-oriented string representation of this instance.
+   *
+   * @returns {string} The human-oriented representation.
+   */
+  toString() {
+    const name = this.constructor.name;
+    const body = inspect(this._ops);
+
+    return `${name} ${body}`;
+  }
+
+  /**
+   * Main implementation of {@link #isDocument}. Subclasses must fill this in.
+   *
+   * @abstract
+   * @returns {boolean} `true` if this instance can be used as a document or
+   *   `false` if not.
+   */
+  _impl_isDocument() {
+    return this._mustOverride();
+  }
+
+  /**
+   * {class|function} Class (constructor function) of operation objects to be
+   * used with instances of this class, _or_ a predicate which identifies valid
+   * operations. Subclasses must be fill this in.
+   *
+   * **TODO:** The `function` form is allowed specifically so that `BodyDelta`
+   * can use simple objects as operations. `BodyDelta` should be changed to use
+   * proper class instances for its operations. Once that is done, {@link
+   * #checkOp} will be able to be simplified a bit.
+   *
+   * @abstract
+   */
+  static get _impl_opClassOrPredicate() {
+    return this._mustOverride();
+  }
+}

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -9,9 +9,13 @@ import { CommonBase, Errors } from 'util-common';
 
 
 /**
- * Delta for caret information, consisting of a simple ordered list of
- * operations. Instances of this class can be applied to instances of `Caret`
- * and `CaretSnapshot` to produce updated instances of those classes.
+ * Base class for document deltas. These are ordered lists of operations which
+ * indicate how to take one document state and transform it into a new document
+ * state. Subclasses of this class specialize on particular aspects of a
+ * (larger) document.
+ *
+ * Instances of (subclasses of) this class are used as the main payload data for
+ * the various "change" and "snapshot" classes.
  *
  * Instances of this class are immutable.
  */
@@ -115,8 +119,8 @@ export default class BaseDelta extends CommonBase {
     if (this === other) {
       return true;
     } else if (!(other instanceof BaseDelta)) {
-      // **Note:** This handles non-objects and `null`s, making the final
-      // `return` expression pretty straightforward.
+      // **Note:** This handles non-objects and `null`s, making the next
+      // pair of checks (below) more straightforward.
       return false;
     }
 
@@ -199,7 +203,7 @@ export default class BaseDelta extends CommonBase {
   /**
    * {class|function} Class (constructor function) of operation objects to be
    * used with instances of this class, _or_ a predicate which identifies valid
-   * operations. Subclasses must be fill this in.
+   * operations. Subclasses must fill this in.
    *
    * **TODO:** The `function` form is allowed specifically so that `BodyDelta`
    * can use simple objects as operations. `BodyDelta` should be changed to use

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -211,7 +211,7 @@ export default class BaseSnapshot extends CommonBase {
 
   /**
    * {class} Class (constructor function) of change objects to be used with
-   * instances of this class. Subclasses must be fill this in.
+   * instances of this class. Subclasses must fill this in.
    *
    * @abstract
    */

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -159,7 +159,7 @@ export default class BaseSnapshot extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this._revNum, this._contents];
+    return [this._revNum, this._contents.ops];
   }
 
   /**

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -106,6 +106,9 @@ export default class BodyDelta extends BaseDelta {
    * equal, `other` must be an instance of this class with an `ops` which is
    * `DataUtil.equalData()` to this instance's `ops`.
    *
+   * **TODO:** Once this class uses a real ops class, let the superclass's
+   * implementation of this method stand.
+   *
    * @param {*} other Instance to compare to.
    * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
    *   not.

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -4,14 +4,10 @@
 
 import Delta from 'quill-delta';
 
-import { TArray, TBoolean, TObject } from 'typecheck';
-import { CommonBase, DataUtil, Errors, ObjectUtil } from 'util-common';
+import { TBoolean, TObject } from 'typecheck';
+import { DataUtil, Errors, ObjectUtil } from 'util-common';
 
-/**
- * {BodyDelta|null} Empty instance. Initialized in the static getter of the
- * same name.
- */
-let EMPTY = null;
+import BaseDelta from './BaseDelta';
 
 /**
  * Always-frozen list of body OT operations. This uses Quill's `Delta` class to
@@ -27,16 +23,7 @@ let EMPTY = null;
  * the near future, once the operations of this class become more strongly
  * typed (and verified).
  */
-export default class BodyDelta extends CommonBase {
-  /** {BodyDelta} Empty instance of this class. */
-  static get EMPTY() {
-    if (EMPTY === null) {
-      EMPTY = new BodyDelta([]);
-    }
-
-    return EMPTY;
-  }
-
+export default class BodyDelta extends BaseDelta {
   /**
    * Given a Quill `Delta` instance, returns an instance of this class with the
    * same operations.
@@ -64,31 +51,7 @@ export default class BodyDelta extends CommonBase {
       throw e;
     }
 
-    return new BodyDelta(quillDelta.ops);
-  }
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {array<object>} ops The transformation operations of this instance.
-   *   If not deeply frozen, the actual stored `ops` will be a deep-frozen clone
-   *   of the given value.
-   */
-  constructor(ops) {
-    super();
-
-    /**
-     * {array} Array of operations. **TODO:** The contents of `ops` should be
-     * validated more completely.
-     */
-    this._ops = DataUtil.deepFreeze(TArray.check(ops, TObject.simple));
-
-    Object.freeze(this);
-  }
-
-  /** {array} Array of operations. Always a deep-frozen value. */
-  get ops() {
-    return this._ops;
+    return new BodyDelta(DataUtil.deepFreeze(quillDelta.ops));
   }
 
   /**
@@ -157,46 +120,6 @@ export default class BodyDelta extends CommonBase {
   }
 
   /**
-   * Returns `true` iff this instance has the form of a "document," or put
-   * another way, iff it is valid to compose with an empty snapshot. In Quill
-   * terms, a document is a delta that consists _only_ of `insert` operations.
-   *
-   * **Note:** Generally speaking, instances for which `isDocument()` is true
-   * can _also_ be used as non-document deltas.
-   *
-   * @returns {boolean} `true` if this instance can be treated as a document
-   *   delta or `false` if not.
-   */
-  isDocument() {
-    for (const op of this.ops) {
-      if (!ObjectUtil.hasOwnProperty(op, 'insert')) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Returns `true` iff this instance is empty (that is, it has an empty list
-   * of ops).
-   *
-   * @returns {boolean} `true` if this instance is empty or `false` if not.
-   */
-  isEmpty() {
-    return this.ops.length === 0;
-  }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return [this.ops];
-  }
-
-  /**
    * Produces a Quill `Delta` (per se) with the same contents as this instance.
    *
    * @returns {Delta} A Quill `Delta` with the same contents as `this`.
@@ -237,5 +160,33 @@ export default class BodyDelta extends CommonBase {
     const quillResult = quillThis.transform(quillOther, thisIsFirst);
 
     return BodyDelta.fromQuillForm(quillResult);
+  }
+
+  /**
+   * Main implementation of {@link #isDocument}.
+   *
+   * @returns {boolean} `true` if this instance can be used as a document or
+   *   `false` if not.
+   */
+  _impl_isDocument() {
+    for (const op of this.ops) {
+      if (!ObjectUtil.hasOwnProperty(op, 'insert')) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * {function} Predicate which indicates valid operation values for use with
+   * this class.
+   */
+  static get _impl_opClassOrPredicate() {
+    function bodyOpPredicate(v) {
+      return ObjectUtil.isSimple(v) && DataUtil.isDeepFrozen(v);
+    }
+
+    return bodyOpPredicate;
   }
 }

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -79,9 +79,9 @@ export default class BodyDelta extends CommonBase {
 
     /**
      * {array} Array of operations. **TODO:** The contents of `ops` should be
-     * validated.
+     * validated more completely.
      */
-    this._ops = DataUtil.deepFreeze(TArray.check(ops));
+    this._ops = DataUtil.deepFreeze(TArray.check(ops, TObject.simple));
 
     Object.freeze(this);
   }

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -69,24 +69,19 @@ export default class BodySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Calculates the difference from a given snapshot to this one. The return
-   * value is a change which can be composed with this instance to produce the
-   * snapshot passed in here as an argument. That is, `newerSnapshot ==
-   * this.compose(this.diff(newerSnapshot))`.
+   * Main implementation of {@link #diff}, which produces a delta (not a
+   * change).
    *
    * @param {BodySnapshot} newerSnapshot Snapshot to take the difference
    *   from.
-   * @returns {BodyChange} Change which represents the difference between
+   * @returns {BodyDelta} Delta which represents the difference between
    *   `newerSnapshot` and this instance.
    */
-  diff(newerSnapshot) {
-    BodySnapshot.check(newerSnapshot);
-
+  _impl_diffAsDelta(newerSnapshot) {
     const oldContents = this.contents;
     const newContents = newerSnapshot.contents;
-    const delta       = oldContents.diff(newContents);
 
-    return new BodyChange(newerSnapshot.revNum, delta);
+    return oldContents.diff(newContents);
   }
 
   /**

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -2,18 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
-import { TArray } from 'typecheck';
-import { CommonBase, DataUtil } from 'util-common';
-
+import BaseDelta from './BaseDelta';
 import CaretOp from './CaretOp';
-
-/**
- * {CaretDelta|null} Empty instance. Initialized in the static getter of the
- * same name.
- */
-let EMPTY = null;
 
 /**
  * Delta for caret information, consisting of a simple ordered list of
@@ -22,69 +12,14 @@ let EMPTY = null;
  *
  * Instances of this class are immutable.
  */
-export default class CaretDelta extends CommonBase {
-  /** {CaretDelta} Empty instance. */
-  static get EMPTY() {
-    if (EMPTY === null) {
-      EMPTY = new CaretDelta([]);
-    }
-
-    return EMPTY;
-  }
-
+export default class CaretDelta extends BaseDelta {
   /**
-   * Constructs an instance.
-   *
-   * @param {array<CaretOp>} ops Array of individual caret information
-   *   modification operations.
-   */
-  constructor(ops) {
-    super();
-
-    /**
-     * {array<object>} Array of operations to perform on the (implied) base
-     * `CaretSnapshot` to produce the new revision.
-     */
-    this._ops = Object.freeze(TArray.check(ops, CaretOp.check));
-  }
-
-  /**
-   * {array<CaretOp>} Array of operations to be applied. This is guaranteed to
-   * be a frozen (immutable) value.
-   */
-  get ops() {
-    return this._ops;
-  }
-
-  /**
-   * Compares this to another possible-instance, for equality. To be considered
-   * equal, `other` must be an instance of this class with an `ops` which is
-   * `DataUtil.equalData()` to this instance's `ops`.
-   *
-   * @param {*} other Instance to compare to.
-   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
-   *   not.
-   */
-  equals(other) {
-    if (this === other) {
-      return true;
-    }
-
-    return (other instanceof CaretDelta)
-      && DataUtil.equalData(this._ops, other._ops);
-  }
-
-  /**
-   * Returns `true` iff this instance has the form of a "document," or put
-   * another way, iff it is valid to compose with an empty snapshot. For this
-   * class, to be considered a document `ops` must consist only of
-   * `op_beginSession` instances, and no two ops may refer to the same session
-   * ID.
+   * Main implementation of {@link #isDocument}.
    *
    * @returns {boolean} `true` if this instance can be used as a document or
    *   `false` if not.
    */
-  isDocument() {
+  _impl_isDocument() {
     const ids = new Set();
 
     for (const op of this.ops) {
@@ -112,23 +47,10 @@ export default class CaretDelta extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
+   * {class} Class (constructor function) of operation objects to be used with
+   * instances of this class.
    */
-  toCodecArgs() {
-    return [this._ops];
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    const name = this.constructor.name;
-    const body = inspect(this._ops);
-
-    return `${name} ${body}`;
+  static get _impl_opClassOrPredicate() {
+    return CaretOp;
   }
 }

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -2,18 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
-import { TArray } from 'typecheck';
-import { CommonBase, DataUtil } from 'util-common';
-
+import BaseDelta from './BaseDelta';
 import PropertyOp from './PropertyOp';
-
-/**
- * {PropertyDelta|null} Empty instance. Initialized in the static getter of the
- * same name.
- */
-let EMPTY = null;
 
 /**
  * Delta for property (document metadata) information, consisting of a simple
@@ -22,69 +12,14 @@ let EMPTY = null;
  *
  * Instances of this class are immutable.
  */
-export default class PropertyDelta extends CommonBase {
-  /** {PropertyDelta} Empty instance. */
-  static get EMPTY() {
-    if (EMPTY === null) {
-      EMPTY = new PropertyDelta([]);
-    }
-
-    return EMPTY;
-  }
-
+export default class PropertyDelta extends BaseDelta {
   /**
-   * Constructs an instance.
-   *
-   * @param {array<object>} ops Array of individual property modification
-   *   operations.
-   */
-  constructor(ops) {
-    super();
-
-    /**
-     * {array<object>} Array of operations to perform on the (implied) base
-     * `PropertySnapshot` to produce the new revision.
-     */
-    this._ops = Object.freeze(TArray.check(ops, PropertyOp.check));
-  }
-
-  /**
-   * {array<PropertyOp>} Array of operations to be applied. This is guaranteed
-   * to be a frozen (immutable) value.
-   */
-  get ops() {
-    return this._ops;
-  }
-
-  /**
-   * Compares this to another possible-instance, for equality. To be considered
-   * equal, `other` must be an instance of this class with an `ops` which is
-   * `DataUtil.equalData()` to this instance's `ops`.
-   *
-   * @param {*} other Instance to compare to.
-   * @returns {boolean} `true` if `this` and `other` are equal, or `false` if
-   *   not.
-   */
-  equals(other) {
-    if (this === other) {
-      return true;
-    }
-
-    return (other instanceof PropertyDelta)
-      && DataUtil.equalData(this._ops, other._ops);
-  }
-
-  /**
-   * Returns `true` iff this instance has the form of a "document," or put
-   * another way, iff it is valid to compose with an empty snapshot. For this
-   * class, to be considered a document `ops` must consist only of
-   * `op_setProperty` instances, and no two ops may refer to the same property
-   * name.
+   * Main implementation of {@link #isDocument}.
    *
    * @returns {boolean} `true` if this instance can be used as a document or
    *   `false` if not.
    */
-  isDocument() {
+  _impl_isDocument() {
     const names = new Set();
 
     for (const op of this.ops) {
@@ -112,23 +47,10 @@ export default class PropertyDelta extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
+   * {class} Class (constructor function) of operation objects to be used with
+   * instances of this class.
    */
-  toCodecArgs() {
-    return [this._ops];
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    const name = this.constructor.name;
-    const body = inspect(this._ops);
-
-    return `${name} ${body}`;
+  static get _impl_opClassOrPredicate() {
+    return PropertyOp;
   }
 }

--- a/local-modules/doc-common/main.js
+++ b/local-modules/doc-common/main.js
@@ -6,6 +6,7 @@ import { Codec } from 'codec';
 
 import AuthorId from './AuthorId';
 import BaseChange from './BaseChange';
+import BaseDelta from './BaseDelta';
 import BaseSnapshot from './BaseSnapshot';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
@@ -41,6 +42,7 @@ Codec.theOne.registerClass(Timestamp);
 export {
   AuthorId,
   BaseChange,
+  BaseDelta,
   BaseSnapshot,
   BodyChange,
   BodyDelta,

--- a/local-modules/doc-common/tests/MockDelta.js
+++ b/local-modules/doc-common/tests/MockDelta.js
@@ -2,36 +2,67 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CommonBase, DataUtil, Errors } from 'util-common';
+import { CommonBase } from 'util-common';
+
+import { BaseDelta } from 'doc-common';
+
+/**
+ * Mock operation class.
+ */
+class MockOp extends CommonBase {
+  constructor(name) {
+    super();
+    this.name = name;
+  }
+
+  equals(other) {
+    return (other instanceof MockOp) && (this.name === other.name);
+  }
+}
 
 /**
  * Mock "delta" class for testing.
  */
-export default class MockDelta extends CommonBase {
-  static get EMPTY() {
-    if (!this._EMPTY) {
-      this._EMPTY = new MockDelta();
-    }
-    return this._EMPTY;
+export default class MockDelta extends BaseDelta {
+  /** {array<object>} Would-be ops array that contains an invalid element. */
+  static get INVALID_OPS() {
+    return ['not_an_op'];
   }
 
-  constructor(ops = []) {
-    super();
-
-    if (!(Array.isArray(ops) && (ops.length <= 3))) {
-      throw Errors.bad_value(ops, 'length 0..3 array');
-    }
-
-    this.ops = ops;
-    Object.freeze(this);
+  /**
+   * {array<object>} Ops array that will indicate that the delta is not a
+   * document.
+   */
+  static get NOT_DOCUMENT_OPS() {
+    return [new MockOp('not_document')];
   }
 
-  isDocument() {
-    return this.ops[0] !== 'not_document';
+  /** {array<object>} Ops array that will be considered valid. */
+  static get VALID_OPS() {
+    return [new MockOp('yes')];
   }
 
-  equals(other) {
-    return (other instanceof MockDelta)
-      && DataUtil.equalData(this.ops, other.ops);
+  /**
+   * Makes a valid op with the indicated name.
+   *
+   * @param {string} name Name of the op.
+   * @returns {object} An op with the indicated name.
+   */
+  static makeOp(name) {
+    return new MockOp(name);
+  }
+
+  _impl_isDocument() {
+    const op0 = this.ops[0];
+
+    return op0 ? (op0.name !== 'not_document') : true;
+  }
+
+  /**
+   * {class} Class (constructor function) of operation objects to be used with
+   * instances of this class.
+   */
+  static get _impl_opClassOrPredicate() {
+    return MockOp;
   }
 }

--- a/local-modules/doc-common/tests/test_BaseChange.js
+++ b/local-modules/doc-common/tests/test_BaseChange.js
@@ -61,26 +61,24 @@ describe('doc-common/BaseChange', () => {
 
       test(0,   MockDelta.EMPTY);
       test(123, MockDelta.EMPTY);
-      test(0,   new MockDelta());
-      test(909, new MockDelta(), null);
-      test(909, new MockDelta(), Timestamp.MIN_VALUE);
-      test(909, new MockDelta(), Timestamp.MIN_VALUE, null);
-      test(242, MockDelta.EMPTY, null,                null);
-      test(242, MockDelta.EMPTY, null,                'florp9019');
-      test(242, MockDelta.EMPTY, Timestamp.MAX_VALUE, 'florp9019');
+      test(0,   new MockDelta([]));
+      test(909, new MockDelta([]), null);
+      test(909, new MockDelta([]), Timestamp.MIN_VALUE);
+      test(909, new MockDelta([]), Timestamp.MIN_VALUE, null);
+      test(242, MockDelta.EMPTY,   null,                null);
+      test(242, MockDelta.EMPTY,   null,                'florp9019');
+      test(242, MockDelta.EMPTY,   Timestamp.MAX_VALUE, 'florp9019');
     });
 
     it('should accept a valid `delta` array, which should get passed to the delta constructor', () => {
-      const array  = ['valid', 'length 3', '(see the MockDelta constructor)'];
+      const array  = MockDelta.VALID_OPS;
       const result = new MockChange(0, array);
 
-      assert.strictEqual(result.delta.ops, array);
+      assert.deepEqual(result.delta.ops, array);
     });
 
     it('should reject an invalid `delta` array, via the delta constructor', () => {
-      const array  = ['invalid', 'length', 4, '(see the MockDelta constructor)'];
-
-      assert.throws(() => { new MockChange(0, array); });
+      assert.throws(() => { new MockChange(0, MockDelta.INVALID_OPS); });
     });
 
     it('should reject invalid arguments', () => {
@@ -152,9 +150,9 @@ describe('doc-common/BaseChange', () => {
       });
     }
 
-    test('withAuthorId', [99, new MockDelta(), Timestamp.MIN_VALUE, 'florp'], 3, 'blort');
-    test('withDelta', [999, new MockDelta(), Timestamp.MAX_VALUE, 'like'], 1, new MockDelta());
-    test('withRevNum', [9999, new MockDelta(), Timestamp.MIN_VALUE, 'zorch'], 0, 123);
-    test('withTimestamp', [99999, new MockDelta(), Timestamp.MIN_VALUE, 'zorch'], 2, Timestamp.MAX_VALUE);
+    test('withAuthorId', [99, new MockDelta([]), Timestamp.MIN_VALUE, 'florp'], 3, 'blort');
+    test('withDelta', [999, new MockDelta([]), Timestamp.MAX_VALUE, 'like'], 1, new MockDelta(MockDelta.VALID_OPS));
+    test('withRevNum', [9999, new MockDelta([]), Timestamp.MIN_VALUE, 'zorch'], 0, 123);
+    test('withTimestamp', [99999, new MockDelta([]), Timestamp.MIN_VALUE, 'zorch'], 2, Timestamp.MAX_VALUE);
   });
 });

--- a/local-modules/doc-common/tests/test_BaseDelta.js
+++ b/local-modules/doc-common/tests/test_BaseDelta.js
@@ -1,0 +1,122 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import MockDelta from './MockDelta';
+
+describe('doc-common/BaseDelta', () => {
+  describe('.EMPTY', () => {
+    const EMPTY = MockDelta.EMPTY;
+
+    it('should be an instance of the subclass', () => {
+      assert.instanceOf(EMPTY, MockDelta);
+    });
+
+    it('should be a frozen object', () => {
+      assert.isFrozen(EMPTY);
+    });
+
+    it('should have an empty `ops`', () => {
+      assert.strictEqual(EMPTY.ops.length, 0);
+    });
+
+    it('should have a frozen `ops`', () => {
+      assert.isFrozen(EMPTY.ops);
+    });
+
+    it('should be `.isEmpty()`', () => {
+      assert.isTrue(EMPTY.isEmpty());
+    });
+  });
+
+  describe('constructor()', () => {
+    describe('valid arguments', () => {
+      const values = [
+        [],
+        MockDelta.VALID_OPS,
+        MockDelta.NOT_DOCUMENT_OPS,
+        [MockDelta.makeOp('x'), MockDelta.makeOp('y')]
+      ];
+
+      for (const v of values) {
+        it(`should succeed for: ${inspect(v)}`, () => {
+          new MockDelta(v);
+        });
+      }
+    });
+
+    describe('invalid arguments', () => {
+      const values = [
+        null,
+        undefined,
+        123,
+        'florp',
+        { insert: 123 },
+        new Map(),
+        [null],
+        [undefined],
+        ['x'],
+        [1, 2, 3],
+        MockDelta.INVALID_OPS
+      ];
+
+      for (const v of values) {
+        it(`should fail for: ${inspect(v)}`, () => {
+          assert.throws(() => new MockDelta(v));
+        });
+      }
+    });
+  });
+
+  describe('isDocument()', () => {
+    describe('`true` cases', () => {
+      const values = [
+        [],
+        MockDelta.VALID_OPS
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(new MockDelta(v).isDocument());
+        });
+      }
+    });
+
+    describe('`false` cases', () => {
+      assert.isFalse(new MockDelta(MockDelta.NOT_DOCUMENT_OPS).isDocument());
+    });
+  });
+
+  describe('isEmpty()', () => {
+    describe('valid empty values', () => {
+      const values = [
+        new MockDelta([]),
+        MockDelta.EMPTY,
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(v.isEmpty());
+        });
+      }
+    });
+
+    describe('valid non-empty values', () => {
+      const values = [
+        MockDelta.VALID_OPS,
+        MockDelta.NOT_DOCUMENT_OPS
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${inspect(v)}`, () => {
+          const delta = new MockDelta(v);
+          assert.isFalse(delta.isEmpty());
+        });
+      }
+    });
+  });
+});

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -21,7 +21,7 @@ class MockSnapshot extends BaseSnapshot {
   }
 
   _impl_diffAsDelta(newerSnapshot) {
-    return ['diff_delta', newerSnapshot.contents.ops[0]];
+    return [MockDelta.makeOp('diff_delta'), newerSnapshot.contents.ops[0]];
   }
 
   static get _impl_changeClass() {
@@ -61,8 +61,7 @@ describe('doc-common/BaseSnapshot', () => {
       }
 
       test([]);
-      test(['x']);
-      test(['x', 2, 3]);
+      test(MockDelta.VALID_OPS);
     });
 
     it('should accept valid revision numbers', () => {
@@ -82,30 +81,22 @@ describe('doc-common/BaseSnapshot', () => {
       }
 
       test([]);
-      test(['x']);
-      test(['x', 2, 3]);
+      test(MockDelta.VALID_OPS);
     });
 
     it('should produce a frozen instance', () => {
-      const snap = new MockSnapshot(0, ['blort']);
+      const snap = new MockSnapshot(0, MockDelta.VALID_OPS);
       assert.isFrozen(snap);
     });
 
     it('should reject an invalid array', () => {
-      // The `MockDelta` contructor requires the `ops` array to have three or
-      // fewer elements.
-      const badArray1 = [1, 2, 3, 4];
-
-      // This will become a valid delta for which `isDocument()` is `false`.
-      const badArray2 = ['not_document'];
-
-      assert.throws(() => { new MockSnapshot(0, badArray1); });
-      assert.throws(() => { new MockSnapshot(0, badArray2); });
+      assert.throws(() => { new MockSnapshot(0, MockDelta.INVALID_OPS); });
+      assert.throws(() => { new MockSnapshot(0, MockDelta.NOT_DOCUMENT_OPS); });
     });
 
     it('should reject a non-document delta', () => {
       // This is a valid delta for which `isDocument()` is `false`.
-      const badDelta = new MockDelta(['not_document']);
+      const badDelta = new MockDelta(MockDelta.NOT_DOCUMENT_OPS);
 
       assert.throws(() => { new MockSnapshot(0, badDelta); });
     });
@@ -129,7 +120,7 @@ describe('doc-common/BaseSnapshot', () => {
   describe('diff()', () => {
     it('should call through to the impl and wrap the result in a timeless authorless change', () => {
       const oldSnap = new MockSnapshot(10, []);
-      const newSnap = new MockSnapshot(20, ['new_snap']);
+      const newSnap = new MockSnapshot(20, [MockDelta.makeOp('new_snap')]);
       const result  = oldSnap.diff(newSnap);
 
       assert.instanceOf(result, MockChange);
@@ -138,7 +129,8 @@ describe('doc-common/BaseSnapshot', () => {
       assert.isNull(result.timestamp);
       assert.isNull(result.authorId);
 
-      assert.deepEqual(result.delta.ops, ['diff_delta', 'new_snap']);
+      assert.deepEqual(result.delta.ops,
+        [MockDelta.makeOp('diff_delta'), MockDelta.makeOp('new_snap')]);
     });
 
     it('should reject instances of the wrong snapshot class', () => {
@@ -172,11 +164,11 @@ describe('doc-common/BaseSnapshot', () => {
         assert.isTrue(snap.equals(snap), inspect(snap));
       }
 
-      test(0, []);
-      test(0, MockDelta.EMPTY);
-      test(37, []);
-      test(37, MockDelta.EMPTY);
-      test(914, ['a', 'b', 'c']);
+      test(0,   []);
+      test(0,   MockDelta.EMPTY);
+      test(37,  []);
+      test(37,  MockDelta.EMPTY);
+      test(914, MockDelta.VALID_OPS);
     });
 
     it('should return `true` when passed an identically-constructed value', () => {
@@ -188,17 +180,17 @@ describe('doc-common/BaseSnapshot', () => {
         assert.isTrue(snap2.equals(snap1), label);
       }
 
-      test(0, []);
-      test(0, MockDelta.EMPTY);
-      test(37, []);
-      test(37, MockDelta.EMPTY);
-      test(914, ['a', 'b', 'c']);
+      test(0,   []);
+      test(0,   MockDelta.EMPTY);
+      test(37,  []);
+      test(37,  MockDelta.EMPTY);
+      test(914, MockDelta.VALID_OPS);
     });
 
     it('should return `true` when equal property values are not also `===`', () => {
       // This validates that the base class calls `.equals()` on the delta.
-      const snap1 = new MockSnapshot(37, [1, 2, 3]);
-      const snap2 = new MockSnapshot(37, [1, 2, 3]);
+      const snap1 = new MockSnapshot(37, MockDelta.VALID_OPS);
+      const snap2 = new MockSnapshot(37, MockDelta.VALID_OPS);
 
       assert.isTrue(snap1.equals(snap2));
       assert.isTrue(snap2.equals(snap1));
@@ -213,8 +205,8 @@ describe('doc-common/BaseSnapshot', () => {
     });
 
     it('should return `false` when deltas are not equal', () => {
-      const snap1 = new MockSnapshot(123, [1]);
-      const snap2 = new MockSnapshot(123, [2, 3]);
+      const snap1 = new MockSnapshot(123, [MockDelta.makeOp('x')]);
+      const snap2 = new MockSnapshot(123, [MockDelta.makeOp('y')]);
 
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
@@ -241,8 +233,8 @@ describe('doc-common/BaseSnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `contents`', () => {
-      const delta  = new MockDelta(['yo']);
-      const snap   = new MockSnapshot(123, [3]);
+      const delta  = new MockDelta([MockDelta.makeOp('yo')]);
+      const snap   = new MockSnapshot(123, [MockDelta.makeOp('hello')]);
       const result = snap.withContents(delta);
 
       assert.strictEqual(result.revNum,   123);
@@ -265,7 +257,7 @@ describe('doc-common/BaseSnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `revNum`', () => {
-      const delta  = new MockDelta([1, 2]);
+      const delta  = new MockDelta(MockDelta.VALID_OPS);
       const snap   = new MockSnapshot(123, delta);
       const result = snap.withRevNum(456);
 

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -7,6 +7,19 @@ import { describe, it } from 'mocha';
 import Delta from 'quill-delta';
 
 import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
+import { DataUtil } from 'util-common';
+
+/**
+ * Helper to call `new BodyDelta()` with a deep-frozen argument.
+ *
+ * @param {*} ops Value to pass to the constructor, which doesn't have to be
+ *   frozen.
+ * @returns {BodyDelta} the result of calling the constructor with a deep-frozen
+ *   version of `ops`.
+ */
+function newBodyDelta(ops) {
+  return new BodyDelta(DataUtil.deepFreeze(ops));
+}
 
 describe('doc-common/BodyChange', () => {
   describe('.FIRST', () => {
@@ -44,16 +57,16 @@ describe('doc-common/BodyChange', () => {
         assert.strictEqual(result.authorId, authorId);
       }
 
-      test(0,   new BodyDelta([{ retain: 100 }]));
+      test(0,   newBodyDelta([{ retain: 100 }]));
       test(123, BodyDelta.EMPTY);
-      test(909, new BodyDelta([{ insert: 'x' }]), null);
-      test(909, new BodyDelta([{ insert: 'x' }]), Timestamp.MIN_VALUE);
+      test(909, newBodyDelta([{ insert: 'x' }]), null);
+      test(909, newBodyDelta([{ insert: 'x' }]), Timestamp.MIN_VALUE);
       test(242, BodyDelta.EMPTY,                  null, null);
       test(242, BodyDelta.EMPTY,                  null, 'florp9019');
     });
 
     it('should accept an array for the `delta`, which should get passed to the `BodyDelta` constructor', () => {
-      const ops    = [{ retain: 100 }];
+      const ops    = DataUtil.deepFreeze([{ retain: 100 }]);
       const result = new BodyChange(0, ops);
 
       assert.deepEqual(result.delta.ops, ops);

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -8,6 +8,19 @@ import Delta from 'quill-delta';
 import { inspect } from 'util';
 
 import { BodyDelta } from 'doc-common';
+import { DataUtil } from 'util-common';
+
+/**
+ * Helper to call `new BodyDelta()` with a deep-frozen argument.
+ *
+ * @param {*} ops Value to pass to the constructor, which doesn't have to be
+ *   frozen.
+ * @returns {BodyDelta} the result of calling the constructor with a deep-frozen
+ *   version of `ops`.
+ */
+function newWithFrozenOps(ops) {
+  return new BodyDelta(DataUtil.deepFreeze(ops));
+}
 
 describe('doc-common/BodyDelta', () => {
   describe('.EMPTY', () => {
@@ -54,7 +67,7 @@ describe('doc-common/BodyDelta', () => {
       test('blort');
       test({ insert: '123' });
       test([{ insert: '123' }]);
-      test(new BodyDelta([{ insert: '123' }]));
+      test(BodyDelta.EMPTY);
     });
   });
 
@@ -78,7 +91,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should succeed for: ${inspect(v)}`, () => {
-          new BodyDelta(v);
+          newWithFrozenOps(v);
         });
       }
     });
@@ -100,6 +113,7 @@ describe('doc-common/BodyDelta', () => {
       for (const v of values) {
         it(`should fail for: ${inspect(v)}`, () => {
           assert.throws(() => new BodyDelta(v));
+          assert.throws(() => newWithFrozenOps(v));
         });
       }
     });
@@ -127,14 +141,14 @@ describe('doc-common/BodyDelta', () => {
     });
 
     it('should reject calls when `this` is not a document', () => {
-      const delta = new BodyDelta([{ retain: 10 }]);
+      const delta = newWithFrozenOps([{ retain: 10 }]);
       const other = BodyDelta.EMPTY;
       assert.throws(() => delta.diff(other));
     });
 
     it('should reject calls when `other` is not a document', () => {
       const delta = BodyDelta.EMPTY;
-      const other = new BodyDelta([{ retain: 10 }]);
+      const other = new newWithFrozenOps([{ retain: 10 }]);
       assert.throws(() => delta.diff(other));
     });
 
@@ -149,9 +163,9 @@ describe('doc-common/BodyDelta', () => {
     // These tests take composition triples `origDoc + change = newDoc` and test
     // `compose()` and `diff()` in various combinations.
     function test(label, origDoc, change, newDoc) {
-      origDoc = new BodyDelta(origDoc);
-      change  = new BodyDelta(change);
-      newDoc  = new BodyDelta(newDoc);
+      origDoc = newWithFrozenOps(origDoc);
+      change  = newWithFrozenOps(change);
+      newDoc  = newWithFrozenOps(newDoc);
 
       describe(label, () => {
         it('should produce the expected composition', () => {
@@ -215,7 +229,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(new BodyDelta(v).isDocument());
+          assert.isTrue(newWithFrozenOps(v).isDocument());
         });
       }
     });
@@ -232,7 +246,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(new BodyDelta(v).isDocument());
+          assert.isFalse(newWithFrozenOps(v).isDocument());
         });
       }
     });
@@ -241,7 +255,7 @@ describe('doc-common/BodyDelta', () => {
   describe('isEmpty()', () => {
     describe('valid empty values', () => {
       const values = [
-        new BodyDelta([]),
+        newWithFrozenOps([]),
         BodyDelta.EMPTY,
       ];
 
@@ -261,7 +275,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          const delta = new BodyDelta(v);
+          const delta = newWithFrozenOps(v);
           assert.isFalse(delta.isEmpty());
         });
       }
@@ -271,7 +285,7 @@ describe('doc-common/BodyDelta', () => {
   describe('toQuillForm()', () => {
     it('should produce `Delta` instances with strict-equal ops', () => {
       function test(ops) {
-        const delta  = new BodyDelta(ops);
+        const delta  = newWithFrozenOps(ops);
         const result = delta.toQuillForm();
         assert.instanceOf(result, Delta);
         assert.strictEqual(result.ops, delta.ops);
@@ -307,8 +321,8 @@ describe('doc-common/BodyDelta', () => {
 
     it('should produce the expected transformations', () => {
       function test(d1, d2, expectedTrue, expectedFalse = expectedTrue) {
-        d1 = new BodyDelta(d1);
-        d2 = new BodyDelta(d2);
+        d1 = newWithFrozenOps(d1);
+        d2 = newWithFrozenOps(d2);
 
         const xformTrue  = d1.transform(d2, true);
         const xformFalse = d1.transform(d2, false);

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -61,9 +61,10 @@ describe('doc-common/BodyDelta', () => {
   describe('constructor()', () => {
     describe('valid arguments', () => {
       // This one is not a valid `ops` array, but per docs, the constructor
-      // doesn't inspect the contents of `ops` arrays and so using this value
-      // should succeed (for some values of the terms "should" and "succeed").
-      const invalidNonEmptyOps = [null, undefined, ['x'], { a: 10 }, 1, 2, 3];
+      // doesn't inspect the contents of `ops` arrays other than seeing that
+      // elements are all simple objects, and so using this value should succeed
+      // (for some values of the terms "should" and "succeed").
+      const invalidNonEmptyOps = [{ a: 10 }, { b: 'florp' }];
 
       const values = [
         [],
@@ -89,7 +90,11 @@ describe('doc-common/BodyDelta', () => {
         123,
         'florp',
         { insert: 123 },
-        new Map()
+        new Map(),
+        [null],
+        [undefined],
+        ['x'],
+        [1, 2, 3]
       ];
 
       for (const v of values) {

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -10,7 +10,7 @@ import { DEFAULT_DOCUMENT } from 'hooks-server';
 import { Mutex } from 'promise-util';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
-import { CommonBase } from 'util-common';
+import { CommonBase, DataUtil } from 'util-common';
 
 import CaretControl from './CaretControl';
 import BodyControl from './BodyControl';
@@ -25,14 +25,14 @@ const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
 /**
  * {BodyDelta} Message used as document to indicate a major validation error.
  */
-const ERROR_NOTE = new BodyDelta(
-  [{ insert: '(Recreated document due to validation error(s).)\n' }]);
+const ERROR_NOTE = new BodyDelta(DataUtil.deepFreeze(
+  [{ insert: '(Recreated document due to validation error(s).)\n' }]));
 
 /**
  * {BodyDelta} Message used as document instead of migrating documents from
  * old schema versions. */
-const MIGRATION_NOTE = new BodyDelta(
-  [{ insert: '(Recreated document due to schema version skew.)\n' }]);
+const MIGRATION_NOTE = new BodyDelta(DataUtil.deepFreeze(
+  [{ insert: '(Recreated document due to schema version skew.)\n' }]));
 
 /**
  * Manager for the "complex" of objects which in aggregate allow access and

--- a/local-modules/typecheck/TBoolean.js
+++ b/local-modules/typecheck/TBoolean.js
@@ -12,16 +12,9 @@ export default class TBoolean extends UtilityClass {
    * Checks a value of type `Boolean`.
    *
    * @param {*} value The (alleged) boolean.
-   * @param {boolean|null} [defaultValue = null] Default value. If passed,
-   *   indicates that `undefined` should be treated as that value. If not
-   *   passed, `undefined` is an error.
-   * @returns {boolean} `value` or `defaultValue`.
+   * @returns {boolean} `value`, if it is indeed a boolean.
    */
-  static check(value, defaultValue = null) {
-    if ((value === undefined) && (defaultValue !== null)) {
-      value = defaultValue;
-    }
-
+  static check(value) {
     if (typeof value !== 'boolean') {
       throw Errors.bad_value(value, Boolean);
     }

--- a/local-modules/typecheck/tests/test_TBoolean.js
+++ b/local-modules/typecheck/tests/test_TBoolean.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TBoolean } from 'typecheck';
 
 describe('typecheck/TBoolean', () => {
-  describe('check(value)', () => {
+  describe('check()', () => {
     it('should return the provided value when passed a boolean', () => {
       assert.strictEqual(TBoolean.check(true), true);
       assert.strictEqual(TBoolean.check(false), false);
@@ -23,17 +23,6 @@ describe('typecheck/TBoolean', () => {
       assert.throws(() => TBoolean.check([]));
       assert.throws(() => TBoolean.check({ }));
       assert.throws(() => TBoolean.check(54));
-    });
-
-  });
-
-  describe('check(value, defaultValue)', () => {
-    it('should return defaultValue if passed undefined', () => {
-      assert.strictEqual(TBoolean.check(undefined, true), true);
-    });
-
-    it('should return value if passed anything but undefined', () => {
-      assert.strictEqual(TBoolean.check(false, true), false);
     });
   });
 });

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -49,4 +49,18 @@ export default class ObjectUtil extends UtilityClass {
   static hasOwnProperty(value, name) {
     return Object.prototype.hasOwnProperty.call(value, name);
   }
+
+  /**
+   * Tests whether a value is a "simple object." A simple object is defined as
+   * being a value of type `object` which is not `null` and whose direct
+   * prototype is `Object.prototype`. Notably, arrays are _not_ simple objects.
+   *
+   * @param {*} value Value to check.
+   * @returns {boolean} `true` if `value` is a simple object, or `false` if not.
+   */
+  static isSimple(value) {
+    return (typeof value === 'object')
+        && (value !== null)
+        && (Object.getPrototypeOf(value) === Object.prototype);
+  }
 }

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -235,7 +235,7 @@ describe('util-core/DataUtil', () => {
 
     it('should return `false` for non-equal values', () => {
       function test(v1, v2) {
-        assert.isFalse(DataUtil.equalData(v1, v2), v1);
+        assert.isFalse(DataUtil.equalData(v1, v2), inspect(v1));
       }
 
       test(null, undefined);
@@ -279,6 +279,27 @@ describe('util-core/DataUtil', () => {
       test({ x: 1 }, 1);
 
       test(new Functor('x', 1, 2, 3), [1, 2, 3]);
+    });
+
+    it('should return `false` given an object/array with non-data bindings', () => {
+      function test(v) {
+        const obj = { a: 10, b: v, c: 20 };
+        assert.isFalse(DataUtil.equalData(obj, obj), inspect(v));
+
+        const arr = [1, 2, 3, v, 4, 5, 6];
+        assert.isFalse(DataUtil.equalData(arr, arr), inspect(v));
+      }
+
+      // Direct.
+      test(/regex_is_not_data/);
+      test(new Map());
+
+      // Nested.
+      test([/regex_is_not_data/]);
+      test([new Map()]);
+      test({ x: /regex_is_not_data/ });
+      test({ x: new Map() });
+      test([[[[[[[[[[[/regex_is_not_data/]]]]]]]]]]]);
     });
   });
 

--- a/local-modules/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/util-core/tests/test_ObjectUtil.js
@@ -58,4 +58,42 @@ describe('util-core/ObjectUtil', () => {
       assert.isFalse(ObjectUtil.hasOwnProperty(value, 'floopty'));
     });
   });
+
+  describe('isSimple()', () => {
+    it('should return `true` for simple objects', () => {
+      function test(value) {
+        assert.isTrue(ObjectUtil.isSimple(value));
+      }
+
+      test({});
+      test({ a: 10 });
+      test({ a: 10, b: 20 });
+      test({ [Symbol('blort')]: [1, 2, 3] });
+    });
+
+    it('should return `false` for non-simple objects', () => {
+      function test(value) {
+        assert.isFalse(ObjectUtil.isSimple(value));
+      }
+
+      test([]);
+      test([1]);
+      test(() => true);
+      test(new Map());
+    });
+
+    it('should return `false` for non-objects', () => {
+      function test(value) {
+        assert.isFalse(ObjectUtil.isSimple(value));
+      }
+
+      test(null);
+      test(undefined);
+      test(false);
+      test(true);
+      test('x');
+      test(Symbol('x'));
+      test(37);
+    });
+  });
 });


### PR DESCRIPTION
The big-ticket item in this PR is that `BaseDelta` got extracted as a common base class of all the concrete `*Delta` classes. Subclasses fill in a property that defines valid operations and a method which defines "document deltas" (vs. ones that can only be used as diffs). One or more future PRs will likely pull more functionality into the base class.

The class `BodyDelta` remains a bit off compared to the other delta classes, because of its origin as specifically tied to Quill. Things are okay as they stand, but ideally we would (and likely we will) move toward having a real class (not just ad-hoc simple objects) be used for the operations which live within these instances.

Other highlights:

* Extracted a base `diff()` out of `*Snapshot.diff()`, leaving an abstract method `_impl_diffAsDelta()` which gets filled in per subclass.
* Removed a layer from the codec-encoding of snapshot and change classes (encode the ops of the delta and not the delta itself). This became reasonable to do now that `BaseDelta` exists and imposes more structure on the concrete delta classes.
* Likewise, simplified the linkage between change classes and their respective delta classes.
* Added a bunch of tests.