### PR TITLE
Quill history, and miscellanea.

### DIFF
--- a/local-modules/README.md
+++ b/local-modules/README.md
@@ -8,7 +8,7 @@ contexts.
 
 ### Module naming conventions
 
-* `<name>-base` &mdash; A module that is akin to a "base class," that is, a
+* `<name>-core` &mdash; A module that is akin to a "base class," that is, a
   module expected to be used primarily by defining another module which expands
   on its behavior in some fashion.
 * `<name>-common` &mdash; A module that contains code that is meant to be
@@ -39,7 +39,10 @@ Internal to a module, the convention is a little more nuanced:
 * Files are allowed to _either_ define a single class or define a collection of
   data.
 * If a file defines a class, then that class is the single default export of
-  the file, and there are no other exports.
+  the file, and there are no other exports. In this case, the file's base name
+  and the class name should be the same including capitalization. For example,
+  the class `FooBlort` should reside in a file named `FooBlort.js` (and notably
+  not, `foo-blort.js`).
 * If a file defines a collection of data, then it is exported (as with the main
   module) as a set of explicit names and _no_ default.
 

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -827,7 +827,13 @@ export default class BodyClient extends StateMachine {
 
     // Tell Quill if necessary.
     if (needQuillUpdate) {
+      // The `cutoff()` calls force the update to be treated as an atomic "undo"
+      // item that will not get combined with edits that the local user has
+      // made. **Note:** As of this writing, `cutoff()` is listed in the Quill
+      // docs as an "experimental" feature.
+      this._quill.history.cutoff();
       this._quill.updateContents(quillDelta.toQuillForm(), CLIENT_SOURCE);
+      this._quill.history.cutoff();
     }
   }
 

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -373,13 +373,6 @@ export default class BodyClient extends StateMachine {
     const firstEvent = this._quill.currentEvent;
     this._updateWithSnapshot(snapshot);
 
-    // This prevents "undo" from backing over the snapshot. When first starting
-    // up, this means the user can't undo and find themselves looking at the
-    // "loading..." text. And during a reconnection, it prevents hard-to-predict
-    // glitches (in that the Quill state could have diverged significantly from
-    // the stored document state).
-    this._quill.history.clear();
-
     // The above action should have caused the Quill instance to make a change
     // which shows up on its event chain. Grab it, and verify that indeed it's
     // the change we're expecting.
@@ -847,6 +840,13 @@ export default class BodyClient extends StateMachine {
   _updateWithSnapshot(snapshot) {
     this._snapshot = snapshot;
     this._quill.setContents(snapshot.contents.toQuillForm(), CLIENT_SOURCE);
+
+    // This prevents "undo" from backing over the snapshot. When first starting
+    // up, this means the user can't undo and find themselves looking at the
+    // "loading..." text. And during a reconnection, it prevents hard-to-predict
+    // glitches (in that the Quill state could have diverged significantly from
+    // the stored document state).
+    this._quill.history.clear();
   }
 
   /**

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -373,6 +373,13 @@ export default class BodyClient extends StateMachine {
     const firstEvent = this._quill.currentEvent;
     this._updateWithSnapshot(snapshot);
 
+    // This prevents "undo" from backing over the snapshot. When first starting
+    // up, this means the user can't undo and find themselves looking at the
+    // "loading..." text. And during a reconnection, it prevents hard-to-predict
+    // glitches (in that the Quill state could have diverged significantly from
+    // the stored document state).
+    this._quill.history.clear();
+
     // The above action should have caused the Quill instance to make a change
     // which shows up on its event chain. Grab it, and verify that indeed it's
     // the change we're expecting.


### PR DESCRIPTION
The main point of this PR is to play nice with Quill's "history" module vis-a-vis undo behavior.

**Bonus:** Updated conventions docs w/r/t recently-clarified and agreed-upon situation.
