### PR TITLE
Property OT addition / alignment

### DIFF
--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -261,7 +261,7 @@ export default class Caret extends CommonBase {
   /**
    * Compares this to another value, for equality.
    *
-   * @param {Caret} other Caret to compare to.
+   * @param {*} other Value to compare to.
    * @returns {boolean} `true` iff `other` is also an instance of this class,
    *   and `this` and `other` have equal contents.
    */

--- a/local-modules/doc-common/Property.js
+++ b/local-modules/doc-common/Property.js
@@ -1,0 +1,68 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+import { CommonBase, DataUtil } from 'util-common';
+
+/**
+ * Pair consisting of a string name and an arbitrary data value representing a
+ * single property within a `PropertySnapshot`. Instances of this class are
+ * always frozen (immutable).
+ */
+export default class Property extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} name Name of the property. Must be in "identifier" syntax.
+   * @param {*} value Value associated with `name`. Must be a data value.
+   */
+  constructor(name, value) {
+    super();
+
+    /** {string} Property name. */
+    this._name = TString.identifier(name);
+
+    /** {*} Property value. */
+    this._value = DataUtil.deepFreeze(value);
+
+    Object.freeze(this);
+  }
+
+  /** {string} Property name. */
+  get name() {
+    return this._name;
+  }
+
+  /** {*} Property value. Always a deep-frozen data value. */
+  get value() {
+    return this._value;
+  }
+
+  /**
+   * Compares this to another value, for equality.
+   *
+   * @param {*} other Value to compare to.
+   * @returns {boolean} `true` iff `other` is also an instance of this class,
+   *   and `this` and `other` have equal contents.
+   */
+  equals(other) {
+    if (this === other) {
+      return true;
+    } else if (!(other instanceof Property)) {
+      return false;
+    }
+
+    return (this._name === other._name)
+      && DataUtil.equalData(this._value, other._value);
+  }
+
+  /**
+   * Converts this instance to codec reconstruction arguments.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  toCodecArgs() {
+    return [this._name, this._value];
+  }
+}

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -27,13 +27,13 @@ export default class PropertyDelta extends BaseDelta {
 
       switch (opProps.opName) {
         case PropertyOp.SET_PROPERTY: {
-          const sessionId = opProps.name;
+          const name = opProps.name;
 
-          if (names.has(sessionId)) {
+          if (names.has(name)) {
             return false;
           }
 
-          names.add(sessionId);
+          names.add(name);
           break;
         }
 

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -27,7 +27,7 @@ export default class PropertyDelta extends BaseDelta {
 
       switch (opProps.opName) {
         case PropertyOp.SET_PROPERTY: {
-          const name = opProps.name;
+          const name = opProps.property.name;
 
           if (names.has(name)) {
             return false;

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -6,6 +6,7 @@ import { TString } from 'typecheck';
 import { Errors } from 'util-common';
 
 import BaseOp from './BaseOp';
+import Property from './Property';
 
 /**
  * Operation which can be applied to a `PropertySnapshot`.
@@ -43,9 +44,7 @@ export default class PropertyOp extends BaseOp {
    * @returns {PropertyOp} An appropriately-constructed operation.
    */
   static op_setProperty(name, value) {
-    TString.identifier(name);
-
-    return new PropertyOp(PropertyOp.SET_PROPERTY, name, value);
+    return new PropertyOp(PropertyOp.SET_PROPERTY, new Property(name, value));
   }
 
   /**
@@ -65,8 +64,8 @@ export default class PropertyOp extends BaseOp {
       }
 
       case PropertyOp.SET_PROPERTY: {
-        const [name, value] = payload.args;
-        return Object.freeze({ opName, name, value });
+        const [property] = payload.args;
+        return Object.freeze({ opName, property });
       }
 
       default: {

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -41,7 +41,7 @@ export default class PropertySnapshot extends BaseSnapshot {
 
       switch (opProps.opName) {
         case PropertyOp.SET_PROPERTY: {
-          this._properties.set(opProps.name, op);
+          this._properties.set(opProps.property.name, op);
           break;
         }
 
@@ -67,7 +67,7 @@ export default class PropertySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Gets an iterator over the `[name, value]` entries that make up the
+   * Gets an iterator over the `[name, property]` entries that make up the
    * snapshot.
    *
    * **Note:** This has identical semantics to the `Map` method of the same
@@ -78,8 +78,8 @@ export default class PropertySnapshot extends BaseSnapshot {
    */
   * entries() {
     for (const op of this.contents.ops) {
-      const { name, value } = op.props;
-      yield [name, value];
+      const property = op.props.property;
+      yield [property.name, property];
     }
   }
 
