### PR TITLE
More `BaseSnapshot` extraction.

### DIFF
--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
+import { TArray, TObject } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import BaseChange from './BaseChange';
@@ -105,7 +105,7 @@ export default class BaseSnapshot extends CommonBase {
    * Composes a change on top of this instance, to produce a new instance. If
    * the given `change` has an empty `delta` and has a `revNum` which is the
    * same as this instance, then this method returns `this`. Otherwise, this
-   * method always returns a new instance.
+   * method returns a new instance.
    *
    * @param {BaseChange} change Change to compose on top of this instance. Must
    *   be an instance of the `changeClass` as defined by the subclass.
@@ -123,6 +123,32 @@ export default class BaseSnapshot extends CommonBase {
     }
 
     return new this.constructor(change.revNum, this._impl_composeWithDelta(delta));
+  }
+
+  /**
+   * Composes a sequence of changes on top of this instance, in order, to
+   * produce a new instance. If the given array of changes is empty, this method
+   * returns `this`. If all of the changes have an empty `delta` and the same
+   * `revNum` as this instance, this method returns `this`. Otherwise, this
+   * method returns a new instance.
+   *
+   * @param {array<BaseChange>} changes Changes to compose on top of this
+   *   instance. Each array element must be an instance of the `changeClass` as
+   *   defined by the subclass.
+   * @returns {BaseSnapshot} New instance consisting of the composition of
+   *   this instance with all of the `changes`. Will be a direct instance of the
+   *   same class as `this`.
+   */
+  composeAll(changes) {
+    TArray.check(changes);
+
+    let result = this;
+
+    for (const c of changes) {
+      result = result.compose(c);
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -27,23 +27,6 @@ export default class BodySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Composes a change on top of this instance, to produce a new instance.
-   *
-   * @param {BodyChange} change Change to compose on top of this instance.
-   * @returns {BodySnapshot} New instance consisting of the composition of
-   *   this instance with `change`.
-   */
-  compose(change) {
-    BodyChange.check(change);
-
-    const contents = change.delta.isEmpty()
-      ? this.contents
-      : this.contents.compose(change.delta);
-
-    return new BodySnapshot(change.revNum, contents);
-  }
-
-  /**
    * Composes a sequence of changes on top of this instance, in order, to
    * produce a new instance.
    *
@@ -66,6 +49,19 @@ export default class BodySnapshot extends BaseSnapshot {
 
     const lastChange = changes[changes.length - 1];
     return new BodySnapshot(lastChange.revNum, contents);
+  }
+
+  /**
+   * Main implementation of {@link #compose}. Takes a delta (not a change
+   * instance), and produces a document delta (not a snapshot).
+   *
+   * @param {BodyDelta} delta Difference to compose with this instance's
+   *   contents.
+   * @returns {BodyDelta} Delta which represents the composed document
+   *   contents.
+   */
+  _impl_composeWithDelta(delta) {
+    return this.contents.compose(delta);
   }
 
   /**

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TArray } from 'typecheck';
-
 import BaseSnapshot from './BaseSnapshot';
 import BodyChange from './BodyChange';
 
@@ -24,31 +22,6 @@ export default class BodySnapshot extends BaseSnapshot {
   constructor(revNum, contents) {
     super(revNum, contents);
     Object.freeze(this);
-  }
-
-  /**
-   * Composes a sequence of changes on top of this instance, in order, to
-   * produce a new instance.
-   *
-   * @param {array<BodyChange>} changes Changes to compose on top of this
-   *   instance.
-   * @returns {BodySnapshot} New instance consisting of the composition of
-   *   this instance with all of the `changes`.
-   */
-  composeAll(changes) {
-    TArray.check(changes, BodyChange.check);
-
-    if (changes.length === 0) {
-      return this;
-    }
-
-    let contents = this.contents;
-    for (const c of changes) {
-      contents = contents.compose(c.delta);
-    }
-
-    const lastChange = changes[changes.length - 1];
-    return new BodySnapshot(lastChange.revNum, contents);
   }
 
   /**

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import { inspect } from 'util';
 
-import { BaseSnapshot } from 'doc-common';
+import { BaseChange, BaseSnapshot } from 'doc-common';
 
 import MockChange from './MockChange';
 import MockDelta from './MockDelta';
@@ -20,12 +20,25 @@ class MockSnapshot extends BaseSnapshot {
     Object.freeze(this);
   }
 
+  _impl_composeWithDelta(delta) {
+    return [MockDelta.makeOp('composed_delta'), delta.ops[0]];
+  }
+
   _impl_diffAsDelta(newerSnapshot) {
     return [MockDelta.makeOp('diff_delta'), newerSnapshot.contents.ops[0]];
   }
 
   static get _impl_changeClass() {
     return MockChange;
+  }
+}
+
+/**
+ * A second mock subclass of `BaseChange`.
+ */
+class AnotherChange extends BaseChange {
+  static get _impl_deltaClass() {
+    return MockDelta;
   }
 }
 
@@ -114,6 +127,55 @@ describe('doc-common/BaseSnapshot', () => {
       test([]);
       test([789]);
       test({ a: 10 });
+    });
+  });
+
+  describe('compose()', () => {
+    it('should call through to the impl and wrap the result in a new instance', () => {
+      const snap   = new MockSnapshot(10, [MockDelta.makeOp('some_op')]);
+      const change = new MockChange(20, [MockDelta.makeOp('change_op')]);
+      const result = snap.compose(change);
+
+      assert.instanceOf(result, MockSnapshot);
+      assert.strictEqual(result.revNum, 20);
+      assert.instanceOf(result.contents, MockDelta);
+
+      assert.deepEqual(result.contents.ops,
+        [MockDelta.makeOp('composed_delta'), MockDelta.makeOp('change_op')]);
+    });
+
+    it('should return `this` given a same-`revNum` empty-`delta` change', () => {
+      const snap   = new MockSnapshot(10, [MockDelta.makeOp('some_op')]);
+      const change = new MockChange(10, []);
+      const result = snap.compose(change);
+
+      assert.strictEqual(result, snap);
+    });
+
+    it('should reject instances of the wrong change class', () => {
+      const snap   = new MockSnapshot(10, []);
+      const change = new AnotherChange(0, []);
+
+      assert.throws(() => { snap.compose(change); });
+    });
+
+    it('should reject non-change arguments', () => {
+      const snap = new MockSnapshot(10, []);
+
+      function test(v) {
+        assert.throws(() => { snap.compose(v); });
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test('blort');
+      test([]);
+      test(['florp']);
+      test({ x: 10 });
+      test(new Map());
+      test(MockDelta.EMPTY);
+      test(MockSnapshot.EMPTY);
     });
   });
 

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -21,7 +21,15 @@ class MockSnapshot extends BaseSnapshot {
   }
 
   _impl_composeWithDelta(delta) {
-    return [MockDelta.makeOp('composed_delta'), delta.ops[0]];
+    let resultName = 'composed_delta';
+    const op0 = this.contents.ops[0];
+
+    if (op0 && op0.name.startsWith(resultName)) {
+      // The first op gets a `+` suffix for each additional composition.
+      resultName = op0.name + '+';
+    }
+
+    return [MockDelta.makeOp(resultName), ...delta.ops];
   }
 
   _impl_diffAsDelta(newerSnapshot) {
@@ -176,6 +184,62 @@ describe('doc-common/BaseSnapshot', () => {
       test(new Map());
       test(MockDelta.EMPTY);
       test(MockSnapshot.EMPTY);
+    });
+  });
+
+  describe('composeAll()', () => {
+    it('should call through to the impl and wrap the result in a new instance', () => {
+      const snap    = new MockSnapshot(10, [MockDelta.makeOp('some_op')]);
+      const change1 = new MockChange(21, [MockDelta.makeOp('change_op1')]);
+      const change2 = new MockChange(22, [MockDelta.makeOp('change_op2')]);
+      const result = snap.composeAll([change1, change2]);
+
+      assert.instanceOf(result, MockSnapshot);
+      assert.strictEqual(result.revNum, 22);
+      assert.instanceOf(result.contents, MockDelta);
+
+      assert.deepEqual(result.contents.ops,
+        [MockDelta.makeOp('composed_delta+'), MockDelta.makeOp('change_op2')]);
+    });
+
+    it('should return `this` given same-`revNum` empty-`delta` changes', () => {
+      const snap   = new MockSnapshot(10, [MockDelta.makeOp('some_op')]);
+      const change = new MockChange(10, []);
+      const result = snap.composeAll([change, change, change, change]);
+
+      assert.strictEqual(result, snap);
+    });
+
+    it('should reject instances of the wrong change class', () => {
+      const snap   = new MockSnapshot(10, []);
+      const change = new AnotherChange(0, []);
+
+      assert.throws(() => { snap.composeAll([change]); });
+    });
+
+    it('should reject non-change array elements', () => {
+      const snap = new MockSnapshot(10, []);
+
+      function test(v) {
+        assert.throws(() => { snap.compose([v]); });
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test('blort');
+      test([]);
+      test(['florp']);
+      test({ x: 10 });
+      test(new Map());
+      test(MockDelta.EMPTY);
+      test(MockSnapshot.EMPTY);
+    });
+
+    it('should reject non-array arguments', () => {
+      const snap   = new MockSnapshot(10, []);
+
+      assert.throws(() => { snap.composeAll(123); });
     });
   });
 


### PR DESCRIPTION
This PR extracts a common outer `compose()` from the three OT snapshot classes as well as pulling in a complete implementation of `composeAll()` from `BodySnapshot`.

With this, all of the existing commonality between the three classes has now been DRYed out, though there is arguably some commonality just between caret and property snapshots that deserves further scrutiny (but it can wait for a while).