### PR TITLE
Switch to using our own operation class for `BodyDelta`.

### DIFF
--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -56,20 +56,6 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
-   * Checks the given value to see if it is a valid array of operations for use
-   * with this class. This does _not_ check to see if the array is frozen.
-   *
-   * @param {*} value The alleged operation.
-   * @returns {array<object>} `value` if it is indeed valid.
-   * @throws {Error} if `value` is not valid.
-   */
-  static checkOpArray(value) {
-    // **Note:** `this` in the context of a static method is the class, not an
-    // instance.
-    return TArray.check(value, this.opClass.check);
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {array<object>} ops Array of operations. Each operation must be an
@@ -79,12 +65,14 @@ export default class BaseDelta extends CommonBase {
   constructor(ops) {
     super();
 
+    TArray.check(ops, this.constructor.opClass.check);
+
     if (!Object.isFrozen(ops)) {
       ops = Object.freeze(ops.slice());
     }
 
     /** {array<object>} Array of operations. */
-    this._ops = this.constructor.checkOpArray(ops);
+    this._ops = ops;
 
     Object.freeze(this);
   }

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -197,14 +197,8 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
-   * {class|function} Class (constructor function) of operation objects to be
-   * used with instances of this class, _or_ a predicate which identifies valid
-   * operations. Subclasses must fill this in.
-   *
-   * **TODO:** The `function` form is allowed specifically so that `BodyDelta`
-   * can use simple objects as operations. `BodyDelta` should be changed to use
-   * proper class instances for its operations. Once that is done, {@link
-   * #checkOp} will be able to be simplified a bit.
+   * {class} Class (constructor function) of operation objects to be used with
+   * instances of this class.
    *
    * @abstract
    */

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -65,7 +65,7 @@ export default class BaseDelta extends CommonBase {
   constructor(ops) {
     super();
 
-    TArray.check(ops, this.constructor.opClass.check);
+    TArray.check(ops, op => this.constructor.opClass.check(op));
 
     if (!Object.isFrozen(ops)) {
       ops = Object.freeze(ops.slice());

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -187,10 +187,10 @@ export default class BodyDelta extends BaseDelta {
   }
 
   /**
-   * {function} Predicate which indicates valid operation values for use with
-   * this class.
+   * {class} Class (constructor function) of operation objects to be used with
+   * instances of this class.
    */
-  static get _impl_opClassOrPredicate() {
+  static get _impl_opClass() {
     return BodyOp;
   }
 }

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -236,10 +236,11 @@ export default class BodyOp extends CommonBase {
 
       case BodyOp.INSERT_EMBED: {
         const { value: { name, args: [arg0] }, attributes } = props;
+        const insert = { [name]: arg0 };
 
         return attributes
-          ? { [name]: arg0, attributes }
-          : { [name]: arg0 };
+          ? { insert, attributes }
+          : { insert };
       }
 
       case BodyOp.INSERT_TEXT: {

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -9,10 +9,9 @@ import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
  * Operation on a text document body.
  *
  * This class is designed to bridge the two worlds of the Bayou OT framework and
- * Quill's ad-hoc-object-based deltas. As such, it defines a number of
- * properties that act as a Quill-compatible "front" for the underlying
- * operation payload, each one marked prominently to indicate that fact.
- * ***These properties should never be used directly by Bayou code.***
+ * Quill's ad-hoc-object-based deltas. As such, it defines a static method
+ * `fromQuillForm()` and an instance method `toQuillForm()` to convert back and
+ * forth as needed.
  */
 export default class BodyOp extends CommonBase {
   /** {string} Operation name for "delete" operations. */
@@ -43,21 +42,16 @@ export default class BodyOp extends CommonBase {
    * @returns {BodyOp} Corresponding instance of this class.
    */
   static fromQuillForm(quillOp) {
-    if (quillOp instanceof BodyOp) {
-      // No need to make a new instance if this is the tail end of a round trip.
-      return quillOp;
-    }
-
     const { attributes = null, delete: del, insert, retain } = quillOp;
 
     if (insert !== undefined) {
       if (typeof insert === 'string') {
         return BodyOp.op_insertText(insert, attributes);
       } else {
-        // An "embed" is represented as a single-binding `object`, where the
+        // An "embed" is represented as a single-binding plain object, where the
         // key of the binding is the type of the embed, and the bound value is
         // an arbitrary value as defined by the type.
-        const [key, value] = Object.entries(insert).next();
+        const [[key, value]] = Object.entries(insert);
         return BodyOp.op_insertEmbed(new Functor(key, value), attributes);
       }
     } else if (del !== undefined) {
@@ -145,58 +139,9 @@ export default class BodyOp extends CommonBase {
     Object.freeze(this);
   }
 
-  /**
-   * {object|undefined} **Quill interop:** The Quill-compatible `attributes`
-   * property of the operation, or `undefined` if either set to `null` or not
-   * defined for this instance.
-   */
-  get attributes() {
-    return this.props.attributes || undefined;
-  }
-
-  /**
-   * {Int|undefined} **Quill interop:** The Quill-compatible `delete` property
-   * of the operation, or `undefined` if not defined for this instance.
-   */
-  get delete() {
-    const { opName, count } = this.props;
-
-    return (opName === BodyOp.DELETE) ? count : undefined;
-  }
-
-  /**
-   * {string|Int|undefined} **Quill interop:** The Quill-compatible `insert`
-   * property of the operation, or `undefined` if not defined for this instance.
-   */
-  get insert() {
-    const { opName, text, value } = this.props;
-
-    switch (opName) {
-      case BodyOp.INSERT_EMBED: {
-        return { [value.name]: value.args[0] };
-      }
-      case BodyOp.INSERT_TEXT: {
-        return text;
-      }
-      default: {
-        return undefined;
-      }
-    }
-  }
-
   /** {Functor} The operation payload (name and arguments). */
   get payload() {
     return this._payload;
-  }
-
-  /**
-   * {Int|undefined} **Quill interop:** The Quill-compatible `retain` property
-   * of the operation, or `undefined` if not defined for this instance.
-   */
-  get retain() {
-    const { opName, count } = this.props;
-
-    return (opName === BodyOp.RETAIN) ? count : undefined;
   }
 
   /**
@@ -216,8 +161,8 @@ export default class BodyOp extends CommonBase {
       }
 
       case BodyOp.INSERT_EMBED: {
-        const [value] = payload.args;
-        return Object.freeze({ opName, value });
+        const [value, attributes] = payload.args;
+        return Object.freeze({ opName, value, attributes });
       }
 
       case BodyOp.INSERT_TEXT: {
@@ -254,12 +199,69 @@ export default class BodyOp extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance is an "insert" operation of some
+   * sort.
+   *
+   * @returns {boolean} `true` if this instance is an "insert," or `false` if
+   *   not.
+   */
+  isInsert() {
+    const opName = this._payload.name;
+    return (opName === BodyOp.INSERT_TEXT) || (opName === BodyOp.INSERT_EMBED);
+  }
+
+  /**
    * Converts this instance to codec reconstruction arguments.
    *
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
     return [this._payload];
+  }
+
+  /**
+   * Produces a Quill `Delta` operation (per se) with equivalent semantics to
+   * this this instance.
+   *
+   * @returns {object} A Quill `Delta` operation with the same semantics as
+   *   `this`.
+   */
+  toQuillForm() {
+    const props = this.props;
+
+    switch (props.opName) {
+      case BodyOp.DELETE: {
+        return { delete: props.count };
+      }
+
+      case BodyOp.INSERT_EMBED: {
+        const { value: { name, args: [arg0] }, attributes } = props;
+
+        return attributes
+          ? { [name]: arg0, attributes }
+          : { [name]: arg0 };
+      }
+
+      case BodyOp.INSERT_TEXT: {
+        const { text: insert, attributes } = props;
+
+        return attributes
+          ? { insert, attributes }
+          : { insert };
+      }
+
+      case BodyOp.RETAIN: {
+        const { count: retain, attributes } = props;
+
+        return attributes
+          ? { retain, attributes }
+          : { retain };
+      }
+
+      default: {
+        throw Errors.wtf(`Weird operation name: ${props.opName}`);
+      }
+    }
   }
 
   /**
@@ -285,7 +287,7 @@ export default class BodyOp extends CommonBase {
     }
 
     try {
-      TObject.checkSimple(value);
+      TObject.simple(value);
       return DataUtil.deepFreeze(value);
     } catch (e) {
       // More specific error.

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -50,7 +50,7 @@ export default class CaretDelta extends BaseDelta {
    * {class} Class (constructor function) of operation objects to be used with
    * instances of this class.
    */
-  static get _impl_opClassOrPredicate() {
+  static get _impl_opClass() {
     return CaretOp;
   }
 }

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -50,7 +50,7 @@ export default class PropertyDelta extends BaseDelta {
    * {class} Class (constructor function) of operation objects to be used with
    * instances of this class.
    */
-  static get _impl_opClassOrPredicate() {
+  static get _impl_opClass() {
     return PropertyOp;
   }
 }

--- a/local-modules/doc-common/tests/MockDelta.js
+++ b/local-modules/doc-common/tests/MockDelta.js
@@ -62,7 +62,7 @@ export default class MockDelta extends BaseDelta {
    * {class} Class (constructor function) of operation objects to be used with
    * instances of this class.
    */
-  static get _impl_opClassOrPredicate() {
+  static get _impl_opClass() {
     return MockOp;
   }
 }

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -6,20 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import Delta from 'quill-delta';
 
-import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
-import { DataUtil } from 'util-common';
-
-/**
- * Helper to call `new BodyDelta()` with a deep-frozen argument.
- *
- * @param {*} ops Value to pass to the constructor, which doesn't have to be
- *   frozen.
- * @returns {BodyDelta} the result of calling the constructor with a deep-frozen
- *   version of `ops`.
- */
-function newBodyDelta(ops) {
-  return new BodyDelta(DataUtil.deepFreeze(ops));
-}
+import { BodyChange, BodyDelta, BodyOp, Timestamp } from 'doc-common';
 
 describe('doc-common/BodyChange', () => {
   describe('.FIRST', () => {
@@ -57,16 +44,16 @@ describe('doc-common/BodyChange', () => {
         assert.strictEqual(result.authorId, authorId);
       }
 
-      test(0,   newBodyDelta([{ retain: 100 }]));
+      test(0,   new BodyDelta([BodyOp.op_retain(100)]));
       test(123, BodyDelta.EMPTY);
-      test(909, newBodyDelta([{ insert: 'x' }]), null);
-      test(909, newBodyDelta([{ insert: 'x' }]), Timestamp.MIN_VALUE);
-      test(242, BodyDelta.EMPTY,                  null, null);
-      test(242, BodyDelta.EMPTY,                  null, 'florp9019');
+      test(909, new BodyDelta([BodyOp.op_insertText('x')]), null);
+      test(909, new BodyDelta([BodyOp.op_insertText('x')]), Timestamp.MIN_VALUE);
+      test(242, BodyDelta.EMPTY,                           null, null);
+      test(242, BodyDelta.EMPTY,                           null, 'florp9019');
     });
 
     it('should accept an array for the `delta`, which should get passed to the `BodyDelta` constructor', () => {
-      const ops    = DataUtil.deepFreeze([{ retain: 100 }]);
+      const ops    = [BodyOp.op_retain(100)];
       const result = new BodyChange(0, ops);
 
       assert.deepEqual(result.delta.ops, ops);

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -81,13 +81,11 @@ describe('doc-common/BodyDelta', () => {
       const values = [
         null,
         undefined,
+        false,
         123,
         'florp',
         { insert: 'x' },
-        [{ insert: 'x' }],
         new Map(),
-        [null],
-        [undefined],
         ['x'],
         [1, 2, 3]
       ];
@@ -95,7 +93,7 @@ describe('doc-common/BodyDelta', () => {
       for (const v of values) {
         it(`should fail for: ${inspect(v)}`, () => {
           assert.throws(() => new BodyDelta(v));
-          assert.throws(() => new BodyDelta(v));
+          assert.throws(() => new BodyDelta([v]));
         });
       }
     });

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -9,18 +9,6 @@ import { inspect } from 'util';
 
 import { BodyDelta, BodyOp } from 'doc-common';
 
-/**
- * Helper to call `new BodyDelta()` with a deep-frozen argument.
- *
- * @param {*} ops Value to pass to the constructor, which doesn't have to be
- *   frozen.
- * @returns {BodyDelta} the result of calling the constructor with a deep-frozen
- *   version of `ops`.
- */
-function newWithFrozenOps(ops) {
-  return new BodyDelta(ops);
-}
-
 describe('doc-common/BodyDelta', () => {
   describe('.EMPTY', () => {
     const EMPTY = BodyDelta.EMPTY;
@@ -84,7 +72,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should succeed for: ${inspect(v)}`, () => {
-          newWithFrozenOps(v);
+          new BodyDelta(v);
         });
       }
     });
@@ -107,7 +95,7 @@ describe('doc-common/BodyDelta', () => {
       for (const v of values) {
         it(`should fail for: ${inspect(v)}`, () => {
           assert.throws(() => new BodyDelta(v));
-          assert.throws(() => newWithFrozenOps(v));
+          assert.throws(() => new BodyDelta(v));
         });
       }
     });
@@ -135,14 +123,14 @@ describe('doc-common/BodyDelta', () => {
     });
 
     it('should reject calls when `this` is not a document', () => {
-      const delta = newWithFrozenOps([BodyOp.op_retain(10)]);
+      const delta = new BodyDelta([BodyOp.op_retain(10)]);
       const other = BodyDelta.EMPTY;
       assert.throws(() => delta.diff(other));
     });
 
     it('should reject calls when `other` is not a document', () => {
       const delta = BodyDelta.EMPTY;
-      const other = new newWithFrozenOps([BodyOp.op_retain(10)]);
+      const other = new BodyDelta([BodyOp.op_retain(10)]);
       assert.throws(() => delta.diff(other));
     });
 
@@ -157,9 +145,9 @@ describe('doc-common/BodyDelta', () => {
     // These tests take composition triples `origDoc + change = newDoc` and test
     // `compose()` and `diff()` in various combinations.
     function test(label, origDoc, change, newDoc) {
-      origDoc = newWithFrozenOps(origDoc);
-      change  = newWithFrozenOps(change);
-      newDoc  = newWithFrozenOps(newDoc);
+      origDoc = new BodyDelta(origDoc);
+      change  = new BodyDelta(change);
+      newDoc  = new BodyDelta(newDoc);
 
       describe(label, () => {
         it('should produce the expected composition', () => {
@@ -223,7 +211,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`true\` for: ${inspect(v)}`, () => {
-          assert.isTrue(newWithFrozenOps(v).isDocument());
+          assert.isTrue(new BodyDelta(v).isDocument());
         });
       }
     });
@@ -240,7 +228,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          assert.isFalse(newWithFrozenOps(v).isDocument());
+          assert.isFalse(new BodyDelta(v).isDocument());
         });
       }
     });
@@ -249,7 +237,7 @@ describe('doc-common/BodyDelta', () => {
   describe('isEmpty()', () => {
     describe('valid empty values', () => {
       const values = [
-        newWithFrozenOps([]),
+        new BodyDelta([]),
         BodyDelta.EMPTY,
       ];
 
@@ -269,7 +257,7 @@ describe('doc-common/BodyDelta', () => {
 
       for (const v of values) {
         it(`should return \`false\` for: ${inspect(v)}`, () => {
-          const delta = newWithFrozenOps(v);
+          const delta = new BodyDelta(v);
           assert.isFalse(delta.isEmpty());
         });
       }
@@ -279,7 +267,7 @@ describe('doc-common/BodyDelta', () => {
   describe('toQuillForm()', () => {
     it('should produce `Delta` instances with appropriately-converted ops', () => {
       function test(ops) {
-        const delta  = newWithFrozenOps(ops);
+        const delta  = new BodyDelta(ops);
         const result = delta.toQuillForm();
         assert.instanceOf(result, Delta);
         assert.strictEqual(result.ops, delta.ops);
@@ -315,8 +303,8 @@ describe('doc-common/BodyDelta', () => {
 
     it('should produce the expected transformations', () => {
       function test(d1, d2, expectedTrue, expectedFalse = expectedTrue) {
-        d1 = newWithFrozenOps(d1);
-        d2 = newWithFrozenOps(d2);
+        d1 = new BodyDelta(d1);
+        d2 = new BodyDelta(d2);
 
         const xformTrue  = d1.transform(d2, true);
         const xformFalse = d1.transform(d2, false);

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -10,7 +10,7 @@ import { DEFAULT_DOCUMENT } from 'hooks-server';
 import { Mutex } from 'promise-util';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
-import { CommonBase, DataUtil } from 'util-common';
+import { CommonBase } from 'util-common';
 
 import CaretControl from './CaretControl';
 import BodyControl from './BodyControl';
@@ -20,19 +20,21 @@ import DocServer from './DocServer';
 const log = new Logger('doc');
 
 /** {BodyDelta} Default contents when creating a new document. */
-const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
+const DEFAULT_TEXT = BodyDelta.fromQuillForm(DEFAULT_DOCUMENT);
 
 /**
  * {BodyDelta} Message used as document to indicate a major validation error.
  */
-const ERROR_NOTE = new BodyDelta(DataUtil.deepFreeze(
-  [{ insert: '(Recreated document due to validation error(s).)\n' }]));
+const ERROR_NOTE = BodyDelta.fromQuillForm([
+  { insert: '(Recreated document due to validation error(s).)\n' }
+]);
 
 /**
  * {BodyDelta} Message used as document instead of migrating documents from
  * old schema versions. */
-const MIGRATION_NOTE = new BodyDelta(DataUtil.deepFreeze(
-  [{ insert: '(Recreated document due to schema version skew.)\n' }]));
+const MIGRATION_NOTE = BodyDelta.fromQuillForm([
+  { insert: '(Recreated document due to schema version skew.)\n' }
+]);
 
 /**
  * Manager for the "complex" of objects which in aggregate allow access and

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.27.2
+version = 0.28.0


### PR DESCRIPTION
This PR represents a major milestone in stabilizing our document storage format.

What's going on here is that we no longer use Quill's ad-hoc-object-based format for delta operations, instead using a more strongly-typed and well-interfaced class, `BodyOp`, which follows the same pattern as our other OT operation classes. We convert from one form to the other as necessary to interoperate with Quill (and particularly to take advantage of the reasonably well-tested Quill `Delta` OT operations).

This could use a bit more test coverage, to be sure. Nonetheless, it seems to be working well enough as-is, so I'm gonna go with it.