### PR TITLE
A little more work on test running.

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -95,7 +95,7 @@ export default class Application {
     const port   = pickPort ? 0 : Hooks.theOne.listenPort;
     const server = this._server;
 
-    await promisify(cb => server.listen(port, cb))();
+    await promisify(cb => server.listen(port, value => cb(null, value)))();
 
     const resultPort = server.address().port;
 

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -1,0 +1,103 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { reporters } from 'mocha';
+
+import { CommonBase } from 'util-common';
+
+/**
+ * Mocha reporter which uses its built-in `spec` reporter to write to the
+ * console while also collecting data for eventual writing to a file.
+ */
+export default class CollectingReporter extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {mocha.Runner} runner The Mocha test driver.
+   * @param {*} options Options as originally passed to the `Mocha` constructor.
+   */
+  constructor(runner, options) {
+    super();
+
+    // Store `this` in the array which we got passed in as a "reporter option,"
+    // because Mocha has no better way to provide access to the reporter
+    // instance that it constructed. See `ServerTests` in this module for the
+    // code that consumes this value.
+    options.reporterOptions.holder[0] = this;
+
+    /** {object} Mocha's default `spec` reporter. */
+    this._specReporter = new reporters.spec(runner);
+
+    /** {array<mocha.Suite>} Current stack of active test suites. */
+    this._suites = [];
+
+    /**
+     * {array<{ test, status, suites }>} Array of collected test results, each
+     * an ad-hoc plain object.
+     */
+    this._results = [];
+
+    runner.on('suite', (suite) => {
+      this._suites.push(suite);
+    });
+
+    runner.on('suite end', () => {
+      this._suites.pop();
+    });
+
+    runner.on('pending', (test) => {
+      this._addResult(test, 'pending');
+    });
+
+    runner.on('pass', (test) => {
+      this._addResult(test, 'pass');
+    });
+
+    runner.on('fail', (test) => {
+      this._addResult(test, 'fail');
+    });
+  }
+
+  /**
+   * Gets a list of output lines representing the test results, suitable for
+   * writing to a file.
+   *
+   * @returns {array<string>} Output lines.
+   */
+  resultLines() {
+    const lines = [];
+    const stats = { fail: 0, pass: 0, pending: 0 };
+
+    for (const { test, status, suites } of this._results) {
+      const testPath = [...suites.map(s => s.title), test.title].join(' / ');
+      const speed = (test.speed === 'fast') ? '' : ', ${test.speed}ms';
+      const statusStr = `(${status}${speed})`;
+
+      lines.push(`${statusStr} ${testPath}`);
+      stats[status]++;
+    }
+
+    lines.push('');
+    lines.push('Summary:');
+    lines.push(`  Total:  ${stats.tests}`);
+    lines.push(`  Passed: ${stats.pass}`);
+    lines.push(`  Failed: ${stats.fail}`);
+    lines.push('');
+    lines.push((stats.fail === 0) ? 'All good! Yay!' : 'Alas.');
+
+    return lines;
+  }
+
+  /**
+   * Adds a single test result to the accumulated list of same.
+   *
+   * @param {mocha.Test} test The test that was run.
+   * @param {string} status Its success status.
+   */
+  _addResult(test, status) {
+    // `slice(1)` because we don't care about the anonymous top-level suite.
+    const suites = this._suites.slice(1);
+    this._results.push({ test, status, suites });
+  }
+}

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -73,7 +73,11 @@ export default class CollectingReporter extends CommonBase {
       this._addResult(test, 'fail');
     });
 
