### PR TITLE
Align `CaretSnapshot` and `PropertySnapshot`.

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -810,7 +810,7 @@ export default class BodyClient extends StateMachine {
    *   current state, which is expected to preserve any state that Quill has
    *   that isn't yet represented in `_snapshot`. This must be used in cases
    *   where Quill's state has progressed ahead of `_snapshot` due to local
-   * activity.
+   *   activity.
    */
   _updateWithChange(change, quillDelta = change.delta) {
     const needQuillUpdate = !quillDelta.isEmpty();

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -460,7 +460,7 @@ export default class CaretOverlay {
           }
 
           if (props.key === 'color') {
-            const caret = newSnapshot.caretForSession(sessionId);
+            const caret = newSnapshot.get(sessionId);
 
             this._updateAvatarColor(caret);
           }

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -161,13 +161,13 @@ export default class CaretOverlay {
     const quill = this._editorComplex.bodyQuill;
 
     // For each session…
-    for (const caret of this._lastCaretSnapshot.carets) {
+    for (const [sessionId, caret] of this._lastCaretSnapshot.entries()) {
       // Is this caret us? If so, don't draw anything.
-      if (caret.sessionId === this._editorComplex.sessionId) {
+      if (sessionId === this._editorComplex.sessionId) {
         continue;
       }
 
-      const avatarReference = this._useReferences.get(caret.sessionId);
+      const avatarReference = this._useReferences.get(sessionId);
 
       if (caret.length === 0) {
         // Length of zero means an insertion point instead of a selection

--- a/local-modules/doc-client/CaretStore.js
+++ b/local-modules/doc-client/CaretStore.js
@@ -132,7 +132,7 @@ export default class CaretStore {
           // respect to, so try to do that.
           const change = await sessionProxy.caret_getChangeAfter(snapshot.revNum);
           snapshot = snapshot.compose(change);
-          docSession.log.detail(`Got caret change. ${snapshot.carets.length} caret(s).`);
+          docSession.log.detail(`Got caret change. ${snapshot.size} caret(s).`);
         }
       } catch (e) {
         // Assume that the error isn't truly fatal. Most likely, it's because
@@ -151,7 +151,7 @@ export default class CaretStore {
           // latter is why this section isn't just part of an `else` block to
           // the previous `if`).
           snapshot = await sessionProxy.caret_snapshot();
-          docSession.log.detail(`Got ${snapshot.carets.length} new caret(s)!`);
+          docSession.log.detail(`Got ${snapshot.size} new caret(s)!`);
         }
       } catch (e) {
         // Assume that the error is transient and most likely due to the session

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -69,20 +69,6 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Gets the caret info for the given session, if any.
-   *
-   * @param {string} sessionId Session in question.
-   * @returns {Caret|null} Corresponding caret, or `null` if there is none.
-   */
-  caretForSession(sessionId) {
-    TString.nonEmpty(sessionId);
-
-    const found = this._carets.get(sessionId);
-
-    return found ? found.props.caret : null;
-  }
-
-  /**
    * Gets an iterator over the `[sessionId, caret]` entries that make up the
    * snapshot.
    *
@@ -92,7 +78,7 @@ export default class CaretSnapshot extends BaseSnapshot {
    * @yields {Iterator<[string, Caret]>} Iterator over the entries. The keys are
    *   the session IDs, and the values are the corresponding caret values.
    */
-  *entries() {
+  * entries() {
     for (const op of this.contents.ops) {
       const caret = op.props.caret;
       yield [caret.sessionId, caret];
@@ -110,15 +96,27 @@ export default class CaretSnapshot extends BaseSnapshot {
    * @returns {Caret} Corresponding caret.
    */
   get(sessionId) {
+    const found = this.getOrNull(sessionId);
+
+    if (found) {
+      return found;
+    }
+
+    throw Errors.bad_use(`No such session: ${sessionId}`);
+  }
+
+  /**
+   * Gets the caret info for the given session, if any.
+   *
+   * @param {string} sessionId Session in question.
+   * @returns {Caret|null} Corresponding caret, or `null` if there is none.
+   */
+  getOrNull(sessionId) {
     TString.nonEmpty(sessionId);
 
     const found = this._carets.get(sessionId);
 
-    if (found) {
-      return found.props.caret;
-    }
-
-    throw Errors.bad_use(`No such session: ${sessionId}`);
+    return found ? found.props.caret : null;
   }
 
   /**
@@ -163,8 +161,7 @@ export default class CaretSnapshot extends BaseSnapshot {
    *   session, or `false` if not.
    */
   has(sessionId) {
-    TString.nonEmpty(sessionId);
-    return this._carets.has(sessionId);
+    return this.getOrNull(sessionId) !== null;
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -56,28 +56,6 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
-   * {array<Caret>} Array of active carets. It is guaranteed to be a frozen
-   * (immutable) value.
-   */
-  get carets() {
-    const result = [];
-
-    for (const op of this._carets.values()) {
-      result.push(op.props.caret);
-    }
-
-    return Object.freeze(result);
-  }
-
-  /**
-   * {array<string>} Array of session IDs for all active carets. It is
-   * guaranteed to be a frozen (immutable) value.
-   */
-  get sessionIds() {
-    return Object.freeze([...this._carets.keys()]);
-  }
-
-  /**
    * {Int} The number of carets defined by this instance.
    *
    * **Note:** This has identical semantics to the `Map` property of the same

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -15,6 +15,9 @@ import CaretOp from './CaretOp';
 /**
  * Snapshot of information about all active sessions on a particular document.
  * Instances of this class are always frozen (immutable).
+ *
+ * When thought of in terms of a map, instances of this class can be taken to
+ * be maps from session ID strings to `Caret` values.
  */
 export default class CaretSnapshot extends BaseSnapshot {
   /**
@@ -128,13 +131,16 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Gets whether or not this instance represents the given session.
+   * Gets whether or not this instance has a caret for the given session.
+   *
+   * **Note:** This has identical semantics to the `Map` method of the same
+   * name, except that it will reject `name`s of the wrong type.
    *
    * @param {string} sessionId Session in question.
-   * @returns {boolean} `true` if this instance has info for the indicated
+   * @returns {boolean} `true` if this instance has a caret for the indicated
    *   session, or `false` if not.
    */
-  hasSession(sessionId) {
+  has(sessionId) {
     TString.nonEmpty(sessionId);
     return this.caretForSession(sessionId) !== null;
   }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -75,8 +75,8 @@ export default class CaretSnapshot extends BaseSnapshot {
    * **Note:** This has identical semantics to the `Map` method of the same
    * name.
    *
-   * @yields {Iterator<[string, Caret]>} Iterator over the entries. The keys are
-   *   the session IDs, and the values are the corresponding caret values.
+   * @yields {[string, Caret]} Snapshot entries. The keys are the session IDs,
+   *   and the values are the corresponding caret values.
    */
   * entries() {
     for (const op of this.contents.ops) {

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -100,6 +100,28 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
+   * Gets the caret info for the given session. It is an error if this instance
+   * has no caret for the indicated session.
+   *
+   * **Note:** This differs from the semantics of the `Map` method of the same
+   * name in that the not-found case is an error.
+   *
+   * @param {string} sessionId Session in question.
+   * @returns {Caret} Corresponding caret.
+   */
+  get(sessionId) {
+    TString.nonEmpty(sessionId);
+
+    const found = this._carets.get(sessionId);
+
+    if (found) {
+      return found.props.caret;
+    }
+
+    throw Errors.bad_use(`No such session: ${sessionId}`);
+  }
+
+  /**
    * Compares this to another possible-instance, for equality of content.
    *
    * @param {*} other Value to compare to.
@@ -142,7 +164,7 @@ export default class CaretSnapshot extends BaseSnapshot {
    */
   has(sessionId) {
     TString.nonEmpty(sessionId);
-    return this.caretForSession(sessionId) !== null;
+    return this._carets.has(sessionId);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -78,6 +78,16 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
+   * {Int} The number of carets defined by this instance.
+   *
+   * **Note:** This has identical semantics to the `Map` property of the same
+   * name.
+   */
+  get size() {
+    return this.contents.ops.length;
+  }
+
+  /**
    * Gets the caret info for the given session, if any.
    *
    * @param {string} sessionId Session in question.
@@ -89,6 +99,23 @@ export default class CaretSnapshot extends BaseSnapshot {
     const found = this._carets.get(sessionId);
 
     return found ? found.props.caret : null;
+  }
+
+  /**
+   * Gets an iterator over the `[sessionId, caret]` entries that make up the
+   * snapshot.
+   *
+   * **Note:** This has identical semantics to the `Map` method of the same
+   * name.
+   *
+   * @yields {Iterator<[string, Caret]>} Iterator over the entries. The keys are
+   *   the session IDs, and the values are the corresponding caret values.
+   */
+  *entries() {
+    for (const op of this.contents.ops) {
+      const caret = op.props.caret;
+      yield [caret.sessionId, caret];
+    }
   }
 
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -54,19 +54,30 @@ export default class PropertySnapshot extends BaseSnapshot {
   }
 
   /**
-   * {Map<string, *>} Map from property names to values. Guaranteed to be
-   * immutable.
+   * {Int} The number of properties defined by this instance.
+   *
+   * **Note:** This has identical semantics to the `Map` property of the same
+   * name.
    */
-  get properties() {
-    const result = new Map();
+  get size() {
+    return this.contents.ops.length;
+  }
 
-    for (const op of this._properties.values()) {
+  /**
+   * Gets an iterator over the `[name, value]` entries that make up the
+   * snapshot.
+   *
+   * **Note:** This has identical semantics to the `Map` method of the same
+   * name.
+   *
+   * @yields {Iterator<[string, *]>} Iterator over the entries. The keys are
+   *   the property names, and the values are the corresponding property values.
+   */
+  *entries() {
+    for (const op of this.contents.ops) {
       const { name, value } = op.props;
-      result.set(name, value);
+      yield [name, value];
     }
-
-    Object.freeze(result);
-    return result;
   }
 
   /**
@@ -104,6 +115,9 @@ export default class PropertySnapshot extends BaseSnapshot {
    * Gets the property value for the given name, if any. Throws an error if
    * `name` is not a bound property.
    *
+   * **Note:** This differs from the semantics of the `Map` method of the same
+   * name in that the not-found case is an error.
+   *
    * @param {string} name Property name.
    * @returns {*} Corresponding property value.
    */
@@ -121,6 +135,9 @@ export default class PropertySnapshot extends BaseSnapshot {
 
   /**
    * Gets whether or not this instance has the indicated property.
+   *
+   * **Note:** This has identical semantics to the `Map` method of the same
+   * name.
    *
    * @param {string} name Property name.
    * @returns {boolean} `true` if this instance has a binding for the indicated

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -13,6 +13,9 @@ import PropertyOp from './PropertyOp';
 /**
  * Snapshot of information about all active sessions on a particular document.
  * Instances of this class are always frozen (immutable).
+ *
+ * When thought of in terms of a map, instances of this class can be taken to
+ * be maps from string keys to arbitrary data values.
  */
 export default class PropertySnapshot extends BaseSnapshot {
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -73,8 +73,8 @@ export default class PropertySnapshot extends BaseSnapshot {
    * **Note:** This has identical semantics to the `Map` method of the same
    * name.
    *
-   * @yields {Iterator<[string, *]>} Iterator over the entries. The keys are
-   *   the property names, and the values are the corresponding property values.
+   * @yields {[string, *]} Snapshot entries. The keys are the property names,
+   *   and the values are the corresponding property values.
    */
   * entries() {
     for (const op of this.contents.ops) {

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -137,7 +137,7 @@ export default class PropertySnapshot extends BaseSnapshot {
    * Gets whether or not this instance has the indicated property.
    *
    * **Note:** This has identical semantics to the `Map` method of the same
-   * name.
+   * name, except that it will reject `name`s of the wrong type.
    *
    * @param {string} name Property name.
    * @returns {boolean} `true` if this instance has a binding for the indicated

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -76,7 +76,7 @@ export default class PropertySnapshot extends BaseSnapshot {
    * @yields {Iterator<[string, *]>} Iterator over the entries. The keys are
    *   the property names, and the values are the corresponding property values.
    */
-  *entries() {
+  * entries() {
     for (const op of this.contents.ops) {
       const { name, value } = op.props;
       yield [name, value];

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -155,30 +155,6 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
-  describe('caretForSession()', () => {
-    it('should return the caret associated with an existing session', () => {
-      const snap = new CaretSnapshot(999, [op1, op2, op3]);
-
-      assert.strictEqual(snap.caretForSession(caret1.sessionId), caret1);
-      assert.strictEqual(snap.caretForSession(caret2.sessionId), caret2);
-      assert.strictEqual(snap.caretForSession(caret3.sessionId), caret3);
-    });
-
-    it('should return `null` when given a session ID that is not in the snapshot', () => {
-      const snap = new CaretSnapshot(999, [op1, op3]);
-
-      assert.isNull(snap.caretForSession(caret2.sessionId));
-    });
-
-    it('should throw an error if given an invalid session ID', () => {
-      const snap = new CaretSnapshot(999, []);
-
-      assert.throws(() => { snap.caretForSession(123); });
-      assert.throws(() => { snap.caretForSession(['x']); });
-      assert.throws(() => { snap.caretForSession(''); });
-    });
-  });
-
   describe('compose()', () => {
     it('should produce an equal instance when passed an empty change with the same `revNum`', () => {
       let which = 0;
@@ -468,6 +444,30 @@ describe('doc-common/CaretSnapshot', () => {
       assert.throws(() => { snap.get(123); });
       assert.throws(() => { snap.get(['x']); });
       assert.throws(() => { snap.get(''); });
+    });
+  });
+
+  describe('getOrNull()', () => {
+    it('should return the caret associated with an existing session', () => {
+      const snap = new CaretSnapshot(999, [op1, op2, op3]);
+
+      assert.strictEqual(snap.getOrNull(caret1.sessionId), caret1);
+      assert.strictEqual(snap.getOrNull(caret2.sessionId), caret2);
+      assert.strictEqual(snap.getOrNull(caret3.sessionId), caret3);
+    });
+
+    it('should return `null` when given a session ID that is not in the snapshot', () => {
+      const snap = new CaretSnapshot(999, [op1, op3]);
+
+      assert.isNull(snap.getOrNull(caret2.sessionId));
+    });
+
+    it('should throw an error if given an invalid session ID', () => {
+      const snap = new CaretSnapshot(999, []);
+
+      assert.throws(() => { snap.getOrNull(123); });
+      assert.throws(() => { snap.getOrNull(['x']); });
+      assert.throws(() => { snap.getOrNull(''); });
     });
   });
 

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -447,6 +447,30 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
+  describe('get()', () => {
+    it('should return the caret associated with an existing session', () => {
+      const snap = new CaretSnapshot(999, [op1, op2, op3]);
+
+      assert.strictEqual(snap.get(caret1.sessionId), caret1);
+      assert.strictEqual(snap.get(caret2.sessionId), caret2);
+      assert.strictEqual(snap.get(caret3.sessionId), caret3);
+    });
+
+    it('should throw an error when given a session ID that is not in the snapshot', () => {
+      const snap = new CaretSnapshot(999, [op1, op3]);
+
+      assert.throws(() => { snap.get(caret2.sessionId); });
+    });
+
+    it('should throw an error if given an invalid session ID', () => {
+      const snap = new CaretSnapshot(999, []);
+
+      assert.throws(() => { snap.get(123); });
+      assert.throws(() => { snap.get(['x']); });
+      assert.throws(() => { snap.get(''); });
+    });
+  });
+
   describe('has()', () => {
     it('should return `true` when given a session ID for an existing session', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);

--- a/local-modules/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/doc-common/tests/test_CaretSnapshot.js
@@ -447,27 +447,27 @@ describe('doc-common/CaretSnapshot', () => {
     });
   });
 
-  describe('hasSession()', () => {
+  describe('has()', () => {
     it('should return `true` when given a session ID for an existing session', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
-      assert.isTrue(snap.hasSession(caret1.sessionId));
-      assert.isTrue(snap.hasSession(caret2.sessionId));
-      assert.isTrue(snap.hasSession(caret3.sessionId));
+      assert.isTrue(snap.has(caret1.sessionId));
+      assert.isTrue(snap.has(caret2.sessionId));
+      assert.isTrue(snap.has(caret3.sessionId));
     });
 
     it('should return `false` when given a session ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
-      assert.isFalse(snap.hasSession(caret2.sessionId));
+      assert.isFalse(snap.has(caret2.sessionId));
     });
 
     it('should throw an error if given an invalid session ID', () => {
       const snap = new CaretSnapshot(999, []);
 
-      assert.throws(() => { snap.hasSession(123); });
-      assert.throws(() => { snap.hasSession(['x']); });
-      assert.throws(() => { snap.hasSession(''); });
+      assert.throws(() => { snap.has(123); });
+      assert.throws(() => { snap.has(['x']); });
+      assert.throws(() => { snap.has(''); });
     });
   });
 

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -396,9 +396,30 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('get()', () => {
     it('should return the value associated with an existing property', () => {
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      function test(name, value) {
+        const op = PropertyOp.op_setProperty(name, value);
+        const snap = new PropertySnapshot(1, [
+          PropertyOp.op_setProperty('a', 1),
+          PropertyOp.op_setProperty('b', 2),
+          PropertyOp.op_setProperty('c', 3),
+          op,
+          PropertyOp.op_setProperty('X', 11),
+          PropertyOp.op_setProperty('Y', 22),
+          PropertyOp.op_setProperty('Z', 33)
+        ]);
 
-      assert.strictEqual(snap.get('blort'), 'zorch');
+        assert.strictEqual(snap.get(name), op.props.value);
+      }
+
+      test('zilch', undefined);
+      test('zilch', null);
+      test('zilch', false);
+      test('zilch', []);
+      test('zilch', {});
+      test('zilch', 0);
+
+      test('foo',   'bar');
+      test('florp', ['like']);
     });
 
     it('should always return a deep-frozen value even when the constructor was passed an unfrozen value', () => {
@@ -420,12 +441,18 @@ describe('doc-common/PropertySnapshot', () => {
   describe('has()', () => {
     it('should return `true` for an existing property', () => {
       const snap = new PropertySnapshot(1, [
-        PropertyOp.op_setProperty('blort', 'zorch'),
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_setProperty('blort',  'zorch'),
+        PropertyOp.op_setProperty('florp',  'like'),
+        PropertyOp.op_setProperty('zilch',  null),
+        PropertyOp.op_setProperty('zip',    undefined),
+        PropertyOp.op_setProperty('zither', false)
       ]);
 
       assert.isTrue(snap.has('blort'));
       assert.isTrue(snap.has('florp'));
+      assert.isTrue(snap.has('zilch'));
+      assert.isTrue(snap.has('zip'));
+      assert.isTrue(snap.has('zither'));
     });
 
     it('should return `false` for a non-existent property', () => {

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -154,7 +154,7 @@ export default class CaretControl extends CommonBase {
     // Construct the new/updated caret and updated snapshot.
 
     let snapshot     = this._snapshot;
-    const oldCaret   = snapshot.caretForSession(sessionId);
+    const oldCaret   = snapshot.getOrNull(sessionId);
     const revNum     = docRevNum; // Done to match the caret field name.
     const lastActive = Timestamp.now();
     const newFields  = { revNum, lastActive, index, length };

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -261,17 +261,6 @@ export default class CaretControl extends CommonBase {
    */
   async _sessionReaped(sessionId) {
     const snapshot = this._snapshot;
-
-    // **TODO:** These conditionals check for a weird case that has shown up
-    // intermittently, namely that `_snapshot` doesn't have a `caretForSession`
-    // method. It is unclear what's going on as of this writing, and the hope is
-    // that this check and message may help sort things out.
-    if (!snapshot) {
-      this._log.wtf('Snapshot not set? Currently:', snapshot);
-    } else if (!snapshot.caretForSession) {
-      this._log.wtf('`caretForSession` not defined? Snapshot:', snapshot);
-    }
-
     const oldCaret = snapshot.caretForSession(sessionId);
 
     if (oldCaret !== null) {

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -225,7 +225,7 @@ export default class CaretControl extends CommonBase {
       if (minTime.compareTo(caret.lastActive) > 0) {
         // Too old!
         this._log.info(`[${sessionId}] Caret became inactive.`);
-        toRemove.push(caret);
+        toRemove.push(sessionId);
       }
     }
 
@@ -233,19 +233,19 @@ export default class CaretControl extends CommonBase {
   }
 
   /**
-   * Removes the sessions associated with the indicated carets from the local
-   * snapshot, and also pushes the removal to the storage layer.
+   * Removes the indicated sessions from the local snapshot, and also pushes the
+   * removal to the storage layer.
    *
-   * @param {...Caret} carets Carets representing the sessions to be removed.
+   * @param {...string} sessionIds IDs of the sessions to be removed.
    */
-  _removeSessions(...carets) {
+  _removeSessions(...sessionIds) {
     const storage     = this._caretStorage;
     const oldSnapshot = this._snapshot;
     let   newSnapshot = oldSnapshot;
 
-    for (const c of carets) {
-      newSnapshot = newSnapshot.withoutCaret(c);
-      storage.delete(c);
+    for (const sessionId of sessionIds) {
+      newSnapshot = newSnapshot.withoutSession(sessionId);
+      storage.delete(sessionId);
     }
 
     if (newSnapshot !== oldSnapshot) {
@@ -260,11 +260,8 @@ export default class CaretControl extends CommonBase {
    * @param {string} sessionId ID of the session that got reaped.
    */
   async _sessionReaped(sessionId) {
-    const snapshot = this._snapshot;
-    const oldCaret = snapshot.caretForSession(sessionId);
-
-    if (oldCaret !== null) {
-      this._removeSessions(oldCaret);
+    if (this._snapshot.hasSession(sessionId)) {
+      this._removeSessions(sessionId);
     }
   }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -260,7 +260,7 @@ export default class CaretControl extends CommonBase {
    * @param {string} sessionId ID of the session that got reaped.
    */
   async _sessionReaped(sessionId) {
-    if (this._snapshot.hasSession(sessionId)) {
+    if (this._snapshot.has(sessionId)) {
       this._removeSessions(sessionId);
     }
   }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -206,7 +206,10 @@ export default class CaretControl extends CommonBase {
     this._integrateRemoteSessions();
 
     // Extract all the currently-used caret colors.
-    const usedColors = this._snapshot.carets.map(c => c.color);
+    const usedColors = [];
+    for (const [sessionId_unused, caret] of this._snapshot.entries()) {
+      usedColors.push(caret.color);
+    }
 
     return CaretColor.colorForSession(sessionId, usedColors);
   }
@@ -218,10 +221,10 @@ export default class CaretControl extends CommonBase {
     const minTime  = Timestamp.now().addMsec(-MAX_SESSION_IDLE_MSEC);
     const toRemove = [];
 
-    for (const caret of this._snapshot.carets) {
+    for (const [sessionId, caret] of this._snapshot.entries()) {
       if (minTime.compareTo(caret.lastActive) > 0) {
         // Too old!
-        this._log.info(`[${caret.sessionId}] Caret became inactive.`);
+        this._log.info(`[${sessionId}] Caret became inactive.`);
         toRemove.push(caret);
       }
     }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -363,8 +363,8 @@ export default class CaretStorage extends CommonBase {
     const setUpdates    = []; // List of new and deleted sessions.
 
     for (const sessionId of this._localSessions) {
-      const caret       = this._carets.caretForSession(sessionId);
-      const storedCaret = this._storedCarets.caretForSession(sessionId);
+      const caret       = this._carets.getOrNull(sessionId);
+      const storedCaret = this._storedCarets.getOrNull(sessionId);
       const path        = Paths.forCaret(sessionId);
 
       if (caret && storedCaret && caret.equals(storedCaret)) {

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -5,6 +5,7 @@
 import { Caret, CaretSnapshot } from 'doc-common';
 import { Errors, TransactionSpec } from 'file-store';
 import { CallPiler, Delay } from 'promise-util';
+import { TString } from 'typecheck';
 import { CommonBase, FrozenBuffer } from 'util-common';
 
 import FileComplex from './FileComplex';
@@ -109,18 +110,17 @@ export default class CaretStorage extends CommonBase {
    * written to file storage (unless superseded by another change to the same
    * session in the meantime).
    *
-   * @param {Caret} caret Caret for the session to be deleted. Only the
-   *   `sessionId` of the caret is actually used.
+   * @param {string} sessionId ID of the session to be deleted.
    */
-  delete(caret) {
-    Caret.check(caret);
+  delete(sessionId) {
+    TString.nonEmpty(sessionId);
 
     // Indicate that the local server is asserting authority over this session.
     // This means that, when it comes time to write out caret info, this session
     // will be removed from file storage.
-    this._localSessions.add(caret.sessionId);
+    this._localSessions.add(sessionId);
 
-    this._carets = this._carets.withoutCaret(caret);
+    this._carets = this._carets.withoutSession(sessionId);
     this._needsWrite();
   }
 

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -144,7 +144,7 @@ export default class CaretStorage extends CommonBase {
     // Remove any caret that isn't represented in this instance. Such carets are
     // remote carets for sessions that have since been deleted.
     for (const [sessionId, caret_unused] of snapshot.entries()) {
-      if (!carets.hasSession(sessionId)) {
+      if (!carets.has(sessionId)) {
         const newSnapshot = snapshot.withoutSession(sessionId);
         if (newSnapshot !== snapshot) {
           snapshot = newSnapshot;
@@ -246,7 +246,7 @@ export default class CaretStorage extends CommonBase {
     let caretData;
 
     for (const sessionId of currentSessionIds) {
-      if (!this._carets.hasSession(sessionId)) {
+      if (!this._carets.has(sessionId)) {
         this._log.info('New remote caret:', sessionId);
         ops.push(fc.op_readPath(Paths.forCaret(sessionId)));
       }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -493,7 +493,7 @@ export default class CaretStorage extends CommonBase {
 
     // Detects changes to any of the already-known remote sessions.
     for (const sessionId of this._remoteSessionIds()) {
-      const caret = this._carets.caretForSession(sessionId);
+      const caret = this._carets.get(sessionId);
       ops.push(fc.op_whenPathNot(Paths.forCaret(sessionId), caret));
     }
 

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -155,7 +155,7 @@ export default class CaretStorage extends CommonBase {
 
     // Update all the remote carets.
     for (const sessionId of this._remoteSessionIds()) {
-      const newSnapshot = snapshot.withCaret(carets.caretForSession(sessionId));
+      const newSnapshot = snapshot.withCaret(carets.get(sessionId));
       if (newSnapshot !== snapshot) {
         snapshot = newSnapshot;
         this._log.detail('Integrated caret update:', sessionId);

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -143,7 +143,7 @@ export default class CaretStorage extends CommonBase {
 
     // Remove any caret that isn't represented in this instance. Such carets are
     // remote carets for sessions that have since been deleted.
-    for (const sessionId of snapshot.sessionIds) {
+    for (const [sessionId, caret_unused] of snapshot.entries()) {
       if (!carets.hasSession(sessionId)) {
         const newSnapshot = snapshot.withoutSession(sessionId);
         if (newSnapshot !== snapshot) {
@@ -328,11 +328,15 @@ export default class CaretStorage extends CommonBase {
    * @returns {array<string>} Array of the session IDs in question.
    */
   _remoteSessionIds() {
-    const allSessionIds = this._carets.sessionIds;
+    const result = [];
 
-    return allSessionIds.filter((id) => {
-      return !this._localSessions.has(id);
-    });
+    for (const [sessionId, caret_unused] of this._carets.entries()) {
+      if (!this._localSessions.has(sessionId)) {
+        result.push(sessionId);
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -341,21 +341,16 @@ export default class LocalFile extends BaseFile {
    * @param {function} filter Filter function. It is passed storage IDs and
    *   is expected to return `true` for keys which should be present in the
    *   iteration.
-   * @returns {Iterator<[string, FrozenBuffer]>} Iterator over filtered storage
-   *   entries.
+   * @yields {[string, FrozenBuffer]} Filtered storage entries.
    */
-  _filterStorage(filter) {
+  * _filterStorage(filter) {
     const storage = this._storage;
 
-    function* yieldEntries() {
-      for (const [storageId, value] of storage) {
-        if (filter(storageId)) {
-          yield [storageId, value];
-        }
+    for (const [storageId, value] of storage) {
+      if (filter(storageId)) {
+        yield [storageId, value];
       }
     }
-
-    return yieldEntries();
   }
 
   /**

--- a/local-modules/util-common/IterableUtil.js
+++ b/local-modules/util-common/IterableUtil.js
@@ -78,8 +78,6 @@ export default class IterableUtil extends UtilityClass {
       }
     }
 
-    return {
-      [Symbol.iterator]: () => { return makeIterator(); }
-    };
+    return { [Symbol.iterator]: makeIterator };
   }
 }

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -85,9 +85,9 @@ export default class PropertyIterable extends CommonBase {
   /**
    * Gets an iterator which iterates over this instance's object's properties.
    *
-   * @returns {object} The iterator.
+   * @yields {object} The property descriptors.
    */
-  [Symbol.iterator]() {
+  * [Symbol.iterator]() {
     const filter = this._filter;
     let   object = this._object;
 
@@ -95,42 +95,38 @@ export default class PropertyIterable extends CommonBase {
     // shadowed by a superclass.
     const covered = new Map();
 
-    function* propIterate() {
-      while (object) {
-        const names = Object.getOwnPropertyNames(object);
-        for (const name of names) {
-          if (covered.get(name)) {
-            continue;
-          }
-          covered.set(name, true);
-          const desc = Object.getOwnPropertyDescriptor(object, name);
-          desc.name   = name;
-          desc.target = object;
-          if (filter && !filter(desc)) {
-            continue;
-          }
-          yield desc;
+    while (object) {
+      const names = Object.getOwnPropertyNames(object);
+      for (const name of names) {
+        if (covered.get(name)) {
+          continue;
         }
-
-        const symbols = Object.getOwnPropertySymbols(object);
-        for (const symbol of symbols) {
-          if (covered.get(symbol)) {
-            continue;
-          }
-          covered.set(symbol, true);
-          const desc = Object.getOwnPropertyDescriptor(object, symbol);
-          desc.name   = symbol;
-          desc.target = object;
-          if (filter && !filter(desc)) {
-            continue;
-          }
-          yield desc;
+        covered.set(name, true);
+        const desc = Object.getOwnPropertyDescriptor(object, name);
+        desc.name   = name;
+        desc.target = object;
+        if (filter && !filter(desc)) {
+          continue;
         }
-
-        object = Object.getPrototypeOf(object);
+        yield desc;
       }
-    }
 
-    return propIterate();
+      const symbols = Object.getOwnPropertySymbols(object);
+      for (const symbol of symbols) {
+        if (covered.get(symbol)) {
+          continue;
+        }
+        covered.set(symbol, true);
+        const desc = Object.getOwnPropertyDescriptor(object, symbol);
+        desc.name   = symbol;
+        desc.target = object;
+        if (filter && !filter(desc)) {
+          continue;
+        }
+        yield desc;
+      }
+
+      object = Object.getPrototypeOf(object);
+    }
   }
 }


### PR DESCRIPTION
Since my head was already in this space, I figured I'd take a stab at aligning the interfaces of `CaretSnapshot` and `PropertySnapshot`, which as it turns out really are quite similar. In addition, both of them now define methods that are reasonably similar to the equivalent methods on the built-in `Map` class. I'm not going to bother pulling out a new common base class for these two right now, but what I've done here sets things up to make that a pretty easy change when the time comes.

In the process of all this, I ran across and fixed a couple bugs in `PropertySnapshot`.

**Bonus:** Fixed a handful of places that could benefit from modern generator method syntax.