### PR TITLE
Miscellaneous progress on test reporting

### DIFF
--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -5,7 +5,7 @@
 import { inspect } from 'util';
 
 import { TInt } from 'typecheck';
-import { CommonBase, Errors, Functor, InfoError } from 'util-common';
+import { CommonBase, ErrorUtil, Errors, Functor, InfoError } from 'util-common';
 
 import CodableError from './CodableError';
 
@@ -144,40 +144,6 @@ export default class Response extends CommonBase {
       return [];
     }
 
-    const stack = error.stack;
-
-    if (typeof stack !== 'string') {
-      return [];
-    }
-
-    // Match on each line of the stack that looks like a function/method call
-    // (`...at...`). Using `map()` strip each one of the unintersting parts.
-    return stack.match(/^ +at .*$/mg).map((line) => {
-      // Lines that name functions are expected to be of the form
-      // `    at func.name (/path/to/file:NN:NN)`, where `func.name` might
-      // actually be `new func.name` or `func.name [as other.name]` (or both).
-      let match = line.match(/^ +at ([^()]+) \(([^()]+)\)$/);
-      let funcName;
-      let filePath;
-
-      if (match) {
-        funcName = match[1];
-        filePath = match[2];
-      } else {
-        // Anonymous functions (including top-level code) have the form
-        // `    at /path/to/file:NN:NN`.
-        match = line.match(/^ +at ([^()]*)$/);
-        funcName = '(anon)';
-        filePath = match[1];
-      }
-
-      const fileSplit = filePath.match(/\/?[^/]+/g) || ['?'];
-      const splitLen  = fileSplit.length;
-      const fileName  = (splitLen < 2)
-        ? fileSplit[0]
-        : `...${fileSplit[splitLen - 2]}${fileSplit[splitLen - 1]}`;
-
-      return `${funcName} (${fileName})`;
-    });
+    return ErrorUtil.stackLines(error);
   }
 }

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -133,8 +133,9 @@ export default class Response extends CommonBase {
    * stack, this returns an empty array.
    *
    * @param {*} error Error value.
-   * @returns {string|null} Cleaned up error stack, `[]` if this is an error-ish
-   *   value with no stack, or `null` if `error` is `null`.
+   * @returns {array<string>|null} Cleaned up error stack as an array of stack
+   *   lines. Will be `[]` if this is an error-ish value with no stack, or
+   *   `null` if `error` is `null`.
    */
   static _fixErrorStack(error) {
     if (error === null) {

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -5,7 +5,7 @@
 import { reporters } from 'mocha';
 import { format, inspect } from 'util';
 
-import { CommonBase } from 'util-common';
+import { CommonBase, ErrorUtil } from 'util-common';
 
 /**
  * Mocha reporter which uses its built-in `spec` reporter to write to the
@@ -115,10 +115,14 @@ export default class CollectingReporter extends CommonBase {
       }
 
       if (error !== null) {
-        const errString = (error instanceof Error)
-          ? error.stack
-          : inspect(error);
-        const errLines = errString.replace(/\n{2,}/, '\n').split('\n');
+        let errLines;
+        if (error instanceof Error) {
+          const msgLines   = error.toString().split('\n');
+          const stackLines = ErrorUtil.stackLines(error).map(s => `  at ${s}`);
+          errLines = [...msgLines, ...stackLines];
+        } else {
+          errLines = inspect(error).split('\n');
+        }
 
         anyExtra = true;
         lines.push('');

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -92,9 +92,12 @@ export default class CollectingReporter extends CommonBase {
     const stats = { fail: 0, pass: 0, pending: 0, total: 0 };
 
     for (const { test, status, suites, log } of this._results) {
-      const testPath = [...suites.map(s => s.title), test.title].join(' / ');
-      const speed = (test.speed === 'fast') ? '' : `, ${test.duration}ms`;
-      const statusStr = `(${status}${speed})`;
+      const testPath =
+        `${[...suites.map(s => s.title)].join(' / ')} :: ${test.title}`
+          .replace(/\n/, ' ');
+      const speed = test.speed || 'fast';
+      const speedStr = (speed === 'fast') ? '' : `, ${speed} ${test.duration}ms`;
+      const statusStr = `(${status}${speedStr})`;
 
       lines.push(`${statusStr} ${testPath}`);
       stats[status]++;
@@ -110,9 +113,10 @@ export default class CollectingReporter extends CommonBase {
 
     lines.push('');
     lines.push('Summary:');
-    lines.push(`  Total:  ${stats.total}`);
-    lines.push(`  Passed: ${stats.pass}`);
-    lines.push(`  Failed: ${stats.fail}`);
+    lines.push(`  Total:   ${stats.total}`);
+    lines.push(`  Passed:  ${stats.pass}`);
+    lines.push(`  Failed:  ${stats.fail}`);
+    lines.push(`  Pending: ${stats.pending}`);
     lines.push('');
     lines.push((stats.fail === 0) ? 'All good! Yay!' : 'Alas.');
 

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -93,7 +93,7 @@ export default class CollectingReporter extends CommonBase {
 
     for (const { test, status, suites, log } of this._results) {
       const testPath = [...suites.map(s => s.title), test.title].join(' / ');
-      const speed = (test.speed === 'fast') ? '' : ', ${test.duration}ms';
+      const speed = (test.speed === 'fast') ? '' : `, ${test.duration}ms`;
       const statusStr = `(${status}${speed})`;
 
       lines.push(`${statusStr} ${testPath}`);

--- a/local-modules/util-common/ErrorUtil.js
+++ b/local-modules/util-common/ErrorUtil.js
@@ -1,0 +1,59 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TObject } from 'typecheck';
+import { UtilityClass } from 'util-core';
+
+/**
+ * JSON helper utilities.
+ */
+export default class JsonUtil extends UtilityClass {
+  /**
+   * Gets an array of stack lines out of an error, in a consistent format meant
+   * to be reasonable for logging.
+   *
+   * @param {Error} error Error value.
+   * @returns {array<string>} Cleaned up error stack as an array of lines, each
+   *   one corresponding to one call in the stack.
+   */
+  static stackLines(error) {
+    TObject.check(error, Error);
+
+    const stack = error.stack;
+
+    if (typeof stack !== 'string') {
+      return [];
+    }
+
+    // Match on each line of the stack that looks like a function/method call
+    // (`...at...`). Using `map()` strip each one of the unintersting parts.
+    return stack.match(/^ +at .*$/mg).map((line) => {
+      // Lines that name functions are expected to be of the form
+      // `    at func.name (/path/to/file:NN:NN)`, where `func.name` might
+      // actually be `new func.name` or `func.name [as other.name]` (or both).
+      let match = line.match(/^ +at ([^()]+) \(([^()]+)\)$/);
+      let funcName;
+      let filePath;
+
+      if (match) {
+        funcName = match[1];
+        filePath = match[2];
+      } else {
+        // Anonymous functions (including top-level code) have the form
+        // `    at /path/to/file:NN:NN`.
+        match = line.match(/^ +at ([^()]*)$/);
+        funcName = '(anon)';
+        filePath = match[1];
+      }
+
+      const fileSplit = filePath.match(/\/?[^/]+/g) || ['?'];
+      const splitLen  = fileSplit.length;
+      const fileName  = (splitLen < 2)
+        ? fileSplit[0]
+        : `...${fileSplit[splitLen - 2]}${fileSplit[splitLen - 1]}`;
+
+      return `${funcName} (${fileName})`;
+    });
+  }
+}

--- a/local-modules/util-common/index.js
+++ b/local-modules/util-common/index.js
@@ -5,6 +5,7 @@
 import ColorSelector from './ColorSelector';
 import ColorUtil from './ColorUtil';
 import DeferredLoader from './DeferredLoader';
+import ErrorUtil from './ErrorUtil';
 import FrozenBuffer from './FrozenBuffer';
 import IterableUtil from './IterableUtil';
 import JsonUtil from './JsonUtil';
@@ -18,6 +19,7 @@ export {
   ColorSelector,
   ColorUtil,
   DeferredLoader,
+  ErrorUtil,
   FrozenBuffer,
   IterableUtil,
   JsonUtil,

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -161,6 +161,11 @@ export default class InfoError extends Error {
    * meant to work cross-platform, taking into account known differences between
    * Chrome / Chromium and Safari.
    *
+   * **TODO:** This should be removed and call sites fixed to use
+   * {@link UtilError#stackLines()}, except that method would have to be fixed
+   * to be (a) accessible here (wrong module) and (b) become explicitly aware of
+   * Safari's style.
+   *
    * @param {string} orig The original `.stack` string.
    * @returns {array<string>} Array of trace items.
    */


### PR DESCRIPTION
This PR has a couple of fixes and improvements to the server-side test reporting code, specifically the part that's creating the on-disk report file.

**Bonus:** Extracted some error stack cleanup code from the API handler code. It's used by the server test reporter, and eventually will also replace similar code in `InfoError` (but that will be another day / another PR).