### PR TITLE
Make stringification of `Timestamp` more consistent.

### DIFF
--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TInt } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
@@ -218,16 +220,19 @@ export default class Timestamp extends CommonBase {
   }
 
   /**
-   * Returns a string form for this instance. This is always of the form
-   * `<secs>.<usecs>` where `<usecs>` is always six digits long.
+   * Custom inspector function, as called by `util.inspect()`. This is always of
+   * the form `Timestamp(<secs>.<usecs>)` where `<usecs>` is always six digits
+   * long.
    *
-   * @returns {string} The string form.
+   * @param {Int} depth_unused Current inspection depth.
+   * @param {object} opts_unused Inspection options.
+   * @returns {string} The inspection string form of this instance.
    */
-  toString() {
+  [inspect.custom](depth_unused, opts_unused) {
     // A little cheeky, but this left-pads the usecs with zeroes.
     const usecs = ('' + (this._usecs + USECS_PER_SEC)).slice(1);
 
-    return `${this._secs}.${usecs}`;
+    return `${this.constructor.name}(${this._secs}.${usecs})`;
   }
 
   /**

--- a/local-modules/doc-common/tests/test_Timestamp.js
+++ b/local-modules/doc-common/tests/test_Timestamp.js
@@ -115,4 +115,38 @@ describe('doc-common/Timestamp', () => {
       assert.strictEqual(Timestamp.orNull(value), value);
     });
   });
+
+  describe('constructor()', () => {
+    it('should accept two in-range integers and reflect those values in the corresponding fields', () => {
+      function test(secs, usecs) {
+        const result = new Timestamp(secs, usecs);
+        assert.strictEqual(result.secs, secs);
+        assert.strictEqual(result.usecs, usecs);
+      }
+
+      test(Timestamp.MIN_VALUE.secs, Timestamp.MIN_VALUE.usecs);
+      test(Timestamp.MAX_VALUE.secs, Timestamp.MAX_VALUE.usecs);
+      test(Timestamp.MIN_VALUE.secs + 12345, 543219);
+    });
+  });
+
+  describe('toString()', () => {
+    it('should convert as expected', () => {
+      function test(secs, usecs) {
+        const result = new Timestamp(secs, usecs);
+
+        let ustr = `${usecs}`;
+        while (ustr.length < 6) {
+          ustr = `0${ustr}`;
+        }
+
+        const expected = `Timestamp(${secs}.${ustr})`;
+        assert.strictEqual(result.toString(), expected);
+      }
+
+      test(Timestamp.MIN_VALUE.secs, Timestamp.MIN_VALUE.usecs);
+      test(Timestamp.MAX_VALUE.secs, Timestamp.MAX_VALUE.usecs);
+      test(Timestamp.MIN_VALUE.secs + 12345, 543219);
+    });
+  });
 });


### PR DESCRIPTION
Just a wee bit of rework to make its implementation and behavior more consistent with the rest of the system.