### PR TITLE
Sort out file validation and creation.

### DIFF
--- a/local-modules/app-setup/RootAccess.js
+++ b/local-modules/app-setup/RootAccess.js
@@ -44,7 +44,6 @@ export default class RootAccess {
     TString.nonEmpty(docId);
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
-    await fileComplex.initIfMissingOrInvalid();
 
     // Under normal circumstances, this method is called in the context of an
     // active API connection, but it can also be called when debugging, and in

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -108,8 +108,8 @@ export default class BodyControl extends BaseControl {
       return SchemaHandler.STATUS_ERROR;
     }
 
-    const data          = transactionResult.data;
-    const revNum        = data.get(Paths.BODY_REVISION_NUMBER);
+    const data   = transactionResult.data;
+    const revNum = data.get(Paths.BODY_REVISION_NUMBER);
 
     if (!revNum) {
       this.log.info('Corrupt document: Missing revision number.');
@@ -178,9 +178,9 @@ export default class BodyControl extends BaseControl {
    * @returns {Int} The instantaneously-current revision number.
    */
   async _impl_currentRevNum() {
-    const fc = this.fileCodec;
+    const fc          = this.fileCodec;
     const storagePath = Paths.BODY_REVISION_NUMBER;
-    const spec = new TransactionSpec(
+    const spec        = new TransactionSpec(
       fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)
     );

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -104,7 +104,7 @@ export default class BodyControl extends BaseControl {
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
-      this.log.error('Major problem trying to read file!');
+      this.log.error('Major problem trying to read file!', e);
       return SchemaHandler.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -27,12 +27,6 @@ const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /**
  * Controller for the active caret info for a given document.
- *
- * There is only ever exactly one instance of this class per document, no matter
- * how many active editors there are on that document. (This guarantee is
- * provided by virtue of the fact that `DocServer` only ever creates one
- * `FileComplex` per document, and each `FileComplex` instance only ever makes
- * one instance of this class.
  */
 export default class CaretControl extends BaseControl {
   /**

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -220,7 +220,7 @@ export default class CaretStorage extends BaseComplexMember {
 
     try {
       const spec = new TransactionSpec(
-        fc.op_listPath(Paths.CARET_SESSION_PREFIX));
+        fc.op_listPathPrefix(Paths.CARET_SESSION_PREFIX));
       const transactionResult = await fc.transact(spec);
       for (const p of transactionResult.paths) {
         currentSessionIds.add(Paths.sessionFromCaretPath(p));

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -93,8 +93,8 @@ export default class DocServer extends Singleton {
 
     const resultPromise = (async () => {
       try {
-        const file      = await Hooks.theOne.fileStore.getFile(docId);
-        const result    = new FileComplex(this._codec, file);
+        const file   = await Hooks.theOne.fileStore.getFile(docId);
+        const result = new FileComplex(this._codec, file);
 
         await result.init();
 

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -92,16 +92,29 @@ export default class DocServer extends Singleton {
     // Nothing in the cache. Asynchronously construct the ultimate result.
 
     const resultPromise = (async () => {
-      const file      = await Hooks.theOne.fileStore.getFile(docId);
-      const result    = new FileComplex(this._codec, file);
-      const resultRef = weak(result, this._complexReaper(docId));
+      try {
+        const file      = await Hooks.theOne.fileStore.getFile(docId);
+        const result    = new FileComplex(this._codec, file);
 
-      // Replace the promise in the cache with a weak reference to the actaul
-      // result.
-      this._complexes.set(docId, resultRef);
+        await result.init();
 
-      result.log.info('Constructed new complex.');
-      return result;
+        const resultRef = weak(result, this._complexReaper(docId));
+
+        // Replace the promise in the cache with a weak reference to the actaul
+        // result.
+        this._complexes.set(docId, resultRef);
+
+        result.log.info('Constructed new complex.');
+        return result;
+      } catch (e) {
+        log.error(`Trouble constructing complex ${docId}.`, e);
+
+        // Remove the promise in the cache, so that we will try again instead of
+        // continuing to report this error.
+        this._complexes.delete(docId);
+
+        throw e; // Becomes the rejection value of the promise.
+      }
     })();
 
     // Store the the promise for the result in the cache, and return it.

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -1,0 +1,144 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
+import { DEFAULT_DOCUMENT } from 'hooks-server';
+import { Mutex } from 'promise-util';
+import { Errors } from 'util-common';
+
+import BaseComplexMember from './BaseComplexMember';
+import CaretControl from './CaretControl';
+import BodyControl from './BodyControl';
+
+/** {BodyDelta} Default contents when creating a new document. */
+const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
+
+/**
+ * {BodyDelta} Message used as document to indicate a major validation error.
+ */
+const ERROR_NOTE = new BodyDelta([
+  ['text', '(Recreated document due to validation error(s).)\n']
+]);
+
+/**
+ * {BodyDelta} Message used as document instead of migrating documents from
+ * old schema versions. */
+const MIGRATION_NOTE = new BodyDelta([
+  ['text', '(Recreated document due to schema version skew.)\n']
+]);
+
+/**
+ * Handler for the "bootstrap" setup of a file, including initializing new
+ * files, validating existing files, and dealing with validation problems.
+ */
+export default class FileBootstrap extends BaseComplexMember {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
+   */
+  constructor(fileAccess) {
+    super(fileAccess);
+
+    /** {Mutex} Mutex to avoid overlapping initialization operations. */
+    this._initMutex = new Mutex();
+
+    /** {boolean} Whether or not initialization has been completed. */
+    this._initialized = false;
+
+    /**
+     * {BodyControl|null} Document body content controller. Set to non-`null` in
+     * the corresponding getter.
+     */
+    this._bodyControl = new BodyControl(fileAccess);
+
+    /**
+     * {CaretControl|null} Caret info controller. Set to non-`null` in the
+     * corresponding getter.
+     */
+    this._caretControl = new CaretControl(fileAccess);
+
+    Object.seal(this);
+  }
+
+  /** {BodyControl} The body content controller to use with this instance. */
+  get bodyControl() {
+    if (!this._initialized) {
+      throw Errors.bad_use('Must be `init()`ed before access.');
+    }
+
+    return this._bodyControl;
+  }
+
+  /** {CaretControl} The caret info controller to use with this instance. */
+  get caretControl() {
+    if (!this._initialized) {
+      throw Errors.bad_use('Must be `init()`ed before access.');
+    }
+
+    return this._caretControl;
+  }
+
+  /**
+   * Initializes the document content.
+   *
+   * @returns {boolean} `true` once setup and initialization are complete.
+   */
+  async init() {
+    return this._initMutex.withLockHeld(async () => {
+      if (!this._initialized) {
+        await this._init();
+        this._initialized = true;
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Main guts of `init()`, which is called while the init mutex is locked.
+   *
+   * @returns {boolean} `true` once setup and initialization are complete.
+   */
+  async _init() {
+    const control = this._bodyControl;
+    const status  = await control.validationStatus();
+
+    if (status === BodyControl.STATUS_OK) {
+      // All's well.
+      return true;
+    }
+
+    // The document needs to be initialized.
+
+    let firstText;
+
+    if (status === BodyControl.STATUS_MIGRATE) {
+      // **TODO:** Ultimately, this code path will evolve into forward
+      // migration of documents found to be in older formats. For now, we just
+      // fall through to the document creation logic below, which will leave
+      // a note what's going on in the document contents.
+      this.log.info('Needs migration. (But just noting that fact for now.)');
+      firstText = MIGRATION_NOTE;
+    } else if (status === BodyControl.STATUS_ERROR) {
+      // **TODO:** Ultimately, it should be a Really Big Deal if we find
+      // ourselves here. We might want to implement some form of "hail mary"
+      // attempt to recover _something_ of use from the document storage.
+      this.log.info('Major problem with stored data!');
+      firstText = ERROR_NOTE;
+    } else {
+      // The document simply didn't exist.
+      firstText = DEFAULT_TEXT;
+    }
+
+    // `revNum` is `1` because a newly-created body always has an empty
+    // change for revision `0`.
+    const change = new BodyChange(1, firstText, Timestamp.now());
+
+    await control.create();
+    await control.update(change);
+
+    return true;
+  }
+}

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -135,6 +135,8 @@ export default class FileBootstrap extends BaseComplexMember {
 
     // **TODO:** The following should all happen in a single transaction.
 
+    await this._schemaHandler.create();
+
     const control = this._bodyControl;
     await control.create();
     await control.update(change);

--- a/local-modules/doc-server/FileComplex.js
+++ b/local-modules/doc-server/FileComplex.js
@@ -2,32 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BodyChange, BodyDelta, Timestamp } from 'doc-common';
-import { DEFAULT_DOCUMENT } from 'hooks-server';
-import { Mutex } from 'promise-util';
-
 import BaseComplexMember from './BaseComplexMember';
-import CaretControl from './CaretControl';
-import BodyControl from './BodyControl';
 import DocServer from './DocServer';
 import FileAccess from './FileAccess';
-
-/** {BodyDelta} Default contents when creating a new document. */
-const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
-
-/**
- * {BodyDelta} Message used as document to indicate a major validation error.
- */
-const ERROR_NOTE = new BodyDelta([
-  ['text', '(Recreated document due to validation error(s).)\n']
-]);
-
-/**
- * {BodyDelta} Message used as document instead of migrating documents from
- * old schema versions. */
-const MIGRATION_NOTE = new BodyDelta([
-  ['text', '(Recreated document due to schema version skew.)\n']
-]);
+import FileBootstrap from './FileBootstrap';
 
 /**
  * Manager for the "complex" of objects which in aggregate allow access and
@@ -49,90 +27,31 @@ export default class FileComplex extends BaseComplexMember {
     super(new FileAccess(codec, file));
 
     /**
-     * {BodyControl|null} Document body content controller. Set to non-`null` in
-     * the corresponding getter.
+     * {FileBootstrap} Bootstrap handler, and also where the complex members are
+     * most directly stored.
      */
-    this._bodyControl = null;
+    this._bootstrap = new FileBootstrap(this._fileAccess);
 
-    /**
-     * {CaretControl|null} Caret info controller. Set to non-`null` in the
-     * corresponding getter.
-     */
-    this._caretControl = null;
-
-    /** {Mutex} Mutex to avoid overlapping initialization operations. */
-    this._initMutex = new Mutex();
-
-    Object.seal(this);
+    Object.freeze(this);
   }
 
   /** {BodyControl} The body content controller to use with this instance. */
   get bodyControl() {
-    if (this._bodyControl === null) {
-      this._bodyControl = new BodyControl(this._fileAccess);
-      this.log.info('Constructed body controller.');
-    }
-
-    return this._bodyControl;
+    return this._bootstrap.bodyControl;
   }
 
   /** {CaretControl} The caret info controller to use with this instance. */
   get caretControl() {
-    if (this._caretControl === null) {
-      this._caretControl = new CaretControl(this._fileAccess);
-      this.log.info('Constructed caret controller.');
-    }
-
-    return this._caretControl;
+    return this._bootstrap.caretControl;
   }
 
   /**
-   * Initializes the document content, if either the file doesn't exist or the
-   * content doesn't pass validation.
+   * Initializes the document content.
    *
    * @returns {boolean} `true` once setup and initialization are complete.
    */
-  async initIfMissingOrInvalid() {
-    return this._initMutex.withLockHeld(async () => {
-      const control = this.bodyControl;
-      const status  = await control.validationStatus();
-
-      if (status === BodyControl.STATUS_OK) {
-        // All's well.
-        return true;
-      }
-
-      // The document needs to be initialized.
-
-      let firstText;
-
-      if (status === BodyControl.STATUS_MIGRATE) {
-        // **TODO:** Ultimately, this code path will evolve into forward
-        // migration of documents found to be in older formats. For now, we just
-        // fall through to the document creation logic below, which will leave
-        // a note what's going on in the document contents.
-        this.log.info('Needs migration. (But just noting that fact for now.)');
-        firstText = MIGRATION_NOTE;
-      } else if (status === BodyControl.STATUS_ERROR) {
-        // **TODO:** Ultimately, it should be a Really Big Deal if we find
-        // ourselves here. We might want to implement some form of "hail mary"
-        // attempt to recover _something_ of use from the document storage.
-        this.log.info('Major problem with stored data!');
-        firstText = ERROR_NOTE;
-      } else {
-        // The document simply didn't exist.
-        firstText = DEFAULT_TEXT;
-      }
-
-      // `revNum` is `1` because a newly-created body always has an empty
-      // change for revision `0`.
-      const change = new BodyChange(1, firstText, Timestamp.now());
-
-      await control.create();
-      await control.update(change);
-
-      return true;
-    });
+  async init() {
+    return this._bootstrap.init();
   }
 
   /**
@@ -156,10 +75,8 @@ export default class FileComplex extends BaseComplexMember {
    * @param {string} sessionId ID of the session that got reaped.
    */
   async _sessionReaped(sessionId) {
-    // Pass through to the caret controller (if present), since it might have a
-    // record of the session.
-    if (this._caretControl) {
-      await this._caretControl._sessionReaped(sessionId);
-    }
+    // Pass through to the caret controller, since it might have a record of the
+    // session.
+    await this.caretControl._sessionReaped(sessionId);
   }
 }

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -1,0 +1,102 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { ProductInfo } from 'env-server';
+import { TransactionSpec } from 'file-store';
+import { TString } from 'typecheck';
+
+import BaseComplexMember from './BaseComplexMember';
+import Paths from './Paths';
+
+/**
+ * Handler for the schema of a file. As of this writing, this class merely knows
+ * how to reject existing documents with schemas other than the latest. In the
+ * long term, it will be the locus of responsibility for migration of content
+ * from older schemas.
+ */
+export default class SchemaHandler extends BaseComplexMember {
+  /** {string} Return value from `validationStatus()`, see which for details. */
+  static get STATUS_ERROR() {
+    return 'status_error';
+  }
+
+  /** {string} Return value from `validationStatus()`, see which for details. */
+  static get STATUS_MIGRATE() {
+    return 'status_migrate';
+  }
+
+  /** {string} Return value from `validationStatus()`, see which for details. */
+  static get STATUS_NOT_FOUND() {
+    return 'status_not_found';
+  }
+
+  /** {string} Return value from `validationStatus()`, see which for details. */
+  static get STATUS_OK() {
+    return 'status_ok';
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
+   */
+  constructor(fileAccess) {
+    super(fileAccess);
+
+    /** {string} The document schema version to use and expect. */
+    this._schemaVersion = TString.nonEmpty(ProductInfo.theOne.INFO.version);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Evaluates the condition of the document, reporting a "validation status."
+   * The return value is one of the `STATUS_*` constants defined by this class:
+   *
+   * * `STATUS_OK` &mdash; No problems.
+   * * `STATUS_MIGRATE` &mdash; Document is in a format that is not understood.
+   * * `STATUS_NOT_FOUND` &mdash; The document doesn't exist.
+   * * `STATUS_ERROR` &mdash; Document is in an unrecoverably-bad state.
+   *
+   * This method will also emit information to the log about problems.
+   *
+   * @returns {string} The validation status.
+   */
+  async validationStatus() {
+    if (!(await this.file.exists())) {
+      return SchemaHandler.STATUS_NOT_FOUND;
+    }
+
+    let transactionResult;
+
+    try {
+      const fc = this.fileCodec;
+      const spec = new TransactionSpec(
+        fc.op_readPath(Paths.SCHEMA_VERSION)
+      );
+      transactionResult = await fc.transact(spec);
+    } catch (e) {
+      this.log.error('Major problem trying to read file!');
+      return SchemaHandler.STATUS_ERROR;
+    }
+
+    const data          = transactionResult.data;
+    const schemaVersion = data.get(Paths.SCHEMA_VERSION);
+
+    if (!schemaVersion) {
+      this.log.info('Corrupt document: Missing schema version.');
+      return SchemaHandler.STATUS_ERROR;
+    }
+
+    const expectSchemaVersion = this._schemaVersion;
+    if (schemaVersion !== expectSchemaVersion) {
+      const got = schemaVersion;
+      this.log.info(`Mismatched schema version: got ${got}; expected ${expectSchemaVersion}`);
+      return SchemaHandler.STATUS_MIGRATE;
+    }
+
+    return SchemaHandler.STATUS_OK;
+  }
+}

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -103,7 +103,7 @@ export default class SchemaHandler extends BaseComplexMember {
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
-      this.log.error('Major problem trying to read file!');
+      this.log.error('Major problem trying to read file!', e);
       return SchemaHandler.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -58,8 +58,7 @@ export default class SchemaHandler extends BaseComplexMember {
   async create() {
     this.log.info('Creating / re-creating file.');
 
-    const fc = this.fileCodec; // Avoids boilerplate immediately below.
-
+    const fc   = this.fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
       // If the file already existed, this clears out the old contents.
       // **TODO:** In cases where this is a re-creation based on a migration

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -282,7 +282,7 @@ export default class Transactor extends CommonBase {
     const prefix = op.arg('storagePath');
 
     for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {
-      if (StoragePath.isPrefix(prefix, storagePath)) {
+      if (StoragePath.isPrefixOrSame(prefix, storagePath)) {
         // We have a prefix match. Strip off components beyond the one
         // immediately under the prefix, if any. (`+1` to skip the slash
         // immediately after the prefix.)

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -274,11 +274,11 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `listPath` operations.
+   * Handler for `listPathPrefix` operations.
    *
    * @param {FileOp} op The operation.
    */
-  _op_listPath(op) {
+  _op_listPathPrefix(op) {
     const prefix = op.arg('storagePath');
 
     for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -258,6 +258,22 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `deletePathPrefix` operations.
+   *
+   * @param {FileOp} op The operation.
+   */
+  _op_deletePathPrefix(op) {
+    const prefix = op.arg('storagePath');
+
+    for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {
+      if (StoragePath.isPrefixOrSame(prefix, storagePath)) {
+        // We have a match.
+        this._updatedStorage.set(storagePath, null);
+      }
+    }
+  }
+
+  /**
    * Handler for `listPath` operations.
    *
    * @param {FileOp} op The operation.

--- a/local-modules/file-store-local/tests/test_LocalFile_transact.js
+++ b/local-modules/file-store-local/tests/test_LocalFile_transact.js
@@ -287,12 +287,12 @@ describe('file-store-local/LocalFile.transact', () => {
     });
   });
 
-  describe('op listPath', () => {
+  describe('op listPathPrefix', () => {
     it('should return an empty set when no results are found', async () => {
       const file = new LocalFile('0', TempFiles.uniquePath());
       await file.create();
 
-      const spec = new TransactionSpec(FileOp.op_listPath('/blort'));
+      const spec = new TransactionSpec(FileOp.op_listPathPrefix('/blort'));
       const result = await file.transact(spec);
       assert.instanceOf(result.paths, Set);
       assert.strictEqual(result.paths.size, 0);
@@ -308,7 +308,7 @@ describe('file-store-local/LocalFile.transact', () => {
       );
       await file.transact(spec);
 
-      spec = new TransactionSpec(FileOp.op_listPath('/yep'));
+      spec = new TransactionSpec(FileOp.op_listPathPrefix('/yep'));
       const result = await file.transact(spec);
       const paths = result.paths;
 
@@ -327,7 +327,7 @@ describe('file-store-local/LocalFile.transact', () => {
       );
       await file.transact(spec);
 
-      spec = new TransactionSpec(FileOp.op_listPath('/blort'));
+      spec = new TransactionSpec(FileOp.op_listPathPrefix('/blort'));
       const result = await file.transact(spec);
       const paths = result.paths;
 
@@ -346,7 +346,7 @@ describe('file-store-local/LocalFile.transact', () => {
       );
       await file.transact(spec);
 
-      spec = new TransactionSpec(FileOp.op_listPath('/blort'));
+      spec = new TransactionSpec(FileOp.op_listPathPrefix('/blort'));
       const result = await file.transact(spec);
       const paths = result.paths;
 
@@ -373,7 +373,7 @@ describe('file-store-local/LocalFile.transact', () => {
       );
       await file.transact(spec);
 
-      spec = new TransactionSpec(FileOp.op_listPath('/blort/x'));
+      spec = new TransactionSpec(FileOp.op_listPathPrefix('/blort/x'));
       const result = await file.transact(spec);
       const paths = result.paths;
 

--- a/local-modules/file-store-local/tests/test_LocalFile_transact.js
+++ b/local-modules/file-store-local/tests/test_LocalFile_transact.js
@@ -298,6 +298,25 @@ describe('file-store-local/LocalFile.transact', () => {
       assert.strictEqual(result.paths.size, 0);
     });
 
+    it('should return a single result for the path itself when bound', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      await file.create();
+
+      let spec = new TransactionSpec(
+        FileOp.op_writePath('/yep', new FrozenBuffer('yep')),
+        FileOp.op_writePath('/nope', new FrozenBuffer('nope'))
+      );
+      await file.transact(spec);
+
+      spec = new TransactionSpec(FileOp.op_listPath('/yep'));
+      const result = await file.transact(spec);
+      const paths = result.paths;
+
+      assert.instanceOf(paths, Set);
+      assert.strictEqual(paths.size, 1);
+      assert.isTrue(paths.has('/yep'));
+    });
+
     it('should return a single result immediately under the path', async () => {
       const file = new LocalFile('0', TempFiles.uniquePath());
       await file.create();

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -146,16 +146,16 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_DELETE, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
-   * A `listPath` operation. This is a read operation that retrieves a list of
-   * all paths immediately under the given prefix that store data. The resulting
-   * list can contain both paths that store blobs as well as "directories" under
-   * which other blobs are stored. If there are no such paths, the result is an
-   * empty list.
+   * A `listPathPrefix` operation. This is a read operation that retrieves a
+   * list of all paths immediately under the given prefix that store data, or
+   * the path itself if it stores data directly. The resulting list can contain
+   * both paths that store blobs as well as "directories" under which other
+   * blobs are stored. If there are no such paths, the result is an empty list.
    *
    * @param {string} storagePath The storage path prefix to list the contents
-   * of.
+   *   of.
    */
-  [CAT_LIST, 'listPath', ['storagePath', TYPE_PATH]],
+  [CAT_LIST, 'listPathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
    * A `readBlob` operation. This is a read operation that retrieves the full

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -136,13 +136,24 @@ const OPERATIONS = DataUtil.deepFreeze([
   [CAT_DELETE, 'deletePath', ['storagePath', TYPE_PATH]],
 
   /*
+   * A `deletePathPrefix` operation. This is a write operation that deletes the
+   * bindings for the given path and all paths which use it as a prefix, if any.
+   * If there were no matching paths bound in the first place, then this
+   * operation does nothing.
+   *
+   * @param {string} storagePath The storage path prefix to delete.
+   */
+  [CAT_DELETE, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
+
+  /*
    * A `listPath` operation. This is a read operation that retrieves a list of
    * all paths immediately under the given prefix that store data. The resulting
    * list can contain both paths that store blobs as well as "directories" under
    * which other blobs are stored. If there are no such paths, the result is an
    * empty list.
    *
-   * @param {string} storagePath The storage path to list contents of.
+   * @param {string} storagePath The storage path prefix to list the contents
+   * of.
    */
   [CAT_LIST, 'listPath', ['storagePath', TYPE_PATH]],
 

--- a/local-modules/file-store/StoragePath.js
+++ b/local-modules/file-store/StoragePath.js
@@ -117,6 +117,21 @@ export default class StoragePath extends UtilityClass {
   }
 
   /**
+   * Indicates whether the first path is either a prefix of or the same as the
+   * second path.
+   *
+   * @param {string} prefix Path prefix.
+   * @param {string} path Path which might either be or start with `prefix`.
+   * @returns {boolean} `true` if `prefix` is indeed the same as `path` or is
+   *   a path prefix of `path`, or `false` if not.
+   */
+  static isPrefixOrSame(prefix, path) {
+    // **Note:** We do the `isPrefix()` call first so as to get its error checks
+    // in all cases.
+    return StoragePath.isPrefix(prefix, path) || (path === prefix);
+  }
+
+  /**
    * Joins an array of components into a single storage path string. Components
    * must _not_ include slashes (`/`). This operation is the inverse of
    * `split()`.

--- a/local-modules/file-store/tests/test_StoragePath.js
+++ b/local-modules/file-store/tests/test_StoragePath.js
@@ -176,16 +176,58 @@ describe('file-store/StoragePath', () => {
       test('/blort/florp', '/blort/florp/aa/bb');
     });
 
+    it('should return `false` when the two values are equal', () => {
+      function test(prefix, path) {
+        assert.isFalse(StoragePath.isPrefix(prefix, path));
+      }
+
+      test('/a',      '/a');
+      test('/ab',     '/ab');
+      test('/x/y/zz', '/x/y/zz');
+    });
+
     it('should return `false` for non-prefix relationships', () => {
       function test(prefix, path) {
         assert.isFalse(StoragePath.isPrefix(prefix, path));
       }
 
-      test('/a', '/b');
-      test('/a', '/b/a');
+      test('/a',   '/aa');
+      test('/aa',  '/a');
+      test('/a',   '/b');
+      test('/a',   '/b/a');
       test('/a/b', '/a');
-      test('/a', '/aa');
+      test('/ax',  '/axb');
+      test('/ax',  '/axb/c');
       test('/a/b', '/a/bb');
+    });
+
+    it('should throw an error if either argument is not a valid absolute path', () => {
+      function test(value) {
+        assert.throws(() => StoragePath.isPrefix('/x', value));
+        assert.throws(() => StoragePath.isPrefix(value, '/x'));
+        assert.throws(() => StoragePath.isPrefix(value, value));
+      }
+
+      // Non-strings.
+      test(null);
+      test(undefined);
+      test(false);
+      test(123);
+      test(new Map());
+      test(['x']);
+      test({ x: 10 });
+
+      // Not valid absolute path syntax.
+      test('');
+      test('foo');
+      test('foo/');
+      test('/boo$');
+      test('/@');
+      test('/!x');
+      test('florp/');
+      test('/florp/');
+      test('x/y');
+      test('x/y/');
     });
   });
 

--- a/local-modules/file-store/tests/test_StoragePath.js
+++ b/local-modules/file-store/tests/test_StoragePath.js
@@ -159,75 +159,91 @@ describe('file-store/StoragePath', () => {
     });
   });
 
-  describe('isPrefix()', () => {
-    it('should return `true` for prefix relationships', () => {
-      function test(prefix, path) {
-        assert.isTrue(StoragePath.isPrefix(prefix, path));
-      }
+  describe('isPrefix*()', () => {
+    // Common tests for both `isPrefix*()` methods, because they only differ in
+    // how `===` arguments are treated.
+    function outerTest(methodName, equalExpectation) {
+      const func = (prefix, path) => {
+        return StoragePath[methodName](prefix, path);
+      };
 
-      test('/a', '/a/b');
-      test('/a', '/a/b/c');
-      test('/a', '/a/b/c/d');
-      test('/a', '/a/b/c/d/e');
-      test('/a', '/a/b/c/d/e/f');
-      test('/blort/florp', '/blort/florp/a');
-      test('/blort/florp', '/blort/florp/aa');
-      test('/blort/florp', '/blort/florp/aa/b');
-      test('/blort/florp', '/blort/florp/aa/bb');
+      it('should return `true` for prefix relationships', () => {
+        function test(prefix, path) {
+          assert.isTrue(func(prefix, path));
+        }
+
+        test('/a', '/a/b');
+        test('/a', '/a/b/c');
+        test('/a', '/a/b/c/d');
+        test('/a', '/a/b/c/d/e');
+        test('/a', '/a/b/c/d/e/f');
+        test('/blort/florp', '/blort/florp/a');
+        test('/blort/florp', '/blort/florp/aa');
+        test('/blort/florp', '/blort/florp/aa/b');
+        test('/blort/florp', '/blort/florp/aa/bb');
+      });
+
+      it(`should return \`${equalExpectation}\` when the two values are equal`, () => {
+        function test(prefix, path) {
+          assert.strictEqual(func(prefix, path), equalExpectation);
+        }
+
+        test('/a',      '/a');
+        test('/ab',     '/ab');
+        test('/x/y/zz', '/x/y/zz');
+      });
+
+      it('should return `false` for non-prefix, non-equal relationships', () => {
+        function test(prefix, path) {
+          assert.isFalse(func(prefix, path));
+        }
+
+        test('/a',   '/aa');
+        test('/aa',  '/a');
+        test('/a',   '/b');
+        test('/a',   '/b/a');
+        test('/a/b', '/a');
+        test('/ax',  '/axb');
+        test('/ax',  '/axb/c');
+        test('/a/b', '/a/bb');
+      });
+
+      it('should throw an error if either argument is not a valid absolute path', () => {
+        function test(value) {
+          assert.throws(() => func('/x', value));
+          assert.throws(() => func(value, '/x'));
+          assert.throws(() => func(value, value));
+        }
+
+        // Non-strings.
+        test(null);
+        test(undefined);
+        test(false);
+        test(123);
+        test(new Map());
+        test(['x']);
+        test({ x: 10 });
+
+        // Not valid absolute path syntax.
+        test('');
+        test('foo');
+        test('foo/');
+        test('/boo$');
+        test('/@');
+        test('/!x');
+        test('florp/');
+        test('/florp/');
+        test('x/y');
+        test('x/y/');
+      });
+    }
+
+    describe('isPrefix()', () => {
+      outerTest('isPrefix', false);
     });
 
-    it('should return `false` when the two values are equal', () => {
-      function test(prefix, path) {
-        assert.isFalse(StoragePath.isPrefix(prefix, path));
-      }
-
-      test('/a',      '/a');
-      test('/ab',     '/ab');
-      test('/x/y/zz', '/x/y/zz');
-    });
-
-    it('should return `false` for non-prefix relationships', () => {
-      function test(prefix, path) {
-        assert.isFalse(StoragePath.isPrefix(prefix, path));
-      }
-
-      test('/a',   '/aa');
-      test('/aa',  '/a');
-      test('/a',   '/b');
-      test('/a',   '/b/a');
-      test('/a/b', '/a');
-      test('/ax',  '/axb');
-      test('/ax',  '/axb/c');
-      test('/a/b', '/a/bb');
-    });
-
-    it('should throw an error if either argument is not a valid absolute path', () => {
-      function test(value) {
-        assert.throws(() => StoragePath.isPrefix('/x', value));
-        assert.throws(() => StoragePath.isPrefix(value, '/x'));
-        assert.throws(() => StoragePath.isPrefix(value, value));
-      }
-
-      // Non-strings.
-      test(null);
-      test(undefined);
-      test(false);
-      test(123);
-      test(new Map());
-      test(['x']);
-      test({ x: 10 });
-
-      // Not valid absolute path syntax.
-      test('');
-      test('foo');
-      test('foo/');
-      test('/boo$');
-      test('/@');
-      test('/!x');
-      test('florp/');
-      test('/florp/');
-      test('x/y');
-      test('x/y/');
+    describe('isPrefixOrSame()', () => {
+      outerTest('isPrefixOrSame', true);
     });
   });
 


### PR DESCRIPTION
The main thrust of this PR is to tease apart the file validation and creation code. Before this, most of the salient code was in `BodyControl`, which was an accident of history due to the fact that originally the only thing in the file at all was the document body. Now, there is overall schema-related stuff in a new `SchemaHandler` class, and the behavior (and stated contracts) of `BodyControl.{create,validationStatus}()` have been updated to reflect a more narrow purview.