### PR TITLE
Test `BaseControl` and a bit more.

### DIFF
--- a/local-modules/codec/mocks/index.js
+++ b/local-modules/codec/mocks/index.js
@@ -4,6 +4,4 @@
 
 import MockCodable from './MockCodable';
 
-export {
-  MockCodable
-};
+export { MockCodable };

--- a/local-modules/doc-common/RevisionNumber.js
+++ b/local-modules/doc-common/RevisionNumber.js
@@ -35,7 +35,7 @@ export default class RevisionNumber extends UtilityClass {
    */
   static maxExc(value, maxExc) {
     try {
-      return TInt.maxExc(value, maxExc);
+      return TInt.range(value, 0, maxExc);
     } catch (e) {
       // More appropriate error.
       throw Errors.bad_value(value, RevisionNumber, `value < ${maxExc}`);
@@ -52,7 +52,7 @@ export default class RevisionNumber extends UtilityClass {
    */
   static maxInc(value, maxInc) {
     try {
-      return TInt.maxInc(value, maxInc);
+      return TInt.rangeInc(value, 0, maxInc);
     } catch (e) {
       // More appropriate error.
       throw Errors.bad_value(value, RevisionNumber, `value <= ${maxInc}`);

--- a/local-modules/doc-common/tests/test_RevisionNumber.js
+++ b/local-modules/doc-common/tests/test_RevisionNumber.js
@@ -1,0 +1,186 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { RevisionNumber } from 'doc-common';
+
+/**
+ * Helper to call a given method and ensure that it rejects numbers that aren't
+ * non-negative integers.
+ *
+ * @param {string} name Method name.
+ * @param {...*} args Additional arguments.
+ */
+function rejectBadNumbers(name, ...args) {
+  function test(value) {
+    assert.throws(() => RevisionNumber[name](value, ...args), /^bad_value/);
+  }
+
+  test(-1);
+  test(-0.0001);
+  test(0.5);
+  test(10000000.123);
+  test(Infinity);
+  test(NaN);
+}
+
+/**
+ * Helper to call a given method and ensure that it rejects non-numbers.
+ *
+ * @param {string} name Method name.
+ * @param {...*} args Additional arguments.
+ */
+function rejectNonNumbers(name, ...args) {
+  function test(value) {
+    assert.throws(() => RevisionNumber[name](value, ...args), /^bad_value/);
+  }
+
+  test(null);
+  test(undefined);
+  test(false);
+  test(true);
+  test('10');
+  test([10]);
+  test({ a: 10 });
+  test(new Map());
+}
+
+describe('doc-common/RevisionNumber', () => {
+  describe('check()', () => {
+    it('should accept non-negative integers', () => {
+      function test(value) {
+        assert.strictEqual(RevisionNumber.check(value), value);
+      }
+
+      test(0);
+      test(1);
+      test(2);
+      test(37);
+      test(242);
+      test(914);
+      test(900090009);
+    });
+
+    it('should reject other numbers', () => {
+      rejectBadNumbers('check');
+    });
+
+    it('should reject non-numbers', () => {
+      rejectNonNumbers('check');
+    });
+  });
+
+  describe('maxExc()', () => {
+    it('should accept non-negative integers up to the specified limit', () => {
+      function test(value, limit) {
+        assert.strictEqual(RevisionNumber.maxExc(value, limit), value);
+      }
+
+      test(0,  1);
+      test(0,  10);
+      test(0,  100);
+      test(2,  3);
+      test(2,  33333);
+      test(37, 39);
+    });
+
+    it('should reject non-negative integers beyond the specified limit', () => {
+      function test(value, limit) {
+        assert.throws(() => RevisionNumber.maxExc(value, limit), /^bad_value/);
+      }
+
+      test(0,   0);
+      test(1,   0);
+      test(1,   1);
+      test(100, 1);
+      test(100, 99);
+    });
+
+    it('should reject other numbers', () => {
+      rejectBadNumbers('maxExc', 10);
+    });
+
+    it('should reject non-numbers', () => {
+      rejectNonNumbers('maxExc', 10);
+    });
+  });
+
+  describe('maxInc()', () => {
+    it('should accept non-negative integers up to the specified limit', () => {
+      function test(value, limit) {
+        assert.strictEqual(RevisionNumber.maxInc(value, limit), value);
+      }
+
+      test(0,  0);
+      test(0,  1);
+      test(0,  10);
+      test(0,  100);
+      test(2,  2);
+      test(2,  3);
+      test(2,  33333);
+      test(37, 39);
+      test(37, 38);
+      test(37, 37);
+    });
+
+    it('should reject non-negative integers beyond the specified limit', () => {
+      function test(value, limit) {
+        assert.throws(() => RevisionNumber.maxInc(value, limit), /^bad_value/);
+      }
+
+      test(1,   0);
+      test(2,   1);
+      test(2,   0);
+      test(100, 99);
+      test(100, 98);
+    });
+
+    it('should reject other numbers', () => {
+      rejectBadNumbers('maxInc', 10);
+    });
+
+    it('should reject non-numbers', () => {
+      rejectNonNumbers('maxInc', 10);
+    });
+  });
+
+  describe('min()', () => {
+    it('should accept non-negative integers at or beyond the specified limit', () => {
+      function test(value, limit) {
+        assert.strictEqual(RevisionNumber.min(value, limit), value);
+      }
+
+      test(0,   0);
+      test(1,   0);
+      test(10,  0);
+      test(1,   1);
+      test(99,  1);
+      test(333, 333);
+      test(333, 300);
+    });
+
+    it('should reject non-negative integers below the specified limit', () => {
+      function test(value, limit) {
+        assert.throws(() => RevisionNumber.min(value, limit), /^bad_value/);
+      }
+
+      test(0,   1);
+      test(0,   2);
+      test(0,   3);
+      test(1,   2);
+      test(100, 101);
+      test(100, 10000);
+    });
+
+    it('should reject other numbers', () => {
+      rejectBadNumbers('min', 10);
+    });
+
+    it('should reject non-numbers', () => {
+      rejectNonNumbers('min', 10);
+    });
+  });
+});

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -106,10 +106,14 @@ export default class BaseControl extends BaseComplexMember {
 
     const result = await this._impl_getChangeAfter(baseRevNum, currentRevNum);
 
+    if (result === null) {
+      throw new InfoError('revision_not_available', baseRevNum);
+    }
+
     this.constructor.changeClass.check(result);
 
     if ((result.timestamp !== null) || (result.authorId !== null)) {
-      throw new Errors.bad_value(result, this.constructor.changeClass, 'timestamp === null && authorId === null');
+      throw Errors.bad_value(result, this.constructor.changeClass, 'timestamp === null && authorId === null');
     }
 
     return result;

--- a/local-modules/doc-server/mocks/MockControl.js
+++ b/local-modules/doc-server/mocks/MockControl.js
@@ -3,10 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseControl } from 'doc-server';
+import { MockSnapshot } from 'doc-common/mocks';
 
 /**
  * Subclass of {@link BaseControl} for use in testing.
  */
 export default class MockControl extends BaseControl {
-  // **TODO:** This ultimately probably needs to _not_ be empty.
+  static get _impl_snapshotClass() {
+    return MockSnapshot;
+  }
 }

--- a/local-modules/doc-server/mocks/MockControl.js
+++ b/local-modules/doc-server/mocks/MockControl.js
@@ -9,6 +9,12 @@ import { MockSnapshot } from 'doc-common/mocks';
  * Subclass of {@link BaseControl} for use in testing.
  */
 export default class MockControl extends BaseControl {
+  constructor(fileAccess) {
+    super(fileAccess);
+
+    this.revNum = 0;
+  }
+
   static get _impl_snapshotClass() {
     return MockSnapshot;
   }

--- a/local-modules/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/doc-server/tests/test_BaseComplexMember.js
@@ -9,7 +9,7 @@ import { BaseComplexMember } from 'doc-server';
 
 import { Codec } from 'codec';
 import { FileAccess } from 'doc-server';
-import { MockFile } from 'doc-server/mocks';
+import { MockFile } from 'file-store/mocks';
 
 describe('doc-server/BaseComplexMember', () => {
   describe('constructor()', () => {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -7,7 +7,8 @@ import { describe, it } from 'mocha';
 
 import { Codec } from 'codec';
 import { FileAccess } from 'doc-server';
-import { MockControl, MockFile } from 'doc-server/mocks';
+import { MockControl } from 'doc-server/mocks';
+import { MockFile } from 'file-store/mocks';
 
 describe('doc-server/BaseControl', () => {
   describe('constructor()', () => {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -5,12 +5,56 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
+import { BaseControl } from 'doc-server';
 import { Codec } from 'codec';
+import { MockSnapshot } from 'doc-common/mocks';
 import { FileAccess } from 'doc-server';
 import { MockControl } from 'doc-server/mocks';
 import { MockFile } from 'file-store/mocks';
 
 describe('doc-server/BaseControl', () => {
+  describe('.changeClass', () => {
+    it('should reflect the subclass\'s implementation', () => {
+      const result = MockControl.changeClass;
+      assert.strictEqual(result, MockSnapshot.changeClass);
+    });
+  });
+
+  describe('.snapshotClass', () => {
+    it('should reflect the subclass\'s implementation', () => {
+      const result = MockControl.snapshotClass;
+      assert.strictEqual(result, MockSnapshot);
+    });
+
+    it('should reject an improper subclass choice', () => {
+      class HasBadSnapshot extends BaseControl {
+        static get _impl_snapshotClass() {
+          return Object;
+        }
+      }
+
+      assert.throws(() => HasBadSnapshot.snapshotClass);
+    });
+
+    it('should only ever ask the subclass once', () => {
+      class GoodControl extends BaseControl {
+        static get _impl_snapshotClass() {
+          this.count++;
+          return MockSnapshot;
+        }
+      }
+
+      GoodControl.count = 0;
+      assert.strictEqual(GoodControl.snapshotClass, MockSnapshot);
+      assert.strictEqual(GoodControl.snapshotClass, MockSnapshot);
+      assert.strictEqual(GoodControl.snapshotClass, MockSnapshot);
+      assert.strictEqual(GoodControl.snapshotClass, MockSnapshot);
+      assert.strictEqual(GoodControl.snapshotClass, MockSnapshot);
+
+      assert.strictEqual(GoodControl.count, 1);
+    });
+  });
+
   describe('constructor()', () => {
     it('should accept a `FileAccess` and reflect it in the inherited getters', () => {
       const codec  = Codec.theOne;

--- a/local-modules/file-store/mocks/MockFile.js
+++ b/local-modules/file-store/mocks/MockFile.js
@@ -5,8 +5,7 @@
 import { BaseFile } from 'file-store';
 
 /**
- * Trivial {@link BaseFile} implementation for use with the tests in this
- * module.
+ * Trivial {@link BaseFile} implementation for use with the tests.
  */
 export default class MockFile extends BaseFile {
   // **TODO:** This ultimately probably needs to _not_ be empty.

--- a/local-modules/file-store/mocks/index.js
+++ b/local-modules/file-store/mocks/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import MockControl from './MockControl';
+import MockFile from './MockFile';
 
-export { MockControl };
+export { MockFile };

--- a/local-modules/promise-util/tests/test_Delay.js
+++ b/local-modules/promise-util/tests/test_Delay.js
@@ -9,23 +9,23 @@ import { Delay } from 'promise-util';
 
 describe('promise-util/Delay', () => {
   describe('delay(delayMSec)', () => {
-    it('should eventually resolve to true', () => {
-      assert.isFulfilled(Delay.resolve(10));
-      assert.becomes(Delay.resolve(10), true);
+    it('should eventually resolve to true', async () => {
+      await assert.isFulfilled(Delay.resolve(10));
+      await assert.eventually.strictEqual(Delay.resolve(10), true);
     });
   });
 
   describe('delay(delayMSec, value)', () => {
-    it('should eventually resolve to the supplied value', () => {
-      assert.isFulfilled(Delay.resolve(10, 'floopty'));
-      assert.becomes(Delay.resolve(10, 'floopty'), 'floopty');
+    it('should eventually resolve to the supplied value', async () => {
+      await assert.isFulfilled(Delay.resolve(10, 'floopty'));
+      await assert.eventually.strictEqual(Delay.resolve(10, 'floopty'), 'floopty');
     });
   });
 
   describe('reject(delayMSec, reason)', () => {
-    it('should eventually be rejected with the specified reason', () => {
-      assert.isRejected(Delay.reject(10, 'you smell'));
-      assert.isRejected(Delay.reject(10, 'you smell'), /^you smell$/);
+    it('should eventually be rejected with the specified reason', async () => {
+      await assert.isRejected(Delay.reject(10, 'you smell'));
+      await assert.isRejected(Delay.reject(10, 'you smell'), /^you smell$/);
     });
   });
 });

--- a/local-modules/promise-util/tests/test_Mutex.js
+++ b/local-modules/promise-util/tests/test_Mutex.js
@@ -62,7 +62,7 @@ describe('promise-util/Mutex', () => {
       const result = await mutex.withLockHeld(() => { return 'blort'; });
       assert.strictEqual(result, 'blort');
 
-      assert.isRejected(mutex.withLockHeld(() => { throw new Error('oy'); }));
+      await assert.isRejected(mutex.withLockHeld(() => { throw new Error('oy'); }));
     });
 
     it('should work with an `async` function when there is blatantly no contention', async () => {
@@ -71,7 +71,7 @@ describe('promise-util/Mutex', () => {
       const result = await mutex.withLockHeld(async () => { return 'blort'; });
       assert.strictEqual(result, 'blort');
 
-      assert.isRejected(mutex.withLockHeld(async () => { throw new Error('oy'); }));
+      await assert.isRejected(mutex.withLockHeld(async () => { throw new Error('oy'); }));
     });
 
     it('should provide the lock in request order', async () => {
@@ -91,14 +91,14 @@ describe('promise-util/Mutex', () => {
 
     it('should reject non-function arguments', async () => {
       const mutex = new Mutex();
-      function test(v) {
-        assert.isRejected(mutex.withLockHeld(v));
+      async function test(v) {
+        await assert.isRejected(mutex.withLockHeld(v));
       }
 
-      test(null);
-      test(undefined);
-      test('foo');
-      test(Mutex);
+      await test(null);
+      await test(undefined);
+      await test('foo');
+      await test(Mutex);
     });
   });
 });


### PR DESCRIPTION
This PR is the promised expansion of the tests on `BaseControl` to be less trivial, along with fixing a couple of bugs that those tests revealed. In addition, I cleaned up the mock extractions from the previous PR, and I fixed how some unrelated `async` tests were set up (because I had gotten the structure wrong before). Lastly, I added tests for lowly `RevisionNumber` which was of course so simple and obviously bug-free that it didn't need to have tests…

…not.