-    /** {object} Mocha's default `spec` reporter. */
+    /**
+     * {object} Mocha's default `spec` reporter. This is done _after_ this
+     * instance adds its event handlers, as otherwise the `spec` console output
+     * would get collected into `_console`.
+     */
     this._specReporter = new reporters.spec(runner);
   }
 

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -89,7 +89,7 @@ export default class CollectingReporter extends CommonBase {
    */
   resultLines() {
     const lines = [];
-    const stats = { fail: 0, pass: 0, pending: 0 };
+    const stats = { fail: 0, pass: 0, pending: 0, total: 0 };
 
     for (const { test, status, suites, log } of this._results) {
       const testPath = [...suites.map(s => s.title), test.title].join(' / ');
@@ -98,6 +98,7 @@ export default class CollectingReporter extends CommonBase {
 
       lines.push(`${statusStr} ${testPath}`);
       stats[status]++;
+      stats.total++;
 
       if (log.length !== 0) {
         for (const line of log) {
@@ -109,7 +110,7 @@ export default class CollectingReporter extends CommonBase {
 
     lines.push('');
     lines.push('Summary:');
-    lines.push(`  Total:  ${stats.tests}`);
+    lines.push(`  Total:  ${stats.total}`);
     lines.push(`  Passed: ${stats.pass}`);
     lines.push(`  Failed: ${stats.fail}`);
     lines.push('');

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -56,7 +56,7 @@ export default class ServerTests extends UtilityClass {
 
     log.info('Running server tests...');
 
-    const failures = await promisify((cb) => { mocha.run(cb); })();
+    const failures = await promisify(cb => mocha.run(f => cb(null, f)))();
 
     if (testOut !== null) {
       const output = reporterHolder[0].resultLines().join('\n');

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -4,12 +4,19 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import fs from 'fs';
 import Mocha from 'mocha';
+import { promisify } from 'util';
 
 import { Dirs } from 'env-server';
+import { Logger } from 'see-all';
 import { UtilityClass } from 'util-common';
 
+import CollectingReporter from './CollectingReporter';
 import Utils from './Utils';
+
+/** {Logger} Logger for this module. */
+const log = new Logger('testing');
 
 // One-time setup to hook `chai-as-promised` into the main `chai` module.
 chai.use(chaiAsPromised);
@@ -22,22 +29,41 @@ export default class ServerTests extends UtilityClass {
    * Builds a list of all bayou-local tests, adds them to a test runner,
    * and then executes the tests.
    *
+   * @param {string|null} testOut If non-`null`, filesystem path to write the
+   *   test output to.
    * @returns {number} Count of test failures, which resolves after testing is
    *   complete.
    */
-  static async runAll() {
+  static async runAll(testOut) {
     // TODO: Complain about modules that have no tests at all.
 
     const moduleNames = Utils.localModulesIn(Dirs.theOne.SERVER_DIR);
     const testFiles = Utils.allTestFiles(Dirs.theOne.SERVER_DIR, moduleNames);
-    const mocha = new Mocha();
+
+    // The hacky arrangement with `reporterHolder` is how we exfiltrate the
+    // reporter instance out of Mocha.
+    const reporterHolder = [];
+    const mocha = new Mocha({
+      reporter: CollectingReporter,
+      reporterOptions: { holder: reporterHolder }
+    });
+
+    log.info('Initializing server tests...');
 
     for (const f of testFiles) {
       mocha.addFile(f);
     }
 
-    return new Promise((res, rej_unused) => {
-      mocha.run((failures) => { res(failures); });
-    });
+    log.info('Running server tests...');
+
+    const failures = await promisify((cb) => { mocha.run(cb); })();
+
+    if (testOut !== null) {
+      const output = reporterHolder[0].resultLines().join('\n');
+      fs.writeFileSync(testOut, output);
+      log.info('Wrote test results to file:', testOut);
+    }
+
+    return failures;
   }
 }

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -79,30 +79,44 @@ fi
 # Helper functions
 #
 
-# Runs a test command, teeing its output and noting its status code.
+# Runs a test command, either teeing its output or passing `--test-out` to get
+# output, and always noting its exit status code.
 function run-test {
-    local outFile="${testOutDir}/$1"
+    local tee=0
+    if [[ $1 == '--tee' ]]; then
+        tee=1
+        shift
+    fi
+
+    local outPath="${testOutDir}/$1"
     shift
+
     local -a cmd=("$@")
+    local status=0
 
     echo ''
     echo "Running: ${cmd[@]}"
 
-    # This isn't just a simple matter of `cmd ... | tee ...`, because we want to
-    # get the status code from the left-hand side of the would-be pipeline.
-    # Instead, we use a "process substitution" (`>(...)`), which has mostly the
-    # same effect as a pipe except without masking the main command's status
-    # code.
-    "${cmd[@]}" > >(tee "${outFile}") 2>&1
-    local status="$?"
+    if (( $tee )); then
+        # This isn't just a simple matter of `cmd ... | tee ...`, because we
+        # want to get the status code from the left-hand side of the would-be
+        # pipeline. Instead, we use a "process substitution" (`>(...)`), which
+        # has mostly the same effect as a pipe except without masking the main
+        # command's status code.
+        "${cmd[@]}" > >(tee "${outPath}") 2>&1
+        status="$?"
 
-    # Sleep a moment to let `tee` finish writing output.
-    sleep 1
+        # Sleep a moment to let `tee` finish writing output.
+        sleep 1
+    else
+        "${cmd[@]}" --test-out="${outPath}"
+        status="$?"
+    fi
 
     (
         echo ''
         echo "Exit status: ${status}"
-    ) >> "${outFile}"
+    ) >> "${outPath}"
 
     if (( ${status} != 0 )); then
         testError=1
@@ -135,8 +149,8 @@ fi
 
 mkdir -p "${testOutDir}"
 
-run-test "client-bundle.txt" "${runProduct}" --client-bundle
-run-test "server-test.txt" "${runProduct}" --server-test
-run-test "client-test.txt" "${runProduct}" --client-test
+run-test --tee 'client-bundle.txt' "${runProduct}" --client-bundle
+run-test --tee 'server-test.txt' "${runProduct}" --server-test
+run-test 'client-test.txt' "${runProduct}" --client-test
 
 exit "${testError}"

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -150,7 +150,7 @@ fi
 mkdir -p "${testOutDir}"
 
 run-test --tee 'client-bundle.txt' "${runProduct}" --client-bundle
-run-test --tee 'server-test.txt' "${runProduct}" --server-test
+run-test 'server-test.txt' "${runProduct}" --server-test
 run-test 'client-test.txt' "${runProduct}" --client-test
 
 exit "${testError}"

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ import 'source-map-support/register';
 import 'babel-core/register';
 import 'babel-polyfill';
 
+import fs from 'fs';
 import path from 'path';
 import puppeteer from 'puppeteer';
 import minimist from 'minimist';
@@ -41,7 +42,7 @@ let argError = false;
  */
 const opts = minimist(process.argv.slice(2), {
   boolean: ['client-bundle', 'client-test', 'dev', 'help', 'server-test'],
-  string: ['prog-name'],
+  string: ['prog-name', 'test-out'],
   alias: {
     'h': 'help'
   },
@@ -66,6 +67,9 @@ const devMode = opts['dev'];
 /** {boolean} Server test mode? */
 const serverTestMode = opts['server-test'];
 
+/** {string} Path for test output. */
+let testOut = opts['test-out'];
+
 /** {boolean} Want help? */
 const showHelp = opts['help'];
 
@@ -73,6 +77,14 @@ if ((clientBundleMode + clientTestMode + devMode + serverTestMode) > 1) {
   // eslint-disable-next-line no-console
   console.log('Cannot specify multiple mode options.');
   argError = true;
+} else if (testOut) {
+  if (!(clientTestMode || serverTestMode)) {
+    // eslint-disable-next-line no-console
+    console.log('Cannot specify `--test-out` except when running in a test mode.');
+    argError = true;
+  } else {
+    testOut = path.resolve(testOut);
+  }
 }
 
 if (showHelp || argError) {
@@ -80,7 +92,9 @@ if (showHelp || argError) {
   [
     'Usage:',
     '',
-    `${progName} [--dev | --client-bundle | --server-test ]`,
+    `${progName} [--dev | --client-bundle | --client-test | --server-test ]`,
+    '  [--test-out=<path>]',
+    '',
     '  Run the project.',
     '',
     '  --client-bundle',
@@ -93,6 +107,9 @@ if (showHelp || argError) {
     '    to restart.',
     '  --server-test',
     '    Just run the server tests, and report any errors encountered.',
+    '  --test-out=<path>',
+    '    Where to write the output from a test run in addition to writing to the',
+    '    console. (If not specified, will just write to the console.)',
     '',
     `${progName} [--help | -h]`,
     '  Display this message.'
@@ -246,7 +263,8 @@ async function clientTest() {
     fail:  '(undetermined)'
   };
 
-  console.log(''); // eslint-disable-line no-console
+  const outputLines = [''];
+
   for (let i = 0; i < logLines.length; i++) {
     const line = logLines[i];
     const match = line.match(/^# (tests|pass|fail) ([0-9]+)$/);
@@ -255,19 +273,30 @@ async function clientTest() {
       stats[match[1]] = match[2];
     }
 
-    console.log('%s', line); // eslint-disable-line no-console
+    outputLines.push(line);
   }
 
   const anyFailed = (stats.fail !== '0');
 
+  outputLines.push('');
+  outputLines.push('Summary:');
+  outputLines.push(`  Total:  ${stats.tests}`);
+  outputLines.push(`  Passed: ${stats.pass}`);
+  outputLines.push(`  Failed: ${stats.fail}`);
+  outputLines.push('');
+  outputLines.push(anyFailed ? 'Alas.' : 'All good! Yay!');
+  outputLines.push('');
+
+  const allOutput = outputLines.join('\n');
+
   // eslint-disable-next-line no-console
-  console.log(
-    '\nSummary:\n' +
-    `  Total:  ${stats.tests}\n` +
-    `  Passed: ${stats.pass}\n` +
-    `  Failed: ${stats.fail}\n\n` +
-    (anyFailed ? 'Alas.' : 'All good! Yay!')
-  );
+  console.log('%s', allOutput);
+
+  if (testOut) {
+    fs.writeFileSync(testOut, allOutput);
+    // eslint-disable-next-line no-console
+    console.log('Wrote test results to file:', testOut);
+  }
 
   process.exit(anyFailed ? 1 : 0);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -305,15 +305,9 @@ async function clientTest() {
  * Does a server testing run.
  */
 async function serverTest() {
-  const failures  = await ServerTests.runAll();
-  const anyFailed = (failures !== 0);
+  const failures = await ServerTests.runAll(testOut || null);
 
-  const msg = anyFailed
-    ? `Failed: ${failures}`
-    : 'All good! Yay!';
-  console.log('\n%s', msg); // eslint-disable-line no-console
-
-  process.exit(anyFailed ? 1 : 0);
+  process.exit((failures === 0) ? 0 : 1);
 }
 
 // Initialize logging.

--- a/server/index.js
+++ b/server/index.js
@@ -115,7 +115,7 @@ if (showHelp || argError) {
  */
 async function run(mode) {
   // Set up the server environment bits (including, e.g. the PID file).
-  await ServerEnv.init();
+  await ServerEnv.theOne.init();
 
   // A little spew to identify us.
   const info = ProductInfo.theOne.INFO;
@@ -162,7 +162,7 @@ async function clientTest() {
   // Figure out if there is already a server listening on the designated
   // application port. If not, run one locally in this process.
 
-  const alreadyRunning = await ServerEnv.isAlreadyRunningLocally();
+  const alreadyRunning = await ServerEnv.theOne.isAlreadyRunningLocally();
   let port;
 
   if (alreadyRunning) {


### PR DESCRIPTION
I know we ultimately want to have nice structured test output files, and to that end, the main app now knows how to write test output files directly, instead of having the test runner script `tee` console output.

The format of what's written isn't particularly better than what we had before, but it's at least now something we can iterate on without messing with the human-friendly console output.

**Bonus:** Fix how I was calling `util.promisify()`.