### PR TITLE
Make file creation more cleanly separated per sub-part.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseSnapshot, RevisionNumber } from 'doc-common';
+import { TransactionSpec } from 'file-store';
 import { Delay } from 'promise-util';
 import { TFunction } from 'typecheck';
 import { Errors } from 'util-common';
@@ -61,6 +62,25 @@ export default class BaseControl extends BaseComplexMember {
    */
   constructor(fileAccess) {
     super(fileAccess);
+  }
+
+  /**
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for.
+   */
+  get initSpec() {
+    return TransactionSpec.check(this._impl_initSpec);
+  }
+
+
+  /**
+   * Performs any actions that are required in the wake of having run the
+   * {@link #initSpec} transaction.
+   */
+  async afterInit() {
+    // The only point of this arrangement is to preserve the invariant that
+    // subclasses are only expected to override `_impl_*` methods.
+    await this._impl_afterInit();
   }
 
   /**
@@ -258,13 +278,24 @@ export default class BaseControl extends BaseComplexMember {
   }
 
   /**
-   * {class} Class (constructor function) of snapshot objects to be used with
-   * instances of this class. Subclasses must fill this in.
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for. Subclasses must
+   * fill this in.
    *
    * @abstract
    */
-  static get _impl_snapshotClass() {
+  get _impl_initSpec() {
     return this._mustOverride();
+  }
+
+  /**
+   * Subclass-specific implementation of `afterInit()`. Subclasses must
+   * override this.
+   *
+   * @abstract
+   */
+  async _impl_afterInit() {
+    this._mustOverride();
   }
 
   /**
@@ -345,5 +376,13 @@ export default class BaseControl extends BaseComplexMember {
     return this._mustOverride(baseSnapshot, change, expectedSnapshot);
   }
 
-  // **TODO:** `create()`.
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class. Subclasses must fill this in.
+   *
+   * @abstract
+   */
+  static get _impl_snapshotClass() {
+    return this._mustOverride();
+  }
 }

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -42,7 +42,7 @@ export default class BodyControl extends BaseControl {
   /**
    * Creates or re-creates the document body. This will result in a body with an
    * empty change for revision `0` and a `revNum` of `0`. This method assumes
-   * that the underlying file must already exist (have been `create()d`).
+   * that the underlying file already exists (has been `create()d`).
    */
   async create() {
     this.log.info('Creating document body.');

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -40,34 +40,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Creates or re-creates the document body. This will result in a body with an
-   * empty change for revision `0` and a `revNum` of `0`. This method assumes
-   * that the underlying file already exists (has been `create()d`).
-   */
-  async create() {
-    this.log.info('Creating document body.');
-
-    const fc = this.fileCodec; // Avoids boilerplate immediately below.
-
-    const spec = new TransactionSpec(
-      // If there was any body content (e.g. and most likely data in an earlier
-      // schema, this clears it out.
-      fc.op_deletePathPrefix(Paths.BODY_PREFIX),
-
-      // Initial revision number.
-      fc.op_writePath(Paths.BODY_REVISION_NUMBER, 0),
-
-      // Empty change #0 (per documented interface).
-      fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST),
-    );
-
-    await this.file.transact(spec);
-
-    // Any cached snapshots are no longer valid.
-    this._snapshots = new Map();
-  }
-
-  /**
    * Gets a particular change to the document. The document consists of a
    * sequence of changes, each modifying revision N of the document to produce
    * revision N+1.
@@ -164,11 +136,31 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * {class} Class (constructor function) of snapshot objects to be used with
-   * instances of this class.
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for.
    */
-  static get _impl_snapshotClass() {
-    return BodySnapshot;
+  get _impl_initSpec() {
+    const fc = this.fileCodec; // Avoids boilerplate immediately below.
+
+    return new TransactionSpec(
+      // If there was any body content (e.g. and most likely data in an earlier
+      // schema, this clears it out.
+      fc.op_deletePathPrefix(Paths.BODY_PREFIX),
+
+      // Initial revision number.
+      fc.op_writePath(Paths.BODY_REVISION_NUMBER, 0),
+
+      // Empty change #0 (per documented interface).
+      fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST),
+    );
+  }
+
+  /**
+   * Subclass-specific implementation of `afterInit()`.
+   */
+  async _impl_afterInit() {
+    // Any cached snapshots are no longer valid.
+    this._snapshots = new Map();
   }
 
   /**
@@ -538,5 +530,13 @@ export default class BodyControl extends BaseControl {
     }
 
     return result;
+  }
+
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class.
+   */
+  static get _impl_snapshotClass() {
+    return BodySnapshot;
   }
 }

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -5,6 +5,7 @@
 import {
   Caret, CaretChange, CaretDelta, CaretOp, CaretSnapshot, RevisionNumber, Timestamp
 } from 'doc-common';
+import { TransactionSpec } from 'file-store';
 import { Condition } from 'promise-util';
 import { TInt, TString } from 'typecheck';
 import { Errors } from 'util-common';
@@ -12,6 +13,7 @@ import { Errors } from 'util-common';
 import BaseControl from './BaseControl';
 import CaretColor from './CaretColor';
 import CaretStorage from './CaretStorage';
+import Paths from './Paths';
 
 /**
  * {Int} How many older caret snapshots should be maintained for potential use
@@ -110,6 +112,27 @@ export default class CaretControl extends BaseControl {
     // `update()` it will always turn into an appropriate new snapshot.
     return new CaretChange(
       snapshot.revNum + 1, [CaretOp.op_beginSession(caret)], lastActive);
+  }
+
+  /**
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for.
+   */
+  get _impl_initSpec() {
+    const fc = this.fileCodec; // Avoids boilerplate immediately below.
+
+    return new TransactionSpec(
+      // Clear out old caret data, if any.
+      fc.op_deletePathPrefix(Paths.CARET_PREFIX)
+    );
+  }
+
+  /**
+   * Subclass-specific implementation of `afterInit()`.
+   */
+  async _impl_afterInit() {
+    // No action needed: The system will automatically notice that stuff got
+    // erased.
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -113,14 +113,6 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
-   * {class} Class (constructor function) of snapshot objects to be used with
-   * instances of this class.
-   */
-  static get _impl_snapshotClass() {
-    return CaretSnapshot;
-  }
-
-  /**
    * Underlying implementation of `currentRevNum()`, as required by the
    * superclass.
    *
@@ -397,5 +389,13 @@ export default class CaretControl extends BaseControl {
     }
 
     this.log.info('New caret revision number:', newRevNum);
+  }
+
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class.
+   */
+  static get _impl_snapshotClass() {
+    return CaretSnapshot;
   }
 }

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -135,6 +135,7 @@ export default class FileBootstrap extends BaseComplexMember {
 
     // **TODO:** The following should all happen in a single transaction.
 
+    await this.file.create();
     await this._schemaHandler.create();
 
     const control = this._bodyControl;

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -145,14 +145,15 @@ export default class FileBootstrap extends BaseComplexMember {
       this.fileCodec.op_deleteAll()
     );
 
-    const fullSpec = eraseSpec.concat(this._schemaHandler.initSpec);
+    const schemaSpec = this._schemaHandler.initSpec;
+    const bodySpec   = this._bodyControl.initSpec;
+    const fullSpec   = eraseSpec.concat(schemaSpec).concat(bodySpec);
 
     await this.file.create();
     await this.file.transact(fullSpec);
 
-    const control = this._bodyControl;
-    await control.create();
-    await control.update(change);
+    await this._bodyControl.afterInit();
+    await this._bodyControl.update(change);
 
     return true;
   }

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -134,8 +134,6 @@ export default class FileBootstrap extends BaseComplexMember {
     // change for revision `0`.
     const change = new BodyChange(1, firstText, Timestamp.now());
 
-    // **TODO:** The following should all happen in a single transaction.
-
     const eraseSpec = new TransactionSpec(
       // If the file already existed, this clears out the old contents.
       // **TODO:** In cases where this is a re-creation based on a migration
@@ -147,12 +145,17 @@ export default class FileBootstrap extends BaseComplexMember {
 
     const schemaSpec = this._schemaHandler.initSpec;
     const bodySpec   = this._bodyControl.initSpec;
-    const fullSpec   = eraseSpec.concat(schemaSpec).concat(bodySpec);
+    const caretSpec  = this._caretControl.initSpec;
+    const fullSpec   = eraseSpec.concat(schemaSpec).concat(bodySpec).concat(caretSpec);
 
     await this.file.create();
     await this.file.transact(fullSpec);
 
     await this._bodyControl.afterInit();
+    await this._caretControl.afterInit();
+
+    // **TODO:** Ideally, this would be rolled into the transaction as defined
+    // by `fullSpec` above.
     await this._bodyControl.update(change);
 
     return true;

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -53,7 +53,8 @@ export default class SchemaHandler extends BaseComplexMember {
 
   /**
    * Creates or re-creates the file. This will result in a file that is totally
-   * devoid of content _except_ for a schema version.
+   * devoid of content _except_ for a schema version. This method assumes that
+   * the underlying file already exists (has been `create()d`).
    */
   async create() {
     this.log.info('Creating / re-creating file.');
@@ -68,10 +69,9 @@ export default class SchemaHandler extends BaseComplexMember {
       fc.op_deleteAll(),
 
       // Version for the file schema.
-      fc.op_writePath(Paths.SCHEMA_VERSION, this.schemaVersion)
+      fc.op_writePath(Paths.SCHEMA_VERSION, this._schemaVersion)
     );
 
-    await this.file.create();
     await this.file.transact(spec);
   }
 

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -52,27 +52,14 @@ export default class SchemaHandler extends BaseComplexMember {
   }
 
   /**
-   * Creates or re-creates the file. This will result in a file that is totally
-   * devoid of content _except_ for a schema version. This method assumes that
-   * the underlying file already exists (has been `create()d`).
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for.
    */
-  async create() {
-    this.log.info('Creating / re-creating file.');
-
-    const fc   = this.fileCodec; // Avoids boilerplate immediately below.
-    const spec = new TransactionSpec(
-      // If the file already existed, this clears out the old contents.
-      // **TODO:** In cases where this is a re-creation based on a migration
-      // problem, we probably want to preserve the old data by moving it aside
-      // (e.g. into a `lossage/<timestamp>` prefix) instead of just blasting it
-      // away entirely.
-      fc.op_deleteAll(),
-
+  get initSpec() {
+    return new TransactionSpec(
       // Version for the file schema.
-      fc.op_writePath(Paths.SCHEMA_VERSION, this._schemaVersion)
+      this.fileCodec.op_writePath(Paths.SCHEMA_VERSION, this._schemaVersion)
     );
-
-    await this.file.transact(spec);
   }
 
   /**

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -23,7 +23,7 @@ export default class TransactionSpec extends CommonBase {
     super();
 
     /** {array<FileOp>} Category-sorted array of operations. */
-    this._ops = FileOp.sortByCategory(ops);
+    this._ops = Object.freeze(FileOp.sortByCategory(ops));
 
     // Validate the op combo restrictions.
 
@@ -38,6 +38,8 @@ export default class TransactionSpec extends CommonBase {
     if (this.hasWaitOps() && (this.hasPullOps() || this.hasPushOps())) {
       throw Errors.bad_use('Cannot mix wait operations with reads and modifications.');
     }
+
+    Object.freeze(this);
   }
 
   /**
@@ -59,6 +61,21 @@ export default class TransactionSpec extends CommonBase {
   get timeoutMsec() {
     const result = this.opsWithName('timeout')[0];
     return (result === undefined) ? 'never' : result.arg('durMsec');
+  }
+
+  /**
+   * Concatenates the operations of this instance with that of another instance.
+   * Returns a new instance of this class with the combined operations.
+   *
+   * @param {TransactionSpec} other Instance to concatenate with.
+   * @returns {TransactionSpec} Instance with the operations of both `this` and
+   *   `other`.
+   */
+  concat(other) {
+    TransactionSpec.check(other);
+
+    const ops = this._ops.concat(other.ops);
+    return new TransactionSpec(ops);
   }
 
   /**

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -74,8 +74,8 @@ export default class TransactionSpec extends CommonBase {
   concat(other) {
     TransactionSpec.check(other);
 
-    const ops = this._ops.concat(other.ops);
-    return new TransactionSpec(ops);
+    const ops = this._ops.concat(other._ops);
+    return new TransactionSpec(...ops);
   }
 
   /**

--- a/local-modules/file-store/tests/test_TransactionSpec.js
+++ b/local-modules/file-store/tests/test_TransactionSpec.js
@@ -1,0 +1,56 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { FileOp, TransactionSpec } from 'file-store';
+
+describe('file-store/TransactionSpec', () => {
+  describe('concat()', () => {
+    it('should concatenate a proper argument', () => {
+      function test(ops1, ops2) {
+        const t1      = new TransactionSpec(...ops1);
+        const t2      = new TransactionSpec(...ops2);
+        const result1 = t1.concat(t2);
+        const result2 = t2.concat(t1);
+        const resOps1 = [...result1.ops];
+        const resOps2 = [...result2.ops];
+
+        assert.instanceOf(result1, TransactionSpec);
+        assert.instanceOf(result2, TransactionSpec);
+
+        const expectOps = [...ops1, ...ops2];
+
+        assert.strictEqual(resOps1.length, expectOps.length);
+        assert.strictEqual(resOps2.length, expectOps.length);
+
+        assert.sameMembers(resOps1, expectOps);
+        assert.sameMembers(resOps2, expectOps);
+      }
+
+      test([], []);
+      test([FileOp.op_revNum(10)], []);
+      test([FileOp.op_revNum(10), FileOp.op_timeout(123)], []);
+      test([FileOp.op_revNum(20)], [FileOp.op_checkPathPresent('/foo')]);
+      test(
+        [FileOp.op_timeout(123456), FileOp.op_checkPathAbsent('/bar')],
+        [FileOp.op_checkPathPresent('/blort'), FileOp.op_checkPathAbsent('/florp')]
+      );
+    });
+
+    it('should reject a bad argument', () => {
+      const trans = new TransactionSpec(FileOp.op_timeout(123456));
+
+      function test(value) {
+        assert.throws(() => trans.concat(value));
+      }
+
+      test(null);
+      test(undefined);
+      test([1, 2, 3]);
+      test(new Map());
+    });
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -276,11 +276,6 @@ async function clientTest() {
  * Does a server testing run.
  */
 async function serverTest() {
-  // TODO: Arguably this call shouldn't be necessary. (That is, the test code
-  // that cares about server env stuff should arrange for its appropriate
-  // initialization and perhaps even teardown.)
-  await ServerEnv.init();
-
   const failures  = await ServerTests.runAll();
   const anyFailed = (failures !== 0);
 


### PR DESCRIPTION
This PR splits up the former / would-be `BaseControl.create()` method into two parts, a transaction spec for the initialization action and an `afterInit()` method to fix up the objects' state. With that, it became possible to perform most of the low-level file initialization as a single transaction.

I _think_ this is the last necessary rework in `doc-server` before introducing `PropertyControl`.

**Bonus:** Minor tweak to `--server-test` to make it work better in a local-dev environment.