### PR TITLE
Get the title field hooked up on the client.

### DIFF
--- a/local-modules/data-model-client/DocumentState.js
+++ b/local-modules/data-model-client/DocumentState.js
@@ -2,13 +2,18 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from 'typecheck';
+
 const DEFAULT_STATE = {
   /** {boolean} Whether this document is favorited or not. */
   starred: false,
 };
 
 /** {string} Action type to use for toggling the star state. */
-const TOGGLE_STAR_ACTION = 'toggle-star-action';
+const TOGGLE_STAR_ACTION = 'toggle_star_action';
+
+/** {string} Action type to use for setting the document title. */
+const SET_TITLE_ACTION = 'set_title_action';
 
 /**
  * Class wrapper for the reducer and actions related to top-level
@@ -28,6 +33,11 @@ export default class DocumentState {
           return newState;
         }
 
+        case SET_TITLE_ACTION: {
+          const newState = Object.assign({}, state, { title: action.title });
+          return newState;
+        }
+
         default: {
           return state;
         }
@@ -37,13 +47,29 @@ export default class DocumentState {
 
   /**
    * Creates a dispatch action object for toggling the state of
-   * the star in the reduce store.
+   * the star in the redux store.
    *
    * @returns {object} The dispatch action.
    */
   static toggleStarAction() {
     return {
       type: TOGGLE_STAR_ACTION
+    };
+  }
+
+  /**
+   * Creates a dispatch action object for setting the document title
+   * in the redux store.
+   *
+   * @param {string} title The new title.
+   * @returns {object} The dispatch action.
+   */
+  static setTitleAction(title) {
+    TString.nonEmpty(title);
+
+    return {
+      type: SET_TITLE_ACTION,
+      title
     };
   }
 }

