### PR TITLE
"Pre-factor" the two document control classes.

### DIFF
--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -274,7 +274,7 @@ export default class DebugTools {
     const revNum = req.params.revNum;
     const body = this._getExistingBody(req);
     const args = (revNum === undefined) ? [] : [revNum];
-    const snapshot = (await body).snapshot(...args);
+    const snapshot = (await body).getSnapshot(...args);
     const result = Codec.theOne.encodeJson(await snapshot, true);
 
     this._textResponse(res, result);

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -178,7 +178,7 @@ export default class DebugTools {
   async _handle_change(req, res) {
     const revNum = req.params.revNum;
     const body = this._getExistingBody(req);
-    const change = (await body).change(revNum);
+    const change = (await body).getChange(revNum);
     const result = Codec.theOne.encodeJson(await change, true);
 
     this._textResponse(res, result);

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -350,7 +350,7 @@ export default class BodyClient extends StateMachine {
 
     const sessionProxy    = this._sessionProxy;
     const infoPromise     = sessionProxy.getLogInfo();
-    const snapshotPromise = sessionProxy.body_snapshot();
+    const snapshotPromise = sessionProxy.body_getSnapshot();
 
     try {
       const info = await infoPromise;

--- a/local-modules/doc-client/CaretStore.js
+++ b/local-modules/doc-client/CaretStore.js
@@ -16,7 +16,7 @@ const INITIAL_STATE = CaretSnapshot.EMPTY;
 /**
  * {string} Redux action to dispatch when we receive a new caret snapshot.
  */
-const CARET_SNAPSHOT_UPDATED = 'caret_snapshot_updated';
+const CARET_SNAPSHOT_UPDATED = 'caret_getSnapshot_updated';
 
 /**
  * {Int} Amount of time (in msec) to wait after receiving a caret update from
@@ -150,14 +150,14 @@ export default class CaretStore {
           // because the attempt to get a change failed for some reason. (The
           // latter is why this section isn't just part of an `else` block to
           // the previous `if`).
-          snapshot = await sessionProxy.caret_snapshot();
+          snapshot = await sessionProxy.caret_getSnapshot();
           docSession.log.detail(`Got ${snapshot.size} new caret(s)!`);
         }
       } catch (e) {
         // Assume that the error is transient and most likely due to the session
         // getting terminated / restarted. Null out the session variables, wait
         // a moment, and try again.
-        docSession.log.warn('Trouble with `caret_snapshot`:', e);
+        docSession.log.warn('Trouble with `caret_getSnapshot`:', e);
         docSession   = null;
         sessionProxy = null;
         await Delay.resolve(ERROR_DELAY_MSEC);

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -108,10 +108,12 @@ export default class BaseSnapshot extends CommonBase {
    * method returns a new instance.
    *
    * @param {BaseChange} change Change to compose on top of this instance. Must
-   *   be an instance of the `changeClass` as defined by the subclass.
-   * @returns {BaseSnapshot} New instance consisting of the composition of
-   *   this instance with `change`. Will be a direct instance of the same class
-   *   as `this`.
+   *   be an instance of the `changeClass` as defined by the subclass. **Note:**
+   *   The `authorId` and `timestamp` of the change are irrelevant to this
+   *   operation and so are ignored.
+   * @returns {BaseSnapshot} New instance consisting of the composition of this
+   *   instance with `change`. Will be a direct instance of the same class as
+   *   `this`.
    */
   compose(change) {
     this.constructor.changeClass.check(change);

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -224,7 +224,7 @@ export default class BodyControl extends CommonBase {
    *   indicates the latest (most recent) revision.
    * @returns {BodySnapshot} The corresponding snapshot.
    */
-  async snapshot(revNum = null) {
+  async getSnapshot(revNum = null) {
     const currentRevNum = await this._currentRevNum();
     revNum = (revNum === null)
       ? currentRevNum
@@ -292,7 +292,7 @@ export default class BodyControl extends CommonBase {
     TString.orNull(authorId);
 
     // Snapshot of the base revision. This call validates `baseRevNum`.
-    const base = await this.snapshot(baseRevNum);
+    const base = await this.getSnapshot(baseRevNum);
 
     // Check for an empty `delta`. If it is, we don't bother trying to apply it.
     // See method header comment for more info.
@@ -317,7 +317,7 @@ export default class BodyControl extends CommonBase {
         this._log.info(`Append attempt #${attemptCount}.`);
       }
 
-      const current = await this.snapshot();
+      const current = await this.getSnapshot();
       const result  = await this._applyUpdateTo(base, delta, authorId, current, expected);
 
       if (result !== null) {
@@ -595,7 +595,7 @@ export default class BodyControl extends CommonBase {
       return null;
     }
 
-    const rNext = await this.snapshot(rNextNum);
+    const rNext = await this.getSnapshot(rNextNum);
 
     // (4)
 

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -91,23 +91,6 @@ export default class BodyControl extends CommonBase {
   }
 
   /**
-   * Gets a particular change to the document. The document consists of a
-   * sequence of changes, each modifying revision N of the document to produce
-   * revision N+1.
-   *
-   * @param {Int} revNum The revision number of the change. The result is the
-   *   change which produced that revision. E.g., `0` is a request for the first
-   *   change (the change from the empty document).
-   * @returns {BodyChange} The requested change.
-   */
-  async change(revNum) {
-    RevisionNumber.check(revNum);
-
-    const changes = await this._readChangeRange(revNum, revNum + 1);
-    return changes[0];
-  }
-
-  /**
    * Creates or re-creates the document. If passed, the given `delta` becomes
    * the initial content of the document (which will be in the second change,
    * because by definition the first change of a document is empty).
@@ -162,6 +145,23 @@ export default class BodyControl extends CommonBase {
 
     // Any cached snapshots are no longer valid.
     this._snapshots = new Map();
+  }
+
+  /**
+   * Gets a particular change to the document. The document consists of a
+   * sequence of changes, each modifying revision N of the document to produce
+   * revision N+1.
+   *
+   * @param {Int} revNum The revision number of the change. The result is the
+   *   change which produced that revision. E.g., `0` is a request for the first
+   *   change (the change from the empty document).
+   * @returns {BodyChange} The requested change.
+   */
+  async getChange(revNum) {
+    RevisionNumber.check(revNum);
+
+    const changes = await this._readChangeRange(revNum, revNum + 1);
+    return changes[0];
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -82,7 +82,7 @@ export default class CaretControl extends CommonBase {
    * @returns {CaretChange} Change from the base caret revision to a newer one.
    */
   async getChangeAfter(baseRevNum) {
-    const oldSnapshot = await this.snapshot(baseRevNum);
+    const oldSnapshot = await this.getSnapshot(baseRevNum);
 
     // Iterate if / as long as the base revision is still the current one. This
     // will stop being the case if either there's a local or remote update. The
@@ -113,7 +113,7 @@ export default class CaretControl extends CommonBase {
    * @throws {InfoError} Error of the form `revision_not_available(revNum)` if
    *   the indicated caret revision isn't available.
    */
-  async snapshot(revNum = null) {
+  async getSnapshot(revNum = null) {
     this._removeInactiveSessions();
     this._integrateRemoteSessions();
 

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -53,7 +53,7 @@ export default class DocSession {
    * @returns {BodyChange} The requested change.
    */
   async body_change(revNum) {
-    return this._bodyControl.change(revNum);
+    return this._bodyControl.getChange(revNum);
   }
 
   /**

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -76,7 +76,7 @@ export default class DocSession {
    * @returns {BodySnapshot} The requested snapshot.
    */
   async body_getSnapshot(revNum = null) {
-    return this._bodyControl.snapshot(revNum);
+    return this._bodyControl.getSnapshot(revNum);
   }
 
   /**
@@ -134,7 +134,7 @@ export default class DocSession {
    * @returns {CaretSnapshot} Snapshot of all the active carets.
    */
   async caret_getSnapshot(revNum = null) {
-    return this._caretControl.snapshot(revNum);
+    return this._caretControl.getSnapshot(revNum);
   }
 
   /**

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -52,7 +52,7 @@ export default class DocSession {
    * @param {Int} revNum The revision number of the change.
    * @returns {BodyChange} The requested change.
    */
-  async body_change(revNum) {
+  async body_getChange(revNum) {
     return this._bodyControl.getChange(revNum);
   }
 

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -75,7 +75,7 @@ export default class DocSession {
    *   `null`, indicates the latest (most recent) revision.
    * @returns {BodySnapshot} The requested snapshot.
    */
-  async body_snapshot(revNum = null) {
+  async body_getSnapshot(revNum = null) {
     return this._bodyControl.snapshot(revNum);
   }
 
@@ -98,8 +98,8 @@ export default class DocSession {
   /**
    * Gets a change of caret information from the indicated base caret revision.
    * This will throw an error if the indicated caret revision isn't available,
-   * in which case the client will likely want to use `caret_snapshot()` to get
-   * back in synch.
+   * in which case the client will likely want to use `caret_getSnapshot()` to
+   * get back in synch.
    *
    * **Note:** Caret information and the main document have _separate_ revision
    * numbers. `CaretSnapshot` instances have information about both revision
@@ -133,7 +133,7 @@ export default class DocSession {
    *   `null`, indicates the latest (most recent) revision.
    * @returns {CaretSnapshot} Snapshot of all the active carets.
    */
-  async caret_snapshot(revNum = null) {
+  async caret_getSnapshot(revNum = null) {
     return this._caretControl.snapshot(revNum);
   }
 


### PR DESCRIPTION
This PR aligns the interfaces and cleans up the naming in `BodyControl` and `CaretControl`, in preparation for (a) the extraction of a `BaseControl` class, and (b) the addition of a `PropertyControl` class.