### PR TITLE
Friday afternoon snack: Clean up some codec stuff.

### DIFF
--- a/local-modules/codec/Codec.js
+++ b/local-modules/codec/Codec.js
@@ -7,13 +7,13 @@ import { FrozenBuffer, Singleton } from 'util-common';
 import Registry from './Registry';
 
 /**
- * Encoder and decoder of values for transport over the API (or for storage on
- * disk or in databases), with binding to a name-to-class registry.
+ * Encoder and decoder of values for transport over an API or for storage on
+ * disk or in databases, with binding to a name-to-class registry.
  *
  * **TODO:** This class should probably _not_ be a singleton, in that there are
- * legitimately multiple different API coding contexts which ultimately might
- * want to have different sets of classes (or different name bindings even if
- * the classes overlap).
+ * legitimately multiple different coding contexts which ultimately might want
+ * to have different sets of classes (or different name bindings even if the
+ * classes overlap).
  */
 export default class Codec extends Singleton {
   /**
@@ -165,7 +165,7 @@ export default class Codec extends Singleton {
   }
 
   /**
-   * Registers a class to be accepted for API use. This is a pass-through to
+   * Registers a class to be accepted for codec use. This is a pass-through to
    * the method of the same name on the instance's `Registry`.
    *
    * @param {class} clazz The class to register.
@@ -175,8 +175,8 @@ export default class Codec extends Singleton {
   }
 
   /**
-   * Registers an item codec to be accepted for API use. This is a pass-through
-   * to the method of the same name on the instance's `Registry`.
+   * Registers an item codec to be accepted for codec use. This is a
+   * pass-through to the method of the same name on the instance's `Registry`.
    *
    * @param {ItemCodec} codec The codec to register.
    */

--- a/local-modules/codec/Codec.js
+++ b/local-modules/codec/Codec.js
@@ -121,11 +121,10 @@ export default class Codec extends Singleton {
    * * Objects that are instances of classes (that is, have constructor
    *   functions) are allowed, as long as they at least bind a method
    *   `toCodecArgs()`. In addition, if they have a static `CODEC_TAG` property
-   *   and/or a static `fromCodecArgs()` method, those are used. See {@link
-   *   ItemCodec} for how these are all used to effect encoding and decoding.
-   *   The encoded form is an array with the first element being the value tag
-   *   (typically the class name) and the rest of the elements whatever was
-   *   returned by `toCodecArgs()`.
+   *   then that is used as the tag (class name) in encoded form. The encoded
+   *   form is an array with the first element being the value tag (typically
+   *   the class name) and the rest of the elements whatever was returned by
+   *  `toCodecArgs()`.
    *
    * * All other objects are rejected.
    *

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -113,13 +113,6 @@ export default class ItemCodec extends CommonBase {
 
     const tag = clazz.CODEC_TAG || clazz.name;
 
-    let fromCodecArgs;
-    if (clazz.fromCodecArgs) {
-      fromCodecArgs = TFunction.checkCallable(clazz.fromCodecArgs);
-    } else {
-      fromCodecArgs = (...args) => new clazz(...args);
-    }
-
     const encode = (value, subEncode) => {
       const payload = TArray.check(value.toCodecArgs());
       return payload.map(subEncode);
@@ -127,7 +120,7 @@ export default class ItemCodec extends CommonBase {
 
     const decode = (payload, subDecode) => {
       payload = payload.map(subDecode);
-      return fromCodecArgs(...payload);
+      return new clazz(...payload);
     };
 
     return new ItemCodec(tag, clazz, null, encode, decode);

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -6,11 +6,10 @@ import { TArray, TFunction, TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 /**
- * Handler for API-codable items of a particular class, type, or (in general)
- * kind. This bundles the functionality of identifying codable values, naming
- * them, deriving construction parameters from instances of them, and
- * constructing instances of them from (presumably) previously-derived
- * parameters.
+ * Handler for codable items of a particular class, type, or (in general) kind.
+ * This bundles the functionality of identifying codable values, naming them,
+ * deriving construction parameters from instances of them, and constructing
+ * instances of them from (presumably) previously-derived parameters.
  *
  * The `decode` and `encode` arguments to the constructor are the "workhorses"
  * of an instance of this class. Each of these takes two parameters, the second
@@ -102,8 +101,7 @@ export default class ItemCodec extends CommonBase {
   }
 
   /**
-   * Constructs an instance from a class that has the standard API-coding
-   * methods.
+   * Constructs an instance from a class that has the standard coding methods.
    *
    * @param {function} clazz Class (constructor function) to base the instance
    *   on.

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -54,9 +54,7 @@ export default class Registry extends CommonBase {
    * Registers a class to be accepted for codec use. To be valid, a class must
    * define an instance method `toCodecArgs()`. In addition, it can optionally
    * define a static property `CODEC_TAG` as a replacement for its class name
-   * for use as the tag when encoding; and optionally define a static method
-   * `fromCodecArgs()` to override the default of using the class's constructor
-   * when decoding.
+   * for use as the tag when encoding.
    *
    * @param {object} clazz The class to register.
    */

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -9,9 +9,7 @@ import SpecialCodecs from './SpecialCodecs';
 
 /**
  * Methods for registering and looking up item codecs by name. The names are
- * how classes/types are identified when encoding and decoding instances on
- * the wire (for API transmission and receipt, and for storage to disk or in
- * a database).
+ * how classes/types are identified when encoding and decoding instances.
  */
 export default class Registry extends CommonBase {
   /**
@@ -53,7 +51,7 @@ export default class Registry extends CommonBase {
   }
 
   /**
-   * Registers a class to be accepted for API use. To be valid, a class must
+   * Registers a class to be accepted for codec use. To be valid, a class must
    * define an instance method `toCodecArgs()`. In addition, it can optionally
    * define a static property `CODEC_TAG` as a replacement for its class name
    * for use as the tag when encoding; and optionally define a static method

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Functor, UtilityClass } from 'util-common';
+import { Functor, ObjectUtil, UtilityClass } from 'util-common';
 
 import ItemCodec from './ItemCodec';
 
@@ -109,7 +109,7 @@ export default class SpecialCodecs extends UtilityClass {
   /** {ItemCodec} Codec used for coding plain objects. */
   static get PLAIN_OBJECT() {
     return new ItemCodec(ItemCodec.tagFromType('object'), 'object',
-      this._objectPredicate, this._objectEncode, this._objectDecode);
+      ObjectUtil.isPlain, this._objectEncode, this._objectDecode);
   }
 
   /**
@@ -147,26 +147,6 @@ export default class SpecialCodecs extends UtilityClass {
     }
 
     return result;
-  }
-
-  /**
-   * Checks a value for encodability as a plain object.
-   *
-   * @param {array<*>} value Value to (potentially) encode.
-   * @returns {boolean} `true` iff `value` can be encoded.
-   */
-  static _objectPredicate(value) {
-    // Iterate over all the properties in `value` to see if there are any that
-    // are synthetic. If so, the object is not encodable.
-    for (const k of Object.getOwnPropertyNames(value)) {
-      const prop = Object.getOwnPropertyDescriptor(value, k);
-
-      if ((prop.get !== undefined) || (prop.set !== undefined)) {
-        return false;
-      }
-    }
-
-    return true;
   }
 
   /**

--- a/local-modules/codec/tests/MockApiObject.js
+++ b/local-modules/codec/tests/MockApiObject.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 /**
- * Trivial API-compatible class for use in tests.
+ * Trivial codec-compatible class for use in tests.
  */
 export default class MockApiObject {
   static get CODEC_TAG() {

--- a/local-modules/codec/tests/MockCodable.js
+++ b/local-modules/codec/tests/MockCodable.js
@@ -5,9 +5,9 @@
 /**
  * Trivial codec-compatible class for use in tests.
  */
-export default class MockApiObject {
+export default class MockCodable {
   static get CODEC_TAG() {
-    return 'MockApiObject';
+    return 'MockCodable';
   }
 
   constructor() {
@@ -19,6 +19,6 @@ export default class MockApiObject {
   }
 
   static fromCodecArgs(arguments_unused) {
-    return new MockApiObject();
+    return new MockCodable();
   }
 }

--- a/local-modules/codec/tests/MockCodable.js
+++ b/local-modules/codec/tests/MockCodable.js
@@ -10,15 +10,12 @@ export default class MockCodable {
     return 'MockCodable';
   }
 
-  constructor() {
+  constructor(...args) {
     this.initialized = true;
+    this.args        = args;
   }
 
   toCodecArgs() {
     return ['fake argument', 0, 1, 2];
-  }
-
-  static fromCodecArgs(arguments_unused) {
-    return new MockCodable();
   }
 }

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -28,7 +28,7 @@ describe('api-common/Codec.decode*()', () => {
     }
   });
 
-  describe('decodeData', () => {
+  describe('decodeData()', () => {
     it('should pass non-object values through as-is', () => {
       assert.strictEqual(decodeData(37), 37);
       assert.strictEqual(decodeData(true), true);
@@ -76,7 +76,7 @@ describe('api-common/Codec.decode*()', () => {
     });
   });
 
-  describe('decodeJson', () => {
+  describe('decodeJson()', () => {
     it('should decode as expected', () => {
       assert.strictEqual(decodeJson('null'), null);
       assert.strictEqual(decodeJson('914'), 914);
@@ -84,7 +84,7 @@ describe('api-common/Codec.decode*()', () => {
     });
   });
 
-  describe('decodeJsonBuffer', () => {
+  describe('decodeJsonBuffer()', () => {
     it('should decode as expected', () => {
       function bufAndDecode(s) {
         return decodeJsonBuffer(FrozenBuffer.coerce(s));

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -8,7 +8,7 @@ import { before, describe, it } from 'mocha';
 import { Codec } from 'codec';
 import { FrozenBuffer } from 'util-common';
 
-import MockApiObject from './MockApiObject';
+import MockCodable from './MockCodable';
 
 describe('api-common/Codec.decode*()', () => {
   // Convenient bindings for `decode*()` and `encodeData()` to avoid a lot of
@@ -21,7 +21,7 @@ describe('api-common/Codec.decode*()', () => {
 
   before(() => {
     try {
-      Codec.theOne.registerClass(MockApiObject);
+      Codec.theOne.registerClass(MockCodable);
     } catch (e) {
       // nothing to do here, the try/catch is just in case some other test
       // file has already registered the mock class.
@@ -64,7 +64,7 @@ describe('api-common/Codec.decode*()', () => {
     });
 
     it('should convert propertly formatted values to a decoded instance', () => {
-      const apiObject = new MockApiObject();
+      const apiObject = new MockCodable();
       const encoding = encodeData(apiObject);
       let decodedObject = null;
 

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -24,7 +24,7 @@ describe('api-common/Codec.decode*()', () => {
       Codec.theOne.registerClass(MockApiObject);
     } catch (e) {
       // nothing to do here, the try/catch is just in case some other test
-      // file has already registered the mock API object.
+      // file has already registered the mock class.
     }
   });
 
@@ -63,7 +63,7 @@ describe('api-common/Codec.decode*()', () => {
       assert.deepEqual(decodeData(encoded), orig);
     });
 
-    it('should convert propertly formatted values to an API object', () => {
+    it('should convert propertly formatted values to a decoded instance', () => {
       const apiObject = new MockApiObject();
       const encoding = encodeData(apiObject);
       let decodedObject = null;

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { Codec } from 'codec';
 import { FrozenBuffer } from 'util-common';
 
-import MockApiObject from './MockApiObject';
+import MockCodable from './MockCodable';
 
 class NoCodecTag {
   toCodecArgs() {
@@ -88,7 +88,7 @@ describe('api-common/Codec.encode*()r', () => {
     });
 
     it('should accept objects with an CODEC_TAG property and toCodecArgs() method', () => {
-      const fakeObject = new MockApiObject();
+      const fakeObject = new MockCodable();
 
       assert.doesNotThrow(() => encodeData(fakeObject));
     });

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -29,7 +29,7 @@ describe('api-common/Codec.encode*()r', () => {
   const encodeJson       = (value) => { return codec.encodeJson(value);       };
   const encodeJsonBuffer = (value) => { return codec.encodeJsonBuffer(value); };
 
-  describe('encodeData', () => {
+  describe('encodeData()', () => {
     it('should reject function values', () => {
       assert.throws(() => encodeData(() => 1));
     });
@@ -94,7 +94,7 @@ describe('api-common/Codec.encode*()r', () => {
     });
   });
 
-  describe('encodeJson', () => {
+  describe('encodeJson()', () => {
     it('should produce a string', () => {
       assert.isString(encodeJson(null));
       assert.isString(encodeJson(914));
@@ -108,7 +108,7 @@ describe('api-common/Codec.encode*()r', () => {
     });
   });
 
-  describe('encodeJsonBuffer', () => {
+  describe('encodeJsonBuffer()', () => {
     it('should produce a `FrozenBuffer`', () => {
       assert.instanceOf(encodeJsonBuffer(null), FrozenBuffer);
       assert.instanceOf(encodeJsonBuffer(914), FrozenBuffer);

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -75,13 +75,13 @@ describe('api-common/Codec.encode*()r', () => {
       assert.throws(() => encodeData(value));
     });
 
-    it('should reject API objects with no CODEC_TAG property', () => {
+    it('should reject objects with no CODEC_TAG property', () => {
       const noCodecTag = new NoCodecTag();
 
       assert.throws(() => encodeData(noCodecTag));
     });
 
-    it('should reject API objects with no toCodecArgs() method', () => {
+    it('should reject objects with no toCodecArgs() method', () => {
       const noToCodecArgs = new NoToCodecArgs();
 
       assert.throws(() => encodeData(noToCodecArgs));

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -76,12 +76,23 @@ describe('api-common/Registry', () => {
     });
 
     it('should return the named codec if it is registered', () => {
-      const reg = new Registry();
+      const reg       = new Registry();
       const itemCodec = new ItemCodec('florp', Boolean, null, () => 0, () => 0);
 
       reg.registerCodec(itemCodec);
 
       const testCodec = reg.codecForPayload(['florp']);
+      assert.strictEqual(testCodec, itemCodec);
+    });
+
+    it('should return the codec for a special type if it is registered', () => {
+      const reg       = new Registry();
+      const type      = 'symbol';
+      const itemCodec = new ItemCodec(ItemCodec.tagFromType(type), type, null, () => 0, () => 0);
+
+      reg.registerCodec(itemCodec);
+
+      const testCodec = reg.codecForPayload(Symbol('x'));
       assert.strictEqual(testCodec, itemCodec);
     });
   });

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -24,38 +24,17 @@ class RegistryTestApiObject {
     return ['fake argument', 0, 1, 2];
   }
 
-  static fromCodecArgs(arguments_unused) {
-    return new RegistryTestApiObject();
-  }
 }
 
 class NoCodecTag {
   toCodecArgs() {
     return 'NoCodecTag!';
   }
-
-  static fromCodecArgs() {
-    return new NoCodecTag();
-  }
 }
 
 class NoToCodecArgs {
   constructor() {
     this.CODEC_TAG = 'NoToCodecArgs';
-  }
-
-  static fromCodecArgs() {
-    return new NoToCodecArgs();
-  }
-}
-
-class NoFromCodecArgs {
-  constructor() {
-    this.CODEC_TAG = 'NoFromCodecArgs';
-  }
-
-  toCodecArgs() {
-    return new NoFromCodecArgs();
   }
 }
 
@@ -66,10 +45,9 @@ describe('api-common/Registry', () => {
       assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
     });
 
-    it('should allow classes without `CODEC_TAG` or `fromCodecArgs()`', () => {
+    it('should allow classes without `CODEC_TAG`', () => {
       const reg = new Registry();
       assert.doesNotThrow(() => reg.registerClass(NoCodecTag));
-      assert.doesNotThrow(() => reg.registerClass(NoFromCodecArgs));
     });
 
     it('should reject a class without `toCodecArgs()`', () => {

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -23,7 +23,6 @@ class RegistryTestClass {
   toCodecArgs() {
     return ['fake argument', 0, 1, 2];
   }
-
 }
 
 class NoCodecTag {

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -11,13 +11,13 @@ import { ItemCodec } from 'codec';
 // by path.
 import Registry from 'codec/Registry';
 
-class RegistryTestApiObject {
+class RegistryTestClass {
   constructor() {
     this.initialized = true;
   }
 
   static get CODEC_TAG() {
-    return 'RegistryTestApiObject';
+    return 'RegistryTestClass';
   }
 
   toCodecArgs() {
@@ -39,10 +39,10 @@ class NoToCodecArgs {
 }
 
 describe('api-common/Registry', () => {
-  describe('register(class)', () => {
+  describe('register()', () => {
     it('should accept a class with all salient properties', () => {
       const reg = new Registry();
-      assert.doesNotThrow(() => reg.registerClass(RegistryTestApiObject));
+      assert.doesNotThrow(() => reg.registerClass(RegistryTestClass));
     });
 
     it('should allow classes without `CODEC_TAG`', () => {
@@ -67,7 +67,7 @@ describe('api-common/Registry', () => {
     });
   });
 
-  describe('codecForPayload(payload)', () => {
+  describe('codecForPayload()', () => {
     it('should throw an error if an unregistered tag is requested', () => {
       const reg = new Registry();
       assert.throws(() => reg.codecForPayload(['florp']));

--- a/local-modules/typecheck/tests/test_TObject.js
+++ b/local-modules/typecheck/tests/test_TObject.js
@@ -60,7 +60,6 @@ describe('typecheck/TObject', () => {
       test({});
       test({ a: 10 });
       test({ a: 10, b: 20 });
-      test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
     it('should reject non-plain objects', () => {
@@ -74,6 +73,7 @@ describe('typecheck/TObject', () => {
       test(new Map());
       test({ get x() { return 'x'; } });
       test({ set x(v) { /*empty*/ } });
+      test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
     it('should reject non-objects', () => {

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -53,7 +53,9 @@ export default class ObjectUtil extends UtilityClass {
   /**
    * Tests whether a value is a "plain object." A plain object is defined as
    * being a value of type `object` which is not `null`, whose direct prototype
-   * is `Object.prototype`, and which does not define any synthetic properties.
+   * is `Object.prototype`, which does not define synthetic properties, and
+   * which does not bind any properties using `Symbol`s.
+   *
    * Notably, arrays are _not_ plain objects.
    *
    * @param {*} value Value to check.

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -64,11 +64,12 @@ export default class ObjectUtil extends UtilityClass {
   static isPlain(value) {
     if (   (value === null)
         || (typeof value !== 'object')
-        || (Object.getPrototypeOf(value) !== Object.prototype)) {
+        || (Object.getPrototypeOf(value) !== Object.prototype)
+        || (Object.getOwnPropertySymbols(value).length !== 0)) {
       return false;
     }
 
-    // Make sure there are no synthetic or symbol-bound properties.
+    // Make sure there are no synthetic properties.
     const descriptors = Object.getOwnPropertyDescriptors(value);
     for (const [name, desc] of Object.entries(descriptors)) {
       if ((typeof name !== 'string') || desc.get || desc.set) {

--- a/local-modules/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/util-core/tests/test_ObjectUtil.js
@@ -68,7 +68,7 @@ describe('util-core/ObjectUtil', () => {
       test({});
       test({ a: 10 });
       test({ a: 10, b: 20 });
-      test({ [Symbol('blort')]: [1, 2, 3] });
+      test({ a: 10, b: 20, c: [1, 2, 3] });
     });
 
     it('should return `false` for non-plain objects', () => {

--- a/local-modules/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/util-core/tests/test_ObjectUtil.js
@@ -82,6 +82,7 @@ describe('util-core/ObjectUtil', () => {
       test(new Map());
       test({ get x() { return 10; } });
       test({ set x(v) { /*empty*/ } });
+      test({ [Symbol('foo')]: 'foo' });
     });
 
     it('should return `false` for non-objects', () => {


### PR DESCRIPTION
Miscellaneous cleanup of codec-related bits, along with an `ObjectUtil` fix. The most significant thing I did was remove the option of defining a `fromCodecArgs()` method on codable classes. I'm aiming for a future where we get to generalize the concept embodied in `toCodecArgs()` as _always_ just the reverse of the constructor. This turns out to be useful in contexts other than codec-type coding (as is evidenced in how the last PR set up a couple of the `toString()` methods).