--- a/local-modules/data-model-client/DocumentState.js
+++ b/local-modules/data-model-client/DocumentState.js
@@ -7,6 +7,9 @@ import { TString } from 'typecheck';
 const DEFAULT_STATE = {
   /** {boolean} Whether this document is favorited or not. */
   starred: false,
+
+  /** {string} Document title. */
+  title: 'Untitled'
 };
 
 /** {string} Action type to use for toggling the star state. */

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -82,7 +82,7 @@ export default class BodyClient extends StateMachine {
    * constructed instance expects to be the primary non-human controller of the
    * Quill instance it manages.
    *
-   * @param {QuillProm} quill Quill editor instance.
+   * @param {QuillProm} quill Quill editor instance for the body.
    * @param {DocSession} docSession Server session control / manager.
    */
   constructor(quill, docSession) {

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -36,7 +36,7 @@ const DEFAULT_BODY_MODULE_CONFIG = {
 
 /** {object} Default Quill module configuration for the title field. */
 const DEFAULT_TITLE_MODULE_CONFIG = {
-  keyboard: BayouKeyHandlers.singleLineKeyHandlers,
+  keyboard: BayouKeyHandlers.defaultSingleLineKeyHandlers,
   toolbar: [
     ['italic', 'underline', 'strike', 'code'], // Toggled buttons.
   ]

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -21,6 +21,7 @@ import BodyClient from './BodyClient';
 import CaretOverlay from './CaretOverlay';
 import CaretState from './CaretState';
 import DocSession from './DocSession';
+import TitleClient from './TitleClient';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('editor-complex');
@@ -88,6 +89,12 @@ export default class EditorComplex extends CommonBase {
      * Set in `_initSession()`.
      */
     this._bodyClient = null;
+
+    /**
+     * {TitleClient|null} Document title client instance (API-to-editor hookup).
+     * Set in `_initSession()`.
+     */
+    this._titleClient = null;
 
     /**
      * {ClientStore} Wrapper for the redux data store for this client.
@@ -184,6 +191,11 @@ export default class EditorComplex extends CommonBase {
     return log;
   }
 
+  /** {TitleClient} The document title client instance. */
+  get titleClient() {
+    return this._titleClient;
+  }
+
   /** {QuillProm} The Quill editor object for the title field. */
   get titleQuill() {
     return this._titleQuill;
@@ -254,11 +266,13 @@ export default class EditorComplex extends CommonBase {
    *   constructor.
    */
   _initSession(sessionKey, fromConstructor) {
-    this._sessionKey = SplitKey.check(sessionKey);
-    this._docSession = new DocSession(this._sessionKey);
+    this._sessionKey  = SplitKey.check(sessionKey);
+    this._docSession  = new DocSession(this._sessionKey);
     this._bodyClient  = new BodyClient(this._bodyQuill, this._docSession);
+    this._titleClient = new TitleClient(this._titleQuill, this._docSession);
 
     this._bodyClient.start();
+    this._titleClient.start();
 
     // Log a note once everything is all set up.
     (async () => {

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -10,7 +10,7 @@ import { SplitKey } from 'api-common';
 import { ClientStore } from 'data-model-client';
 import { Hooks } from 'hooks-client';
 import { Condition } from 'promise-util';
-import { BayouKeyHandlers, QuillProm, QuillUtil } from 'quill-util';
+import { BayouKeyHandlers, QuillProm } from 'quill-util';
 import { Logger } from 'see-all';
 import { TObject } from 'typecheck';
 import { Header } from 'ui-header';
@@ -176,14 +176,14 @@ export default class EditorComplex extends CommonBase {
     return this._bodyClient;
   }
 
-  /** {DocSession} The session control instance. */
-  get docSession() {
-    return this._docSession;
-  }
-
   /** {ClientStore} Pub/sub interface for client data model changes. */
   get clientStore() {
     return this._clientStore;
+  }
+
+  /** {DocSession} The session control instance. */
+  get docSession() {
+    return this._docSession;
   }
 
   /** {Logger} Logger to use when _not_ referring to the session. */
@@ -228,25 +228,14 @@ export default class EditorComplex extends CommonBase {
   /**
    * Handles "enter" key events when done on a title field.
    *
-   * @param {object} metaKeys_unused Plain object indicating which meta keys are
+   * @param {object} metaKeys Plain object indicating which meta keys are
    *   active.
-   * @returns {booolean} `false`, always, which tells Quill to stop processing.
+   * @returns {boolean} `false`, always, which tells Quill to stop processing.
    */
-  titleOnEnter(metaKeys_unused) {
-    // **TODO:** This should be a call to `getContents()` so we have a marked-up
-    // delta and not just flat text.
-    const text = this._titleQuill.getText();
-
-    // **TODO:** This is an async call, and its response (which could be an
-    // exception) needs to be handled.
-    this._docSession.propertyClient.set('title', text);
-
-    // **TODO:** The Redux store's title should get updated here too.
-
-    const div = QuillUtil.editorDiv(this._bodyQuill);
-    div.focus();
-
-    return false;
+  titleOnEnter(metaKeys) {
+    // **TODO:** It would be nice if this could be handled more directly by
+    // `TitleClient`.
+    return this._titleClient.titleOnEnter(metaKeys);
   }
 
   /**
@@ -269,7 +258,7 @@ export default class EditorComplex extends CommonBase {
     this._sessionKey  = SplitKey.check(sessionKey);
     this._docSession  = new DocSession(this._sessionKey);
     this._bodyClient  = new BodyClient(this._bodyQuill, this._docSession);
-    this._titleClient = new TitleClient(this._titleQuill, this._docSession);
+    this._titleClient = new TitleClient(this);
 
     this._bodyClient.start();
     this._titleClient.start();

--- a/local-modules/doc-client/PropertyClient.js
+++ b/local-modules/doc-client/PropertyClient.js
@@ -75,7 +75,7 @@ export default class PropertyClient extends CommonBase {
     const proxy    = await this._proxyWhenReady();
     const snapshot = await proxy.property_getSnapshot();
 
-    return snapshot.get(name);
+    return snapshot.get(name).value;
   }
 
   /**

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { DocumentState } from 'data-model-client';
 import { QuillUtil } from 'quill-util';
 import { CommonBase } from 'util-common';
 
@@ -44,7 +45,7 @@ export default class TitleClient extends CommonBase {
    * Starts handling bidirectional updates.
    */
   start() {
-    // **TODO:** Needs to be implemented.
+    // **TODO:** Needs to be implemented nontrivially.
   }
 
   /**
@@ -63,8 +64,12 @@ export default class TitleClient extends CommonBase {
     // exception) needs to be handled.
     this._docSession.propertyClient.set('title', text);
 
-    // **TODO:** The Redux store's title should get updated here too.
+    // Update the Redux store.
+    const store  = this._editorComplex.clientStore;
+    const action = DocumentState.setTitleAction(text);
+    store.dispatch(action);
 
+    // Move focus to the body.
     const div = QuillUtil.editorDiv(this._editorComplex.bodyQuill);
     div.focus();
 

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -48,9 +48,14 @@ export default class TitleClient extends CommonBase {
     // **TODO:** Needs to be implemented nontrivially. This just gets a snapshot
     // of the property at start time and never listens for updates coming from
     // the server.
-    const initialValue = await this._propertyClient.get('title');
-    this._quill.setText(initialValue);
-    this._pushUpdate();
+    try {
+      const initialValue = await this._propertyClient.get('title');
+      this._quill.setText(initialValue);
+      this._pushUpdate();
+    } catch (e) {
+      // Probably that the property wasn't found, which is no big deal.
+      this._log.warn('Trouble getting initial title value.', e);
+    }
 
     // Start noticing when the local client changes the title.
     this._pusherLoop();

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -44,8 +44,15 @@ export default class TitleClient extends CommonBase {
   /**
    * Starts handling bidirectional updates.
    */
-  start() {
-    // **TODO:** Needs to be implemented nontrivially.
+  async start() {
+    // **TODO:** Needs to be implemented nontrivially. This just gets a snapshot
+    // of the property at start time and never listens for updates coming from
+    // the server.
+    const initialValue = await this._propertyClient.get('title');
+    this._quill.setText(initialValue);
+    this._pushUpdate();
+
+    // Start noticing when the local client changes the title.
     this._pusherLoop();
   }
 

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -1,0 +1,43 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase } from 'util-common';
+
+import DocSession from './DocSession';
+
+/**
+ * Plumbing between the title field (managed by Quill) on the client and the
+ * document model (specifically a `title` property) on the server.
+ */
+export default class TitleClient extends CommonBase {
+  /**
+   * Constructs an instance. The constructed instance expects to be the primary
+   * non-human controller of the Quill instance it manages.
+   *
+   * @param {QuillProm} quill Quill editor instance for the title.
+   * @param {DocSession} docSession Server session control / manager.
+   */
+  constructor(quill, docSession) {
+    super();
+
+    /** {Quill} Editor object. */
+    this._quill = quill;
+
+    /** {DocSession} Server session control / manager. */
+    this._docSession = DocSession.check(docSession);
+
+    /** {Logger} Logger specific to this client's session. */
+    this._log = docSession.log;
+
+    /** {PropertyClient} Property data communication handler. */
+    this._propertyClient = docSession.propertyClient;
+  }
+
+  /**
+   * Starts handling bidirectional updates.
+   */
+  start() {
+    // **TODO:** Needs to be implemented.
+  }
+}

--- a/local-modules/quill-util/BayouKeyHandlers.js
+++ b/local-modules/quill-util/BayouKeyHandlers.js
@@ -17,7 +17,7 @@ import { UtilityClass } from 'util-common';
  * An example of usage might be:
  *
  * ```
- * const keyHandlers = BayouKeyHandlers.singleLineKeyHandlers;
+ * const keyHandlers = BayouKeyHandlers.defaultSingleLineKeyHandlers;
  * const quill = new QuillProm(domNode, {
  *   modules: {
  *     [ other configuration options ],
@@ -43,16 +43,29 @@ export default class BayouKeyHandlers extends UtilityClass {
   }
 
   /**
-   * Convenience function that returns the group of key handlers that will
-   * transform a Quill instance into a single-line input field.
+   * Convenience function that returns the default group of key handlers that
+   * will transform a Quill instance into a single-line input field.
    *
    * @returns {object} The key handlers.
    */
-  static get singleLineKeyHandlers() {
+  static get defaultSingleLineKeyHandlers() {
     return Object.assign(
       BayouKeyHandlers.defaultKeyHandlers,
       { onEnter: BayouKeyHandlers._singleLineOnEnter }
     );
+  }
+
+  /**
+   * Gets a key handler object configured for single-line use, with additional
+   * overridden key bindings as given.
+   *
+   * @param {object} [bindings = {}] Additional key bindings.
+   * @returns {object} The key bindings as specified.
+   */
+  static singleLineKeyHandlers(bindings = {}) {
+    return Object.assign(
+      BayouKeyHandlers.defaultSingleLineKeyHandlers,
+      bindings);
   }
 
   /**

--- a/local-modules/ui-header/components/Title.js
+++ b/local-modules/ui-header/components/Title.js
@@ -2,16 +2,44 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import styles from './title.module.less';
 
-export default class Title extends React.Component {
+class Title extends React.Component {
   render() {
     return (
       <p className={ styles.title }>
-        Untitled
+        { this.props.title }
       </p>
     );
   }
 }
+
+/**
+ * Property type validator directives. Used as redux connect
+ * maps the redux store state to this component's properties.
+ */
+Title.propTypes = {
+  title: PropTypes.string.isRequired
+};
+
+/**
+ * Function to map global document state to just the
+ * properties needed by this component.
+ *
+ * @param {object} state The redux state object to be mapped to Owner props.
+ * @returns {object} The Owner props.
+ */
+const mapStateToProps = (state) => {
+  return {
+    title: state.document.title
+  };
+};
+
+/**
+ * Constructs a wrapper class that includes the redux connect binding.
+ */
+export default connect(mapStateToProps)(Title);


### PR DESCRIPTION
[A Dan / Chris joint effort.]

This PR gets the title field on the client hooked up both to the server and to the Redux store. As with my last couple PRs, this one is full of jank and ultimately needs to get cleaned up a _lot_. Most notably, we only deal with the plain-text of the title (not any markup), and we aren't doing full bidirectional synch of data with the server (we merely fake it by asking the server for the title once during initialization and then just push changes to it after that).