### PR TITLE
Make document validation be more fully interface-driven.

### DIFF
--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -5,6 +5,7 @@
 import { CommonBase } from 'util-common';
 
 import FileAccess from './FileAccess';
+import ValidationStatus from './ValidationStatus';
 
 /**
  * Base class for things that hook up to a {@link FileComplex} and for
@@ -47,5 +48,35 @@ export default class BaseComplexMember extends CommonBase {
   /** {Logger} Logger to use with this instance. */
   get log() {
     return this._fileAccess.log;
+  }
+
+  /**
+   * Evaluates the condition of the portion of the document controlled by this
+   * instance, reporting a "validation status." This method must not be called
+   * unless the file is known to exist. Except for {@link SchemaHandler}, this
+   * method must not be called unless the schema version is known to be valid.
+   *
+   * **Note:** Some concrete instances of this class do not participate in
+   * validation. Calling this method on them will result in an error being
+   * thrown.
+   *
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   */
+  async validationStatus() {
+    const result = await this._impl_validationStatus();
+
+    return ValidationStatus.check(result);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #validationStatus}. Subclasses
+   * must override this to either perform validation or throw an error
+   * indicating that they don't participate in validation.
+   *
+   * @abstract
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   */
+  async _impl_validationStatus() {
+    return this._mustOverride();
   }
 }

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -52,9 +52,11 @@ export default class BaseComplexMember extends CommonBase {
 
   /**
    * Evaluates the condition of the portion of the document controlled by this
-   * instance, reporting a "validation status." This method must not be called
-   * unless the file is known to exist. Except for {@link SchemaHandler}, this
-   * method must not be called unless the schema version is known to be valid.
+   * instance, reporting a "validation status." Except for on
+   * {@link FileBootstrap}, this method must not be called unless the file is
+   * known to exist. Except for on {@link FileBootstrap} and
+   * {@link SchemaHandler}, this method must not be called unless the schema
+   * version is known to be valid.
    *
    * **Note:** Some concrete instances of this class do not participate in
    * validation. Calling this method on them will result in an error being

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CommonBase } from 'util-common';
+import { CommonBase, Errors } from 'util-common';
 
 import FileAccess from './FileAccess';
 import ValidationStatus from './ValidationStatus';
@@ -67,16 +67,22 @@ export default class BaseComplexMember extends CommonBase {
   async validationStatus() {
     const result = await this._impl_validationStatus();
 
-    return ValidationStatus.check(result);
+    if (result === null) {
+      throw Errors.bad_use('Not subject to validation. Should not have called.');
+    } else {
+      return ValidationStatus.check(result);
+    }
   }
 
   /**
    * Subclass-specific implementation of {@link #validationStatus}. Subclasses
-   * must override this to either perform validation or throw an error
-   * indicating that they don't participate in validation.
+   * must override this to either perform validation or return `null` to
+   * indicate that they don't participate in validation.
    *
    * @abstract
-   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   * @returns {string|null} One of the constants defined by
+   *  {@link ValidationStatus}, or `null` to indicate that this is not an
+   *  object which participates in validation.
    */
   async _impl_validationStatus() {
     return this._mustOverride();

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -57,85 +57,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Evaluates the condition of the document, reporting a "validation status,"
-   * as defined by {@link SchemaHandler}. This method must not be called unless
-   * the file is known to exist and have an appropriate schema version.
-   *
-   * @returns {string} One of the `STATUS_*` constants defined by
-   *   {@link SchemaHandler}.
-   */
-  async validationStatus() {
-    let transactionResult;
-
-    // Check the revision number.
-
-    try {
-      const fc = this.fileCodec;
-      const spec = new TransactionSpec(
-        fc.op_readPath(Paths.BODY_REVISION_NUMBER)
-      );
-      transactionResult = await fc.transact(spec);
-    } catch (e) {
-      this.log.error('Major problem trying to read file!', e);
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    const data   = transactionResult.data;
-    const revNum = data.get(Paths.BODY_REVISION_NUMBER);
-
-    if (!revNum) {
-      this.log.info('Corrupt document: Missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    try {
-      RevisionNumber.check(revNum);
-    } catch (e) {
-      this.log.info('Corrupt document: Bogus revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    // Make sure all the changes can be read and decoded.
-
-    const MAX = MAX_CHANGE_READS_PER_TRANSACTION;
-    for (let i = 0; i <= revNum; i += MAX) {
-      const lastI = Math.min(i + MAX - 1, revNum);
-      try {
-        await this._readChangeRange(i, lastI + 1);
-      } catch (e) {
-        this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
-        return ValidationStatus.STATUS_ERROR;
-      }
-    }
-
-    // Look for a few changes past the stored revision number to make sure
-    // they're empty.
-
-    try {
-      const fc  = this.fileCodec;
-      const ops = [];
-      for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(Paths.forBodyChange(i)));
-      }
-      const spec = new TransactionSpec(...ops);
-      transactionResult = await fc.transact(spec);
-    } catch (e) {
-      this.log.info('Corrupt document: Weird empty-change read failure.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    // In a valid doc, the loop body won't end up executing at all.
-    for (const storagePath of transactionResult.data.keys()) {
-      this.log.info('Corrupt document. Extra change at path:', storagePath);
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    // All's well!
-
-    return ValidationStatus.STATUS_OK;
-  }
-
-  /**
    * {TransactionSpec} Spec for a transaction which when run will initialize the
    * portion of the file which this class is responsible for.
    */
@@ -369,6 +290,82 @@ export default class BodyControl extends BaseControl {
     // exactly what we want.
     const dCorrection = rExpected.diff(rNext);
     return dCorrection;
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #validationStatus}.
+   *
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   */
+  async _impl_validationStatus() {
+    let transactionResult;
+
+    // Check the revision number.
+
+    try {
+      const fc = this.fileCodec;
+      const spec = new TransactionSpec(
+        fc.op_readPath(Paths.BODY_REVISION_NUMBER)
+      );
+      transactionResult = await fc.transact(spec);
+    } catch (e) {
+      this.log.error('Major problem trying to read file!', e);
+      return ValidationStatus.STATUS_ERROR;
+    }
+
+    const data   = transactionResult.data;
+    const revNum = data.get(Paths.BODY_REVISION_NUMBER);
+
+    if (!revNum) {
+      this.log.info('Corrupt document: Missing revision number.');
+      return ValidationStatus.STATUS_ERROR;
+    }
+
+    try {
+      RevisionNumber.check(revNum);
+    } catch (e) {
+      this.log.info('Corrupt document: Bogus revision number.');
+      return ValidationStatus.STATUS_ERROR;
+    }
+
+    // Make sure all the changes can be read and decoded.
+
+    const MAX = MAX_CHANGE_READS_PER_TRANSACTION;
+    for (let i = 0; i <= revNum; i += MAX) {
+      const lastI = Math.min(i + MAX - 1, revNum);
+      try {
+        await this._readChangeRange(i, lastI + 1);
+      } catch (e) {
+        this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
+        return ValidationStatus.STATUS_ERROR;
+      }
+    }
+
+    // Look for a few changes past the stored revision number to make sure
+    // they're empty.
+
+    try {
+      const fc  = this.fileCodec;
+      const ops = [];
+      for (let i = revNum + 1; i <= (revNum + 10); i++) {
+        ops.push(fc.op_readPath(Paths.forBodyChange(i)));
+      }
+      const spec = new TransactionSpec(...ops);
+      transactionResult = await fc.transact(spec);
+    } catch (e) {
+      this.log.info('Corrupt document: Weird empty-change read failure.');
+      return ValidationStatus.STATUS_ERROR;
+    }
+
+    // In a valid doc, the loop body won't end up executing at all.
+    for (const storagePath of transactionResult.data.keys()) {
+      this.log.info('Corrupt document. Extra change at path:', storagePath);
+      return ValidationStatus.STATUS_ERROR;
+    }
+
+    // All's well!
+
+    return ValidationStatus.STATUS_OK;
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -14,6 +14,7 @@ import BaseControl from './BaseControl';
 import CaretColor from './CaretColor';
 import CaretStorage from './CaretStorage';
 import Paths from './Paths';
+import ValidationStatus from './ValidationStatus';
 
 /**
  * {Int} How many older caret snapshots should be maintained for potential use
@@ -263,6 +264,16 @@ export default class CaretControl extends BaseControl {
     }
 
     return baseSnapshot.diff(expectedSnapshot);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #validationStatus}. In this
+   * case, it does nothing because this class blithely tolerates old data.
+   *
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   */
+  async _impl_validationStatus() {
+    return ValidationStatus.STATUS_OK;
   }
 
   /**

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -191,6 +191,17 @@ export default class CaretStorage extends BaseComplexMember {
   }
 
   /**
+   * Subclass-specific implementation of {@link #validationStatus}. In this
+   * case, it returns `null` because this class doesn't do validation. (Caret
+   * validation is handled by {@link CaretContro}.)
+   *
+   * @returns {object} `null`, always.
+   */
+  async _impl_validationStatus() {
+    return null;
+  }
+
+  /**
    * Indicates that there is local session data that needs to be written to
    * file storage. This will ultimately cause such writing to be done.
    *

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -4,6 +4,7 @@
 
 import { BodyChange, RevisionNumber, Timestamp } from 'doc-common';
 import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
 
 import FileComplex from './FileComplex';
 
@@ -16,7 +17,7 @@ import FileComplex from './FileComplex';
  * underlying `BodyControl` while implicitly adding an author argument to
  * methods that modify the document.
  */
-export default class DocSession {
+export default class DocSession extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -27,6 +28,8 @@ export default class DocSession {
    * @param {string} authorId The author this instance acts on behalf of.
    */
   constructor(fileComplex, sessionId, authorId) {
+    super();
+
     /** {FileComplex} File complex that this instance is part of. */
     this._fileComplex = FileComplex.check(fileComplex);
 

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -166,10 +166,13 @@ export default class FileBootstrap extends BaseComplexMember {
    * Helper for `init()` which determines overall status based on checks from
    * the various file components.
    *
-   * @returns {string} One of the `STATUS_*` constants defined by
-   *   {@link SchemaHandler}.
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
    */
   async _overallValidationStatus() {
+    if (!(await this.file.exists())) {
+      return ValidationStatus.STATUS_NOT_FOUND;
+    }
+
     const schemaStatus = await this._schemaHandler.validationStatus();
 
     if (schemaStatus !== ValidationStatus.STATUS_OK) {

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -116,7 +116,7 @@ export default class FileBootstrap extends BaseComplexMember {
     const members = [
       this._schemaHandler,
       this._bodyControl,
-      //this._caretControl
+      this._caretControl
     ];
 
     for (const member of members) {

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -12,6 +12,7 @@ import BaseComplexMember from './BaseComplexMember';
 import CaretControl from './CaretControl';
 import BodyControl from './BodyControl';
 import SchemaHandler from './SchemaHandler';
+import ValidationStatus from './ValidationStatus';
 
 /** {BodyDelta} Default contents when creating a new document. */
 const DEFAULT_TEXT = new BodyDelta(DEFAULT_DOCUMENT);
@@ -103,7 +104,7 @@ export default class FileBootstrap extends BaseComplexMember {
   async _init() {
     const status  = await this._overallValidationStatus();
 
-    if (status === SchemaHandler.STATUS_OK) {
+    if (status === ValidationStatus.STATUS_OK) {
       // All's well.
       return true;
     }
@@ -112,14 +113,14 @@ export default class FileBootstrap extends BaseComplexMember {
 
     let firstText;
 
-    if (status === SchemaHandler.STATUS_MIGRATE) {
+    if (status === ValidationStatus.STATUS_MIGRATE) {
       // **TODO:** Ultimately, this code path will evolve into forward
       // migration of documents found to be in older formats. For now, we just
       // fall through to the document creation logic below, which will leave
       // a note what's going on in the document contents.
       this.log.info('Needs migration. (But just noting that fact for now.)');
       firstText = MIGRATION_NOTE;
-    } else if (status === SchemaHandler.STATUS_ERROR) {
+    } else if (status === ValidationStatus.STATUS_ERROR) {
       // **TODO:** Ultimately, it should be a Really Big Deal if we find
       // ourselves here. We might want to implement some form of "hail mary"
       // attempt to recover _something_ of use from the document storage.
@@ -171,7 +172,7 @@ export default class FileBootstrap extends BaseComplexMember {
   async _overallValidationStatus() {
     const schemaStatus = await this._schemaHandler.validationStatus();
 
-    if (schemaStatus !== SchemaHandler.STATUS_OK) {
+    if (schemaStatus !== ValidationStatus.STATUS_OK) {
       return schemaStatus;
     }
 

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -8,6 +8,7 @@ import { TString } from 'typecheck';
 
 import BaseComplexMember from './BaseComplexMember';
 import Paths from './Paths';
+import ValidationStatus from './ValidationStatus';
 
 /**
  * Handler for the schema of a file. As of this writing, this class merely knows
@@ -16,26 +17,6 @@ import Paths from './Paths';
  * from older schemas.
  */
 export default class SchemaHandler extends BaseComplexMember {
-  /** {string} Return value from `validationStatus()`, see which for details. */
-  static get STATUS_ERROR() {
-    return 'status_error';
-  }
-
-  /** {string} Return value from `validationStatus()`, see which for details. */
-  static get STATUS_MIGRATE() {
-    return 'status_migrate';
-  }
-
-  /** {string} Return value from `validationStatus()`, see which for details. */
-  static get STATUS_NOT_FOUND() {
-    return 'status_not_found';
-  }
-
-  /** {string} Return value from `validationStatus()`, see which for details. */
-  static get STATUS_OK() {
-    return 'status_ok';
-  }
-
   /**
    * Constructs an instance.
    *
@@ -77,7 +58,7 @@ export default class SchemaHandler extends BaseComplexMember {
    */
   async validationStatus() {
     if (!(await this.file.exists())) {
-      return SchemaHandler.STATUS_NOT_FOUND;
+      return ValidationStatus.STATUS_NOT_FOUND;
     }
 
     let transactionResult;
@@ -90,7 +71,7 @@ export default class SchemaHandler extends BaseComplexMember {
       transactionResult = await fc.transact(spec);
     } catch (e) {
       this.log.error('Major problem trying to read file!', e);
-      return SchemaHandler.STATUS_ERROR;
+      return ValidationStatus.STATUS_ERROR;
     }
 
     const data          = transactionResult.data;
@@ -98,16 +79,16 @@ export default class SchemaHandler extends BaseComplexMember {
 
     if (!schemaVersion) {
       this.log.info('Corrupt document: Missing schema version.');
-      return SchemaHandler.STATUS_ERROR;
+      return ValidationStatus.STATUS_ERROR;
     }
 
     const expectSchemaVersion = this._schemaVersion;
     if (schemaVersion !== expectSchemaVersion) {
       const got = schemaVersion;
       this.log.info(`Mismatched schema version: got ${got}; expected ${expectSchemaVersion}`);
-      return SchemaHandler.STATUS_MIGRATE;
+      return ValidationStatus.STATUS_MIGRATE;
     }
 
-    return SchemaHandler.STATUS_OK;
+    return ValidationStatus.STATUS_OK;
   }
 }

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -44,23 +44,11 @@ export default class SchemaHandler extends BaseComplexMember {
   }
 
   /**
-   * Evaluates the condition of the document, reporting a "validation status."
-   * The return value is one of the `STATUS_*` constants defined by this class:
+   * Subclass-specific implementation of {@link #validationStatus}.
    *
-   * * `STATUS_OK` &mdash; No problems.
-   * * `STATUS_MIGRATE` &mdash; Document is in a format that is not understood.
-   * * `STATUS_NOT_FOUND` &mdash; The document doesn't exist.
-   * * `STATUS_ERROR` &mdash; Document is in an unrecoverably-bad state.
-   *
-   * This method will also emit information to the log about problems.
-   *
-   * @returns {string} The validation status.
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
    */
-  async validationStatus() {
-    if (!(await this.file.exists())) {
-      return ValidationStatus.STATUS_NOT_FOUND;
-    }
-
+  async _impl_validationStatus() {
     let transactionResult;
 
     try {

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -57,24 +57,16 @@ export default class ValidationStatus extends UtilityClass {
    * an error if not.
    *
    * @param {*} value (Alleged) validation status.
-   * @param {boolean} [allowNotFound = false] Whether to allow
-   *   {@link #STATUS_NOT_FOUND} as a value. It defaults to `false`, because
-   *   that value is only allowed in limited circumstances.
    * @returns {string} `value` if it is indeed valid.
    */
-  static check(value, allowNotFound = false) {
+  static check(value) {
     switch (value) {
       case ValidationStatus.STATUS_ERROR:
       case ValidationStatus.STATUS_MIGRATE:
+      case ValidationStatus.STATUS_NOT_FOUND:
       case ValidationStatus.STATUS_OK:
       case ValidationStatus.STATUS_RECOVER: {
         return value;
-      }
-      case ValidationStatus.STATUS_NOT_FOUND: {
-        if (allowNotFound) {
-          return value;
-        }
-        throw Errors.bad_value(value, ValidationStatus, 'value !== STATUS_NOT_FOUND');
       }
     }
 

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -5,46 +5,49 @@
 import { Errors, UtilityClass } from 'util-common';
 
 /**
- * Type representation of "validation status" values as defined by
- * {@link BaseComplexMember#validationStatus}. The values themselves are always
- * just strings. This is just where the constants and type checker code live.
+ * Type representation of "validation status" values as used by
+ * {@link BaseComplexMember#validationStatus} and
+ * {@link FileBootstrap#_overallValidationStatus}. The values themselves are
+ * just string constants. This class is merely where the constants and type
+ * checker code live.
  */
 export default class ValidationStatus extends UtilityClass {
   /**
-   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
-   * which for details.
+   * {string} Validation status value, which indicates an unrecoverable error in
+   * interpreting the document (or document portion) data.
    */
   static get STATUS_ERROR() {
     return 'status_error';
   }
 
   /**
-   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
-   * which for details.
+   * {string} Validation status value, which indicates that the document (or
+   * document portion) is in a format that isn't directly understood, presumably
+   * an older format that needs forward migration.
    */
   static get STATUS_MIGRATE() {
     return 'status_migrate';
   }
 
   /**
-   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
-   * which for details.
+   * {string} Validation status value, which indicates that the file does not
+   * exist.
    */
   static get STATUS_NOT_FOUND() {
     return 'status_not_found';
   }
 
   /**
-   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
-   * which for details.
+   * {string} Validation status value, which indicates that the document (or
+   * document portion) checks out as valid.
    */
   static get STATUS_OK() {
     return 'status_ok';
   }
 
   /**
-   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
-   * which for details.
+   * {string} Validation status value, which indicates that the document (or
+   * document portion) has some errors but _might_ be recoverable.
    */
   static get STATUS_RECOVER() {
     return 'status_recover';
@@ -55,16 +58,24 @@ export default class ValidationStatus extends UtilityClass {
    * an error if not.
    *
    * @param {*} value (Alleged) validation status.
+   * @param {boolean} [allowNotFound = false] Whether to allow
+   *   {@link #STATUS_NOT_FOUND} as a value. It defaults to `false`, because
+   *   that value is only allowed in limited circumstances.
    * @returns {string} `value` if it is indeed valid.
    */
-  static check(value) {
+  static check(value, allowNotFound = false) {
     switch (value) {
       case ValidationStatus.STATUS_ERROR:
       case ValidationStatus.STATUS_MIGRATE:
-      case ValidationStatus.STATUS_NOT_FOUND:
       case ValidationStatus.STATUS_OK:
       case ValidationStatus.STATUS_RECOVER: {
         return value;
+      }
+      case ValidationStatus.STATUS_NOT_FOUND: {
+        if (allowNotFound) {
+          return value;
+        }
+        throw Errors.bad_value(value, ValidationStatus, 'value !== STATUS_NOT_FOUND');
       }
     }
 

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -1,0 +1,73 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Errors, UtilityClass } from 'util-common';
+
+/**
+ * Type representation of "validation status" values as defined by
+ * {@link BaseComplexMember#validationStatus}. The values themselves are always
+ * just strings. This is just where the constants and type checker code live.
+ */
+export default class ValidationStatus extends UtilityClass {
+  /**
+   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
+   * which for details.
+   */
+  static get STATUS_ERROR() {
+    return 'status_error';
+  }
+
+  /**
+   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
+   * which for details.
+   */
+  static get STATUS_MIGRATE() {
+    return 'status_migrate';
+  }
+
+  /**
+   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
+   * which for details.
+   */
+  static get STATUS_NOT_FOUND() {
+    return 'status_not_found';
+  }
+
+  /**
+   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
+   * which for details.
+   */
+  static get STATUS_OK() {
+    return 'status_ok';
+  }
+
+  /**
+   * {string} Return value from {@link BaseComplexMember#validationStatus}, see
+   * which for details.
+   */
+  static get STATUS_RECOVER() {
+    return 'status_recover';
+  }
+
+  /**
+   * Checks that the given value is a valid "validation status" constant. Throws
+   * an error if not.
+   *
+   * @param {*} value (Alleged) validation status.
+   * @returns {string} `value` if it is indeed valid.
+   */
+  static check(value) {
+    switch (value) {
+      case ValidationStatus.STATUS_ERROR:
+      case ValidationStatus.STATUS_MIGRATE:
+      case ValidationStatus.STATUS_NOT_FOUND:
+      case ValidationStatus.STATUS_OK:
+      case ValidationStatus.STATUS_RECOVER: {
+        return value;
+      }
+    }
+
+    throw Errors.bad_value(value, ValidationStatus);
+  }
+}

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -6,10 +6,9 @@ import { Errors, UtilityClass } from 'util-common';
 
 /**
  * Type representation of "validation status" values as used by
- * {@link BaseComplexMember#validationStatus} and
- * {@link FileBootstrap#_overallValidationStatus}. The values themselves are
- * just string constants. This class is merely where the constants and type
- * checker code live.
+ * {@link BaseComplexMember#validationStatus}. The values themselves are just
+ * string constants. This class is merely where the constants and type checker
+ * code live.
  */
 export default class ValidationStatus extends UtilityClass {
   /**

--- a/local-modules/doc-server/index.js
+++ b/local-modules/doc-server/index.js
@@ -10,6 +10,8 @@ import DocServer from './DocServer';
 import DocSession from './DocSession';
 import FileAccess from './FileAccess';
 import FileComplex from './FileComplex';
+import SchemaHandler from './SchemaHandler';
+import ValidationStatus from './ValidationStatus';
 
 export {
   BaseComplexMember,
@@ -19,5 +21,7 @@ export {
   DocServer,
   DocSession,
   FileAccess,
-  FileComplex
+  FileComplex,
+  SchemaHandler,
+  ValidationStatus
 };


### PR DESCRIPTION
[Ok, one more bit of cleanup before adding a property controller class. This time for sure!]

In this PR, the document validation code is regularized and cleaned up, leaving a nice pattern into which new controller classes can be dropped.