@@ -115,14 +115,14 @@ export default class PropertySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Gets the property value for the given name, if any. Throws an error if
-   * `name` is not a bound property.
+   * Gets the property for the given name, if any. Throws an error if `name` is
+   * not a bound property.
    *
    * **Note:** This differs from the semantics of the `Map` method of the same
    * name in that the not-found case is an error.
    *
    * @param {string} name Property name.
-   * @returns {*} Corresponding property value.
+   * @returns {Property} Corresponding property.
    */
   get(name) {
     TString.identifier(name);
@@ -130,7 +130,7 @@ export default class PropertySnapshot extends BaseSnapshot {
     const p = this._properties.get(name);
 
     if (p) {
-      return p.props.value;
+      return p.props.property;
     }
 
     throw Errors.bad_use(`No such property: ${name}`);
@@ -203,7 +203,7 @@ export default class PropertySnapshot extends BaseSnapshot {
 
       switch (opProps.opName) {
         case PropertyOp.SET_PROPERTY: {
-          newProps.set(opProps.name, op);
+          newProps.set(opProps.property.name, op);
           break;
         }
 

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -172,7 +172,7 @@ describe('doc-common/PropertySnapshot', () => {
       const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
-      assert.strictEqual(result.get('florp'), 'like');
+      assert.strictEqual(result.get('florp'), op.props.property);
       assert.isTrue(result.equals(expected));
     });
 
@@ -183,7 +183,7 @@ describe('doc-common/PropertySnapshot', () => {
       const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
 
-      assert.strictEqual(result.get('florp'), 'like');
+      assert.strictEqual(result.get('florp'), op.props.property);
       assert.isTrue(result.equals(expected));
     });
 
@@ -253,13 +253,13 @@ describe('doc-common/PropertySnapshot', () => {
         // Expectations as a map of keys to values.
         const expectMap = new Map();
         for (const op of ops) {
-          const { name, value } = op.props;
-          expectMap.set(name, value);
+          const { property } = op.props;
+          expectMap.set(property.name, property);
         }
 
         const snap = new PropertySnapshot(1, ops);
         for (const [name, value] of snap.entries()) {
-          assert.isTrue(expectMap.has(name)); // Differentiate `null` value from absent key.
+          assert.isTrue(expectMap.has(name));
           assert.strictEqual(value, expectMap.get(name));
           expectMap.delete(name);
         }
@@ -408,7 +408,7 @@ describe('doc-common/PropertySnapshot', () => {
           PropertyOp.op_setProperty('Z', 33)
         ]);
 
-        assert.strictEqual(snap.get(name), op.props.value);
+        assert.strictEqual(snap.get(name), op.props.property);
       }
 
       test('zilch', undefined);
@@ -422,13 +422,13 @@ describe('doc-common/PropertySnapshot', () => {
       test('florp', ['like']);
     });
 
-    it('should always return a deep-frozen value even when the constructor was passed an unfrozen value', () => {
+    it('should always return a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
       const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', value)]);
 
       const result = snap.get('blort');
-      assert.isTrue(DataUtil.isDeepFrozen(result));
-      assert.deepEqual(result, value);
+      assert.isTrue(DataUtil.isDeepFrozen(result.value));
+      assert.deepEqual(result.value, value);
     });
 
     it('should throw an error when given a name that is not bound as a property', () => {


### PR DESCRIPTION
This PR adds a `Property` class to hold property bindings including both name and value, to parallel the `Caret` class (which similarly holds both a session ID and caret details). A future PR will factor out common code; this PR will make that easier to achieve.