### PR TITLE
Monday afternoon miscellanea.

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -76,10 +76,13 @@ export default class Application {
   /**
    * Starts up the server.
    *
+   * @param {boolean} [pickPort = false] If `true`, causes the app to pick an
+   *   arbitrary available port to listen on instead of the configured port.
+   *   This is only meant to be passed as `true` in testing scenarios.
    * @returns {Int} The port being listened on, once listening has started.
    */
-  async start() {
-    const port   = Hooks.theOne.listenPort;
+  async start(pickPort = false) {
+    const port   = pickPort ? 0 : Hooks.theOne.listenPort;
     const server = http.createServer(this._app);
 
     await promisify(cb => server.listen(port, cb))();

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -131,14 +131,14 @@ export default class EditorComplex extends CommonBase {
         modules:  EditorComplex._bodyModuleConfig
       });
 
+      /** {CaretStore} Redux store for caret-related info. */
       this._caretStore = new CaretStore(this);
-
-      // Let the overlay do extra initialization.
-      Hooks.theOne.quillInstanceInit('title', this, this._titleQuill);
-      Hooks.theOne.quillInstanceInit('body', this, this._bodyQuill);
 
       /** {CaretOverlay} The remote caret overlay controller. */
       this._caretOverlay = new CaretOverlay(this, authorOverlayNode);
+
+      // Let the overlay do extra initialization.
+      Hooks.theOne.quillInstanceInit(this);
 
       // Do session setup using the initial key.
       this._initSession(sessionKey, true);

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -138,7 +138,7 @@ export default class EditorComplex extends CommonBase {
       this._caretOverlay = new CaretOverlay(this, authorOverlayNode);
 
       // Let the overlay do extra initialization.
-      Hooks.theOne.quillInstanceInit(this);
+      Hooks.theOne.editorComplexInit(this);
 
       // Do session setup using the initial key.
       this._initSession(sessionKey, true);

--- a/local-modules/env-server/PidFile.js
+++ b/local-modules/env-server/PidFile.js
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { Logger } from 'see-all';
+import { TInt } from 'typecheck';
 import { Singleton } from 'util-common';
 
 import Dirs from './Dirs';
@@ -19,7 +20,9 @@ const log = new Logger('pid');
  */
 export default class PidFile extends Singleton {
   /**
-   * Write the PID file, and arrange for its timely erasure.
+   * Construct an instance. Logging aside, this doesn't cause any external
+   * action to take place (such as writing the PID file); that stuff happens in
+   * {@link #init}.
    */
   constructor() {
     super();
@@ -27,6 +30,17 @@ export default class PidFile extends Singleton {
     /** {string} Path for the PID file. */
     this._pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
 
+    log.info('PID:', process.pid);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Writes the PID file, and arrange for its timely erasure. This should only
+   * get called if we are reasonably sure there isn't another local server
+   * process running.
+   */
+  init() {
     // Erase the file on exit.
     process.once('exit',    this._erasePid.bind(this));
     process.once('SIGINT',  this._handleSignal.bind(this, 'SIGINT'));
@@ -35,7 +49,38 @@ export default class PidFile extends Singleton {
     // Write the PID file.
     fs.writeFileSync(this._pidPath, `${process.pid}\n`);
 
-    log.info('PID:', process.pid);
+    log.info('PID file initialized.');
+  }
+
+  /**
+   * Reads and parses the contents of the PID file, if it exists and contains
+   * a valid process ID (followed by a newline).
+   *
+   * @returns {Int|null} The process ID contained in the file if the file is
+   *   valid, or `null` if the file doesn't exist or contains invalid data.
+   */
+  readFile() {
+    try {
+      const text  = fs.readFileSync(this._pidPath, { encoding: 'utf8' });
+      const match = text.match(/^([0-9]+)\n$/);
+
+      if (match === null) {
+        return null;
+      }
+
+      // `TInt.check()` ensures it's a "safe" integer.
+      const result = TInt.check(parseInt(match));
+
+      log.info(`Server already running: PID ${result}`);
+
+      return result;
+    } catch (e) {
+      // `ENOENT` is "file not found." Anything else is logworthy.
+      if (e.code !== 'ENOENT') {
+        log.error('Trouble reading PID file.', e);
+      }
+      return null;
+    }
   }
 
   /**

--- a/local-modules/env-server/PidFile.js
+++ b/local-modules/env-server/PidFile.js
@@ -11,7 +11,7 @@ import { Singleton } from 'util-common';
 
 import Dirs from './Dirs';
 
-/** Logger. */
+/** {Logger} Logger. */
 const log = new Logger('pid');
 
 /**
@@ -20,7 +20,7 @@ const log = new Logger('pid');
  */
 export default class PidFile extends Singleton {
   /**
-   * Construct an instance. Logging aside, this doesn't cause any external
+   * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (such as writing the PID file); that stuff happens in
    * {@link #init}.
    */

--- a/local-modules/env-server/ServerEnv.js
+++ b/local-modules/env-server/ServerEnv.js
@@ -2,21 +2,126 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import is_running from 'is-running';
+import http from 'http';
+
+import { Hooks } from 'hooks-server';
+import { Logger } from 'see-all';
+import { Errors, UtilityClass } from 'util-common';
+
 import Dirs from './Dirs';
 import PidFile from './PidFile';
 import ProductInfo from './ProductInfo';
 
+/** Logger. */
+const log = new Logger('env-server');
+
 /**
  * Miscellaneous server-side utilities.
  */
-export default class ServerEnv {
+export default class ServerEnv extends UtilityClass {
   /**
    * Initializes this module. This sets up the info for the `Dirs` class, sets
    * up the PID file, and gathers the product metainfo.
    */
-  static init() {
+  static async init() {
     Dirs.theOne;
-    PidFile.theOne;
+
+    const alreadyRunning = await ServerEnv.isAlreadyRunningLocally();
+    if (alreadyRunning) {
+      log.error(
+        'Another server is already running locally.\n' +
+        'Exiting so as not to trample it.');
+      throw Errors.aborted('Another server is already running.');
+    }
+
+    PidFile.theOne.init();
     ProductInfo.theOne;
+  }
+
+  /**
+   * Checks to see if a server is already running on this machine. This is
+   * called by `ServerEnv.init()` to avoid trampling on another process, and it
+   * can be called directly (before calling `ServerEnv.init()`) as needed, too.
+   * (In particular, the latter case is handy when trying to run tests in a
+   * local development environment.)
+   *
+   * @returns {boolean} `true` if a server seems to be running locally already,
+   *   or `false` if not.
+   */
+  static async isAlreadyRunningLocally() {
+    // Check the PID file. If it's non-existent or invalid, then it's reasonable
+    // to say there is no server running. And if it _does_ exist and _is_ valid,
+    // then the so-identified process needs to be running.
+
+    const pid = PidFile.theOne.readFile();
+
+    if (pid === null) {
+      return false;
+    }
+
+    if (!is_running(pid)) {
+      log.warn(`Stale PID file indicates non-existent process: ${pid}`);
+      return false;
+    }
+
+    // There is an identified process, which really does seem to be running.
+    // However, if it's not answering HTTP requests, then we'll consider it
+    // dead.
+
+    const isActive = new Promise((resolve, reject_unused) => {
+      const request = http.get(ServerEnv.loopbackUrl);
+
+      request.setTimeout(10 * 1000); // Give the server 10 seconds to respond.
+      request.end();
+
+      request.on('response', (response) => {
+        response.setTimeout(10 * 1000);
+
+        response.on('data', () => {
+          // Ignore the payload. The `http` API requires us to acknowledge the
+          // data. (There are other ways of doing so too, but this is the
+          // simplest.)
+        });
+
+        response.on('end', () => {
+          // Successful request. That means that, yes, there is indeed already
+          // a server running.
+          resolve(true);
+        });
+
+        response.on('timeout', () => {
+          request.abort();
+          resolve(false);
+        });
+      });
+
+      request.on('error', (error_unused) => {
+        resolve(false);
+      });
+
+      request.on('timeout', () => {
+        request.abort();
+        resolve(false);
+      });
+    });
+
+    const result = await isActive;
+
+    if (!result) {
+      log.warn(
+        'Another server process is running, but it does not seem to be\n' +
+        'answering HTTP requests.');
+    }
+
+    return result;
+  }
+
+  /**
+   * {string} The base URL to use for loopback requests from this machine. This
+   * is always an `http://localhost/` URL.
+   */
+  static get loopbackUrl() {
+    return `http://localhost:${Hooks.theOne.listenPort}`;
   }
 }

--- a/local-modules/env-server/ServerEnv.js
+++ b/local-modules/env-server/ServerEnv.js
@@ -13,7 +13,7 @@ import Dirs from './Dirs';
 import PidFile from './PidFile';
 import ProductInfo from './ProductInfo';
 
-/** Logger. */
+/** {Logger} Logger. */
 const log = new Logger('env-server');
 
 /**

--- a/local-modules/env-server/package.json
+++ b/local-modules/env-server/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
 
   "dependencies": {
+    "is-running": "^2.1.0",
+
     "proppy": "local",
     "see-all": "local",
     "util-common": "local"

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -27,17 +27,14 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * Called on every `Quill` instance that is constructed, just before returning
-   * it to the client.
+   * Called on every `EditorComplex` instance that is constructed, just before
+   * making it active from the user's perspective. This hook is expected to
+   * (or at least allowed to) perform initialization on the Quill instances
+   * within the complex.
    *
-   * @param {string} contextName_unused The name of the context. This is one of
-   *   `body` (for the main editor) or `title` (for the title field editor).
-   * @param {EditorComplex} editorComplex_unused The editor complex
-   *   hosting the Quill instance.
-   * @param {Quill} quill_unused The initialized instance (except for whatever
-   *   needs to be done here).
+   * @param {EditorComplex} editorComplex_unused The editor complex in question.
    */
-  quillInstanceInit(contextName_unused, editorComplex_unused, quill_unused) {
+  quillInstanceInit(editorComplex_unused) {
     // This space intentionally left blank.
   }
 

--- a/local-modules/hooks-client/Hooks.js
+++ b/local-modules/hooks-client/Hooks.js
@@ -11,6 +11,18 @@ import { Singleton } from 'util-common';
  */
 export default class Hooks extends Singleton {
   /**
+   * Called on every `EditorComplex` instance that is constructed, just before
+   * making it active from the user's perspective. This hook is expected to
+   * (or at least allowed to) perform initialization on the Quill instances
+   * within the complex.
+   *
+   * @param {EditorComplex} editorComplex_unused The editor complex in question.
+   */
+  editorComplexInit(editorComplex_unused) {
+    // This space intentionally left blank.
+  }
+
+  /**
    * Called during application startup. This is called just after the logging
    * library has been set up and before almost everything else. It is called
    * in the context of setting up an editor within a web page.
@@ -24,18 +36,6 @@ export default class Hooks extends Singleton {
   run(window_unused, baseUrl_unused) {
     // This space intentionally left (nearly) blank.
     return undefined;
-  }
-
-  /**
-   * Called on every `EditorComplex` instance that is constructed, just before
-   * making it active from the user's perspective. This hook is expected to
-   * (or at least allowed to) perform initialization on the Quill instances
-   * within the complex.
-   *
-   * @param {EditorComplex} editorComplex_unused The editor complex in question.
-   */
-  quillInstanceInit(editorComplex_unused) {
-    // This space intentionally left blank.
   }
 
   /**

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -75,10 +75,14 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {Int} The local port to listen for connections on. The default value is
-   * `8080`. In general, this often but does not necessarily match the values
-   * returned by {@link #baseUrlFromRequest}. It won't match in cases where this
-   * server runs behind a reverse proxy, for example.
+   * {Int} The local port to listen for connections on by default. This
+   * typically but does not _necessarily_ match the values returned by
+   * {@link #baseUrlFromRequest}. It won't match in cases where this server runs
+   * behind a reverse proxy, for example. It also won't match when the system
+   * is brought up in `test` mode, as that mode will pick an arbitrary port to
+   * listen on.
+   *
+   * This (default) implementation of the property always returns `8080`.
    */
   get listenPort() {
     return 8080;

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -76,9 +76,9 @@ export default class Hooks extends Singleton {
 
   /**
    * {Int} The local port to listen for connections on. The default value is
-   * `8080`. In general, this often but does not necessarily match the value
-   * in `baseUrl`. It won't match in cases where this server runs behind a
-   * reverse proxy, for example.
+   * `8080`. In general, this often but does not necessarily match the values
+   * returned by {@link #baseUrlFromRequest}. It won't match in cases where this
+   * server runs behind a reverse proxy, for example.
    */
   get listenPort() {
     return 8080;

--- a/server/index.js
+++ b/server/index.js
@@ -172,8 +172,10 @@ async function clientTest() {
       '      will issue requests to it instead of trying to build a new test bundle.');
   } else {
     // Start up a server in this process, since we determined that this machine
-    // isn't already running one. We run in dev mode so that we can point our
-    // Chrome instance at it.
+    // isn't already running one. We run in test mode so that it will pick a
+    // free port (instead of assuming the usual one is available; it likely
+    // won't be if the tests are running on a shared machine) and will make the
+    // `/debug` endpoints available.
     port = await run('test');
 
     // Wait a few seconds, so that we can be reasonably sure that the request


### PR DESCRIPTION
* Pull the `env-server`-ish stuff out of the client test runner, moving it into `env-server`. This is also a move that is well-aligned with actually testing that code (though this isn't exactly the top area of code that needs testing tbh).
* Rework the `EditorComplex` initialization hooks, based on the changing needs of that layer of the system.
* Fix the `--client-test` runner in cases where it needs to run a server itself, e.g. and notably when running on a shared testing machine. It now correctly determines when it needs to run its own server, and when it does run one it picks an arbitrary port instead of using the configured port. Before this, if a test machine happened to be running two instances of the tests at the same time, one of them would end up using the other's server.