### PR TITLE
Pull a bit more code into `BaseControl`.

### DIFF
--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -361,7 +361,7 @@ describe('doc-server/BaseControl', () => {
       control._impl_getSnapshot = async (revNum_unused) => {
         throw new Error('This should not have been called.');
       };
-      control._impl_update = async (change_unused) => {
+      control._impl_update = async (baseSnapshot_unused, change_unused, expectedSnapshot_unused) => {
         throw new Error('This should not have been called.');
       };
 
@@ -384,7 +384,7 @@ describe('doc-server/BaseControl', () => {
       control._impl_getSnapshot = async (revNum_unused) => {
         throw new Error('This should not have been called.');
       };
-      control._impl_update = async (change_unused) => {
+      control._impl_update = async (baseSnapshot_unused, change_unused, expectedSnapshot_unused) => {
         throw new Error('This should not have been called.');
       };
 
@@ -407,7 +407,7 @@ describe('doc-server/BaseControl', () => {
       control._impl_getSnapshot = async (revNum_unused) => {
         throw new Error('This should not have been called.');
       };
-      control._impl_update = async (change_unused) => {
+      control._impl_update = async (baseSnapshot_unused, change_unused, expectedSnapshot_unused) => {
         throw new Error('This should not have been called.');
       };
 
@@ -425,5 +425,80 @@ describe('doc-server/BaseControl', () => {
       await test(new MockChange(1,  [], Timestamp.MIN_VALUE));
       await test(new MockChange(10, [], Timestamp.MIN_VALUE.addMsec(12345)));
     });
+  });
+
+  it('should reject a too-large `revNum` in valid nontrivial cases', async () => {
+    const control   = new MockControl(FILE_ACCESS);
+    control._impl_currentRevNum = async () => {
+      return 10;
+    };
+    control._impl_getSnapshot = async (revNum) => {
+      return new MockSnapshot(revNum, [new MockOp('x', revNum)]);
+    };
+    control._impl_update = async (baseSnapshot_unused, change_unused, expectedSnapshot_unused) => {
+      throw new Error('This should not have been called.');
+    };
+
+    const change = new MockChange(12, [new MockOp('abc')], Timestamp.MIN_VALUE);
+    await assert.isRejected(control.update(change), /^bad_value/);
+  });
+
+  it('should call through to the impl in valid nontrivial cases', async () => {
+    const control   = new MockControl(FILE_ACCESS);
+    let callCount   = 0;
+    let gotBase     = 'x';
+    let gotChange   = 'x';
+    let gotExpected = 'x';
+
+    control._impl_currentRevNum = async () => {
+      return 10;
+    };
+    control._impl_getSnapshot = async (revNum) => {
+      return new MockSnapshot(revNum, [new MockOp('x', revNum)]);
+    };
+    control._impl_update = async (baseSnapshot, change, expectedSnapshot) => {
+      callCount++;
+      gotBase     = baseSnapshot;
+      gotChange   = change;
+      gotExpected = expectedSnapshot;
+      return new MockChange(14, [new MockOp('q')]);
+    };
+
+    const change = new MockChange(7, [new MockOp('abc')], Timestamp.MIN_VALUE);
+    const result = await control.update(change);
+
+    assert.strictEqual(callCount, 1);
+    assert.deepEqual(gotBase, new MockSnapshot(6, [new MockOp('x', 6)]));
+    assert.strictEqual(gotChange, change);
+    assert.deepEqual(gotExpected,
+      new MockSnapshot(7, [new MockOp('composed_delta'), new MockOp('abc')]));
+
+    assert.instanceOf(result, MockChange);
+    assert.deepEqual(result, new MockChange(14, [new MockOp('q')]));
+  });
+
+  it('should retry the impl call if it returns `null`', async () => {
+    const control = new MockControl(FILE_ACCESS);
+    let callCount = 0;
+
+    control._impl_currentRevNum = async () => {
+      return 10;
+    };
+    control._impl_getSnapshot = async (revNum) => {
+      return new MockSnapshot(revNum, [new MockOp('x', revNum)]);
+    };
+    control._impl_update = async (baseSnapshot_unused, change_unused, expectedSnapshot_unused) => {
+      callCount++;
+      if (callCount === 1) {
+        return null;
+      }
+      return new MockChange(14, [new MockOp('florp')]);
+    };
+
+    const change = new MockChange(7, [new MockOp('abc')], Timestamp.MIN_VALUE);
+    const result = await control.update(change);
+
+    assert.strictEqual(callCount, 2);
+    assert.deepEqual(result, new MockChange(14, [new MockOp('florp')]));
   });
 });


### PR DESCRIPTION
Not much more to it than the title. The nice outcome here is that `CaretControl` is now well positioned to be fixed to interact with the underlying file in a saner way (because it now has the same retry logic that I originally implemented for `BodyControl`).