### PR TITLE
The Boilerplate Reduction Act of 2017

### DIFF
--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -117,7 +117,7 @@ export default class BaseKey extends CommonBase {
   [inspect.custom](depth_unused, opts) {
     const name = this.constructor.name;
 
-    return (opts.depth <= 0)
+    return (opts.depth < 0)
       ? `${name} {...}`
       : `${name} { ${this._url} ${this._impl_printableId()} }`;
   }

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -106,31 +106,20 @@ export default class BaseKey extends CommonBase {
   }
 
   /**
-   * Same as calling the custom inspector function via its symbol-bound method.
+   * Custom inspector function, as called by `util.inspect()`. This
+   * implementation redacts the contents so as to prevent inadvertent logging of
+   * the secret values.
    *
-   * _This_ method exists because, as of this writing, the browser polyfill for
-   * `util.inspect()` doesn't find `util.inspect.custom` methods. **TODO:**
-   * Occasionally check to see if this workaround is still needed, and remove it
-   * if it is finally unnecessary.
-   *
-   * @param {Int} depth Current inspection depth.
+   * @param {Int} depth_unused Current inspection depth.
    * @param {object} opts Inspection options.
    * @returns {string} The inspection string form of this instance.
    */
-  inspect(depth, opts) {
-    return this[inspect.custom](depth, opts);
-  }
+  [inspect.custom](depth_unused, opts) {
+    const name = this.constructor.name;
 
-  /**
-   * Custom inspector function, as called by `util.inspect()`. This is done to
-   * prevent inadvertent logging of the secret values.
-   *
-   * @param {Int} depth_unused Current inspection depth.
-   * @param {object} opts_unused Inspection options.
-   * @returns {string} The inspection string form of this instance.
-   */
-  [inspect.custom](depth_unused, opts_unused) {
-    return this.toString();
+    return (opts.depth <= 0)
+      ? `${name} {...}`
+      : `${name} { ${this._url} ${this._impl_printableId()} }`;
   }
 
   /**
@@ -169,15 +158,5 @@ export default class BaseKey extends CommonBase {
    */
   _impl_printableId() {
     return this.id;
-  }
-
-  /**
-   * Gets the redacted form of this instance.
-   *
-   * @returns {string} The redacted form.
-   */
-  toString() {
-    const tag = this.constructor.name;
-    return `{${tag} ${this._url} ${this._impl_printableId()}}`;
   }
 }

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
 import { TObject } from 'typecheck';
 import { CommonBase } from 'util-common';
 
@@ -163,21 +161,6 @@ export default class BaseChange extends CommonBase {
     }
 
     return result;
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    // `depth: null` means to recurse indefinitely.
-    const bodyArr = inspect(this.toCodecArgs(), { depth: null });
-
-    // The `replace()` removes the bracketing around the inspected array.
-    const body = bodyArr.replace(/^.([^]*).$/, '$1');
-
-    return `${this.constructor.name} {${body}}`;
   }
 
   /**

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -127,6 +127,29 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
+   * Custom inspector function, as called by `util.inspect()`.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth, opts) {
+    if (depth < 0) {
+      return `${this.constructor.name} [...]`;
+    }
+
+    // Set up the inspection opts so that recursive calls respect the topmost
+    // requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+    const body = inspect(this._ops, subOpts);
+
+    return `${this.constructor.name} ${body}`;
+  }
+
+  /**
    * Returns `true` iff this instance has the form of a "document," or put
    * another way, iff it is valid to compose with an instance which represents
    * an empty snapshot. The details of what makes an instance a document vary
@@ -160,18 +183,6 @@ export default class BaseDelta extends CommonBase {
    */
   toCodecArgs() {
     return [this._ops];
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    // `depth: null` means to recurse indefinitely.
-    const body = inspect(this._ops, { depth: null });
-
-    return `${this.constructor.name} ${body}`;
   }
 
   /**

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -59,25 +59,36 @@ export default class BaseOp extends CommonBase {
   }
 
   /**
+   * Custom inspector function, as called by `util.inspect()`.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth, opts) {
+    if (depth < 0) {
+      return `${this.constructor.name}:...`;
+    }
+
+    // Set up the inspection opts so that recursive calls respect the topmost
+    // requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+    const payload = inspect(this._payload, subOpts);
+
+    // Since the payload is a functor -- which has a custom inspect renderer --
+    // the result here looks like `FlorpOp:some_op_name(arg, arg)`.
+    return `${this.constructor.name}:${payload}`;
+  }
+
+  /**
    * Converts this instance to codec reconstruction arguments.
    *
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
     return [this._payload];
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    // `depth: null` means to recurse indefinitely.
-    const payload = inspect(this._payload, { depth : null });
-
-    // Since the payload is a functor -- which has a custom inspect renderer --
-    // the result here looks like `FlorpOp:some_op_name(arg, arg)`.
-    return `${this.constructor.name}:${payload}`;
   }
 }

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
 import { TArray, TObject } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
@@ -212,21 +210,6 @@ export default class BaseSnapshot extends CommonBase {
    */
   toCodecArgs() {
     return [this._revNum, this._contents.ops];
-  }
-
-  /**
-   * Gets a human-oriented string representation of this instance.
-   *
-   * @returns {string} The human-oriented representation.
-   */
-  toString() {
-    // `depth: null` means to recurse indefinitely.
-    const bodyArr = inspect(this.toCodecArgs(), { depth: null });
-
-    // The `replace()` removes the bracketing around the inspected array.
-    const body = bodyArr.replace(/^.([^]*).$/, '$1');
-
-    return `${this.constructor.name} {${body}}`;
   }
 
   /**

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -165,7 +165,7 @@ export default class CommonBase {
   [inspect.custom](depth, opts) {
     const name = this.constructor.name;
 
-    if (depth <= 0) {
+    if (depth < 0) {
       return `${name} {...}`;
     }
 
@@ -196,7 +196,7 @@ export default class CommonBase {
         }
 
         // Call the getter, and add its `inspect()` result to the map of same.
-        values.set(n, inspect(obj[n], subOpts));
+        values.set(n, inspect(this[n], subOpts));
       }
     }
 

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -62,7 +62,7 @@ export default class Functor {
    * @returns {string} The inspection string form of this instance.
    */
   [inspect.custom](depth, opts) {
-    if (depth <= 0) {
+    if (depth < 0) {
       // Minimal expansion if we're at the depth limit.
       return `${this._name}(${this._args.length === 0 ? '' : '...'})`;
     }

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -55,22 +55,6 @@ export default class Functor {
   }
 
   /**
-   * Same as calling the custom inspector function via its symbol-bound method.
-   *
-   * _This_ method exists because, as of this writing, the browser polyfill for
-   * `util.inspect()` doesn't find `util.inspect.custom` methods. **TODO:**
-   * Occasionally check to see if this workaround is still needed, and remove it
-   * if it is finally unnecessary.
-   *
-   * @param {Int} depth Current inspection depth.
-   * @param {object} opts Inspection options.
-   * @returns {string} The inspection string form of this instance.
-   */
-  inspect(depth, opts) {
-    return this[inspect.custom](depth, opts);
-  }
-
-  /**
    * Custom inspector function, as called by `util.inspect()`.
    *
    * @param {Int} depth Current inspection depth.
@@ -78,33 +62,26 @@ export default class Functor {
    * @returns {string} The inspection string form of this instance.
    */
   [inspect.custom](depth, opts) {
-    if (depth < 0) {
+    if (depth <= 0) {
+      // Minimal expansion if we're at the depth limit.
       return `${this._name}(${this._args.length === 0 ? '' : '...'})`;
     }
 
+    // Set up the inspection opts so that recursive calls respect the topmost
+    // requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
     const result = [this._name, '('];
 
-    if (depth < 0) {
-      // Minimal expansion if we're at the depth limit.
-      if (this._args.length !== 0) {
-        result.push('...');
+    let first = true;
+    for (const a of this._args) {
+      if (first) {
+        first = false;
+      } else {
+        result.push(', ');
       }
-    } else {
-      // Set up the inspection opts so that recursive calls respect the topmost
-      // requested depth.
-      const subOpts = (opts.depth === null)
-        ? opts
-        : Object.assign({}, opts, { depth: opts.depth - 1 });
-
-      let first = true;
-      for (const a of this._args) {
-        if (first) {
-          first = false;
-        } else {
-          result.push(', ');
-        }
-        result.push(inspect(a, subOpts));
-      }
+      result.push(inspect(a, subOpts));
     }
 
     result.push(')');
@@ -159,16 +136,6 @@ export default class Functor {
     }
 
     return true;
-  }
-
-  /**
-   * Gets the string form of this instance. This uses `util.inspect()` on the
-   * elements of the `args` array.
-   *
-   * @returns {string} The string form of this instance.
-   */
-  toString() {
-    return inspect(this, { breakLength: Infinity });
   }
 
   /**

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -94,4 +94,15 @@ export default class InfoError extends Error {
   get info() {
     return this._info;
   }
+
+  /**
+   * This just calls through to the superclass's `toString()`. This method
+   * exists so that `CommonBase.mixin()` won't try to override `toString()` on
+   * this class.
+   *
+   * @returns {string} String form of this instance.
+   */
+  toString() {
+    return super.toString();
+  }
 }

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import CoreTypecheck from './CoreTypecheck';
 import Functor from './Functor';
 
@@ -72,6 +74,12 @@ export default class InfoError extends Error {
     /** {Functor} The error info payload. */
     this._info = info;
 
+    /**
+     * {array<string>} Array of stack trace line items, in canonical form. See
+     * {@link #_stackLines} for details.
+     */
+    this._stack = InfoError._stackLines(this.stack);
+
     if (this._cause !== null) {
       // Append the cause's stack to this instance's. **TODO:** Figure out if
       // we can do this lazily, which would mean somehow both overriding
@@ -96,13 +104,86 @@ export default class InfoError extends Error {
   }
 
   /**
-   * This just calls through to the superclass's `toString()`. This method
-   * exists so that `CommonBase.mixin()` won't try to override `toString()` on
-   * this class.
+   * Custom inspector function, as called by `util.inspect()`. This just returns
+   * implementation is similar to the default `Error` inspector, except that
+   * this one formats the first line in a nicer way given the structured error
+   * content.
+   *
+   * @param {Int} depth_unused Current inspection depth. **Note:** This
+   *   implementation mimics the behavior of the default implementation in that
+   *   it includes the stack trace even when `depth` is `0`.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth_unused, opts) {
+    // Set up the inspection opts so that recursive calls respect the topmost
+    // requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+
+    const result = [
+      this.constructor.name,
+      ': ',
+      inspect(this._info, subOpts),
+      '\n'
+    ];
+
+    for (const l of this._stack) {
+      result.push('  at ');
+      result.push(l);
+      result.push('\n');
+    }
+
+    if (this._cause !== null) {
+      result.push('caused by:\n');
+      // `opts` and not `subOpts` so that the cause is inspected at the same
+      // depth (which makes reasonable sense, as it's more of a linear than a
+      // recursive thing, in context).
+      result.push(inspect(this._cause, opts));
+    }
+
+    return result.join('').replace(/\n+$/, '');
+  }
+
+  /**
+   * Gets a concise string form of this instance.
    *
    * @returns {string} String form of this instance.
    */
   toString() {
-    return super.toString();
+    return `${this.constructor.name}:${this._info}`;
+  }
+
+  /**
+   * Gets an array of stack lines from an original `.stack` string. This is
+   * meant to work cross-platform, taking into account known differences between
+   * Chrome / Chromium and Safari.
+   *
+   * @param {string} orig The original `.stack` string.
+   * @returns {array<string>} Array of trace items.
+   */
+  static _stackLines(orig) {
+    const lines = orig.split('\n');
+
+    if (lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+
+    if (lines.length === 0) {
+      return lines;
+    }
+
+    if (/^    at /.test(lines[lines.length - 1])) {
+      // Chrome / Chromium style, which means its first line is a recapitualtion
+      // of the error name and message. We also want to strip off all the `at`s.
+      lines.shift();
+      for (let i = 0; i < lines.length; i++) {
+        lines[i] = lines[i].slice(7);
+      }
+    }
+
+    return lines;
   }
 }


### PR DESCRIPTION
The main thing I did in this PR is add a generic `inspect()` helper method to `CommonBase`, so that, for the most part, we no longer have to add other `inspect()` or `toString()` methods to our classes while still getting reasonably sensible output.

The rest of the PR was cleanup that was enabled by the main change, as well as a couple other bits of adjustment to its expectations (in particular, moving from custom `toString()` methods to custom `inspect()` methods).