### PR TITLE
"Plain" vs. "simple"

### DIFF
--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -45,7 +45,7 @@ export default class Registry extends CommonBase {
     // Register all the special codecs.
     this.registerCodec(SpecialCodecs.ARRAY);
     this.registerCodec(SpecialCodecs.FUNCTOR);
-    this.registerCodec(SpecialCodecs.SIMPLE_OBJECT);
+    this.registerCodec(SpecialCodecs.PLAIN_OBJECT);
     this.registerCodec(SpecialCodecs.selfRepresentative('boolean'));
     this.registerCodec(SpecialCodecs.selfRepresentative('null'));
     this.registerCodec(SpecialCodecs.selfRepresentative('number'));

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -144,8 +144,8 @@ export default class Registry extends CommonBase {
       clazz = value.constructor;
       codecs = this._classToCodecs.get(clazz);
     } else {
-      // The value is a non-class-instance, including possibly being a simple
-      // object (e.g., `{florps: 10}`) or `null`.
+      // The value is a non-class-instance, including possibly being a plain
+      // object (e.g., `{ florps: 10 }`) or `null`.
       clazz = null;
       codecs = this._typeToCodecs.get(valueType);
     }

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -106,14 +106,14 @@ export default class SpecialCodecs extends UtilityClass {
     return [value.name, ...(value.args)].map(subEncode);
   }
 
-  /** {ItemCodec} Codec used for coding simple objects. */
+  /** {ItemCodec} Codec used for coding plain objects. */
   static get SIMPLE_OBJECT() {
     return new ItemCodec(ItemCodec.tagFromType('object'), 'object',
       this._objectPredicate, this._objectEncode, this._objectDecode);
   }
 
   /**
-   * Decodes a simple object.
+   * Decodes a plain object.
    *
    * @param {object} payload Construction payload as previously produced by
    *   `_objectEncode()`.
@@ -132,7 +132,7 @@ export default class SpecialCodecs extends UtilityClass {
   }
 
   /**
-   * Encodes a simple object.
+   * Encodes a plain object.
    *
    * @param {object} value Object to encode.
    * @param {function} subEncode Function to call to encode component values
@@ -150,7 +150,7 @@ export default class SpecialCodecs extends UtilityClass {
   }
 
   /**
-   * Checks a value for encodability as a simple object.
+   * Checks a value for encodability as a plain object.
    *
    * @param {array<*>} value Value to (potentially) encode.
    * @returns {boolean} `true` iff `value` can be encoded.

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -107,7 +107,7 @@ export default class SpecialCodecs extends UtilityClass {
   }
 
   /** {ItemCodec} Codec used for coding plain objects. */
-  static get SIMPLE_OBJECT() {
+  static get PLAIN_OBJECT() {
     return new ItemCodec(ItemCodec.tagFromType('object'), 'object',
       this._objectPredicate, this._objectEncode, this._objectDecode);
   }

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -37,7 +37,7 @@ describe('api-common/Codec.decode*()', () => {
       assert.isNull(decodeData(null));
     });
 
-    it('should accept simple objects', () => {
+    it('should accept plain objects', () => {
       // The tests here are of objects whose values all decode to themselves.
       assert.deepEqual(decodeData({}), {});
       assert.deepEqual(decodeData({ a: true, b: 'yo' }), { a: true, b: 'yo' });

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -50,7 +50,7 @@ describe('api-common/Codec.encode*()r', () => {
       assert.strictEqual(encodeData(null), null);
     });
 
-    it('should pass through simple objects whose values are self-encoding as-is', () => {
+    it('should pass through as-is plain objects whose values are self-encoding', () => {
       assert.deepEqual(encodeData({}), {});
       assert.deepEqual(encodeData({ a: 10 }), { a: 10 });
       assert.deepEqual(encodeData({ b: false }), { b: false });

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -288,7 +288,7 @@ export default class BodyOp extends CommonBase {
     }
 
     try {
-      TObject.simple(value);
+      TObject.plain(value);
       return DataUtil.deepFreeze(value);
     } catch (e) {
       // More specific error.

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -146,7 +146,7 @@ export default class BodyOp extends CommonBase {
 
   /**
    * {object} The properties of this operation, as a conveniently-accessed
-   * simple object. `opName` is always bound to the operation name. Other
+   * plain object. `opName` is always bound to the operation name. Other
    * bindings depend on the operation name. Guaranteed to be an immutable
    * object.
    */
@@ -277,7 +277,7 @@ export default class BodyOp extends CommonBase {
   /**
    * Validates an `attributes` value, and returning a deep-frozen version of it
    * if not already deep-frozen. Throws an error if invalid. In order to be
-   * valid, it must be either a simple data object or `null`.
+   * valid, it must be either a plain data object or `null`.
    *
    * @param {*} value The (alleged) attributes.
    * @returns {object|null} `value` if valid.

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -94,7 +94,7 @@ export default class Caret extends CommonBase {
    * @param {string|Caret} sessionIdOrBase Session ID that identifies the caret,
    *   or a base caret instance which provides the session and default values
    *   for fields.
-   * @param {object} [fields = {}] Fields of the caret, as simple object mapping
+   * @param {object} [fields = {}] Fields of the caret, as plain object mapping
    *   field names to values.
    */
   constructor(sessionIdOrBase, fields = {}) {
@@ -292,7 +292,7 @@ export default class Caret extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    // Convert the `_fields` map to a simple object for the purpose of coding.
+    // Convert the `_fields` map to a plain object for the purpose of coding.
     const fields = {};
     for (const [k, v] of this._fields) {
       fields[k] = v;

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -109,7 +109,7 @@ export default class Caret extends CommonBase {
       sessionId = TString.nonEmpty(sessionIdOrBase);
     }
 
-    TObject.simple(fields);
+    TObject.plain(fields);
 
     super();
 

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -89,7 +89,7 @@ export default class CaretOp extends CommonBase {
 
   /**
    * {object} The properties of this operation, as a conveniently-accessed
-   * simple object. `opName` is always bound to the operation name. Other
+   * plain object. `opName` is always bound to the operation name. Other
    * bindings depend on the operation name. Guaranteed to be an immutable
    * object.
    */

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -68,7 +68,7 @@ export default class PropertyOp extends CommonBase {
 
   /**
    * {object} The properties of this operation, as a conveniently-accessed
-   * simple object. `opName` is always bound to the operation name. Other
+   * plain object. `opName` is always bound to the operation name. Other
    * bindings depend on the operation name. Guaranteed to be an immutable
    * object.
    */

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -25,9 +25,9 @@ export default class TObject extends UtilityClass {
   }
 
   /**
-   * Checks that a value is of type `Object` and is furthermore a simple
-   * object, which is to say, not any of an array, a function, or an instance of
-   * a class other than `Object` itself.
+   * Checks that a value is of type `Object` and is furthermore a plain object,
+   * which is to say, not any of an array, a function, or an instance of a class
+   * other than `Object` itself.
    *
    * @param {*} value Value to check.
    * @returns {object} `value`.
@@ -39,11 +39,11 @@ export default class TObject extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, 'simple object');
+    throw Errors.bad_value(value, 'plain object');
   }
 
   /**
-   * Checks a value of type `Object`, which must be a simple object with exactly
+   * Checks a value of type `Object`, which must be a plain object with exactly
    * the indicated set of keys as "own" properties.
    *
    * @param {*} value Value to check.

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -32,7 +32,7 @@ export default class TObject extends UtilityClass {
    * @param {*} value Value to check.
    * @returns {object} `value`.
    */
-  static simple(value) {
+  static plain(value) {
     if (   (typeof value === 'object')
         && (value !== null)
         && (Object.getPrototypeOf(value) === Object.prototype)) {
@@ -51,7 +51,7 @@ export default class TObject extends UtilityClass {
    * @returns {object} `value`.
    */
   static withExactKeys(value, keys) {
-    TObject.simple(value);
+    TObject.plain(value);
 
     // Make a copy, check for and delete allowed keys, and see if anything's
     // left.

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -52,7 +52,7 @@ describe('typecheck/TObject', () => {
   });
 
   describe('simple()', () => {
-    it('should accept simple objects', () => {
+    it('should accept plain objects', () => {
       function test(value) {
         assert.strictEqual(TObject.simple(value), value);
       }
@@ -63,7 +63,7 @@ describe('typecheck/TObject', () => {
       test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
-    it('should reject non-simple objects', () => {
+    it('should reject non-plain objects', () => {
       function test(value) {
         assert.throws(() => { TObject.simple(value); });
       }
@@ -113,7 +113,7 @@ describe('typecheck/TObject', () => {
       assert.throws(() => TObject.withExactKeys(value, ['a', 'b', 'c']));
     });
 
-    it('should reject non-simple objects', () => {
+    it('should reject non-plain objects', () => {
       assert.throws(() => TObject.withExactKeys(new Map(),  []));
       assert.throws(() => TObject.withExactKeys(['z'],      []));
       assert.throws(() => TObject.withExactKeys(() => true, []));

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -51,10 +51,10 @@ describe('typecheck/TObject', () => {
     });
   });
 
-  describe('simple()', () => {
+  describe('plain()', () => {
     it('should accept plain objects', () => {
       function test(value) {
-        assert.strictEqual(TObject.simple(value), value);
+        assert.strictEqual(TObject.plain(value), value);
       }
 
       test({});
@@ -65,7 +65,7 @@ describe('typecheck/TObject', () => {
 
     it('should reject non-plain objects', () => {
       function test(value) {
-        assert.throws(() => { TObject.simple(value); });
+        assert.throws(() => { TObject.plain(value); });
       }
 
       test([]);
@@ -76,7 +76,7 @@ describe('typecheck/TObject', () => {
 
     it('should reject non-objects', () => {
       function test(value) {
-        assert.throws(() => { TObject.simple(value); });
+        assert.throws(() => { TObject.plain(value); });
       }
 
       test(null);

--- a/local-modules/util-core/DataUtil.js
+++ b/local-modules/util-core/DataUtil.js
@@ -165,7 +165,7 @@ export default class DataUtil extends UtilityClass {
     switch (proto1) {
       case Object.prototype:
       case Array.prototype: {
-        // One of the acceptable standard types (either array or simple object).
+        // One of the acceptable standard types (either array or plain object).
         // We still need to compare the properties / elements.
 
         const names1 = Object.getOwnPropertyNames(value1);
@@ -255,7 +255,7 @@ export default class DataUtil extends UtilityClass {
       case Object.prototype:
       case Array.prototype: {
         // We have a frozen composite of one of the acceptable standard types
-        // (either array or simple object). We still need to check the
+        // (either array or plain object). We still need to check the
         // properties / elements.
 
         for (const k of Object.getOwnPropertyNames(value)) {

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -58,7 +58,7 @@ export default class ObjectUtil extends UtilityClass {
    * @param {*} value Value to check.
    * @returns {boolean} `true` if `value` is a plain object, or `false` if not.
    */
-  static isSimple(value) {
+  static isPlain(value) {
     return (typeof value === 'object')
         && (value !== null)
         && (Object.getPrototypeOf(value) === Object.prototype);

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -12,7 +12,7 @@ import UtilityClass from './UtilityClass';
 export default class ObjectUtil extends UtilityClass {
   /**
    * Extracts the named keys from the given object, returning a new frozen
-   * simple object (frozen but not deep-frozen) with those bindings. It is an
+   * plain object (frozen but not deep-frozen) with those bindings. It is an
    * error if the given value doesn't have all of the named bindings.
    *
    * @param {object} value Object to extract bindings from.
@@ -51,12 +51,12 @@ export default class ObjectUtil extends UtilityClass {
   }
 
   /**
-   * Tests whether a value is a "simple object." A simple object is defined as
+   * Tests whether a value is a "plain object." A plain object is defined as
    * being a value of type `object` which is not `null` and whose direct
-   * prototype is `Object.prototype`. Notably, arrays are _not_ simple objects.
+   * prototype is `Object.prototype`. Notably, arrays are _not_ plain objects.
    *
    * @param {*} value Value to check.
-   * @returns {boolean} `true` if `value` is a simple object, or `false` if not.
+   * @returns {boolean} `true` if `value` is a plain object, or `false` if not.
    */
   static isSimple(value) {
     return (typeof value === 'object')

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -149,7 +149,7 @@ describe('util-core/DataUtil', () => {
       test({ a: 10, b: { c: { d: test } } });
     });
 
-    it('should fail if given a non-simple object or a composite that contains same', () => {
+    it('should fail if given a non-plain object or a composite that contains same', () => {
       function test(value) {
         assert.throws(() => { DataUtil.deepFreeze(value); });
       }
@@ -368,7 +368,7 @@ describe('util-core/DataUtil', () => {
     test(new Functor('x', new Functor('y', [])));
   });
 
-  it('should return `false` for non-simple objects or composites with same', () => {
+  it('should return `false` for non-plain objects or composites with same', () => {
     function test(value) {
       assert.isFalse(DataUtil.isDeepFrozen(value));
     }

--- a/local-modules/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/util-core/tests/test_ObjectUtil.js
@@ -60,7 +60,7 @@ describe('util-core/ObjectUtil', () => {
   });
 
   describe('isSimple()', () => {
-    it('should return `true` for simple objects', () => {
+    it('should return `true` for plain objects', () => {
       function test(value) {
         assert.isTrue(ObjectUtil.isSimple(value));
       }
@@ -71,7 +71,7 @@ describe('util-core/ObjectUtil', () => {
       test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
-    it('should return `false` for non-simple objects', () => {
+    it('should return `false` for non-plain objects', () => {
       function test(value) {
         assert.isFalse(ObjectUtil.isSimple(value));
       }

--- a/local-modules/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/util-core/tests/test_ObjectUtil.js
@@ -59,10 +59,10 @@ describe('util-core/ObjectUtil', () => {
     });
   });
 
-  describe('isSimple()', () => {
+  describe('isPlain()', () => {
     it('should return `true` for plain objects', () => {
       function test(value) {
-        assert.isTrue(ObjectUtil.isSimple(value));
+        assert.isTrue(ObjectUtil.isPlain(value));
       }
 
       test({});
@@ -73,7 +73,7 @@ describe('util-core/ObjectUtil', () => {
 
     it('should return `false` for non-plain objects', () => {
       function test(value) {
-        assert.isFalse(ObjectUtil.isSimple(value));
+        assert.isFalse(ObjectUtil.isPlain(value));
       }
 
       test([]);
@@ -84,7 +84,7 @@ describe('util-core/ObjectUtil', () => {
 
     it('should return `false` for non-objects', () => {
       function test(value) {
-        assert.isFalse(ObjectUtil.isSimple(value));
+        assert.isFalse(ObjectUtil.isPlain(value));
       }
 
       test(null);


### PR DESCRIPTION
The things I keep referring to as "simple objects" are called "plain objects" by the rest of the JavaScript world. This PR aligns our codebase with that reality.

(Hereby soliciting an unambiguously better name than "functor" for that class, too.)