### PR TITLE
First cut of `PropertyControl`.

### DIFF
--- a/local-modules/api-server/Schema.js
+++ b/local-modules/api-server/Schema.js
@@ -11,6 +11,8 @@ import { PropertyIterable } from 'util-common';
  *
  * * Methods whose names start with an underscore (`_`) are excluded from
  *   schemas.
+ * * Methods whose names are symbols (e.g. `Symbol('foo')`) are excluded from
+ *   schemas.
  * * Constructor methods are excluded from schemas.
  * * Methods inherited from the base `Object` prototype are excluded from
  *   schemas.
@@ -86,9 +88,11 @@ export default class Schema {
     for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
       const name = desc.name;
 
-      if (name.match(/^_/) || (name === 'constructor')) {
-        // Because we don't want properties whose names are prefixed with `_`,
-        // and we don't want to expose the constructor function.
+      if ((typeof name !== 'string') || name.match(/^_/) || (name === 'constructor')) {
+        // Because we don't want properties whose names aren't strings (that is,
+        // are symbols), are prefixed with `_`, or are constructor functions. In
+        // all cases these are effectively private with respect to the API
+        // boundary.
         continue;
       }
 

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -174,7 +174,11 @@ export default class BaseSnapshot extends CommonBase {
   diff(newerSnapshot) {
     this.constructor.check(newerSnapshot);
 
-    const diffDelta = this._impl_diffAsDelta(newerSnapshot);
+    // Avoid bothering with a heavyweight diff operation if the deltas are
+    // equal.
+    const diffDelta = this._contents.equals(newerSnapshot._contents)
+      ? this.constructor.deltaClass.EMPTY
+      : this._impl_diffAsDelta(newerSnapshot);
 
     return new this.constructor.changeClass(newerSnapshot.revNum, diffDelta);
   }

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -228,6 +228,27 @@ describe('doc-common/BaseSnapshot', () => {
         [new MockOp('diff_delta'), new MockOp('new_snap')]);
     });
 
+    it('should return an empty change when given an argument with identical contents', () => {
+      function test(s1, s2) {
+        const result = s1.diff(s2);
+
+        assert.strictEqual(result.revNum, s2.revNum);
+        assert.lengthOf(result.delta.ops, 0);
+      }
+
+      const snap1 = new MockSnapshot(10, [new MockOp('some_op')]);
+      const snap2 = new MockSnapshot(20, [new MockOp('some_op')]);
+      const snap3 = new MockSnapshot(30, snap2.contents);
+
+      test(snap1, snap1);
+      test(snap1, snap2);
+      test(snap1, snap3);
+      test(snap2, snap1);
+      test(snap2, snap3);
+      test(snap3, snap1);
+      test(snap3, snap2);
+    });
+
     it('should reject instances of the wrong snapshot class', () => {
       const oldSnap = new MockSnapshot(10, []);
       const newSnap = new AnotherSnapshot(20, []);

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -72,7 +72,7 @@ export default class BodyControl extends BaseControl {
       fc.op_writePath(Paths.BODY_REVISION_NUMBER, 0),
 
       // Empty change #0 (per documented interface).
-      fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST),
+      fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST)
     );
   }
 

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -55,6 +55,26 @@ export default class Paths extends UtilityClass {
     return `${Paths.CARET_PREFIX}/set_update`;
   }
 
+  /**
+   * {string} `StoragePath` prefix string for property (metadata) information.
+   */
+  static get PROPERTY_PREFIX() {
+    return '/prop';
+  }
+
+  /** {string} `StoragePath` prefix string for property changes. */
+  static get PROPERTY_CHANGE_PREFIX() {
+    return `${Paths.PROPERTY_PREFIX}/change`;
+  }
+
+  /**
+   * {string} `StoragePath` string for the property data revision number. This
+   * corresponds to the highest change number.
+   */
+  static get PROPERTY_REVISION_NUMBER() {
+    return `${Paths.PROPERTY_PREFIX}/revision_number`;
+  }
+
   /** {string} `StoragePath` string for the file schema (format) version. */
   static get SCHEMA_VERSION() {
     return '/schema_version';
@@ -85,6 +105,20 @@ export default class Paths extends UtilityClass {
   static forCaret(sessionId) {
     TString.check(sessionId);
     return `${Paths.CARET_SESSION_PREFIX}/${sessionId}`;
+  }
+
+  /**
+   * Gets the `StoragePath` string corresponding to the indicated revision
+   * number, specifically to store the property data change that results in that
+   * revision.
+   *
+   * @param {RevisionNumber} revNum The revision number.
+   * @returns {string} The corresponding `StoragePath` string for property
+   *   change storage.
+   */
+  static forPropertyChange(revNum) {
+    RevisionNumber.check(revNum);
+    return `${Paths.PROPERTY_CHANGE_PREFIX}/${revNum}`;
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -1,0 +1,162 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { PropertyChange, PropertySnapshot } from 'doc-common';
+import { TransactionSpec } from 'file-store';
+import { Delay } from 'promise-util';
+
+import BaseControl from './BaseControl';
+import Paths from './Paths';
+import ValidationStatus from './ValidationStatus';
+
+/**
+ * Controller for the property metadata of a particular document.
+ *
+ * **TODO:** Store properties to the file.
+ */
+export default class PropertyControl extends BaseControl {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileAccess} fileAccess Low-level file access and related
+   *   miscellanea.
+   */
+  constructor(fileAccess) {
+    super(fileAccess);
+
+    /** {PropertySnapshot} Current snapshot. */
+    this._snapshot = PropertySnapshot.EMPTY;
+
+    Object.seal(this);
+  }
+
+  /**
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for.
+   */
+  get _impl_initSpec() {
+    const fc = this.fileCodec; // Avoids boilerplate immediately below.
+
+    return new TransactionSpec(
+      // Clear out old property data, if any.
+      fc.op_deletePathPrefix(Paths.PROPERTY_PREFIX),
+
+      // Initial revision number.
+      fc.op_writePath(Paths.PROPERTY_REVISION_NUMBER, 0),
+
+      // Empty change #0.
+      fc.op_writePath(Paths.forPropertyChange(0), PropertyChange.FIRST)
+    );
+  }
+
+  /**
+   * Subclass-specific implementation of `afterInit()`.
+   */
+  async _impl_afterInit() {
+    // No action needed... yet.
+  }
+
+  /**
+   * Underlying implementation of `currentRevNum()`, as required by the
+   * superclass.
+   *
+   * @returns {Int} The instantaneously-current revision number.
+   */
+  async _impl_currentRevNum() {
+    return this._snapshot.revNum;
+  }
+
+  /**
+   * Underlyingimplementation of `getChangeAfter()`, as required by the
+   * superclass.
+   *
+   * @param {Int} baseRevNum Revision number for the base to get a change with
+   *   respect to. Guaranteed to refer to the instantaneously-current revision
+   *   or earlier.
+   * @param {Int} currentRevNum_unused The instantaneously-current revision
+   *   number that was determined just before this method was called.
+   * @returns {PropertyChange|null} Change with respect to the revision
+   *   indicated by `baseRevNum`, or `null` to indicate that the revision was
+   *   not available as a base.
+   */
+  async _impl_getChangeAfter(baseRevNum, currentRevNum_unused) {
+    // **TODO:** Real implementation.
+
+    const oldSnapshot = this._snapshot;
+
+    if (oldSnapshot.revNum !== baseRevNum) {
+      return null;
+    }
+
+    // Just spin (with delays) waiting for a change.
+    for (;;) {
+      await Delay.resolve(2000);
+      if (oldSnapshot !== this._snapshot) {
+        break;
+      }
+      this.log('Waiting for property update...');
+    }
+
+    return oldSnapshot.diff(this._snapshot);
+  }
+
+  /**
+   * Underlying implementation of `getSnapshot()`, as required by the
+   * superclass.
+   *
+   * @param {Int} revNum Which revision to get. Guaranteed to be a revision
+   *   number for the instantaneously-current revision or earlier.
+   * @returns {PropertySnapshot|null} Snapshot of the indicated revision, or
+   *   `null` to indicate that the revision is not available.
+   */
+  async _impl_getSnapshot(revNum) {
+    // **TODO:** Real implementation.
+
+    const snapshot = this._snapshot;
+    return (revNum === snapshot.revNum) ? snapshot : null;
+  }
+
+  /**
+   * Main implementation of `update()`, as required by the superclass.
+   *
+   * @param {PropertySnapshot} baseSnapshot Snapshot of the base from which the
+   *   change is defined.
+   * @param {PropertyChange} change The change to apply, same as for `update()`.
+   * @param {PropertySnapshot} expectedSnapshot The implied expected result as
+   *   defined by `update()`.
+   * @returns {PropertyChange|null} Result for the outer call to `update()`,
+   *   or `null` if the application failed due losing a race.
+   */
+  async _impl_update(baseSnapshot, change, expectedSnapshot) {
+    // **TODO:** Real implementation.
+
+    if (this._snapshot === baseSnapshot) {
+      this._snapshot = expectedSnapshot;
+    } else {
+      // This is arguably super-wrong, but it will work well enough to bootstrap
+      // the rest of the implementation.
+      this._snapshot = this._snapshot.compose(change);
+    }
+
+    return expectedSnapshot.diff(this._snapshot);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #validationStatus}.
+   *
+   * @returns {string} One of the constants defined by {@link ValidationStatus}.
+   */
+  async _impl_validationStatus() {
+    // **TODO:** Actually validate.
+    return ValidationStatus.STATUS_OK;
+  }
+
+  /**
+   * {class} Class (constructor function) of snapshot objects to be used with
+   * instances of this class.
+   */
+  static get _impl_snapshotClass() {
+    return PropertySnapshot;
+  }
+}

--- a/local-modules/doc-server/index.js
+++ b/local-modules/doc-server/index.js
@@ -10,6 +10,7 @@ import DocServer from './DocServer';
 import DocSession from './DocSession';
 import FileAccess from './FileAccess';
 import FileComplex from './FileComplex';
+import PropertyControl from './PropertyControl';
 import SchemaHandler from './SchemaHandler';
 import ValidationStatus from './ValidationStatus';
 
@@ -22,6 +23,7 @@ export {
   DocSession,
   FileAccess,
   FileComplex,
+  PropertyControl,
   SchemaHandler,
   ValidationStatus
 };

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.30.0
+version = 0.31.0


### PR DESCRIPTION
This PR introduces the long-awaited `PropertyControl`, that is, the server code that manages document metadata. The implementation is very stubbed out (lots of `TODO`s) but should be sufficient for use by the client side, at least for the time being.

**Bonuses:**
* Properly ignore symbol-bound properties at the API boundary.
* Add a fast path for `BaseSnapshot.diff()` when passed an argument with equal contents.