### PR TITLE
One more round on `BodyOp`

### DIFF
--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -21,19 +21,22 @@ export default class BodyOp extends BaseOp {
     return 'delete';
   }
 
-  /** {string} Operation name for "insert embed" operations. */
-  static get INSERT_EMBED() {
-    return 'insert_embed';
-  }
-
-  /** {string} Operation name for "insert text" operations. */
-  static get INSERT_TEXT() {
-    return 'insert_text';
+  /**
+   * {string} Operation name for "embed" (insert / append embedded object)
+   * operations.
+   */
+  static get EMBED() {
+    return 'embed';
   }
 
   /** {string} Operation name for "retain" operations. */
   static get RETAIN() {
     return 'retain';
+  }
+
+  /** {string} Operation name for "text" (insert / append text) operations. */
+  static get TEXT() {
+    return 'text';
   }
 
   /**
@@ -115,7 +118,7 @@ export default class BodyOp extends BaseOp {
     value           = DataUtil.deepFreeze(Functor.check(value));
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.INSERT_EMBED, value, ...attribArg);
+    return new BodyOp(BodyOp.EMBED, value, ...attribArg);
   }
 
   /**
@@ -130,7 +133,7 @@ export default class BodyOp extends BaseOp {
     TString.nonEmpty(text);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.INSERT_TEXT, text, ...attribArg);
+    return new BodyOp(BodyOp.TEXT, text, ...attribArg);
   }
 
   /**
@@ -166,12 +169,12 @@ export default class BodyOp extends BaseOp {
         return Object.freeze({ opName, count });
       }
 
-      case BodyOp.INSERT_EMBED: {
+      case BodyOp.EMBED: {
         const [value, attributes = null] = payload.args;
         return Object.freeze({ opName, value, attributes });
       }
 
-      case BodyOp.INSERT_TEXT: {
+      case BodyOp.TEXT: {
         const [text, attributes = null] = payload.args;
         return Object.freeze({ opName, text, attributes });
       }
@@ -196,7 +199,7 @@ export default class BodyOp extends BaseOp {
    */
   isInsert() {
     const opName = this._payload.name;
-    return (opName === BodyOp.INSERT_TEXT) || (opName === BodyOp.INSERT_EMBED);
+    return (opName === BodyOp.TEXT) || (opName === BodyOp.EMBED);
   }
 
   /**
@@ -214,7 +217,7 @@ export default class BodyOp extends BaseOp {
         return { delete: props.count };
       }
 
-      case BodyOp.INSERT_EMBED: {
+      case BodyOp.EMBED: {
         const { value: { name, args: [arg0] }, attributes } = props;
         const insert = { [name]: arg0 };
 
@@ -223,7 +226,7 @@ export default class BodyOp extends BaseOp {
           : { insert };
       }
 
-      case BodyOp.INSERT_TEXT: {
+      case BodyOp.TEXT: {
         const { text: insert, attributes } = props;
 
         return attributes

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -74,7 +74,7 @@ export default class BodyOp extends BaseOp {
           // Invalid form for an embed.
           throw Errors.bad_value(quillOp, 'Quill delta operation');
         }
-        return BodyOp.op_embed(new Functor(key, value), attributes);
+        return BodyOp.op_embed(key, value, attributes);
       } else {
         // Neither in text nor embed form.
         throw Errors.bad_value(quillOp, 'Quill delta operation');
@@ -108,14 +108,19 @@ export default class BodyOp extends BaseOp {
   /**
    * Constructs a new "insert embed" operation.
    *
-   * @param {Functor} value Functor representing the embed type (functor name)
-   *   and construction argument (functor argument).
+   * @param {string} type The "type" of the embed. Must conform to "identifier"
+   *   syntax.
+   * @param {*} value Arbitrary embed data, as defined by the embed type. Must
+   *   be a deep-freezable data value (see {@link DataUtil#deepFreeze}).
    * @param {object|null} [attributes = null] Attributes to apply to (or
    *   associate with) the text, or `null` if there are no attributes to apply.
    * @returns {BodyOp} The corresponding operation.
    */
-  static op_embed(value, attributes = null) {
-    value           = DataUtil.deepFreeze(Functor.check(value));
+  static op_embed(type, value, attributes = null) {
+    TString.identifier(type);
+    value = DataUtil.deepFreeze(value);
+
+    value           = new Functor(type, value);
     const attribArg = BodyOp._attributesArg(attributes);
 
     return new BodyOp(BodyOp.EMBED, value, ...attribArg);

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -122,21 +122,6 @@ export default class BodyOp extends BaseOp {
   }
 
   /**
-   * Constructs a new "insert text" operation.
-   *
-   * @param {string} text The text to insert. Must be non-empty.
-   * @param {object|null} [attributes = null] Attributes to apply to (or
-   *   associate with) the text, or `null` if there are no attributes to apply.
-   * @returns {BodyOp} The corresponding operation.
-   */
-  static op_insertText(text, attributes = null) {
-    TString.nonEmpty(text);
-    const attribArg = BodyOp._attributesArg(attributes);
-
-    return new BodyOp(BodyOp.TEXT, text, ...attribArg);
-  }
-
-  /**
    * Constructs a new "retain" operation.
    *
    * @param {Int} count The number of elements (characters or embeds) to retain.
@@ -151,6 +136,21 @@ export default class BodyOp extends BaseOp {
     const attribArg = BodyOp._attributesArg(attributes);
 
     return new BodyOp(BodyOp.RETAIN, count, ...attribArg);
+  }
+
+  /**
+   * Constructs a new "insert text" operation.
+   *
+   * @param {string} text The text to insert. Must be non-empty.
+   * @param {object|null} [attributes = null] Attributes to apply to (or
+   *   associate with) the text, or `null` if there are no attributes to apply.
+   * @returns {BodyOp} The corresponding operation.
+   */
+  static op_insertText(text, attributes = null) {
+    TString.nonEmpty(text);
+    const attribArg = BodyOp._attributesArg(attributes);
+
+    return new BodyOp(BodyOp.TEXT, text, ...attribArg);
   }
 
   /**
@@ -174,14 +174,14 @@ export default class BodyOp extends BaseOp {
         return Object.freeze({ opName, value, attributes });
       }
 
-      case BodyOp.TEXT: {
-        const [text, attributes = null] = payload.args;
-        return Object.freeze({ opName, text, attributes });
-      }
-
       case BodyOp.RETAIN: {
         const [count, attributes = null] = payload.args;
         return Object.freeze({ opName, count, attributes });
+      }
+
+      case BodyOp.TEXT: {
+        const [text, attributes = null] = payload.args;
+        return Object.freeze({ opName, text, attributes });
       }
 
       default: {
@@ -226,20 +226,20 @@ export default class BodyOp extends BaseOp {
           : { insert };
       }
 
-      case BodyOp.TEXT: {
-        const { text: insert, attributes } = props;
-
-        return attributes
-          ? { insert, attributes }
-          : { insert };
-      }
-
       case BodyOp.RETAIN: {
         const { count: retain, attributes } = props;
 
         return attributes
           ? { retain, attributes }
           : { retain };
+      }
+
+      case BodyOp.TEXT: {
+        const { text: insert, attributes } = props;
+
+        return attributes
+          ? { insert, attributes }
+          : { insert };
       }
 
       default: {

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TInt, TObject, TString } from 'typecheck';
-import { DataUtil, Errors, Functor, ObjectUtil } from 'util-common';
+import { DataUtil, Errors, ObjectUtil } from 'util-common';
 
 import BaseOp from './BaseOp';
 
@@ -175,7 +175,7 @@ export default class BodyOp extends BaseOp {
 
       case BodyOp.EMBED: {
         const [type, value, attributes = null] = payload.args;
-        return Object.freeze({ opName, value: new Functor(type, value), attributes });
+        return Object.freeze({ opName, type, value, attributes });
       }
 
       case BodyOp.RETAIN: {
@@ -222,8 +222,8 @@ export default class BodyOp extends BaseOp {
       }
 
       case BodyOp.EMBED: {
-        const { value: { name, args: [arg0] }, attributes } = props;
-        const insert = { [name]: arg0 };
+        const { type, value, attributes } = props;
+        const insert = { [type]: value };
 
         return attributes
           ? { insert, attributes }

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -64,7 +64,7 @@ export default class BodyOp extends BaseOp {
 
     if (insert !== undefined) {
       if (typeof insert === 'string') {
-        return BodyOp.op_insertText(insert, attributes);
+        return BodyOp.op_text(insert, attributes);
       } else if (ObjectUtil.isPlain(insert)) {
         // An "embed" is represented as a single-binding plain object, where the
         // key of the binding is the type of the embed, and the bound value is
@@ -74,7 +74,7 @@ export default class BodyOp extends BaseOp {
           // Invalid form for an embed.
           throw Errors.bad_value(quillOp, 'Quill delta operation');
         }
-        return BodyOp.op_insertEmbed(new Functor(key, value), attributes);
+        return BodyOp.op_embed(new Functor(key, value), attributes);
       } else {
         // Neither in text nor embed form.
         throw Errors.bad_value(quillOp, 'Quill delta operation');
@@ -114,7 +114,7 @@ export default class BodyOp extends BaseOp {
    *   associate with) the text, or `null` if there are no attributes to apply.
    * @returns {BodyOp} The corresponding operation.
    */
-  static op_insertEmbed(value, attributes = null) {
+  static op_embed(value, attributes = null) {
     value           = DataUtil.deepFreeze(Functor.check(value));
     const attribArg = BodyOp._attributesArg(attributes);
 
@@ -146,7 +146,7 @@ export default class BodyOp extends BaseOp {
    *   associate with) the text, or `null` if there are no attributes to apply.
    * @returns {BodyOp} The corresponding operation.
    */
-  static op_insertText(text, attributes = null) {
+  static op_text(text, attributes = null) {
     TString.nonEmpty(text);
     const attribArg = BodyOp._attributesArg(attributes);
 

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -120,10 +120,9 @@ export default class BodyOp extends BaseOp {
     TString.identifier(type);
     value = DataUtil.deepFreeze(value);
 
-    value           = new Functor(type, value);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.EMBED, value, ...attribArg);
+    return new BodyOp(BodyOp.EMBED, type, value, ...attribArg);
   }
 
   /**
@@ -175,8 +174,8 @@ export default class BodyOp extends BaseOp {
       }
 
       case BodyOp.EMBED: {
-        const [value, attributes = null] = payload.args;
-        return Object.freeze({ opName, value, attributes });
+        const [type, value, attributes = null] = payload.args;
+        return Object.freeze({ opName, value: new Functor(type, value), attributes });
       }
 
       case BodyOp.RETAIN: {

--- a/local-modules/doc-common/tests/test_BodyChange.js
+++ b/local-modules/doc-common/tests/test_BodyChange.js
@@ -46,10 +46,10 @@ describe('doc-common/BodyChange', () => {
 
       test(0,   new BodyDelta([BodyOp.op_retain(100)]));
       test(123, BodyDelta.EMPTY);
-      test(909, new BodyDelta([BodyOp.op_insertText('x')]), null);
-      test(909, new BodyDelta([BodyOp.op_insertText('x')]), Timestamp.MIN_VALUE);
-      test(242, BodyDelta.EMPTY,                           null, null);
-      test(242, BodyDelta.EMPTY,                           null, 'florp9019');
+      test(909, new BodyDelta([BodyOp.op_text('x')]), null);
+      test(909, new BodyDelta([BodyOp.op_text('x')]), Timestamp.MIN_VALUE);
+      test(242, BodyDelta.EMPTY,                      null, null);
+      test(242, BodyDelta.EMPTY,                      null, 'florp9019');
     });
 
     it('should accept an array for the `delta`, which should get passed to the `BodyDelta` constructor', () => {

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -44,9 +44,9 @@ describe('doc-common/BodyDelta', () => {
       const result     = BodyDelta.fromQuillForm(quillDelta);
 
       assert.deepEqual(result.ops, [
-        BodyOp.op_insertText('foo'),
+        BodyOp.op_text('foo'),
         BodyOp.op_retain(10),
-        BodyOp.op_insertText('bar', { bold: true })
+        BodyOp.op_text('bar', { bold: true })
       ]);
     });
 
@@ -59,8 +59,8 @@ describe('doc-common/BodyDelta', () => {
       test(undefined);
       test(false);
       test('blort');
-      test(BodyOp.op_insertText('123'));
-      test([BodyOp.op_insertText('123')]);
+      test(BodyOp.op_text('123'));
+      test([BodyOp.op_text('123')]);
       test(BodyDelta.EMPTY);
     });
   });
@@ -69,12 +69,12 @@ describe('doc-common/BodyDelta', () => {
     describe('valid arguments', () => {
       const values = [
         [],
-        [BodyOp.op_insertText('x')],
-        [BodyOp.op_insertText('x', { bold: true })],
+        [BodyOp.op_text('x')],
+        [BodyOp.op_text('x', { bold: true })],
         [BodyOp.op_delete(123)],
         [BodyOp.op_retain(123)],
         [BodyOp.op_retain(123, { bold: true })],
-        [BodyOp.op_insertText('x'), BodyOp.op_insertText('y', { bold: true })]
+        [BodyOp.op_text('x'), BodyOp.op_text('y', { bold: true })]
       ];
 
       for (const v of values) {
@@ -177,32 +177,32 @@ describe('doc-common/BodyDelta', () => {
     }
 
     test('full replacement',
-      [BodyOp.op_insertText('111')],
-      [BodyOp.op_insertText('222'), BodyOp.op_delete(3)],
-      [BodyOp.op_insertText('222')]);
+      [BodyOp.op_text('111')],
+      [BodyOp.op_text('222'), BodyOp.op_delete(3)],
+      [BodyOp.op_text('222')]);
     test('insert at start',
-      [BodyOp.op_insertText('111')],
-      [BodyOp.op_insertText('222')],
-      [BodyOp.op_insertText('222111')]);
+      [BodyOp.op_text('111')],
+      [BodyOp.op_text('222')],
+      [BodyOp.op_text('222111')]);
     test('append at end',
-      [BodyOp.op_insertText('111')],
-      [BodyOp.op_retain(3), BodyOp.op_insertText('222')],
-      [BodyOp.op_insertText('111222')]);
+      [BodyOp.op_text('111')],
+      [BodyOp.op_retain(3), BodyOp.op_text('222')],
+      [BodyOp.op_text('111222')]);
     test('surround',
-      [BodyOp.op_insertText('111')],
-      [BodyOp.op_insertText('222'), BodyOp.op_retain(3), BodyOp.op_insertText('333')],
-      [BodyOp.op_insertText('222111333')]);
+      [BodyOp.op_text('111')],
+      [BodyOp.op_text('222'), BodyOp.op_retain(3), BodyOp.op_text('333')],
+      [BodyOp.op_text('222111333')]);
     test('replace one middle bit',
-      [BodyOp.op_insertText('Drink more Slurm.')],
-      [BodyOp.op_retain(6), BodyOp.op_insertText('LESS'), BodyOp.op_delete(4)],
-      [BodyOp.op_insertText('Drink LESS Slurm.')]);
+      [BodyOp.op_text('Drink more Slurm.')],
+      [BodyOp.op_retain(6), BodyOp.op_text('LESS'), BodyOp.op_delete(4)],
+      [BodyOp.op_text('Drink LESS Slurm.')]);
     test('replace two middle bits',
-      [BodyOp.op_insertText('[[hello]] [[goodbye]]')],
+      [BodyOp.op_text('[[hello]] [[goodbye]]')],
       [
-        BodyOp.op_retain(2), BodyOp.op_insertText('YO'), BodyOp.op_delete(5), BodyOp.op_retain(5),
-        BodyOp.op_insertText('LATER'), BodyOp.op_delete(7)
+        BodyOp.op_retain(2), BodyOp.op_text('YO'), BodyOp.op_delete(5), BodyOp.op_retain(5),
+        BodyOp.op_text('LATER'), BodyOp.op_delete(7)
       ],
-      [BodyOp.op_insertText('[[YO]] [[LATER]]')]);
+      [BodyOp.op_text('[[YO]] [[LATER]]')]);
   });
 
   describe('equals()', () => {
@@ -213,8 +213,8 @@ describe('doc-common/BodyDelta', () => {
       }
 
       test([]);
-      test([BodyOp.op_insertText('aaa')]);
-      test([BodyOp.op_insertText('aaa'), BodyOp.op_insertText('bbb')]);
+      test([BodyOp.op_text('aaa')]);
+      test([BodyOp.op_text('aaa'), BodyOp.op_text('bbb')]);
     });
 
     it('should return `true` when passed an identically-constructed value', () => {
@@ -226,13 +226,13 @@ describe('doc-common/BodyDelta', () => {
       }
 
       test([]);
-      test([BodyOp.op_insertText('aaa')]);
-      test([BodyOp.op_insertText('aaa'), BodyOp.op_insertText('bbb')]);
+      test([BodyOp.op_text('aaa')]);
+      test([BodyOp.op_text('aaa'), BodyOp.op_text('bbb')]);
     });
 
     it('should return `true` when equal ops are not also `===`', () => {
-      const ops1 = [BodyOp.op_insertText('aaa'), BodyOp.op_insertText('bbb')];
-      const ops2 = [BodyOp.op_insertText('aaa'), BodyOp.op_insertText('bbb')];
+      const ops1 = [BodyOp.op_text('aaa'), BodyOp.op_text('bbb')];
+      const ops2 = [BodyOp.op_text('aaa'), BodyOp.op_text('bbb')];
       const d1 = new BodyDelta(ops1);
       const d2 = new BodyDelta(ops2);
 
@@ -241,8 +241,8 @@ describe('doc-common/BodyDelta', () => {
     });
 
     it('should return `false` when array lengths differ', () => {
-      const op1 = BodyOp.op_insertText('aaa');
-      const op2 = BodyOp.op_insertText('bbb');
+      const op1 = BodyOp.op_text('aaa');
+      const op2 = BodyOp.op_text('bbb');
       const d1 = new BodyDelta([op1]);
       const d2 = new BodyDelta([op1, op2]);
 
@@ -259,11 +259,11 @@ describe('doc-common/BodyDelta', () => {
         assert.isFalse(d2.equals(d1));
       }
 
-      const op1 = BodyOp.op_insertText('foo');
-      const op2 = BodyOp.op_insertText('bar');
-      const op3 = BodyOp.op_insertText('baz');
-      const op4 = BodyOp.op_insertText('biff');
-      const op5 = BodyOp.op_insertText('quux');
+      const op1 = BodyOp.op_text('foo');
+      const op2 = BodyOp.op_text('bar');
+      const op3 = BodyOp.op_text('baz');
+      const op4 = BodyOp.op_text('biff');
+      const op5 = BodyOp.op_text('quux');
 
       test([op1],                     [op2]);
       test([op1, op2],                [op1, op3]);
@@ -293,9 +293,9 @@ describe('doc-common/BodyDelta', () => {
     describe('`true` cases', () => {
       const values = [
         [],
-        [BodyOp.op_insertText('line 1')],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_insertText('\n')],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_insertText('\n'), BodyOp.op_insertText('line 2')]
+        [BodyOp.op_text('line 1')],
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n')],
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_text('line 2')]
       ];
 
       for (const v of values) {
@@ -310,9 +310,9 @@ describe('doc-common/BodyDelta', () => {
         [BodyOp.op_retain(37)],
         [BodyOp.op_delete(914)],
         [BodyOp.op_retain(37, { bold: true })],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_retain(9)],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_retain(14), BodyOp.op_insertText('\n')],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_insertText('\n'), BodyOp.op_retain(23), BodyOp.op_insertText('line 2')]
+        [BodyOp.op_text('line 1'), BodyOp.op_retain(9)],
+        [BodyOp.op_text('line 1'), BodyOp.op_retain(14), BodyOp.op_text('\n')],
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_retain(23), BodyOp.op_text('line 2')]
       ];
 
       for (const v of values) {
@@ -339,8 +339,8 @@ describe('doc-common/BodyDelta', () => {
 
     describe('valid non-empty values', () => {
       const values = [
-        [BodyOp.op_insertText('x')],
-        [BodyOp.op_insertText('line 1'), BodyOp.op_insertText('\n'), BodyOp.op_insertText('line 2')],
+        [BodyOp.op_text('x')],
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_text('line 2')],
         [BodyOp.op_retain(100)]
       ];
 
@@ -372,13 +372,13 @@ describe('doc-common/BodyDelta', () => {
       }
 
       test([]);
-      test([BodyOp.op_insertEmbed(new Functor('zither', 123))]);
-      test([BodyOp.op_insertText('blort')]);
+      test([BodyOp.op_embed(new Functor('zither', 123))]);
+      test([BodyOp.op_text('blort')]);
       test([BodyOp.op_retain(123)]);
       test([
         BodyOp.op_retain(123, { bold: true }),
         BodyOp.op_delete(10),
-        BodyOp.op_insertText('foo')
+        BodyOp.op_text('foo')
       ]);
     });
   });
@@ -418,27 +418,27 @@ describe('doc-common/BodyDelta', () => {
       }
 
       test(
-        [BodyOp.op_insertText('blort')],
-        [BodyOp.op_insertText('blort')],
-        [BodyOp.op_retain(5), BodyOp.op_insertText('blort')],
-        [BodyOp.op_insertText('blort')]);
+        [BodyOp.op_text('blort')],
+        [BodyOp.op_text('blort')],
+        [BodyOp.op_retain(5), BodyOp.op_text('blort')],
+        [BodyOp.op_text('blort')]);
       test(
         [BodyOp.op_delete(10)],
         [BodyOp.op_delete(10)],
         []);
       test(
         [BodyOp.op_delete(10)],
-        [BodyOp.op_delete(10), BodyOp.op_insertText('florp')],
-        [BodyOp.op_insertText('florp')]);
+        [BodyOp.op_delete(10), BodyOp.op_text('florp')],
+        [BodyOp.op_text('florp')]);
       test(
-        [BodyOp.op_insertText('111')],
-        [BodyOp.op_insertText('222')],
-        [BodyOp.op_retain(3), BodyOp.op_insertText('222')],
-        [BodyOp.op_insertText('222')]);
+        [BodyOp.op_text('111')],
+        [BodyOp.op_text('222')],
+        [BodyOp.op_retain(3), BodyOp.op_text('222')],
+        [BodyOp.op_text('222')]);
       test(
-        [BodyOp.op_retain(10), BodyOp.op_insertText('111')],
-        [BodyOp.op_retain(20), BodyOp.op_insertText('222')],
-        [BodyOp.op_retain(23), BodyOp.op_insertText('222')]);
+        [BodyOp.op_retain(10), BodyOp.op_text('111')],
+        [BodyOp.op_retain(20), BodyOp.op_text('222')],
+        [BodyOp.op_retain(23), BodyOp.op_text('222')]);
     });
   });
 });

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -8,7 +8,6 @@ import Delta from 'quill-delta';
 import { inspect } from 'util';
 
 import { BodyDelta, BodyOp } from 'doc-common';
-import { Functor } from 'util-common';
 
 import MockDelta from './MockDelta';
 
@@ -372,7 +371,7 @@ describe('doc-common/BodyDelta', () => {
       }
 
       test([]);
-      test([BodyOp.op_embed(new Functor('zither', 123))]);
+      test([BodyOp.op_embed('zither', 123)]);
       test([BodyOp.op_text('blort')]);
       test([BodyOp.op_retain(123)]);
       test([

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -137,18 +137,6 @@ describe('doc-common/BodyOp', () => {
     });
   });
 
-  describe('op_text()', () => {
-    it('should produce a value with expected payload', () => {
-      const attrib = { italic: true, bold: null };
-
-      const result1 = BodyOp.op_text('florp');
-      assert.deepEqual(result1.payload, new Functor('text', 'florp'));
-
-      const result2 = BodyOp.op_text('like', attrib);
-      assert.deepEqual(result2.payload, new Functor('text', 'like', attrib));
-    });
-  });
-
   describe('op_retain()', () => {
     it('should produce a value with expected payload', () => {
       const attrib = { header: 1 };
@@ -158,6 +146,18 @@ describe('doc-common/BodyOp', () => {
 
       const result2 = BodyOp.op_retain(456, attrib);
       assert.deepEqual(result2.payload, new Functor('retain', 456, attrib));
+    });
+  });
+
+  describe('op_text()', () => {
+    it('should produce a value with expected payload', () => {
+      const attrib = { italic: true, bold: null };
+
+      const result1 = BodyOp.op_text('florp');
+      assert.deepEqual(result1.payload, new Functor('text', 'florp'));
+
+      const result2 = BodyOp.op_text('like', attrib);
+      assert.deepEqual(result2.payload, new Functor('text', 'like', attrib));
     });
   });
 

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -130,10 +130,10 @@ describe('doc-common/BodyOp', () => {
       const attrib = { bold: true };
 
       const result1 = BodyOp.op_insertEmbed(embed);
-      assert.deepEqual(result1.payload, new Functor('insert_embed', embed));
+      assert.deepEqual(result1.payload, new Functor('embed', embed));
 
       const result2 = BodyOp.op_insertEmbed(embed, attrib);
-      assert.deepEqual(result2.payload, new Functor('insert_embed', embed, attrib));
+      assert.deepEqual(result2.payload, new Functor('embed', embed, attrib));
     });
   });
 
@@ -142,10 +142,10 @@ describe('doc-common/BodyOp', () => {
       const attrib = { italic: true, bold: null };
 
       const result1 = BodyOp.op_insertText('florp');
-      assert.deepEqual(result1.payload, new Functor('insert_text', 'florp'));
+      assert.deepEqual(result1.payload, new Functor('text', 'florp'));
 
       const result2 = BodyOp.op_insertText('like', attrib);
-      assert.deepEqual(result2.payload, new Functor('insert_text', 'like', attrib));
+      assert.deepEqual(result2.payload, new Functor('text', 'like', attrib));
     });
   });
 
@@ -174,12 +174,12 @@ describe('doc-common/BodyOp', () => {
     const embed  = new Functor('blort', { x: 10 });
 
     test(BodyOp.op_delete(668),                 { opName: 'delete', count: 668 });
-    test(BodyOp.op_insertEmbed(embed),          { opName: 'insert_embed', value: embed, attributes: null });
-    test(BodyOp.op_insertEmbed(embed, null),    { opName: 'insert_embed', value: embed, attributes: null });
-    test(BodyOp.op_insertEmbed(embed, attrib),  { opName: 'insert_embed', value: embed, attributes: attrib });
-    test(BodyOp.op_insertText('hello'),         { opName: 'insert_text', text: 'hello', attributes: null });
-    test(BodyOp.op_insertText('hello', null),   { opName: 'insert_text', text: 'hello', attributes: null });
-    test(BodyOp.op_insertText('hello', attrib), { opName: 'insert_text', text: 'hello', attributes: attrib });
+    test(BodyOp.op_insertEmbed(embed),          { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_insertEmbed(embed, null),    { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_insertEmbed(embed, attrib),  { opName: 'embed', value: embed, attributes: attrib });
+    test(BodyOp.op_insertText('hello'),         { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_insertText('hello', null),   { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_insertText('hello', attrib), { opName: 'text', text: 'hello', attributes: attrib });
     test(BodyOp.op_retain(5),                   { opName: 'retain', count: 5, attributes: null });
     test(BodyOp.op_retain(5, null),             { opName: 'retain', count: 5, attributes: null });
     test(BodyOp.op_retain(5, attrib),           { opName: 'retain', count: 5, attributes: attrib });

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -131,10 +131,10 @@ describe('doc-common/BodyOp', () => {
       const attrib = { bold: true };
 
       const result1 = BodyOp.op_embed('blort', { x: 10 });
-      assert.deepEqual(result1.payload, new Functor('embed', new Functor('blort', { x: 10 })));
+      assert.deepEqual(result1.payload, new Functor('embed', 'blort', { x: 10 }));
 
       const result2 = BodyOp.op_embed('florp', ['like'], attrib);
-      assert.deepEqual(result2.payload, new Functor('embed', new Functor('florp', ['like']), attrib));
+      assert.deepEqual(result2.payload, new Functor('embed', 'florp', ['like'], attrib));
     });
 
     it('should reject a non-identifier `type`', () => {

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -108,10 +108,10 @@ describe('doc-common/BodyOp', () => {
 
     test({ delete: 1 },                      BodyOp.op_delete(1));
     test({ delete: 10000 },                  BodyOp.op_delete(10000));
-    test({ insert: 'hello' },                BodyOp.op_insertText('hello'));
-    test({ insert: 'yo', attributes: at1 },  BodyOp.op_insertText('yo', at1));
-    test({ insert: qemb1 },                  BodyOp.op_insertEmbed(bemb1));
-    test({ insert: qemb2, attributes: at2 }, BodyOp.op_insertEmbed(bemb2, at2));
+    test({ insert: 'hello' },                BodyOp.op_text('hello'));
+    test({ insert: 'yo', attributes: at1 },  BodyOp.op_text('yo', at1));
+    test({ insert: qemb1 },                  BodyOp.op_embed(bemb1));
+    test({ insert: qemb2, attributes: at2 }, BodyOp.op_embed(bemb2, at2));
     test({ retain: 123 },                    BodyOp.op_retain(123));
     test({ retain: 12345 },                  BodyOp.op_retain(12345));
     test({ retain: 1, attributes: at1 },     BodyOp.op_retain(1, at1));
@@ -124,27 +124,27 @@ describe('doc-common/BodyOp', () => {
     });
   });
 
-  describe('op_insertEmbed()', () => {
+  describe('op_embed()', () => {
     it('should produce a value with expected payload', () => {
       const embed  = new Functor('blort', { x: 10 });
       const attrib = { bold: true };
 
-      const result1 = BodyOp.op_insertEmbed(embed);
+      const result1 = BodyOp.op_embed(embed);
       assert.deepEqual(result1.payload, new Functor('embed', embed));
 
-      const result2 = BodyOp.op_insertEmbed(embed, attrib);
+      const result2 = BodyOp.op_embed(embed, attrib);
       assert.deepEqual(result2.payload, new Functor('embed', embed, attrib));
     });
   });
 
-  describe('op_insertText()', () => {
+  describe('op_text()', () => {
     it('should produce a value with expected payload', () => {
       const attrib = { italic: true, bold: null };
 
-      const result1 = BodyOp.op_insertText('florp');
+      const result1 = BodyOp.op_text('florp');
       assert.deepEqual(result1.payload, new Functor('text', 'florp'));
 
-      const result2 = BodyOp.op_insertText('like', attrib);
+      const result2 = BodyOp.op_text('like', attrib);
       assert.deepEqual(result2.payload, new Functor('text', 'like', attrib));
     });
   });
@@ -173,21 +173,21 @@ describe('doc-common/BodyOp', () => {
     const attrib = { italic: true, bold: null };
     const embed  = new Functor('blort', { x: 10 });
 
-    test(BodyOp.op_delete(668),                 { opName: 'delete', count: 668 });
-    test(BodyOp.op_insertEmbed(embed),          { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_insertEmbed(embed, null),    { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_insertEmbed(embed, attrib),  { opName: 'embed', value: embed, attributes: attrib });
-    test(BodyOp.op_insertText('hello'),         { opName: 'text', text: 'hello', attributes: null });
-    test(BodyOp.op_insertText('hello', null),   { opName: 'text', text: 'hello', attributes: null });
-    test(BodyOp.op_insertText('hello', attrib), { opName: 'text', text: 'hello', attributes: attrib });
-    test(BodyOp.op_retain(5),                   { opName: 'retain', count: 5, attributes: null });
-    test(BodyOp.op_retain(5, null),             { opName: 'retain', count: 5, attributes: null });
-    test(BodyOp.op_retain(5, attrib),           { opName: 'retain', count: 5, attributes: attrib });
+    test(BodyOp.op_delete(668),           { opName: 'delete', count: 668 });
+    test(BodyOp.op_embed(embed),          { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_embed(embed, null),    { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_embed(embed, attrib),  { opName: 'embed', value: embed, attributes: attrib });
+    test(BodyOp.op_text('hello'),         { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_text('hello', null),   { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_text('hello', attrib), { opName: 'text', text: 'hello', attributes: attrib });
+    test(BodyOp.op_retain(5),             { opName: 'retain', count: 5, attributes: null });
+    test(BodyOp.op_retain(5, null),       { opName: 'retain', count: 5, attributes: null });
+    test(BodyOp.op_retain(5, attrib),     { opName: 'retain', count: 5, attributes: attrib });
   });
 
   describe('equals()', () => {
     it('should return `true` when passed itself', () => {
-      const op = BodyOp.op_insertText('florp');
+      const op = BodyOp.op_text('florp');
       assert.isTrue(op.equals(op));
     });
 
@@ -199,11 +199,11 @@ describe('doc-common/BodyOp', () => {
       }
 
       test('op_delete', 100);
-      test('op_insertEmbed', new Functor('florp', 'like'));
-      test('op_insertEmbed', new Functor('florp', 'like'), { bold: true });
-      test('op_insertText', 'foo', { italic: true });
-      test('op_insertText', 'foo');
-      test('op_insertText', 'foo', { italic: true });
+      test('op_embed', new Functor('florp', 'like'));
+      test('op_embed', new Functor('florp', 'like'), { bold: true });
+      test('op_text', 'foo', { italic: true });
+      test('op_text', 'foo');
+      test('op_text', 'foo', { italic: true });
       test('op_retain', 100);
       test('op_retain', 100, { header: 3 });
     });
@@ -219,21 +219,21 @@ describe('doc-common/BodyOp', () => {
       const emb1 = new Functor('x', 'zorch');
       const emb2 = new Functor('x', 'splat');
 
-      test(BodyOp.op_delete(100),            BodyOp.op_retain(100));
-      test(BodyOp.op_delete(100),            BodyOp.op_delete(101));
-      test(BodyOp.op_insertEmbed(emb1),      BodyOp.op_insertEmbed(emb2));
-      test(BodyOp.op_insertEmbed(emb1, at1), BodyOp.op_insertEmbed(emb1));
-      test(BodyOp.op_insertEmbed(emb1, at1), BodyOp.op_insertEmbed(emb1, at2));
-      test(BodyOp.op_insertText('x'),        BodyOp.op_insertText('y'));
-      test(BodyOp.op_insertText('x', at1),   BodyOp.op_insertText('x'));
-      test(BodyOp.op_insertText('x', at1),   BodyOp.op_insertText('x', at2));
-      test(BodyOp.op_retain(100),            BodyOp.op_retain(900));
-      test(BodyOp.op_retain(1, at1),         BodyOp.op_retain(1));
-      test(BodyOp.op_retain(1, at1),         BodyOp.op_retain(1, at2));
+      test(BodyOp.op_delete(100),      BodyOp.op_retain(100));
+      test(BodyOp.op_delete(100),      BodyOp.op_delete(101));
+      test(BodyOp.op_embed(emb1),      BodyOp.op_embed(emb2));
+      test(BodyOp.op_embed(emb1, at1), BodyOp.op_embed(emb1));
+      test(BodyOp.op_embed(emb1, at1), BodyOp.op_embed(emb1, at2));
+      test(BodyOp.op_text('x'),        BodyOp.op_text('y'));
+      test(BodyOp.op_text('x', at1),   BodyOp.op_text('x'));
+      test(BodyOp.op_text('x', at1),   BodyOp.op_text('x', at2));
+      test(BodyOp.op_retain(100),      BodyOp.op_retain(900));
+      test(BodyOp.op_retain(1, at1),   BodyOp.op_retain(1));
+      test(BodyOp.op_retain(1, at1),   BodyOp.op_retain(1, at2));
     });
 
     it('should return `false` when passed a non-instance', () => {
-      const op = BodyOp.op_insertText('zorch');
+      const op = BodyOp.op_text('zorch');
 
       assert.isFalse(op.equals(undefined));
       assert.isFalse(op.equals(null));
@@ -249,10 +249,10 @@ describe('doc-common/BodyOp', () => {
         assert.isTrue(v.isInsert());
       }
 
-      test(BodyOp.op_insertEmbed(new Functor('x')));
-      test(BodyOp.op_insertEmbed(new Functor('x'), { bold: true }));
-      test(BodyOp.op_insertText('foo'));
-      test(BodyOp.op_insertText('foo', { bold: true }));
+      test(BodyOp.op_embed(new Functor('x')));
+      test(BodyOp.op_embed(new Functor('x'), { bold: true }));
+      test(BodyOp.op_text('foo'));
+      test(BodyOp.op_text('foo', { bold: true }));
     });
   });
 });

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -100,18 +100,20 @@ describe('doc-common/BodyOp', () => {
     const at1 = { x: 10, y: 20, z: 30 };
     const at2 = { p: [[[['p']]]], d: { d: 'd' }, q: true };
 
-    const bemb1 = new Functor('image', 'some_url');
-    const qemb1 = { [bemb1.name]: bemb1.args[0] };
+    const name1  = 'image';
+    const value1 = 'https://example.com/some_url';
+    const qemb1  = { [name1]: value1 };
 
-    const bemb2 = new Functor('blort', { x: 'x', y: 'y' });
-    const qemb2 = { [bemb2.name]: bemb2.args[0] };
+    const name2  = 'blort';
+    const value2 = { x: 'x', y: 'y' };
+    const qemb2  = { [name2]: value2 };
 
     test({ delete: 1 },                      BodyOp.op_delete(1));
     test({ delete: 10000 },                  BodyOp.op_delete(10000));
     test({ insert: 'hello' },                BodyOp.op_text('hello'));
     test({ insert: 'yo', attributes: at1 },  BodyOp.op_text('yo', at1));
-    test({ insert: qemb1 },                  BodyOp.op_embed(bemb1));
-    test({ insert: qemb2, attributes: at2 }, BodyOp.op_embed(bemb2, at2));
+    test({ insert: qemb1 },                  BodyOp.op_embed(name1, value1));
+    test({ insert: qemb2, attributes: at2 }, BodyOp.op_embed(name2, value2, at2));
     test({ retain: 123 },                    BodyOp.op_retain(123));
     test({ retain: 12345 },                  BodyOp.op_retain(12345));
     test({ retain: 1, attributes: at1 },     BodyOp.op_retain(1, at1));
@@ -126,14 +128,27 @@ describe('doc-common/BodyOp', () => {
 
   describe('op_embed()', () => {
     it('should produce a value with expected payload', () => {
-      const embed  = new Functor('blort', { x: 10 });
       const attrib = { bold: true };
 
-      const result1 = BodyOp.op_embed(embed);
-      assert.deepEqual(result1.payload, new Functor('embed', embed));
+      const result1 = BodyOp.op_embed('blort', { x: 10 });
+      assert.deepEqual(result1.payload, new Functor('embed', new Functor('blort', { x: 10 })));
 
-      const result2 = BodyOp.op_embed(embed, attrib);
-      assert.deepEqual(result2.payload, new Functor('embed', embed, attrib));
+      const result2 = BodyOp.op_embed('florp', ['like'], attrib);
+      assert.deepEqual(result2.payload, new Functor('embed', new Functor('florp', ['like']), attrib));
+    });
+
+    it('should reject a non-identifier `type`', () => {
+      assert.throws(() => BodyOp.op_embed('', 1));
+      assert.throws(() => BodyOp.op_embed('*', 1));
+      assert.throws(() => BodyOp.op_embed(null, 1));
+      assert.throws(() => BodyOp.op_embed([], 1));
+      assert.throws(() => BodyOp.op_embed(['x'], 1));
+      assert.throws(() => BodyOp.op_embed({ florp: 'like' }, 1));
+    });
+
+    it('should reject a non-data `value`', () => {
+      assert.throws(() => BodyOp.op_embed('x', new Map()));
+      assert.throws(() => BodyOp.op_embed('x', { get x() { return 10; } }));
     });
   });
 
@@ -171,18 +186,18 @@ describe('doc-common/BodyOp', () => {
     }
 
     const attrib = { italic: true, bold: null };
-    const embed  = new Functor('blort', { x: 10 });
+    const embed  = new Functor('x', ['y']);
 
-    test(BodyOp.op_delete(668),           { opName: 'delete', count: 668 });
-    test(BodyOp.op_embed(embed),          { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_embed(embed, null),    { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_embed(embed, attrib),  { opName: 'embed', value: embed, attributes: attrib });
-    test(BodyOp.op_text('hello'),         { opName: 'text', text: 'hello', attributes: null });
-    test(BodyOp.op_text('hello', null),   { opName: 'text', text: 'hello', attributes: null });
-    test(BodyOp.op_text('hello', attrib), { opName: 'text', text: 'hello', attributes: attrib });
-    test(BodyOp.op_retain(5),             { opName: 'retain', count: 5, attributes: null });
-    test(BodyOp.op_retain(5, null),       { opName: 'retain', count: 5, attributes: null });
-    test(BodyOp.op_retain(5, attrib),     { opName: 'retain', count: 5, attributes: attrib });
+    test(BodyOp.op_delete(668),               { opName: 'delete', count: 668 });
+    test(BodyOp.op_embed('x', ['y']),         { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_embed('x', ['y'], null),   { opName: 'embed', value: embed, attributes: null });
+    test(BodyOp.op_embed('x', ['y'], attrib), { opName: 'embed', value: embed, attributes: attrib });
+    test(BodyOp.op_text('hello'),             { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_text('hello', null),       { opName: 'text', text: 'hello', attributes: null });
+    test(BodyOp.op_text('hello', attrib),     { opName: 'text', text: 'hello', attributes: attrib });
+    test(BodyOp.op_retain(5),                 { opName: 'retain', count: 5, attributes: null });
+    test(BodyOp.op_retain(5, null),           { opName: 'retain', count: 5, attributes: null });
+    test(BodyOp.op_retain(5, attrib),         { opName: 'retain', count: 5, attributes: attrib });
   });
 
   describe('equals()', () => {
@@ -199,8 +214,9 @@ describe('doc-common/BodyOp', () => {
       }
 
       test('op_delete', 100);
-      test('op_embed', new Functor('florp', 'like'));
-      test('op_embed', new Functor('florp', 'like'), { bold: true });
+      test('op_embed', 'florp', 'like');
+      test('op_embed', 'florp', ['like', 'yeah']);
+      test('op_embed', 'florp', 'like', { bold: true });
       test('op_text', 'foo', { italic: true });
       test('op_text', 'foo');
       test('op_text', 'foo', { italic: true });
@@ -216,20 +232,19 @@ describe('doc-common/BodyOp', () => {
 
       const at1  = { bold: true };
       const at2  = { bold: true, italic: true };
-      const emb1 = new Functor('x', 'zorch');
-      const emb2 = new Functor('x', 'splat');
 
-      test(BodyOp.op_delete(100),      BodyOp.op_retain(100));
-      test(BodyOp.op_delete(100),      BodyOp.op_delete(101));
-      test(BodyOp.op_embed(emb1),      BodyOp.op_embed(emb2));
-      test(BodyOp.op_embed(emb1, at1), BodyOp.op_embed(emb1));
-      test(BodyOp.op_embed(emb1, at1), BodyOp.op_embed(emb1, at2));
-      test(BodyOp.op_text('x'),        BodyOp.op_text('y'));
-      test(BodyOp.op_text('x', at1),   BodyOp.op_text('x'));
-      test(BodyOp.op_text('x', at1),   BodyOp.op_text('x', at2));
-      test(BodyOp.op_retain(100),      BodyOp.op_retain(900));
-      test(BodyOp.op_retain(1, at1),   BodyOp.op_retain(1));
-      test(BodyOp.op_retain(1, at1),   BodyOp.op_retain(1, at2));
+      test(BodyOp.op_delete(100),        BodyOp.op_retain(100));
+      test(BodyOp.op_delete(100),        BodyOp.op_delete(101));
+      test(BodyOp.op_embed('x', 1),      BodyOp.op_embed('y', 1));
+      test(BodyOp.op_embed('x', 1),      BodyOp.op_embed('x', 2));
+      test(BodyOp.op_embed('x', 1, at1), BodyOp.op_embed('x', 1));
+      test(BodyOp.op_embed('x', 1, at1), BodyOp.op_embed('x', 1, at2));
+      test(BodyOp.op_text('x'),          BodyOp.op_text('y'));
+      test(BodyOp.op_text('x', at1),     BodyOp.op_text('x'));
+      test(BodyOp.op_text('x', at1),     BodyOp.op_text('x', at2));
+      test(BodyOp.op_retain(100),        BodyOp.op_retain(900));
+      test(BodyOp.op_retain(1, at1),     BodyOp.op_retain(1));
+      test(BodyOp.op_retain(1, at1),     BodyOp.op_retain(1, at2));
     });
 
     it('should return `false` when passed a non-instance', () => {
@@ -249,10 +264,19 @@ describe('doc-common/BodyOp', () => {
         assert.isTrue(v.isInsert());
       }
 
-      test(BodyOp.op_embed(new Functor('x')));
-      test(BodyOp.op_embed(new Functor('x'), { bold: true }));
+      test(BodyOp.op_embed('x', 1));
+      test(BodyOp.op_embed('x', 1), { bold: true });
       test(BodyOp.op_text('foo'));
       test(BodyOp.op_text('foo', { bold: true }));
+    });
+
+    it('should return `false` for non-inserts', () => {
+      function test(v) {
+        assert.isFalse(v.isInsert());
+      }
+
+      test(BodyOp.op_delete(1));
+      test(BodyOp.op_retain(1));
     });
   });
 });

--- a/local-modules/doc-common/tests/test_BodyOp.js
+++ b/local-modules/doc-common/tests/test_BodyOp.js
@@ -186,12 +186,11 @@ describe('doc-common/BodyOp', () => {
     }
 
     const attrib = { italic: true, bold: null };
-    const embed  = new Functor('x', ['y']);
 
     test(BodyOp.op_delete(668),               { opName: 'delete', count: 668 });
-    test(BodyOp.op_embed('x', ['y']),         { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_embed('x', ['y'], null),   { opName: 'embed', value: embed, attributes: null });
-    test(BodyOp.op_embed('x', ['y'], attrib), { opName: 'embed', value: embed, attributes: attrib });
+    test(BodyOp.op_embed('x', ['y']),         { opName: 'embed', type: 'x', value: ['y'], attributes: null });
+    test(BodyOp.op_embed('x', ['y'], null),   { opName: 'embed', type: 'x', value: ['y'], attributes: null });
+    test(BodyOp.op_embed('x', ['y'], attrib), { opName: 'embed', type: 'x', value: ['y'], attributes: attrib });
     test(BodyOp.op_text('hello'),             { opName: 'text', text: 'hello', attributes: null });
     test(BodyOp.op_text('hello', null),       { opName: 'text', text: 'hello', attributes: null });
     test(BodyOp.op_text('hello', attrib),     { opName: 'text', text: 'hello', attributes: attrib });

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -26,14 +26,14 @@ const DEFAULT_TEXT = BodyDelta.fromOpArgArray(DEFAULT_DOCUMENT);
  * {BodyDelta} Message used as document to indicate a major validation error.
  */
 const ERROR_NOTE = BodyDelta.fromOpArgArray([
-  ['insert_text', '(Recreated document due to validation error(s).)\n']
+  ['text', '(Recreated document due to validation error(s).)\n']
 ]);
 
 /**
  * {BodyDelta} Message used as document instead of migrating documents from
  * old schema versions. */
 const MIGRATION_NOTE = BodyDelta.fromOpArgArray([
-  ['insert_text', '(Recreated document due to schema version skew.)\n']
+  ['text', '(Recreated document due to schema version skew.)\n']
 ]);
 
 /**

--- a/local-modules/hooks-server/default-document.js
+++ b/local-modules/hooks-server/default-document.js
@@ -6,11 +6,11 @@
  * Default (initial) contents of documents.
  */
 export default [
-  ['insert_text', 'Welcome to Bayou!'],
-  ['insert_text', '\n', { header: 1 }],
-  ['insert_text', 'Now go grab a '],
-  ['insert_text', 'boat', { bold: true }],
-  ['insert_text', ' and start '],
-  ['insert_text', 'a-rowin\'', { italic: true }],
-  ['insert_text', '.\n']
+  ['text', 'Welcome to Bayou!'],
+  ['text', '\n', { header: 1 }],
+  ['text', 'Now go grab a '],
+  ['text', 'boat', { bold: true }],
+  ['text', ' and start '],
+  ['text', 'a-rowin\'', { italic: true }],
+  ['text', '.\n']
 ];

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.29.0
+version = 0.29.1


### PR DESCRIPTION
* Got rid of the `insert_*` prefix on text and embed ops, as it's at best superfluous and at worst misleading (in at least some contexts).
* Got rid of the inner functor layer in embed ops. It was a needlessly bit of hierarchy that was originally done _just_ to be parallel with the Quill form.

Bumped the product version because the renamings cause old change data to be invalid.