### PR TITLE
Refactoring in `doc-server`

### DIFF
--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject } from 'typecheck';
+import { TFunction } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import AuthorId from './AuthorId';
@@ -68,7 +68,7 @@ export default class BaseChange extends CommonBase {
       // Call the `_impl` and verify the result.
       const clazz = this._impl_deltaClass;
 
-      TObject.check(clazz.prototype, BaseDelta);
+      TFunction.checkClass(clazz, BaseDelta);
       this._deltaClass = clazz;
     }
 

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -4,7 +4,7 @@
 
 import { inspect } from 'util';
 
-import { TArray, TBoolean, TObject } from 'typecheck';
+import { TArray, TBoolean, TFunction } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import BaseOp from './BaseOp';
@@ -49,7 +49,7 @@ export default class BaseDelta extends CommonBase {
       // Call the `_impl` and verify the result.
       const clazz = this._impl_opClass;
 
-      TObject.check(clazz.prototype, BaseOp);
+      TFunction.checkClass(clazz, BaseOp);
       this._opClass = clazz;
     }
 

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TArray, TObject } from 'typecheck';
+import { TArray, TFunction } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import BaseChange from './BaseChange';
@@ -41,7 +41,7 @@ export default class BaseSnapshot extends CommonBase {
       // Call the `_impl` and verify the result.
       const clazz = this._impl_changeClass;
 
-      TObject.check(clazz.prototype, BaseChange);
+      TFunction.checkClass(clazz, BaseChange);
       this._changeClass = clazz;
     }
 

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -7,7 +7,8 @@ import { CommonBase } from 'util-common';
 import FileAccess from './FileAccess';
 
 /**
- * Base class for things that hook up to a {@link FileComplex}.
+ * Base class for things that hook up to a {@link FileComplex} and for
+ * `FileComplex` itself.
  */
 export default class BaseComplexMember extends CommonBase {
   /**
@@ -33,14 +34,14 @@ export default class BaseComplexMember extends CommonBase {
     return this._fileAccess.file;
   }
 
+  /** {FileAccess} Low-level file access and associated miscellanea. */
+  get fileAccess() {
+    return this._fileAccess;
+  }
+
   /** {FileCodec} File-codec wrapper to use when dealing with encoded data. */
   get fileCodec() {
     return this._fileAccess.fileCodec;
-  }
-
-  /** {FileComplex} File complex that this instance is part of. */
-  get fileComplex() {
-    return this._fileAccess.fileComplex;
   }
 
   /** {Logger} Logger to use with this instance. */

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -4,14 +4,7 @@
 
 import { CommonBase } from 'util-common';
 
-/**
- * {class|null} The class `FileClass`, or `null` if it hasn't yet been fetched.
- * This arrangement is done because directly `import`ing it would result in a
- * circular dependency between `FileComplex` and this class, which &mdash; as
- * observed in practice &mdash; leads to a failure to initialize subclasses of
- * this class. Alas!
- */
-let FileComplex = null;
+import FileAccess from './FileAccess';
 
 /**
  * Base class for things that hook up to a {@link FileComplex}.
@@ -20,46 +13,46 @@ export default class BaseComplexMember extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex that this instance is part
-   *   of.
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
    */
-  constructor(fileComplex) {
-    if (FileComplex === null) {
-      FileComplex = require('./FileComplex').default;
-    }
-
+  constructor(fileAccess) {
     super();
 
-    /** {FileComplex} File complex that this instance is part of. */
-    this._fileComplex = FileComplex.check(fileComplex);
+    /** {FileAccess} Low-level file access and associated miscellanea. */
+    this._fileAccess = FileAccess.check(fileAccess);
+  }
 
-    /** {BaseFile} The underlying document storage. */
-    this._file = fileComplex.file;
-
-    /** {FileCodec} File-codec wrapper to use. */
-    this._fileCodec = fileComplex.fileCodec;
-
-    /** {Logger} Logger specific to this document's ID. */
-    this._log = fileComplex.log;
+  /** {Codec} Codec instance to use with the underlying file. */
+  get codec() {
+    return this._fileAccess.codec;
   }
 
   /** {BaseFile} The underlying document storage. */
   get file() {
-    return this._file;
+    return this._fileAccess.file;
   }
 
   /** {FileCodec} File-codec wrapper to use when dealing with encoded data. */
   get fileCodec() {
-    return this._fileCodec;
+    return this._fileAccess.fileCodec;
   }
 
   /** {FileComplex} File complex that this instance is part of. */
   get fileComplex() {
-    return this._fileComplex;
+    return this._fileAccess.fileComplex;
   }
 
   /** {Logger} Logger to use with this instance. */
   get log() {
-    return this._log;
+    return this._fileAccess.log;
+  }
+
+  /**
+   * {string} The document schema version to use for new documents and to expect
+   * in existing documents.
+   */
+  get schemaVersion() {
+    return this._fileAccess.schemaVersion;
   }
 }

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -25,7 +25,7 @@ export default class BaseComplexMember extends CommonBase {
    */
   constructor(fileComplex) {
     if (FileComplex === null) {
-      FileComplex = require('./FileComplex');
+      FileComplex = require('./FileComplex').default;
     }
 
     super();

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -31,7 +31,7 @@ export default class BaseComplexMember extends CommonBase {
     super();
 
     /** {FileComplex} File complex that this instance is part of. */
-    this._fileComplex = /*FileComplex.check*/(fileComplex);
+    this._fileComplex = FileComplex.check(fileComplex);
 
     /** {BaseFile} The underlying document storage. */
     this._file = fileComplex.file;

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -2,7 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { RevisionNumber } from 'doc-common';
+import { BaseSnapshot, RevisionNumber } from 'doc-common';
+import { TFunction } from 'typecheck';
+import { InfoError } from 'util-common';
 
 import BaseComplexMember from './BaseComplexMember';
 
@@ -12,6 +14,25 @@ import BaseComplexMember from './BaseComplexMember';
  * all managed and hooked up via {@link FileComplex}.
  */
 export default class BaseControl extends BaseComplexMember {
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class.
+   */
+  static get snapshotClass() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._snapshotClass) {
+      // Call the `_impl` and verify the result.
+      const clazz = this._impl_snapshotClass;
+
+      TFunction.checkClass(clazz, BaseSnapshot);
+      this._snapshotClass = clazz;
+    }
+
+    return this._snapshotClass;
+  }
+
   /**
    * Constructs an instance.
    *
@@ -44,6 +65,46 @@ export default class BaseControl extends BaseComplexMember {
   }
 
   /**
+   * Gets a snapshot of the full contents of the portion of the file controlled
+   * by this instance. It is an error to request a revision that does not yet
+   * exist. For subclasses that don't keep full history, it is also an error to
+   * request a revision that is _no longer_ available; in this case, the error
+   * name is always `revision_not_available`.
+   *
+   * @param {Int|null} revNum Which revision to get. If passed as `null`,
+   *   indicates the current (most recent) revision. **Note:** Due to the
+   *   asynchronous nature of the system, when passed as `null` the resulting
+   *   revision might already have been superseded by the time it is returned to
+   *   the caller.
+   * @returns {BaseSnapshot} Snapshot of the indicated revision. Always an
+   *   instance of the concrete snapshot type appropriate for this instance.
+   */
+  async getSnapshot(revNum = null) {
+    const currentRevNum = await this.currentRevNum();
+    revNum = (revNum === null)
+      ? currentRevNum
+      : RevisionNumber.maxInc(revNum, currentRevNum);
+
+    const result = await this._impl_getSnapshot(revNum);
+
+    if (result === null) {
+      throw new InfoError('revision_not_available', revNum);
+    }
+
+    return this.constructor.snapshotClass.check(result);
+  }
+
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class. Subclasses must fill this in.
+   *
+   * @abstract
+   */
+  static get _impl_snapshotClass() {
+    return this._mustOverride();
+  }
+
+  /**
    * Subclass-specific implementation of `currentRevNum()`. Subclasses must
    * override this.
    *
@@ -54,6 +115,21 @@ export default class BaseControl extends BaseComplexMember {
     return this._mustOverride();
   }
 
-  // **TODO:** Eventually this class will have the base versions of things like
-  // `snapshot()` and `getChangeAfter()`.
+  /**
+   * Subclass-specific implementation of `getSnapshot()`. Subclasses must
+   * override this.
+   *
+   * @abstract
+   * @param {Int} revNum Which revision to get. Guaranteed to be a revision
+   *   number for the instantaneously-current revision or earlier.
+   * @returns {BaseSnapshot|null} Snapshot of the indicated revision. Must
+   *   either be an instance of the concrete snapshot type appropriate for this
+   *   instance or `null`. `null` specifically indicates that `revNum` is a
+   *   revision older than what this instance can provide.
+   */
+  async _impl_getSnapshot(revNum) {
+    return this._mustOverride(revNum);
+  }
+
+  // **TODO:** `create()`, `getChangeAfter()`, and `update()`.
 }

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { RevisionNumber } from 'doc-common';
+
 import BaseComplexMember from './BaseComplexMember';
 
 /**
@@ -18,6 +20,38 @@ export default class BaseControl extends BaseComplexMember {
    */
   constructor(fileComplex) {
     super(fileComplex);
+  }
+
+  /**
+   * Gets the instantaneously-current revision number of the portion of the file
+   * controlled by this instance. It is an error to call this on an
+   * uninitialized document (e.g., when the underlying file is empty).
+   *
+   * **Note:** Due to the asynchronous nature of the system, the value returned
+   * here could be out-of-date by the time it is received by the caller. As
+   * such, even when used promptly, it should not be treated as "definitely
+   * current" but more like "probably current but possibly just a lower bound."
+   *
+   * @returns {Int} The instantaneously-current revision number.
+   */
+  async currentRevNum() {
+    // This method merely exists to enforce the return-type contract as
+    // specified in the method docs.
+
+    const revNum = await this._impl_currentRevNum();
+
+    return RevisionNumber.check(revNum);
+  }
+
+  /**
+   * Subclass-specific implementation of `currentRevNum()`. Subclasses must
+   * override this.
+   *
+   * @abstract
+   * @returns {Int} The instantaneously-current revision number.
+   */
+  async _impl_currentRevNum() {
+    return this._mustOverride();
   }
 
   // **TODO:** Eventually this class will have the base versions of things like

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -46,11 +46,11 @@ export default class BaseControl extends BaseComplexMember {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex that this instance is part
-   *   of.
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
    */
-  constructor(fileComplex) {
-    super(fileComplex);
+  constructor(fileAccess) {
+    super(fileAccess);
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -337,7 +337,7 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Underlyingimplementation of `getChangeAfter()`, as required by the
+   * Underlying implementation of `getChangeAfter()`, as required by the
    * superclass.
    *
    * @param {Int} baseRevNum Revision number for the base to get a change with

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -62,11 +62,11 @@ export default class BodyControl extends BaseControl {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex that this instance is part
-   *   of.
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
    */
-  constructor(fileComplex) {
-    super(fileComplex);
+  constructor(fileAccess) {
+    super(fileAccess);
 
     /**
      * {Map<RevisionNumber, BodySnapshot>} Mapping from revision numbers to
@@ -94,7 +94,7 @@ export default class BodyControl extends BaseControl {
 
       // Version for the file schema. **TODO:** As above, this path isn't
       // body-specific and so would be better handled elsewhere.
-      fc.op_writePath(Paths.SCHEMA_VERSION, this.fileComplex.schemaVersion),
+      fc.op_writePath(Paths.SCHEMA_VERSION, this.schemaVersion),
 
       // Initial revision number.
       fc.op_writePath(Paths.BODY_REVISION_NUMBER, 0),
@@ -256,7 +256,7 @@ export default class BodyControl extends BaseControl {
       return BodyControl.STATUS_ERROR;
     }
 
-    const expectSchemaVersion = this.fileComplex.schemaVersion;
+    const expectSchemaVersion = this.schemaVersion;
     if (schemaVersion !== expectSchemaVersion) {
       const got = schemaVersion;
       this.log.info(`Mismatched schema version: got ${got}; expected ${expectSchemaVersion}`);

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -38,17 +38,17 @@ export default class CaretControl extends BaseControl {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex that this instance is part
-   *   of.
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
    */
-  constructor(fileComplex) {
-    super(fileComplex);
+  constructor(fileAccess) {
+    super(fileAccess);
 
     /**
      * {CaretStorage} File storage handler. This is responsible for all of the
      * file reading and writing.
      */
-    this._caretStorage = new CaretStorage(fileComplex);
+    this._caretStorage = new CaretStorage(fileAccess);
 
     /**
      * {CaretSnapshot} Latest caret info. Starts out as an empty stub; gets

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -235,6 +235,16 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
+   * Underlying implementation of `currentRevNum()`, as required by the
+   * superclass.
+   *
+   * @returns {Int} The instantaneously-current revision number.
+   */
+  async _impl_currentRevNum() {
+    return this._snapshot.revNum;
+  }
+
+  /**
    * Merges any new remote session info into the snapshot.
    */
   _integrateRemoteSessions() {

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -42,11 +42,11 @@ export default class CaretStorage extends BaseComplexMember {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex that this instance is part
-   *   of.
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
    */
-  constructor(fileComplex) {
-    super(fileComplex);
+  constructor(fileAccess) {
+    super(fileAccess);
 
     /**
      * {Set<string>} Set of session IDs, indicating all of the editing sessions

--- a/local-modules/doc-server/FileAccess.js
+++ b/local-modules/doc-server/FileAccess.js
@@ -1,0 +1,80 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Codec } from 'codec';
+import { ProductInfo } from 'env-server';
+import { BaseFile, FileCodec } from 'file-store';
+import { Logger } from 'see-all';
+import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+/** {Logger} Logger to use for this module. */
+const log = new Logger('doc');
+
+/**
+ * Convenient access for the lower-level bits of a file, along with a single
+ * {@link Logger} instance for use with a file complex. This class mainly exists
+ * exists so as to make it easier to test {@link BaseControl} and its subclasses
+ * in isolation, since otherwise they would all have mutual dependencies via
+ * {@link FileComplex}.
+ */
+export default class FileAccess extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Codec} codec Codec instance to use.
+   * @param {BaseFile} file The underlying document storage.
+   */
+  constructor(codec, file) {
+    super();
+
+    /** {Codec} Codec instance to use. */
+    this._codec = Codec.check(codec);
+
+    /** {BaseFile} The underlying document storage. */
+    this._file = BaseFile.check(file);
+
+    /** {Logger} Logger for this instance. */
+    this._log = log.withPrefix(`[${file.id}]`);
+
+    /** {string} The document schema version to use and expect. */
+    this._schemaVersion = TString.nonEmpty(ProductInfo.theOne.INFO.version);
+
+    /** {FileCodec} File-codec wrapper to use. */
+    this._fileCodec = new FileCodec(file, codec);
+
+    Object.freeze(this);
+  }
+
+  /** {Codec} Codec instance to use with the underlying file. */
+  get codec() {
+    return this._codec;
+  }
+
+  /** {BaseFile} The underlying document storage. */
+  get file() {
+    return this._file;
+  }
+
+  /** {FileCodec} File-codec wrapper to use. */
+  get fileCodec() {
+    return this._fileCodec;
+  }
+
+  /**
+   * {Logger} Logger to use with this instance. It prefixes logged items with
+   * the file's ID.
+   */
+  get log() {
+    return this._log;
+  }
+
+  /**
+   * {string} The document schema version to use for new documents and to expect
+   * in existing documents.
+   */
+  get schemaVersion() {
+    return this._schemaVersion;
+  }
+}

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -65,12 +65,14 @@ export default class FileComplex extends CommonBase {
 
     /** {Mutex} Mutex to avoid overlapping initialization operations. */
     this._initMutex = new Mutex();
+
+    Object.seal(this);
   }
 
   /** {BodyControl} The body content controller to use with this instance. */
   get bodyControl() {
     if (this._bodyControl === null) {
-      this._bodyControl = new BodyControl(this);
+      this._bodyControl = new BodyControl(this._fileAccess);
       this.log.info('Constructed body controller.');
     }
 
@@ -80,7 +82,7 @@ export default class FileComplex extends CommonBase {
   /** {CaretControl} The caret info controller to use with this instance. */
   get caretControl() {
     if (this._caretControl === null) {
-      this._caretControl = new CaretControl(this);
+      this._caretControl = new CaretControl(this._fileAccess);
       this.log.info('Constructed caret controller.');
     }
 
@@ -108,14 +110,6 @@ export default class FileComplex extends CommonBase {
    */
   get log() {
     return this._fileAccess.log;
-  }
-
-  /**
-   * {string} The document schema version to use for new documents and to expect
-   * in existing documents.
-   */
-  get schemaVersion() {
-    return this._fileAccess.schemaVersion;
   }
 
   /**

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -5,8 +5,8 @@
 import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
 import { DEFAULT_DOCUMENT } from 'hooks-server';
 import { Mutex } from 'promise-util';
-import { CommonBase } from 'util-common';
 
+import BaseComplexMember from './BaseComplexMember';
 import CaretControl from './CaretControl';
 import BodyControl from './BodyControl';
 import DocServer from './DocServer';
@@ -38,7 +38,7 @@ const MIGRATION_NOTE = BodyDelta.fromOpArgArray([
  * how many active editors there are on that document. (This guarantee is
  * provided by `DocServer`.)
  */
-export default class FileComplex extends CommonBase {
+export default class FileComplex extends BaseComplexMember {
   /**
    * Constructs an instance.
    *
@@ -46,10 +46,7 @@ export default class FileComplex extends CommonBase {
    * @param {BaseFile} file The underlying document storage.
    */
   constructor(codec, file) {
-    super();
-
-    /** {FileAccess} Low-level file access and associated miscellanea. */
-    this._fileAccess = new FileAccess(codec, file);
+    super(new FileAccess(codec, file));
 
     /**
      * {BodyControl|null} Document body content controller. Set to non-`null` in
@@ -87,29 +84,6 @@ export default class FileComplex extends CommonBase {
     }
 
     return this._caretControl;
-  }
-
-  /** {Codec} Codec instance to use with the underlying file. */
-  get codec() {
-    return this._fileAccess.codec;
-  }
-
-  /** {BaseFile} The underlying document storage. */
-  get file() {
-    return this._fileAccess.file;
-  }
-
-  /** {FileCodec} File-codec wrapper to use. */
-  get fileCodec() {
-    return this._fileAccess.fileCodec;
-  }
-
-  /**
-   * {Logger} Logger to use with this instance. It prefixes logged items with
-   * the file's ID.
-   */
-  get log() {
-    return this._fileAccess.log;
   }
 
   /**

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -6,6 +6,7 @@ import BodyControl from './BodyControl';
 import CaretControl from './CaretControl';
 import DocServer from './DocServer';
 import DocSession from './DocSession';
+import FileAccess from './FileAccess';
 import FileComplex from './FileComplex';
 
-export { BodyControl, CaretControl, DocServer, DocSession, FileComplex };
+export { BodyControl, CaretControl, DocServer, DocSession, FileAccess, FileComplex };

--- a/local-modules/doc-server/main.js
+++ b/local-modules/doc-server/main.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import BaseComplexMember from './BaseComplexMember';
+import BaseControl from './BaseControl';
 import BodyControl from './BodyControl';
 import CaretControl from './CaretControl';
 import DocServer from './DocServer';
@@ -9,4 +11,13 @@ import DocSession from './DocSession';
 import FileAccess from './FileAccess';
 import FileComplex from './FileComplex';
 
-export { BodyControl, CaretControl, DocServer, DocSession, FileAccess, FileComplex };
+export {
+  BaseComplexMember,
+  BaseControl,
+  BodyControl,
+  CaretControl,
+  DocServer,
+  DocSession,
+  FileAccess,
+  FileComplex
+};

--- a/local-modules/doc-server/tests/MockControl.js
+++ b/local-modules/doc-server/tests/MockControl.js
@@ -1,0 +1,12 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseControl } from 'doc-server';
+
+/**
+ * Subclass of {@link BaseControl} for use in testing.
+ */
+export default class MockControl extends BaseControl {
+  // **TODO:** This ultimately probably needs to _not_ be empty.
+}

--- a/local-modules/doc-server/tests/MockFile.js
+++ b/local-modules/doc-server/tests/MockFile.js
@@ -1,0 +1,13 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseFile } from 'file-store';
+
+/**
+ * Trivial {@link BaseFile} implementation for use with the tests in this
+ * module.
+ */
+export default class MockFile extends BaseFile {
+  // **TODO:** This ultimately probably needs to _not_ be empty.
+}

--- a/local-modules/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/doc-server/tests/test_BaseComplexMember.js
@@ -5,19 +5,20 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
+import { BaseComplexMember } from 'doc-server';
+
 import { Codec } from 'codec';
 import { FileAccess } from 'doc-server';
 
-import MockControl from './MockControl';
 import MockFile from './MockFile';
 
-describe('doc-server/BaseControl', () => {
+describe('doc-server/BaseComplexMember', () => {
   describe('constructor()', () => {
-    it('should accept a `FileAccess` and reflect it in the inherited getters', () => {
+    it('should accept a `FileAccess` and reflect it in the getters', () => {
       const codec  = Codec.theOne;
       const file   = new MockFile('blort');
       const fa     = new FileAccess(codec, file);
-      const result = new MockControl(fa);
+      const result = new BaseComplexMember(fa);
 
       assert.strictEqual(result.codec,         codec);
       assert.strictEqual(result.file,          file);
@@ -28,10 +29,8 @@ describe('doc-server/BaseControl', () => {
     });
 
     it('should reject non-`FileAccess` arguments', () => {
-      assert.throws(() => new MockControl(null));
-      assert.throws(() => new MockControl({ x: 10 }));
+      assert.throws(() => new BaseComplexMember(null));
+      assert.throws(() => new BaseComplexMember({ x: 10 }));
     });
   });
-
-  // **TODO:** Fill this out!
 });

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -1,0 +1,9 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { describe, it } from 'mocha';
+
+describe('doc-server/BaseControl', () => {
+  it('should have tests!');
+});

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -106,9 +106,18 @@ export default class Errors extends UtilityClass {
 
     CoreTypecheck.checkStringOrNull(extra);
 
+    let inspectedValue;
+    try {
+      inspectedValue = inspect(value);
+    } catch (e) {
+      // Don't let a problem with `inspect()` keep us from throwing something
+      // at least vaguely useful.
+      inspectedValue = '<uninspectable object>';
+    }
+
     return new InfoError(
       'bad_value',
-      inspect(value),
+      inspectedValue,
       expectedType,
       ...((extra === null) ? [] : [extra]));
   }


### PR DESCRIPTION
This PR is the first _nontrivial_ round of refactoring in `doc-server`, meant to pave the way for a new control class (for property metadata). Highlights:

* `BaseControl` now has base implementations for a few different methods, thereby reducing the work needed to be done in the two existing subclasses, and also while now providing a layer of validation for both incoming arguments and outgoing results.
* New class `FileAccess` replaces `FileComplex` when used for access to the low-level file bits and logging. This breaks a pernicious circular dependency which had made it impossible to use `import` in a straightforward way and also prevented reasonable testing in isolation of each of the classes in the complex.
* Wrote a reasonably-complete unit test file for `BaseComplexMember` and started on one for `BaseControl`. The latter is going to be non-trivial to write "for real" because it wants to use mock classes which are currently only defined in a _different_ test directory. To make progress I'm going to have to do a handful of reorganizing elsewhere, which seemed like one step too far for this PR.