### PR TITLE
OT encoding tweakage

### DIFF
--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -13,7 +13,7 @@ import ItemCodec from './ItemCodec';
 export default class SpecialCodecs extends UtilityClass {
   /** {ItemCodec} Codec used for coding arrays. */
   static get ARRAY() {
-    return new ItemCodec('array', Array, this._arrayPredicate,
+    return new ItemCodec('a', Array, this._arrayPredicate,
       this._arrayEncode, this._arrayDecode);
   }
 

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -150,6 +150,10 @@ export default class BaseChange extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
+    // **Note:** `[0]` on the `delta` argument is because `deconstruct()`
+    // returns an _array_ of arguments which can be used to reconstruct an
+    // instance, and we know in this case that deltas always deconstruct to a
+    // single-element array (because the constructor only accepts one argument).
     const result = [this._revNum, this._delta.deconstruct()[0], this._timestamp, this._authorId];
 
     // Trim off one or two trailing `null`s, if possible.

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -150,7 +150,7 @@ export default class BaseChange extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    const result = [this._revNum, this._delta.ops, this._timestamp, this._authorId];
+    const result = [this._revNum, this._delta.deconstruct()[0], this._timestamp, this._authorId];
 
     // Trim off one or two trailing `null`s, if possible.
     for (let i = 3; i >= 2; i--) {

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -140,6 +140,32 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
+   * "Deconstructs" this instance, returning an array of arguments which is
+   * suitable for passing to the constructor of this class.
+   *
+   * More specifically in this case, this returns a top-level single-element
+   * array (because the constructor of this class expects a single argument
+   * which is an array), with the sole element being a compact array-of-arrays
+   * form. Each element of the returned array is a list of arguments which can
+   * be passed to the {@link #opClass} constructor to recreate the corresponding
+   * op.
+   *
+   * The point of this choice of return form is to allow for more compact
+   * representation of instances of this class (and of instances of classes that
+   * use this class) in codec-encoded form. In particular, the name of the
+   * `opClass` gets to be implied instead of redundantly encoded.
+   *
+   * @returns {array<array<*>>} Array of array of operation-construction
+   *   arguments. The result is always a deeply-frozen array.
+   */
+  deconstruct() {
+    const ops = this._ops.map(op => op.deconstruct());
+
+    Object.freeze(ops);
+    return Object.freeze([ops]);
+  }
+
+  /**
    * Compares this to another possible-instance, for equality. To be considered
    * equal:
    *

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -57,33 +57,6 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
-   * Constructs an instance from an array of operation constructor argument
-   * arrays. This is meant to be a convenient way to represent literal delta
-   * content in code, and isn't expected to be used outside of that narrow use
-   * case.
-   *
-   * @param {array<array<*>>} opArgArray Array of op construction argument
-   *   arrays.
-   * @returns {BaseDelta} appropriately-constructed instance of the concrete
-   *   class that this method was called on.
-   */
-  static fromOpArgArray(opArgArray) {
-    TArray.check(opArgArray, TArray.check);
-
-    // **Note:** `this` in the context of a static method is the class, not an
-    // instance.
-
-    const opClass = this.opClass;
-    const ops     = [];
-
-    for (const a of opArgArray) {
-      ops.push(new opClass(...a));
-    }
-
-    return new this(Object.freeze(ops));
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {array<BaseOp>|array<array<*>>} ops Array of operations _or_ array

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -261,7 +261,7 @@ export default class BaseDelta extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this._ops];
+    return this.deconstruct();
   }
 
   /**

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -38,6 +38,17 @@ export default class BaseOp extends CommonBase {
   }
 
   /**
+   * "Deconstructs" this instance, returning an array which is suitable for
+   * passing to the constructor of this class.
+   *
+   * @returns {array<*>} Reconstruction arguments. The result is always deeply
+   * frozen.
+   */
+  deconstruct() {
+    return Object.freeze([this._payload.name, ...this._payload.args]);
+  }
+
+  /**
    * Compares this to another possible-instance, for equality of content. In
    * order to be considered equal to `this`, `other` must be an instance of the
    * same concrete class and have a payload which is `.equals()` to this

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -101,6 +101,6 @@ export default class BaseOp extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this._payload.name, ...this._payload.args];
+    return this.deconstruct();
   }
 }

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -211,6 +211,10 @@ export default class BaseSnapshot extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
+    // **Note:** `[0]` on the `delta` argument is because `deconstruct()`
+    // returns an _array_ of arguments which can be used to reconstruct an
+    // instance, and we know in this case that deltas always deconstruct to a
+    // single-element array (because the constructor only accepts one argument).
     return [this._revNum, this._contents.deconstruct()[0]];
   }
 

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -211,7 +211,7 @@ export default class BaseSnapshot extends CommonBase {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this._revNum, this._contents.ops];
+    return [this._revNum, this._contents.deconstruct()[0]];
   }
 
   /**

--- a/local-modules/doc-common/tests/test_BaseDelta.js
+++ b/local-modules/doc-common/tests/test_BaseDelta.js
@@ -49,33 +49,6 @@ describe('doc-common/BaseDelta', () => {
     });
   });
 
-  describe('fromOpArgArray()', () => {
-    it('should accept an empty array', () => {
-      const result = MockDelta.fromOpArgArray([]);
-
-      assert.lengthOf(result.ops, 0);
-    });
-
-    it('should use the array arguments to make ops', () => {
-      function test(...argses) {
-        const ops = argses.map(a => new MockOp(...a));
-        const result = MockDelta.fromOpArgArray(argses);
-
-        assert.lengthOf(result.ops, ops.length);
-
-        for (let i = 0; i < ops.length; i++) {
-          assert.deepEqual(result.ops[i], ops[i]);
-        }
-      }
-
-      test(['blort']);
-      test(['blort', 1]);
-      test(['blort', 1, 2, 3, 4, 'florp']);
-      test(['x'], ['y'], ['z']);
-      test(['x', ['a']], ['y', { b: 10 }], ['z', [[['pdq']]]]);
-    });
-  });
-
   describe('constructor()', () => {
     describe('valid arguments', () => {
       const values = [

--- a/local-modules/doc-common/tests/test_BaseDelta.js
+++ b/local-modules/doc-common/tests/test_BaseDelta.js
@@ -7,6 +7,7 @@ import { describe, it } from 'mocha';
 import { inspect } from 'util';
 
 import { BaseDelta } from 'doc-common';
+import { DataUtil } from 'util-common';
 
 import { MockDelta, MockOp } from 'doc-common/mocks';
 
@@ -36,7 +37,7 @@ describe('doc-common/BaseDelta', () => {
     });
 
     it('should have an empty `ops`', () => {
-      assert.strictEqual(EMPTY.ops.length, 0);
+      assert.lengthOf(EMPTY.ops, 0);
     });
 
     it('should have a frozen `ops`', () => {
@@ -52,7 +53,7 @@ describe('doc-common/BaseDelta', () => {
     it('should accept an empty array', () => {
       const result = MockDelta.fromOpArgArray([]);
 
-      assert.strictEqual(result.ops.length, 0);
+      assert.lengthOf(result.ops, 0);
     });
 
     it('should use the array arguments to make ops', () => {
@@ -60,7 +61,7 @@ describe('doc-common/BaseDelta', () => {
         const ops = argses.map(a => new MockOp(...a));
         const result = MockDelta.fromOpArgArray(argses);
 
-        assert.strictEqual(result.ops.length, ops.length);
+        assert.lengthOf(result.ops, ops.length);
 
         for (let i = 0; i < ops.length; i++) {
           assert.deepEqual(result.ops[i], ops[i]);
@@ -124,7 +125,7 @@ describe('doc-common/BaseDelta', () => {
         const ops = argses.map(a => new MockOp(...a));
         const result = new MockDelta(argses);
 
-        assert.strictEqual(result.ops.length, ops.length);
+        assert.lengthOf(result.ops, ops.length);
 
         for (let i = 0; i < ops.length; i++) {
           assert.deepEqual(result.ops[i], ops[i]);
@@ -136,6 +137,47 @@ describe('doc-common/BaseDelta', () => {
       test(['blort', 1, 2, 3, 4, 'florp']);
       test(['x'], ['y'], ['z']);
       test(['x', ['a']], ['y', { b: 10 }], ['z', [[['pdq']]]]);
+    });
+  });
+
+  describe('deconstruct()', () => {
+    it('should return a deep-frozen data value', () => {
+      const delta  = new MockDelta([['a', 1, 2, 3, [4, 5, 6]], ['b', { x: ['y'] }]]);
+      const result = delta.deconstruct();
+
+      assert.isTrue(DataUtil.isDeepFrozen(result));
+    });
+
+    it('should return an array of length one, which contains an array-of-arrays', () => {
+      const delta  = new MockDelta([['a', 1], ['b', [1, 2]]]);
+      const result = delta.deconstruct();
+
+      assert.isArray(result);
+      assert.lengthOf(result, 1);
+      assert.isArray(result[0]);
+
+      for (const a of result[0]) {
+        assert.isArray(a);
+      }
+    });
+
+    it('should return a value which successfully round-trips from and to a constructor argument', () => {
+      function test(arg) {
+        const delta1 = new MockDelta(arg);
+        const result = delta1.deconstruct();
+        const delta2 = new MockDelta(...result);
+
+        assert.deepEqual(arg, result[0]);
+        assert.deepEqual(delta1, delta2);
+      }
+
+      test([]);
+      test([['x']]);
+      test([['x', 1, 2, 3]]);
+      test([['x', [1, 2, 3]]]);
+      test([['x', { a: 10, b: 20 }]]);
+      test([['x'], ['y'], ['z']]);
+      test([['x', 1], ['y', 2], ['z', 3]]);
     });
   });
 

--- a/local-modules/doc-common/tests/test_BaseOp.js
+++ b/local-modules/doc-common/tests/test_BaseOp.js
@@ -89,6 +89,33 @@ describe('doc-common/BaseOp', () => {
     });
   });
 
+  describe('deconstruct()', () => {
+    it('should return a deep-frozen array data value', () => {
+      const op     = new MockOp('blort', ['florp', 'like'], { timeline: 'sideways' });
+      const result = op.deconstruct();
+
+      assert.isArray(result);
+      assert.isTrue(DataUtil.isDeepFrozen(result));
+    });
+
+    it('should return a value which successfully round-trips from and to constructor arguments', () => {
+      function test(...args) {
+        const op1    = new MockOp(...args);
+        const result = op1.deconstruct();
+        const op2    = new MockOp(...result);
+
+        assert.deepEqual(args, result);
+        assert.deepEqual(op1, op2);
+      }
+
+      test('foo');
+      test('bar', 1, 2, 3);
+      test('baz', ['florp', 'like']);
+      test('goo', { timeline: 'sideways' });
+      test('boo', [[[[[[[[[['floomp']]]]]]]]]]);
+    });
+  });
+
   describe('equals()', () => {
     it('should return `true` when passed itself', () => {
       const op = new MockOp('x', 'y', 'z');

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -73,7 +73,10 @@ describe('doc-common/BodyDelta', () => {
         [BodyOp.op_delete(123)],
         [BodyOp.op_retain(123)],
         [BodyOp.op_retain(123, { bold: true })],
-        [BodyOp.op_text('x'), BodyOp.op_text('y', { bold: true })]
+        [BodyOp.op_text('x'), BodyOp.op_text('y', { bold: true })],
+        [['text', 'hello']],
+        [['retain', 123]],
+        [['delete', 5], ['text', 'yo']]
       ];
 
       for (const v of values) {
@@ -92,14 +95,16 @@ describe('doc-common/BodyDelta', () => {
         'florp',
         { insert: 'x' },
         new Map(),
+        [null],
+        [true],
         ['x'],
-        [1, 2, 3]
+        [1, 2, 3],
+        [['not.a.valid.identifier', 1, 2, 3]]
       ];
 
       for (const v of values) {
         it(`should fail for: ${inspect(v)}`, () => {
           assert.throws(() => new BodyDelta(v));
-          assert.throws(() => new BodyDelta([v]));
         });
       }
     });

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -3,8 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BodyChange, BodyDelta, BodySnapshot, RevisionNumber } from 'doc-common';
-import { Errors, TransactionSpec } from 'file-store';
-import { Errors as UtilErrors, InfoError } from 'util-common';
+import { TransactionSpec } from 'file-store';
+import { Errors, InfoError } from 'util-common';
 
 import BaseControl from './BaseControl';
 import Paths from './Paths';
@@ -453,7 +453,7 @@ export default class BodyControl extends BaseControl {
     BodyChange.check(change);
 
     if (change.delta.isEmpty()) {
-      throw UtilErrors.wtf('Should not have been called with an empty change.');
+      throw Errors.wtf('Should not have been called with an empty change.');
     }
 
     const revNum     = change.revNum;
@@ -555,7 +555,7 @@ export default class BodyControl extends BaseControl {
     if ((endExc - start) > MAX_CHANGE_READS_PER_TRANSACTION) {
       // The calling code (in this class) should have made sure we weren't
       // violating this restriction.
-      throw UtilErrors.wtf('Too many changes requested at once.');
+      throw Errors.wtf('Too many changes requested at once.');
     }
 
     if (start === endExc) {

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -3,10 +3,10 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Caret, CaretSnapshot } from 'doc-common';
-import { Errors, TransactionSpec } from 'file-store';
+import { TransactionSpec } from 'file-store';
 import { CallPiler, Delay } from 'promise-util';
 import { TString } from 'typecheck';
-import { FrozenBuffer } from 'util-common';
+import { Errors, FrozenBuffer } from 'util-common';
 
 import BaseComplexMember from './BaseComplexMember';
 import Paths from './Paths';

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -13,19 +13,19 @@ import DocServer from './DocServer';
 import FileAccess from './FileAccess';
 
 /** {BodyDelta} Default contents when creating a new document. */
-const DEFAULT_TEXT = BodyDelta.fromOpArgArray(DEFAULT_DOCUMENT);
+const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
 
 /**
  * {BodyDelta} Message used as document to indicate a major validation error.
  */
-const ERROR_NOTE = BodyDelta.fromOpArgArray([
+const ERROR_NOTE = new BodyDelta([
   ['text', '(Recreated document due to validation error(s).)\n']
 ]);
 
 /**
  * {BodyDelta} Message used as document instead of migrating documents from
  * old schema versions. */
-const MIGRATION_NOTE = BodyDelta.fromOpArgArray([
+const MIGRATION_NOTE = new BodyDelta([
   ['text', '(Recreated document due to schema version skew.)\n']
 ]);
 

--- a/local-modules/hooks-server/tests/test_DEFAULT_DOCUMENT.js
+++ b/local-modules/hooks-server/tests/test_DEFAULT_DOCUMENT.js
@@ -14,10 +14,7 @@ describe('hooks-server/DEFAULT_DOCUMENT', () => {
     const doc = DEFAULT_DOCUMENT;
 
     assert.isFrozen(doc);
-
-    const deepFrozen = DataUtil.deepFreeze(doc);
-
-    assert.strictEqual(deepFrozen, doc);
+    assert.isTrue(DataUtil.isDeepFrozen(doc));
   });
 
   it('should be an array-of-arrays', () => {
@@ -32,7 +29,7 @@ describe('hooks-server/DEFAULT_DOCUMENT', () => {
   it('should be usable to construct a `BodyDelta` for which `isDocument()` is `true`', () => {
     const doc = DEFAULT_DOCUMENT;
 
-    const result = BodyDelta.fromOpArgArray(doc);
+    const result = new BodyDelta(doc);
     assert.isTrue(result.isDocument());
   });
 });

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.29.1
+version = 0.30.0


### PR DESCRIPTION
Inspired by the recent interest others have taken in our encoded document form, I took the opportunity to make a few improvements that I'd been considering for a while.

FWIW I'm still not entirely happy with how we embed our encoded object graphs in JSON, but I don't yet have a great alternative.

**Bonus:** Fixed calls to `isTimeout()` which I'd messed up when the method moved between modules.