### PR TITLE
Move some errors, mostly.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -4,7 +4,7 @@
 
 import { BaseSnapshot, RevisionNumber } from 'doc-common';
 import { TFunction } from 'typecheck';
-import { Errors, InfoError } from 'util-common';
+import { Errors } from 'util-common';
 
 import BaseComplexMember from './BaseComplexMember';
 
@@ -107,7 +107,7 @@ export default class BaseControl extends BaseComplexMember {
     const result = await this._impl_getChangeAfter(baseRevNum, currentRevNum);
 
     if (result === null) {
-      throw new InfoError('revision_not_available', baseRevNum);
+      throw Errors.revision_not_available(baseRevNum);
     }
 
     this.constructor.changeClass.check(result);
@@ -143,7 +143,7 @@ export default class BaseControl extends BaseComplexMember {
     const result = await this._impl_getSnapshot(revNum);
 
     if (result === null) {
-      throw new InfoError('revision_not_available', revNum);
+      throw Errors.revision_not_available(revNum);
     }
 
     return this.constructor.snapshotClass.check(result);

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -214,7 +214,7 @@ export default class LocalFile extends BaseFile {
 
     await Promise.race([this._readStorageIfNecessary(), timeoutProm]);
     if (timeout) {
-      throw Errors.transaction_timed_out(timeoutMsec);
+      throw UtilErrors.timed_out(timeoutMsec);
     }
 
     if (!this._fileShouldExist) {
@@ -301,7 +301,7 @@ export default class LocalFile extends BaseFile {
       this._changeCondition.value = false;
       await Promise.race([this._changeCondition.whenTrue(), timeoutProm]);
       if (timeout) {
-        throw Errors.transaction_timed_out(timeoutMsec);
+        throw UtilErrors.timed_out(timeoutMsec);
       }
     }
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -321,7 +321,7 @@ export default class Transactor extends CommonBase {
     const revNum = op.arg('revNum');
 
     if (this._fileFriend.revNum !== revNum) {
-      throw Errors.revision_not_available(revNum);
+      throw UtilErrors.revision_not_available(revNum);
     }
   }
 

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -98,25 +98,4 @@ export default class Errors extends UtilityClass {
     TInt.nonNegative(revNum);
     return new InfoError('revision_not_available', revNum);
   }
-
-  /**
-   * Constructs an error indicating that a transaction timed out.
-   *
-   * @param {Int} timeoutMsec The original length of the timeout, in msec.
-   * @returns {InfoError} An appropriately-constructed error.
-   */
-  static transaction_timed_out(timeoutMsec) {
-    TInt.check(timeoutMsec);
-    return new InfoError('transaction_timed_out', timeoutMsec);
-  }
-
-  /**
-   * Indicates whether or not the given error is a transaction timeout error.
-   *
-   * @param {Error} error Error in question.
-   * @returns {boolean} `true` iff it represents a transaction timeout.
-   */
-  static isTimeout(error) {
-    return InfoError.hasName(error, 'transaction_timed_out');
-  }
 }

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TString } from 'typecheck';
+import { TString } from 'typecheck';
 import { FrozenBuffer, InfoError, UtilityClass } from 'util-common';
 
 import StoragePath from './StoragePath';

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -86,16 +86,4 @@ export default class Errors extends UtilityClass {
     StoragePath.check(storagePath);
     return new InfoError('path_not_found', storagePath);
   }
-
-  /**
-   * Constructs an error indicating that a requested file revision is not
-   * available.
-   *
-   * @param {Int} revNum Requested revision number.
-   * @returns {InfoError} An appropriately-constructed error.
-   */
-  static revision_not_available(revNum) {
-    TInt.nonNegative(revNum);
-    return new InfoError('revision_not_available', revNum);
-  }
 }

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Errors, UtilityClass } from 'util-core';
+import { CoreTypecheck, Errors, UtilityClass } from 'util-core';
 
 /**
  * Type checker for type `Int`.
@@ -19,11 +19,7 @@ export default class TInt extends UtilityClass {
    * @returns {Int} `value`.
    */
   static check(value) {
-    if ((typeof value !== 'number') || !Number.isSafeInteger(value)) {
-      throw Errors.bad_value(value, 'Int');
-    }
-
-    return value;
+    return CoreTypecheck.checkInt(value);
   }
 
   /**
@@ -35,13 +31,7 @@ export default class TInt extends UtilityClass {
    * @returns {Int} `value`.
    */
   static maxExc(value, maxExc) {
-    TInt.check(value);
-    TInt.check(maxExc);
-    if (value >= maxExc) {
-      throw Errors.bad_value(value, 'Int', `value < ${maxExc}`);
-    }
-
-    return value;
+    return CoreTypecheck.checkInt(value, null, maxExc);
   }
 
   /**
@@ -55,6 +45,7 @@ export default class TInt extends UtilityClass {
   static maxInc(value, maxInc) {
     TInt.check(value);
     TInt.check(maxInc);
+
     if (value > maxInc) {
       throw Errors.bad_value(value, 'Int', `value <= ${maxInc}`);
     }
@@ -71,13 +62,7 @@ export default class TInt extends UtilityClass {
    * @returns {Int} `value`.
    */
   static min(value, minInc) {
-    TInt.check(value);
-    TInt.check(minInc);
-    if (value < minInc) {
-      throw Errors.bad_value(value, 'Int', `value >= ${minInc}`);
-    }
-
-    return value;
+    return CoreTypecheck.checkInt(value, minInc);
   }
 
   /**
@@ -88,7 +73,7 @@ export default class TInt extends UtilityClass {
    * @returns {Int} `value`.
    */
   static nonNegative(value) {
-    return TInt.min(value, 0);
+    return CoreTypecheck.checkInt(value, 0);
   }
 
   /**
@@ -104,14 +89,7 @@ export default class TInt extends UtilityClass {
    * @returns {Int} `value`.
    */
   static range(value, minInc, maxExc) {
-    TInt.check(value);
-    TInt.check(minInc);
-    TInt.check(maxExc);
-    if ((value < minInc) || (value >= maxExc)) {
-      throw Errors.bad_value(value, 'Int', `${minInc} <= value < ${maxExc}`);
-    }
-
-    return value;
+    return CoreTypecheck.checkInt(value, minInc, maxExc);
   }
 
   /**
@@ -130,6 +108,7 @@ export default class TInt extends UtilityClass {
     TInt.check(value);
     TInt.check(minInc);
     TInt.check(maxInc);
+
     if ((value < minInc) || (value > maxInc)) {
       throw Errors.bad_value(value, 'Int', `${minInc} <= value <= ${maxInc}`);
     }

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -9,19 +9,54 @@ import { TInt } from 'typecheck';
 
 describe('typecheck/TInt', () => {
   describe('check()', () => {
-    it('should return the provided value when passed a safe integer', () => {
-      const value = 9823674;
+    it('should accept safe integers', () => {
+      function test(value) {
+        assert.strictEqual(TInt.check(value), value);
+      }
 
-      assert.doesNotThrow(() => TInt.check(value));
-      assert.strictEqual(TInt.check(value), value, 'returns same value it was passed when valid');
+      test(-1);
+      test(0);
+      test(1);
+      test(10000000);
     });
 
-    it('should throw an Error when passed a number which is not a safe integer', () => {
+    it('should reject numbers which are not safe integers', () => {
       assert.throws(() => TInt.check(3.1));
+      assert.throws(() => TInt.check(NaN));
+      assert.throws(() => TInt.check(1e100));
     });
 
-    it('should throw an Error when passed a non-number value', () => {
+    it('should reject a non-number value', () => {
       assert.throws(() => TInt.check('this better not work'));
+    });
+  });
+
+  describe('maxExc()', () => {
+    it('accepts in-range integers', () => {
+      function test(value, maxExc) {
+        assert.strictEqual(TInt.maxExc(value, maxExc), value);
+      }
+
+      test(-1,  0);
+      test(-1,  1);
+      test(-1,  10);
+      test(0,   1);
+      test(0,   1000000);
+      test(123, 914);
+      test(913, 914);
+    });
+
+    it('rejects out-of-range integers', () => {
+      function test(value, maxExc) {
+        assert.throws(() => TInt.maxExc(value, maxExc), /^bad_value/);
+      }
+
+      test(-1,  -2);
+      test(0,   -1);
+      test(0,   -1200);
+      test(100, 99);
+      test(100, 90);
+      test(100, -9000);
     });
   });
 
@@ -31,69 +66,98 @@ describe('typecheck/TInt', () => {
       assert.doesNotThrow(() => TInt.maxInc(4, 5));
     });
 
-    it('should throw an error when value > maxInc', () => {
+    it('should throw an error when `value > maxInc`', () => {
       assert.throws(() => TInt.maxInc(4, 3));
     });
   });
 
   describe('min()', () => {
-    it('should allow value >= minInc', () => {
-      assert.doesNotThrow(() => TInt.min(11, 3));
+    it('accepts in-range integers', () => {
+      function test(value, minInc) {
+        assert.strictEqual(TInt.min(value, minInc), value);
+      }
+
+      test(-1,    -1);
+      test(-1,    -10);
+      test(0,     -123);
+      test(0,     0);
+      test(10000, 100);
     });
 
-    it('should throw an error when value < minInc', () => {
-      assert.throws(() => TInt.min(2, 3));
+    it('rejects out-of-range integers', () => {
+      function test(value, minInc) {
+        assert.throws(() => TInt.min(value, minInc), /^bad_value/);
+      }
+
+      test(-1,  0);
+      test(0,   1);
+      test(0,   12);
+      test(100, 101);
+      test(100, 1200);
     });
   });
 
   describe('range()', () => {
-    it('should allow minInc <= value < maxExc', () => {
-      assert.doesNotThrow(() => TInt.range(11, 3, 27));
+    it('accepts in-range integers', () => {
+      function test(value, minInc, maxExc) {
+        assert.strictEqual(TInt.range(value, minInc, maxExc), value);
+      }
+
+      test(-1,  -1,   10);
+      test(-1,  -2,   0);
+      test(0,   0,    1);
+      test(0,   0,    2);
+      test(0,   -1,   2);
+      test(0,   -123, 456);
+      test(40,  38,   41);
+      test(40,  39,   900);
+      test(40,  40,   7123);
     });
 
-    it('should not throw an error when value === minInc', () => {
-      assert.doesNotThrow(() => TInt.range(3, 3, 27));
-    });
+    it('rejects out-of-range integers', () => {
+      function test(value, minInc, maxExc) {
+        assert.throws(() => TInt.range(value, minInc, maxExc), /^bad_value/);
+      }
 
-    it('should throw an error when value < minInc', () => {
-      assert.throws(() => TInt.range(2, 3, 27));
-    });
-
-    it('should throw an error when value === maxExc', () => {
-      assert.throws(() => TInt.range(27, 3, 27));
-    });
-
-    it('should throw an error when value > maxExc', () => {
-      assert.throws(() => TInt.range(37, 3, 27));
+      test(-1,  0,   10);
+      test(-1,  -20, -1);
+      test(0,   -100, -10);
+      test(0,   -100, 0);
+      test(0,   1,    2);
+      test(10,  0,    9);
+      test(10,  4,    10);
+      test(10,  11,   100);
+      test(10,  12,   100);
     });
   });
 
   describe('rangeInc()', () => {
-    it('should allow minInc <= value <= maxInc', () => {
+    it('should allow `minInc <= value <= maxInc`', () => {
       assert.doesNotThrow(() => TInt.rangeInc(11, 3, 27));
     });
 
-    it('should throw an error when value < minInc', () => {
+    it('should throw an error when `value < minInc`', () => {
       assert.throws(() => TInt.rangeInc(2, 3, 27));
     });
 
-    it('should not throw an error when value = maxInc', () => {
+    it('should not throw an error when `value === maxInc`', () => {
       assert.doesNotThrow(() => TInt.rangeInc(27, 3, 27));
     });
 
-    it('should throw an error when value > maxInc', () => {
+    it('should throw an error when `value > maxInc`', () => {
       assert.throws(() => TInt.rangeInc(37, 3, 27));
     });
   });
 
   describe('unsignedByte()', () => {
-    it('should allow integer values from [0..255]', () => {
-      assert.doesNotThrow(() => TInt.unsignedByte(0));
-      assert.doesNotThrow(() => TInt.unsignedByte(128));
-      assert.doesNotThrow(() => TInt.unsignedByte(255));
+    it('should allow integer values in range `[0..255]`', () => {
+      assert.strictEqual(TInt.unsignedByte(0),   0);
+      assert.strictEqual(TInt.unsignedByte(1),   1);
+      assert.strictEqual(TInt.unsignedByte(128), 128);
+      assert.strictEqual(TInt.unsignedByte(255), 255);
     });
 
-    it('should throw an error when value is outside [0..255]', () => {
+    it('should throw an error when value is outsid of range `[0..255]`', () => {
       assert.throws(() => TInt.unsgignedByte(-1));
       assert.throws(() => TInt.unsgignedByte(256));
     });

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TInt } from 'typecheck';
 
 describe('typecheck/TInt', () => {
-  describe('check(value)', () => {
+  describe('check()', () => {
     it('should return the provided value when passed a safe integer', () => {
       const value = 9823674;
 
@@ -16,7 +16,7 @@ describe('typecheck/TInt', () => {
       assert.strictEqual(TInt.check(value), value, 'returns same value it was passed when valid');
     });
 
-    it('should throw an Error when passed an unsafe integer', () => {
+    it('should throw an Error when passed a number which is not a safe integer', () => {
       assert.throws(() => TInt.check(3.1));
     });
 
@@ -25,7 +25,7 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('maxInc(value, maxInc)', () => {
+  describe('maxInc()', () => {
     it('should allow value <= maxInc', () => {
       assert.doesNotThrow(() => TInt.maxInc(4, 4));
       assert.doesNotThrow(() => TInt.maxInc(4, 5));
@@ -36,57 +36,57 @@ describe('typecheck/TInt', () => {
     });
   });
 
-  describe('min(value, inclusiveMinimum)', () => {
-    it('should allow value >= inclusiveMinimum', () => {
+  describe('min()', () => {
+    it('should allow value >= minInc', () => {
       assert.doesNotThrow(() => TInt.min(11, 3));
     });
 
-    it('should throw an error when value < inclusiveMinimum', () => {
+    it('should throw an error when value < minInc', () => {
       assert.throws(() => TInt.min(2, 3));
     });
   });
 
-  describe('range(value, inclusiveMinimum, exclusiveMaximum)', () => {
-    it('should allow inclusiveMinimum <= value < exclusiveMaximum', () => {
+  describe('range()', () => {
+    it('should allow minInc <= value < maxExc', () => {
       assert.doesNotThrow(() => TInt.range(11, 3, 27));
     });
 
-    it('should not throw an error when value = inclusiveMinimum', () => {
+    it('should not throw an error when value === minInc', () => {
       assert.doesNotThrow(() => TInt.range(3, 3, 27));
     });
 
-    it('should throw an error when value < inclusiveMinimum', () => {
+    it('should throw an error when value < minInc', () => {
       assert.throws(() => TInt.range(2, 3, 27));
     });
 
-    it('should throw an error when value = exclusiveMaximum', () => {
+    it('should throw an error when value === maxExc', () => {
       assert.throws(() => TInt.range(27, 3, 27));
     });
 
-    it('should throw an error when value > exclusiveMaximum', () => {
+    it('should throw an error when value > maxExc', () => {
       assert.throws(() => TInt.range(37, 3, 27));
     });
   });
 
-  describe('rangeInc(value, inclusiveMinimum, inclusiveMaximum)', () => {
-    it('should allow inclusiveMinimum <= value <= inclusiveMaximum', () => {
+  describe('rangeInc()', () => {
+    it('should allow minInc <= value <= maxInc', () => {
       assert.doesNotThrow(() => TInt.rangeInc(11, 3, 27));
     });
 
-    it('should throw an error when value < inclusiveMinimum', () => {
+    it('should throw an error when value < minInc', () => {
       assert.throws(() => TInt.rangeInc(2, 3, 27));
     });
 
-    it('should not throw an error when value = inclusiveMaximum', () => {
+    it('should not throw an error when value = maxInc', () => {
       assert.doesNotThrow(() => TInt.rangeInc(27, 3, 27));
     });
 
-    it('should throw an error when value > inclusiveMaximum', () => {
+    it('should throw an error when value > maxInc', () => {
       assert.throws(() => TInt.rangeInc(37, 3, 27));
     });
   });
 
-  describe('unsignedByte(value)', () => {
+  describe('unsignedByte()', () => {
     it('should allow integer values from [0..255]', () => {
       assert.doesNotThrow(() => TInt.unsignedByte(0));
       assert.doesNotThrow(() => TInt.unsignedByte(128));

--- a/local-modules/util-core/CoreTypecheck.js
+++ b/local-modules/util-core/CoreTypecheck.js
@@ -28,6 +28,51 @@ export default class CoreTypecheck extends UtilityClass {
   }
 
   /**
+   * Checks that a value is of type `Int`. That is, it must be an integer (more
+   * specifically a "safe integer") of JavaScript type `number`. In addition, it
+   * optionally checks lower (inclusive) and upper (exclusive) bounds.
+   *
+   * @param {*} value Value to check.
+   * @param {Int|null} [minInc = null] Minimum (inclusive) allowed value, or
+   *   `null` if there is no minimum.
+   * @param {Int|null} [maxExc = null] Maximum (exclusive) allowed value, or
+   *   `null` if there is no maximum.
+   * @returns {Int} `value`.
+   */
+  static checkInt(value, minInc = null, maxExc = null) {
+    if (minInc !== null) {
+      CoreTypecheck.checkInt(minInc);
+    }
+
+    if (maxExc !== null) {
+      CoreTypecheck.checkInt(maxExc);
+    }
+
+    if (   (typeof value === 'number')
+        && Number.isSafeInteger(value)
+        && ((minInc === null) || (value >= minInc))
+        && ((maxExc === null) || (value < maxExc))) {
+      return value;
+    }
+
+    // It's an error, so figure out the details and throw.
+
+    const minMsg = (minInc === null) ? null : `value >= ${minInc}`;
+    const maxMsg = (maxExc === null) ? null : `value < ${maxExc}`;
+    let msgArg;
+
+    if (minMsg) {
+      msgArg = [maxMsg ? `${minMsg} && ${maxMsg}` : minMsg];
+    } else if (maxMsg) {
+      msgArg = [maxMsg];
+    } else {
+      msgArg = [];
+    }
+
+    throw Errors.bad_value(value, 'Int', ...msgArg);
+  }
+
+  /**
    * Checks that a value is of type `string` and has the usual form of a
    * "label-like thing" in programming. This is the same as an identifier,
    * except that dashes are allowed throughout.

--- a/local-modules/util-core/CoreTypecheck.js
+++ b/local-modules/util-core/CoreTypecheck.js
@@ -57,14 +57,11 @@ export default class CoreTypecheck extends UtilityClass {
 
     // It's an error, so figure out the details and throw.
 
-    const minMsg = (minInc === null) ? null : `value >= ${minInc}`;
-    const maxMsg = (maxExc === null) ? null : `value < ${maxExc}`;
     let msgArg;
-
-    if (minMsg) {
-      msgArg = [maxMsg ? `${minMsg} && ${maxMsg}` : minMsg];
-    } else if (maxMsg) {
-      msgArg = [maxMsg];
+    if (minInc !== null) {
+      msgArg = [(maxExc === null) ? `${minInc} <= value < ${maxExc}` : `value >= ${minInc}`];
+    } else if (maxExc !== null) {
+      msgArg = [`value < ${maxExc}`];
     } else {
       msgArg = [];
     }

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -123,6 +123,18 @@ export default class Errors extends UtilityClass {
   }
 
   /**
+   * Constructs an error indicating that a requested revision (of a file or
+   * document, for example) is not available.
+   *
+   * @param {Int} revNum Requested revision number.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static revision_not_available(revNum) {
+    CoreTypecheck.checkInt(revNum, 0);
+    return new InfoError('revision_not_available', revNum);
+  }
+
+  /**
    * Constructs an error indicating that a timeout of some sort occurred.
    *
    * @param {Int} timeoutMsec The original length of the timeout, in msec.

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -123,6 +123,17 @@ export default class Errors extends UtilityClass {
   }
 
   /**
+   * Constructs an error indicating that a timeout of some sort occurred.
+   *
+   * @param {Int} timeoutMsec The original length of the timeout, in msec.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static timed_out(timeoutMsec) {
+    CoreTypecheck.checkInt(timeoutMsec, 0);
+    return new InfoError('timed_out', timeoutMsec);
+  }
+
+  /**
    * Constructs an instance which is meant to indicate that the program
    * exhibited unexpected behavior. This should be used as an indication of a
    * likely bug in the program.
@@ -144,6 +155,16 @@ export default class Errors extends UtilityClass {
    */
   static wtf(cause, message) {
     return Errors._make('wtf', cause, message);
+  }
+
+  /**
+   * Indicates whether or not the given error is a timeout.
+   *
+   * @param {Error} error Error in question.
+   * @returns {boolean} `true` iff it represents a timeout.
+   */
+  static isTimeout(error) {
+    return InfoError.hasName(error, 'timed_out');
   }
 
   /**

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -91,6 +91,160 @@ describe('util-core/CoreTypecheck', () => {
     });
   });
 
+  describe('checkInt()', () => {
+    describe('with no limits', () => {
+      it('accepts integers', () => {
+        function test(value) {
+          assert.strictEqual(CoreTypecheck.checkInt(value), value);
+        }
+
+        test(-1);
+        test(0);
+        test(1);
+        test(10000000);
+      });
+    });
+
+    describe('with a non-`null` value for `minInc`', () => {
+      it('accepts in-range integers', () => {
+        function test(value, minInc) {
+          assert.strictEqual(CoreTypecheck.checkInt(value, minInc), value);
+        }
+
+        test(-1,    -1);
+        test(-1,    -10);
+        test(0,     -123);
+        test(0,     0);
+        test(10000, 100);
+      });
+
+      it('rejects out-of-range integers', () => {
+        function test(value, minInc) {
+          assert.throws(() => CoreTypecheck.checkInt(value, minInc), /^bad_value/);
+        }
+
+        test(-1,  0);
+        test(0,   1);
+        test(0,   12);
+        test(100, 101);
+        test(100, 1200);
+      });
+
+      it('rejects bad values for `minInc`', () => {
+        function test(minInc) {
+          assert.throws(() => CoreTypecheck.checkInt(0, minInc), /^bad_value/);
+        }
+
+        test(false);
+        test(1.2);
+        test('blort');
+      });
+    });
+
+    describe('with a non-`null` value for `maxExc`', () => {
+      it('accepts in-range integers', () => {
+        function test(value, maxExc) {
+          assert.strictEqual(CoreTypecheck.checkInt(value, null, maxExc), value);
+        }
+
+        test(-1,  0);
+        test(-1,  1);
+        test(-1,  10);
+        test(0,   1);
+        test(0,   1000000);
+        test(123, 914);
+        test(913, 914);
+      });
+
+      it('rejects out-of-range integers', () => {
+        function test(value, maxExc) {
+          assert.throws(() => CoreTypecheck.checkInt(value, null, maxExc), /^bad_value/);
+        }
+
+        test(-1,  -2);
+        test(0,   -1);
+        test(0,   -1200);
+        test(100, 99);
+        test(100, 90);
+        test(100, -9000);
+      });
+
+      it('rejects bad values for `maxExc`', () => {
+        function test(maxExc) {
+          assert.throws(() => CoreTypecheck.checkInt(0, null, maxExc), /^bad_value/);
+        }
+
+        test(false);
+        test(1.2);
+        test('blort');
+      });
+    });
+
+    describe('with non-`null` values for both `minInc` and `maxExc`', () => {
+      it('accepts in-range integers', () => {
+        function test(value, minInc, maxExc) {
+          assert.strictEqual(CoreTypecheck.checkInt(value, minInc, maxExc), value);
+        }
+
+        test(-1,  -1,   10);
+        test(-1,  -2,   0);
+        test(0,   0,    1);
+        test(0,   0,    2);
+        test(0,   -1,   2);
+        test(0,   -123, 456);
+        test(40,  38,   41);
+        test(40,  39,   900);
+        test(40,  40,   7123);
+      });
+
+      it('rejects out-of-range integers', () => {
+        function test(value, minInc, maxExc) {
+          assert.throws(() => CoreTypecheck.checkInt(value, minInc, maxExc), /^bad_value/);
+        }
+
+        test(-1,  0,   10);
+        test(-1,  -20, -1);
+        test(0,   -100, -10);
+        test(0,   -100, 0);
+        test(0,   1,    2);
+        test(10,  0,    9);
+        test(10,  4,    10);
+        test(10,  11,   100);
+        test(10,  12,   100);
+      });
+    });
+
+    it('rejects numbers that are not safe integers', () => {
+      function test(value) {
+        assert.throws(() => CoreTypecheck.checkInt(value), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, null, 100), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 5, 50), /^bad_value/);
+      }
+
+      test(-0.5);
+      test(0.5);
+      test(12.34);
+      test(123.456);
+      test(Infinity);
+      test(NaN);
+      test(1e100);
+    });
+
+    it('rejects non-number values', () => {
+      function test(value) {
+        assert.throws(() => CoreTypecheck.checkInt(value), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, null, 2), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1, 2), /^bad_value/);
+      }
+
+      test(undefined);
+      test(null);
+      test('florp');
+    });
+  });
+
   describe('checkLabel()', () => {
     it('accepts label strings', () => {
       function test(value) {


### PR DESCRIPTION
This PR is just a bit of rearrangement to get a couple of errors that were in `file-store` to instead be defined as more general errors available in `util-common`. This was done so that the interface of `doc-server` didn't have to either effectively depend on implementation details, and also didn't have to duplicate code.

**Bonus:** Tightened up the tests for `TInt`.