### PR TITLE
Update our JS runtime dependencies.

### DIFF
--- a/compiler/main.js
+++ b/compiler/main.js
@@ -29,7 +29,7 @@ const BABEL_CONFIG = Object.freeze({
   presets: [
     [
       'env',
-      { targets: { node: 6 } }
+      { targets: { node: 8 } }
     ]
   ]
 });

--- a/doc/development.md
+++ b/doc/development.md
@@ -20,9 +20,8 @@ Development Guide
 Bayou uses [Node](https://nodejs.org) on the server side, and it uses
 [npm](https://npmjs,com) for module management. Install both of these if you
 haven't already done so. As of this writing, the bulk of development and
-testing have been done using `node` versions 7 and 8, and `npm` version 5.
-Notably, the server code is _not_ expected to run on `node` versions earlier
-than 7, and it may soon (probably some time in 2017) require version 8.
+testing have been done using `node` version 8, and `npm` version 5. The system
+will fail to build or run with earlier versions.
 
 To build and run, say:
 

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -13,21 +13,24 @@ import { JsonUtil, Singleton } from 'util-common';
 
 import ProgressMessage from './ProgressMessage';
 
-/** Logger. */
+/** {Logger} Logger. */
 const log = new Logger('client-bundle');
 
+/** {ProgressMessage} Handler that logs progress messages during compilation. */
+const progress = new ProgressMessage(log);
+
 /**
- * The parsed `package.json` for the client. This is used for some of the
- * `webpack` config.
+ * {object} The parsed `package.json` for the client. This is used for some of
+ * the `webpack` config.
  */
 const clientPackage =
   JsonUtil.parseFrozen(
     fs.readFileSync(path.resolve(Dirs.theOne.CLIENT_DIR, 'package.json')));
 
 /**
- * Options passed to the `webpack` compiler constructor. Of particular note,
- * we _do not_ try to restrict the loaders to any particular directories (e.g.
- * via `include` configs), instead _just_ applying them based on filename
+ * {object} Options passed to the `webpack` compiler constructor. Of particular
+ * note, we _do not_ try to restrict the loaders to any particular directories
+ * (e.g. via `include` configs), instead _just_ applying them based on filename
  * extension. As such, any `.js` file will get loaded via our "modern ES"
  * pipeline, and any `.ts` file will get loaded via the TypeScript loader.
  *
@@ -70,7 +73,7 @@ const webpackOptions = {
   },
 
   plugins: [
-    new webpack.ProgressPlugin(new ProgressMessage(log).handler)
+    new webpack.ProgressPlugin(progress.handler)
   ],
 
   resolve: {
@@ -278,6 +281,8 @@ export default class ClientBundle extends Singleton {
    * @param {object} stats Detailed information about the compilation.
    */
   _handleCompilation(error, stats) {
+    progress.reset(); // So the progress message doesn't get stuck at 100%.
+
     const warnings = stats.compilation.warnings;
     const errors = stats.compilation.errors;
 

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -113,12 +113,12 @@ const webpackOptions = {
                   targets: {
                     browsers: [
                       // See <https://github.com/ai/browserslist> for syntax.
-                      'Chrome >= 59',
-                      'ChromeAndroid >= 59',
-                      'Electron >= 1.7',
+                      'Chrome >= 61',
+                      'ChromeAndroid >= 61',
+                      'Electron >= 1.8',
                       'Firefox >= 54',
-                      'iOS >= 10',
-                      'Safari >= 10.1'
+                      'iOS >= 11',
+                      'Safari >= 11'
                     ]
                   }
                 }

--- a/local-modules/client-bundle/ProgressMessage.js
+++ b/local-modules/client-bundle/ProgressMessage.js
@@ -90,4 +90,12 @@ export default class ProgressMessage {
   get handler() {
     return this._handler.bind(this);
   }
+
+  /**
+   * Resets progress, for a new round of work.
+   */
+  reset() {
+    this._lastTime = 0;
+    this._lastFrac= 0;
+  }
 }


### PR DESCRIPTION
This PR moves our stated Node and browser dependencies such that everything we specify supports `async` / `await` directly. No more "transpiling" required[*]! Per a recent blog post, V8 will allegedly soon be able to execute `async` functions much more efficiently, so we are now positioned to take advantage of that without further effort, when that glorious promised day arrives.

**Bonus:** Fixed progress reporting in `client-bundle`.

[*] for those constructs, at least. 