### PR TITLE
Operation encoding

### DIFF
--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -17,13 +17,20 @@ export default class BaseOp extends CommonBase {
    * the static constructor methods defined by concrete subclasses of this
    * class.
    *
-   * @param {Functor} payload The operation payload (name and arguments). All
-   *   arguments must either be frozen or be data values which _can_ be frozen.
-   *   In the latter case, the resulting instance's payload is a deep-frozen
-   *   clone of the value given here.
+   * @param {string} name The operation name.
+   * @param {...*} args The operation arguments. Each argument must either be
+   *   frozen or be a data values which _can_ be frozen. In the latter case, the
+   *   resulting instance's corresponding argument is a deep-frozen clone of the
+   *   value given here.
    */
-  constructor(payload) {
+  constructor(name, ...args) {
     super();
+
+    // **TODO:** Remove the functor argument option, once call sites have been
+    // fixed.
+    const payload = (name instanceof Functor)
+      ? name
+      : new Functor(name, ...args);
 
     /** {Functor} payload The operation payload (name and arguments). */
     this._payload = Functor.check(payload).withFrozenArgs();
@@ -89,6 +96,6 @@ export default class BaseOp extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this._payload];
+    return [this._payload.name, ...this._payload.args];
   }
 }

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -26,14 +26,8 @@ export default class BaseOp extends CommonBase {
   constructor(name, ...args) {
     super();
 
-    // **TODO:** Remove the functor argument option, once call sites have been
-    // fixed.
-    const payload = (name instanceof Functor)
-      ? name
-      : new Functor(name, ...args);
-
-    /** {Functor} payload The operation payload (name and arguments). */
-    this._payload = Functor.check(payload).withFrozenArgs();
+    /** {Functor} The operation payload (name and arguments). */
+    this._payload = new Functor(name, ...args).withFrozenArgs();
 
     Object.freeze(this);
   }

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -99,7 +99,7 @@ export default class BodyOp extends BaseOp {
   static op_delete(count) {
     TInt.min(count, 1);
 
-    return new BodyOp(new Functor(BodyOp.DELETE, count));
+    return new BodyOp(BodyOp.DELETE, count);
   }
 
   /**
@@ -115,7 +115,7 @@ export default class BodyOp extends BaseOp {
     value           = DataUtil.deepFreeze(Functor.check(value));
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(new Functor(BodyOp.INSERT_EMBED, value, ...attribArg));
+    return new BodyOp(BodyOp.INSERT_EMBED, value, ...attribArg);
   }
 
   /**
@@ -130,7 +130,7 @@ export default class BodyOp extends BaseOp {
     TString.nonEmpty(text);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(new Functor(BodyOp.INSERT_TEXT, text, ...attribArg));
+    return new BodyOp(BodyOp.INSERT_TEXT, text, ...attribArg);
   }
 
   /**
@@ -147,7 +147,7 @@ export default class BodyOp extends BaseOp {
     TInt.min(count, 1);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(new Functor(BodyOp.RETAIN, count, ...attribArg));
+    return new BodyOp(BodyOp.RETAIN, count, ...attribArg);
   }
 
   /**

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
-import { Errors, Functor } from 'util-common';
+import { Errors } from 'util-common';
 
 import BaseOp from './BaseOp';
 import Caret from './Caret';
@@ -37,7 +37,7 @@ export default class CaretOp extends BaseOp {
   static op_beginSession(caret) {
     Caret.check(caret);
 
-    return new CaretOp(new Functor(CaretOp.BEGIN_SESSION, caret));
+    return new CaretOp(CaretOp.BEGIN_SESSION, caret);
   }
 
   /**
@@ -49,7 +49,7 @@ export default class CaretOp extends BaseOp {
   static op_endSession(sessionId) {
     TString.nonEmpty(sessionId);
 
-    return new CaretOp(new Functor(CaretOp.END_SESSION, sessionId));
+    return new CaretOp(CaretOp.END_SESSION, sessionId);
   }
 
   /**
@@ -65,7 +65,7 @@ export default class CaretOp extends BaseOp {
     TString.nonEmpty(sessionId);
     Caret.checkField(key, value);
 
-    return new CaretOp(new Functor(CaretOp.SET_FIELD, sessionId, key, value));
+    return new CaretOp(CaretOp.SET_FIELD, sessionId, key, value);
   }
 
   /**

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from 'typecheck';
-import { Errors, Functor } from 'util-common';
+import { Errors } from 'util-common';
 
 import BaseOp from './BaseOp';
 
@@ -31,7 +31,7 @@ export default class PropertyOp extends BaseOp {
   static op_deleteProperty(name) {
     TString.identifier(name);
 
-    return new PropertyOp(new Functor(PropertyOp.DELETE_PROPERTY, name));
+    return new PropertyOp(PropertyOp.DELETE_PROPERTY, name);
   }
 
   /**
@@ -45,7 +45,7 @@ export default class PropertyOp extends BaseOp {
   static op_setProperty(name, value) {
     TString.identifier(name);
 
-    return new PropertyOp(new Functor(PropertyOp.SET_PROPERTY, name, value));
+    return new PropertyOp(PropertyOp.SET_PROPERTY, name, value);
   }
 
   /**

--- a/local-modules/doc-common/tests/MockDelta.js
+++ b/local-modules/doc-common/tests/MockDelta.js
@@ -20,12 +20,12 @@ export default class MockDelta extends BaseDelta {
    * document.
    */
   static get NOT_DOCUMENT_OPS() {
-    return [MockOp.make('not_document')];
+    return [new MockOp('not_document')];
   }
 
   /** {array<object>} Ops array that will be considered valid. */
   static get VALID_OPS() {
-    return [MockOp.make('yes')];
+    return [new MockOp('yes')];
   }
 
   _impl_isDocument() {

--- a/local-modules/doc-common/tests/MockOp.js
+++ b/local-modules/doc-common/tests/MockOp.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseOp } from 'doc-common';
-import { Functor } from 'util-common';
 
 /**
  * Mock operation class for testing.
@@ -16,7 +15,7 @@ export default class MockOp extends BaseOp {
    * @returns {object} An op with the indicated name.
    */
   static make(name) {
-    return new MockOp(new Functor(name));
+    return new MockOp(name);
   }
 
   get name() {

--- a/local-modules/doc-common/tests/MockOp.js
+++ b/local-modules/doc-common/tests/MockOp.js
@@ -8,16 +8,6 @@ import { BaseOp } from 'doc-common';
  * Mock operation class for testing.
  */
 export default class MockOp extends BaseOp {
-  /**
-   * Makes a valid op with the indicated name.
-   *
-   * @param {string} name Name of the op.
-   * @returns {object} An op with the indicated name.
-   */
-  static make(name) {
-    return new MockOp(name);
-  }
-
   get name() {
     return this.payload.name;
   }

--- a/local-modules/doc-common/tests/test_BaseDelta.js
+++ b/local-modules/doc-common/tests/test_BaseDelta.js
@@ -55,7 +55,7 @@ describe('doc-common/BaseDelta', () => {
         [],
         MockDelta.VALID_OPS,
         MockDelta.NOT_DOCUMENT_OPS,
-        [MockOp.make('x'), MockOp.make('y')]
+        [new MockOp('x'), new MockOp('y')]
       ];
 
       for (const v of values) {
@@ -114,8 +114,8 @@ describe('doc-common/BaseDelta', () => {
     });
 
     it('should return `true` when equal ops are not also `===`', () => {
-      const ops1 = [MockOp.make('foo'), MockOp.make('bar')];
-      const ops2 = [MockOp.make('foo'), MockOp.make('bar')];
+      const ops1 = [new MockOp('foo'), new MockOp('bar')];
+      const ops2 = [new MockOp('foo'), new MockOp('bar')];
       const d1 = new MockDelta(ops1);
       const d2 = new MockDelta(ops2);
 
@@ -124,8 +124,8 @@ describe('doc-common/BaseDelta', () => {
     });
 
     it('should return `false` when array lengths differ', () => {
-      const op1 = MockOp.make('foo');
-      const op2 = MockOp.make('bar');
+      const op1 = new MockOp('foo');
+      const op2 = new MockOp('bar');
       const d1 = new MockDelta([op1]);
       const d2 = new MockDelta([op1, op2]);
 
@@ -142,11 +142,11 @@ describe('doc-common/BaseDelta', () => {
         assert.isFalse(d2.equals(d1));
       }
 
-      const op1 = MockOp.make('foo');
-      const op2 = MockOp.make('bar');
-      const op3 = MockOp.make('baz');
-      const op4 = MockOp.make('biff');
-      const op5 = MockOp.make('quux');
+      const op1 = new MockOp('foo');
+      const op2 = new MockOp('bar');
+      const op3 = new MockOp('baz');
+      const op4 = new MockOp('biff');
+      const op5 = new MockOp('quux');
 
       test([op1],                     [op2]);
       test([op1, op2],                [op1, op3]);

--- a/local-modules/doc-common/tests/test_BaseOp.js
+++ b/local-modules/doc-common/tests/test_BaseOp.js
@@ -62,6 +62,7 @@ describe('doc-common/BaseOp', () => {
       }
 
       test(new Map());
+      test(new Functor('x', 1, 2));
       test(/blort/);
       test(() => 'woo');
       test(1, 2, 3, new Map(), 4, 5, 6);

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -31,11 +31,11 @@ class MockSnapshot extends BaseSnapshot {
       resultName = op0.name + '_';
     }
 
-    return [MockOp.make(resultName), ...delta.ops];
+    return [new MockOp(resultName), ...delta.ops];
   }
 
   _impl_diffAsDelta(newerSnapshot) {
-    return [MockOp.make('diff_delta'), newerSnapshot.contents.ops[0]];
+    return [new MockOp('diff_delta'), newerSnapshot.contents.ops[0]];
   }
 
   static get _impl_changeClass() {
@@ -142,8 +142,8 @@ describe('doc-common/BaseSnapshot', () => {
 
   describe('compose()', () => {
     it('should call through to the impl and wrap the result in a new instance', () => {
-      const snap   = new MockSnapshot(10, [MockOp.make('some_op')]);
-      const change = new MockChange(20, [MockOp.make('change_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
+      const change = new MockChange(20, [new MockOp('change_op')]);
       const result = snap.compose(change);
 
       assert.instanceOf(result, MockSnapshot);
@@ -151,11 +151,11 @@ describe('doc-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [MockOp.make('composed_delta'), MockOp.make('change_op')]);
+        [new MockOp('composed_delta'), new MockOp('change_op')]);
     });
 
     it('should return `this` given a same-`revNum` empty-`delta` change', () => {
-      const snap   = new MockSnapshot(10, [MockOp.make('some_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
       const change = new MockChange(10, []);
       const result = snap.compose(change);
 
@@ -191,9 +191,9 @@ describe('doc-common/BaseSnapshot', () => {
 
   describe('composeAll()', () => {
     it('should call through to the impl and wrap the result in a new instance', () => {
-      const snap    = new MockSnapshot(10, [MockOp.make('some_op')]);
-      const change1 = new MockChange(21, [MockOp.make('change_op1')]);
-      const change2 = new MockChange(22, [MockOp.make('change_op2')]);
+      const snap    = new MockSnapshot(10, [new MockOp('some_op')]);
+      const change1 = new MockChange(21, [new MockOp('change_op1')]);
+      const change2 = new MockChange(22, [new MockOp('change_op2')]);
       const result = snap.composeAll([change1, change2]);
 
       assert.instanceOf(result, MockSnapshot);
@@ -201,11 +201,11 @@ describe('doc-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [MockOp.make('composed_delta_'), MockOp.make('change_op2')]);
+        [new MockOp('composed_delta_'), new MockOp('change_op2')]);
     });
 
     it('should return `this` given same-`revNum` empty-`delta` changes', () => {
-      const snap   = new MockSnapshot(10, [MockOp.make('some_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
       const change = new MockChange(10, []);
       const result = snap.composeAll([change, change, change, change]);
 
@@ -248,7 +248,7 @@ describe('doc-common/BaseSnapshot', () => {
   describe('diff()', () => {
     it('should call through to the impl and wrap the result in a timeless authorless change', () => {
       const oldSnap = new MockSnapshot(10, []);
-      const newSnap = new MockSnapshot(20, [MockOp.make('new_snap')]);
+      const newSnap = new MockSnapshot(20, [new MockOp('new_snap')]);
       const result  = oldSnap.diff(newSnap);
 
       assert.instanceOf(result, MockChange);
@@ -258,7 +258,7 @@ describe('doc-common/BaseSnapshot', () => {
       assert.isNull(result.authorId);
 
       assert.deepEqual(result.delta.ops,
-        [MockOp.make('diff_delta'), MockOp.make('new_snap')]);
+        [new MockOp('diff_delta'), new MockOp('new_snap')]);
     });
 
     it('should reject instances of the wrong snapshot class', () => {
@@ -333,8 +333,8 @@ describe('doc-common/BaseSnapshot', () => {
     });
 
     it('should return `false` when deltas are not equal', () => {
-      const snap1 = new MockSnapshot(123, [MockOp.make('x')]);
-      const snap2 = new MockSnapshot(123, [MockOp.make('y')]);
+      const snap1 = new MockSnapshot(123, [new MockOp('x')]);
+      const snap2 = new MockSnapshot(123, [new MockOp('y')]);
 
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
@@ -361,8 +361,8 @@ describe('doc-common/BaseSnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `contents`', () => {
-      const delta  = new MockDelta([MockOp.make('yo')]);
-      const snap   = new MockSnapshot(123, [MockOp.make('hello')]);
+      const delta  = new MockDelta([new MockOp('yo')]);
+      const snap   = new MockSnapshot(123, [new MockOp('hello')]);
       const result = snap.withContents(delta);
 
       assert.strictEqual(result.revNum,   123);

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -303,6 +303,80 @@ describe('util-core/DataUtil', () => {
     });
   });
 
+  describe('isData()', () => {
+    it('should return `true` for primitive values', () => {
+      function test(value) {
+        assert.isTrue(DataUtil.isData(value));
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test(true);
+      test(37);
+      test('a string');
+      test(Symbol('foo'));
+    });
+
+    it('should return `true` for appropriate composites', () => {
+      function test(value) {
+        assert.isTrue(DataUtil.isData(value));
+      }
+
+      test([]);
+      test([1, 2, 3]);
+      test([[1, 2, 3]]);
+
+      test({});
+      test({ a: 10, b: 20 });
+      test({ a: 10, b: Object.freeze({ c: 30 }) });
+
+      test(new Functor('x'));
+      test(new Functor('x', 1));
+      test(new Functor('x', [1, 2, 3]));
+      test(new Functor('x', new Functor('y', 914, 37)));
+    });
+
+    it('should return `false` for non-plain objects or composites with same', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
+
+      const instance = new Number(10);
+      const synthetic = {
+        a: 10,
+        get x() { return 20; }
+      };
+
+      test(instance);
+      test(synthetic);
+      test([instance]);
+      test([synthetic]);
+      test({ a: instance });
+      test({ a: synthetic });
+      test({ a: { b: instance } });
+      test({ a: [1, 2, 3, synthetic] });
+      test(new Functor('x', instance));
+      test(new Functor('x', [synthetic]));
+    });
+
+    it('should return `false` for functions, generators and composites containing same', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
+
+      function func() { return 10; }
+      function* gen() { yield 10; }
+
+      test(func);
+      test(gen);
+      test([func]);
+      test([gen]);
+      test({ a: func });
+      test({ a: [1, 2, gen] });
+    });
+  });
+
   describe('isDeepFrozen()', () => {
     it('should return `true` for primitive values', () => {
       function test(value) {
@@ -336,76 +410,76 @@ describe('util-core/DataUtil', () => {
       test(new Functor('x', Object.freeze([1, 2, 3])));
       test(new Functor('x', new Functor('y', 914, 37)));
     });
-  });
 
-  it('should return `false` for composites that are not frozen even if all elements are', () => {
-    function test(value) {
-      assert.isFalse(DataUtil.isDeepFrozen(value));
-    }
+    it('should return `false` for composites that are not frozen even if all elements are', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
 
-    test([]);
-    test([1, 2, 3]);
-    test([Object.freeze([1, 2, 3])]);
+      test([]);
+      test([1, 2, 3]);
+      test([Object.freeze([1, 2, 3])]);
 
-    test({});
-    test({ a: 10, b: 20 });
-    test({ a: 10, b: Object.freeze({ c: 30 }) });
-  });
-
-  it('should return `false` for frozen composites with non-frozen elements', () => {
-    function test(value) {
-      assert.isFalse(DataUtil.isDeepFrozen(value));
-    }
-
-    test(Object.freeze([[]]));
-    test(Object.freeze([Object.freeze([[]])]));
-
-    test(Object.freeze({ a: {} }));
-    test(Object.freeze({ a: Object.freeze({ b: {} }) }));
-
-    test(new Functor('x', []));
-    test(new Functor('x', 1, 2, 3, []));
-    test(new Functor('x', new Functor('y', [])));
-  });
-
-  it('should return `false` for non-plain objects or composites with same', () => {
-    function test(value) {
-      assert.isFalse(DataUtil.isDeepFrozen(value));
-    }
-
-    const instance = Object.freeze(new Number(10));
-    const synthetic = Object.freeze({
-      a: 10,
-      get x() { return 20; }
+      test({});
+      test({ a: 10, b: 20 });
+      test({ a: 10, b: Object.freeze({ c: 30 }) });
     });
 
-    test(instance);
-    test(synthetic);
-    test(Object.freeze([instance]));
-    test(Object.freeze([synthetic]));
-    test(Object.freeze({ a: instance }));
-    test(Object.freeze({ a: synthetic }));
-    test(Object.freeze({ a: Object.freeze({ b: instance }) }));
-    test(Object.freeze({ a: Object.freeze([1, 2, 3, synthetic]) }));
-    test(new Functor('x', instance));
-    test(new Functor('x', Object.freeze([synthetic])));
-  });
+    it('should return `false` for frozen composites with non-frozen elements', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
 
-  it('should return `false` for functions, generators and composites containing same', () => {
-    function test(value) {
-      assert.isFalse(DataUtil.isDeepFrozen(value));
-    }
+      test(Object.freeze([[]]));
+      test(Object.freeze([Object.freeze([[]])]));
 
-    function func() { return 10; }
-    function* gen() { yield 10; }
-    Object.freeze(func);
-    Object.freeze(gen);
+      test(Object.freeze({ a: {} }));
+      test(Object.freeze({ a: Object.freeze({ b: {} }) }));
 
-    test(func);
-    test(gen);
-    test(Object.freeze([func]));
-    test(Object.freeze([gen]));
-    test(Object.freeze({ a: func }));
-    test(Object.freeze({ a: Object.freeze([1, 2, gen]) }));
+      test(new Functor('x', []));
+      test(new Functor('x', 1, 2, 3, []));
+      test(new Functor('x', new Functor('y', [])));
+    });
+
+    it('should return `false` for non-plain objects or composites with same', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
+
+      const instance = Object.freeze(new Number(10));
+      const synthetic = Object.freeze({
+        a: 10,
+        get x() { return 20; }
+      });
+
+      test(instance);
+      test(synthetic);
+      test(Object.freeze([instance]));
+      test(Object.freeze([synthetic]));
+      test(Object.freeze({ a: instance }));
+      test(Object.freeze({ a: synthetic }));
+      test(Object.freeze({ a: Object.freeze({ b: instance }) }));
+      test(Object.freeze({ a: Object.freeze([1, 2, 3, synthetic]) }));
+      test(new Functor('x', instance));
+      test(new Functor('x', Object.freeze([synthetic])));
+    });
+
+    it('should return `false` for functions, generators and composites containing same', () => {
+      function test(value) {
+        assert.isFalse(DataUtil.isDeepFrozen(value));
+      }
+
+      function func() { return 10; }
+      function* gen() { yield 10; }
+      Object.freeze(func);
+      Object.freeze(gen);
+
+      test(func);
+      test(gen);
+      test(Object.freeze([func]));
+      test(Object.freeze([gen]));
+      test(Object.freeze({ a: func }));
+      test(Object.freeze({ a: Object.freeze([1, 2, gen]) }));
+    });
   });
 });

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.28.0
+version = 0.29.0


### PR DESCRIPTION
This PR removes the internal layer from the encoded form of OT operations, approximately hiding an implementation detail from the encoded form. Though details of the specific operations are still going to be in flux for a little while, this at least nails down the basic encoded format.
