### PR TITLE
Get `PropertyControl` to write changes to the file.

### DIFF
--- a/local-modules/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/doc-common/tests/test_PropertyDelta.js
@@ -1,0 +1,289 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { PropertyDelta, PropertyOp } from 'doc-common';
+
+import { MockDelta } from 'doc-common/mocks';
+
+describe('doc-common/PropertyDelta', () => {
+  describe('.EMPTY', () => {
+    const EMPTY = PropertyDelta.EMPTY;
+
+    it('should be an instance of `PropertyDelta`', () => {
+      assert.instanceOf(EMPTY, PropertyDelta);
+    });
+
+    it('should be a frozen object', () => {
+      assert.isFrozen(EMPTY);
+    });
+
+    it('should have an empty `ops`', () => {
+      assert.strictEqual(EMPTY.ops.length, 0);
+    });
+
+    it('should have a frozen `ops`', () => {
+      assert.isFrozen(EMPTY.ops);
+    });
+
+    it('should be `.isEmpty()`', () => {
+      assert.isTrue(EMPTY.isEmpty());
+    });
+  });
+
+  describe('constructor()', () => {
+    describe('valid arguments', () => {
+      const values = [
+        [],
+        [PropertyOp.op_setProperty('x', 'y')],
+        [PropertyOp.op_setProperty('x', ['y'])],
+        [PropertyOp.op_setProperty('x', { y: 10 })],
+        [PropertyOp.op_deleteProperty('foo')],
+        [['set_property', 'x', 10]],
+        [['delete_property', 'foo']]
+      ];
+
+      for (const v of values) {
+        it(`should succeed for: ${inspect(v)}`, () => {
+          new PropertyDelta(v);
+        });
+      }
+    });
+
+    describe('invalid arguments', () => {
+      const values = [
+        null,
+        undefined,
+        false,
+        123,
+        'florp',
+        { insert: 'x' },
+        new Map(),
+        [null],
+        [true],
+        ['x'],
+        [1, 2, 3],
+        [['not.a.valid.identifier', 1, 2, 3]]
+      ];
+
+      for (const v of values) {
+        it(`should fail for: ${inspect(v)}`, () => {
+          assert.throws(() => new PropertyDelta(v));
+        });
+      }
+    });
+  });
+
+  describe('compose()', () => {
+    it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
+      const result = PropertyDelta.EMPTY.compose(PropertyDelta.EMPTY);
+      assert.instanceOf(result, PropertyDelta);
+      assert.deepEqual(result.ops, []);
+    });
+
+    it('should reject calls when `other` is not an instance of the class', () => {
+      const delta = PropertyDelta.EMPTY;
+
+      assert.throws(() => delta.compose('blort'));
+      assert.throws(() => delta.compose(null));
+      assert.throws(() => delta.compose(new MockDelta([])));
+    });
+
+    it('should result in no more than one op per named property, with `other` taking precedence', () => {
+      function test(ops1, ops2, expectOps) {
+        const d1     = new PropertyDelta(ops1);
+        const d2     = new PropertyDelta(ops2);
+        const result = d1.compose(d2);
+
+        assert.strictEqual(result.ops.length, expectOps.length);
+
+        const opSet = new Set();
+        for (const op of result.ops) {
+          opSet.add(op);
+        }
+        for (const op of expectOps) {
+          assert.isTrue(opSet.has(op), inspect(op));
+          opSet.delete(op);
+        }
+      }
+
+      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
+      const op2 = PropertyOp.op_setProperty('aaa', 'ccc');
+      const op3 = PropertyOp.op_setProperty('aaa', 'ddd');
+      const op4 = PropertyOp.op_setProperty('aaa', 'eee');
+      const op5 = PropertyOp.op_setProperty('bbb', 'ccc');
+      const op6 = PropertyOp.op_setProperty('bbb', 'ddd');
+      const op7 = PropertyOp.op_deleteProperty('aaa');
+
+      test([op1],      [],         [op1]);
+      test([op1, op2], [],         [op2]);
+      test([op1, op7], [],         [op7]);
+      test([op7],      [],         [op7]);
+      test([],         [op1],      [op1]);
+      test([],         [op1, op2], [op2]);
+      test([],         [op1, op7], [op7]);
+      test([],         [op7],      [op7]);
+      test([op3],      [op1],      [op1]);
+      test([op3],      [op1, op2], [op2]);
+      test([op3],      [op1, op7], [op7]);
+      test([op3],      [op7],      [op7]);
+      test([op1, op2], [op3, op4], [op4]);
+      test([op1],      [op5],      [op1, op5]);
+      test([op1, op5], [op6],      [op1, op6]);
+      test([op1, op5], [op7],      [op5, op7]);
+    });
+  });
+
+  describe('equals()', () => {
+    it('should return `true` when passed itself', () => {
+      function test(ops) {
+        const delta = new PropertyDelta(ops);
+        assert.isTrue(delta.equals(delta));
+      }
+
+      test([]);
+      test([PropertyOp.op_setProperty('aaa', 'bbb')]);
+      test([PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('ccc')]);
+    });
+
+    it('should return `true` when passed an identically-constructed value', () => {
+      function test(ops) {
+        const d1 = new PropertyDelta(ops);
+        const d2 = new PropertyDelta(ops);
+        assert.isTrue(d1.equals(d2));
+        assert.isTrue(d2.equals(d1));
+      }
+
+      test([]);
+      test([PropertyOp.op_setProperty('aaa', 'bbb')]);
+      test([PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('ccc')]);
+    });
+
+    it('should return `true` when equal ops are not also `===`', () => {
+      const ops1 = [PropertyOp.op_setProperty('aaa', 'bbb')];
+      const ops2 = [PropertyOp.op_setProperty('aaa', 'bbb')];
+      const d1 = new PropertyDelta(ops1);
+      const d2 = new PropertyDelta(ops2);
+
+      assert.isTrue(d1.equals(d2));
+      assert.isTrue(d2.equals(d1));
+    });
+
+    it('should return `false` when array lengths differ', () => {
+      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
+      const op2 = PropertyOp.op_deleteProperty('ccc');
+      const d1 = new PropertyDelta([op1]);
+      const d2 = new PropertyDelta([op1, op2]);
+
+      assert.isFalse(d1.equals(d2));
+      assert.isFalse(d2.equals(d1));
+    });
+
+    it('should return `false` when corresponding ops differ', () => {
+      function test(ops1, ops2) {
+        const d1 = new PropertyDelta(ops1);
+        const d2 = new PropertyDelta(ops2);
+
+        assert.isFalse(d1.equals(d2));
+        assert.isFalse(d2.equals(d1));
+      }
+
+      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
+      const op2 = PropertyOp.op_setProperty('aaa', 'ccc');
+      const op3 = PropertyOp.op_setProperty('bbb', 'ccc');
+      const op4 = PropertyOp.op_deleteProperty('ddd');
+      const op5 = PropertyOp.op_deleteProperty('eee');
+
+      test([op1],                     [op2]);
+      test([op1, op2],                [op1, op3]);
+      test([op1, op2],                [op3, op2]);
+      test([op1, op2, op3, op4, op5], [op5, op2, op3, op4, op5]);
+      test([op1, op2, op3, op4, op5], [op1, op5, op3, op4, op5]);
+      test([op1, op2, op3, op4, op5], [op1, op2, op5, op4, op5]);
+      test([op1, op2, op3, op4, op5], [op1, op2, op3, op5, op5]);
+      test([op1, op2, op3, op4, op5], [op1, op2, op3, op4, op1]);
+    });
+
+    it('should return `false` when passed a non-instance or an instance of a different class', () => {
+      const delta = new PropertyDelta([]);
+
+      assert.isFalse(delta.equals(undefined));
+      assert.isFalse(delta.equals(null));
+      assert.isFalse(delta.equals(false));
+      assert.isFalse(delta.equals(true));
+      assert.isFalse(delta.equals(914));
+      assert.isFalse(delta.equals(['not', 'a', 'delta']));
+      assert.isFalse(delta.equals(new Map()));
+      assert.isFalse(delta.equals(new MockDelta([])));
+    });
+  });
+
+  describe('isDocument()', () => {
+    describe('`true` cases', () => {
+      const values = [
+        [],
+        [PropertyOp.op_setProperty('aaa', 'bbb')],
+        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('ccc', 'ddd')],
+        [
+          PropertyOp.op_setProperty('aaa', 'bbb'),
+          PropertyOp.op_setProperty('ccc', 'ddd'),
+          PropertyOp.op_setProperty('eee', 'fff')
+        ]
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(new PropertyDelta(v).isDocument());
+        });
+      }
+    });
+
+    describe('`false` cases', () => {
+      const values = [
+        [PropertyOp.op_deleteProperty('xyz')],
+        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('aaa', 'ccc')]
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${inspect(v)}`, () => {
+          assert.isFalse(new PropertyDelta(v).isDocument());
+        });
+      }
+    });
+  });
+
+  describe('isEmpty()', () => {
+    describe('valid empty values', () => {
+      const values = [
+        new PropertyDelta([]),
+        PropertyDelta.EMPTY,
+      ];
+
+      for (const v of values) {
+        it(`should return \`true\` for: ${inspect(v)}`, () => {
+          assert.isTrue(v.isEmpty());
+        });
+      }
+    });
+
+    describe('valid non-empty values', () => {
+      const values = [
+        [PropertyOp.op_setProperty('aaa', 'bbb')],
+        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('ccc', 'ddd')],
+        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('aaa')],
+        [PropertyOp.op_deleteProperty('xyz')]
+      ];
+
+      for (const v of values) {
+        it(`should return \`false\` for: ${inspect(v)}`, () => {
+          const delta = new PropertyDelta(v);
+          assert.isFalse(delta.isEmpty());
+        });
+      }
+    });
+  });
+});

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -550,10 +550,6 @@ export default class BaseControl extends BaseDataManager {
    * the portion of the document controlled by this class. Subclasses must
    * override this.
    *
-   * **Note:** As of this writing, {@link CaretControl} does not operate as a
-   * normal OT class and does not use this. **TODO:** That class should be
-   * fixed to be properly OT-compliant.
-   *
    * @abstract
    */
   static get _impl_revisionNumberPath() {
@@ -574,10 +570,6 @@ export default class BaseControl extends BaseDataManager {
    * Gets the `StoragePath` string corresponding to the indicated revision
    * number, specifically for the portion of the document controlled by this
    * class. Subclasses must override this.
-   *
-   * **Note:** As of this writing, {@link CaretControl} does not operate as a
-   * normal OT class and does not use this. **TODO:** That class should be
-   * fixed to be properly OT-compliant.
    *
    * @abstract
    * @param {RevisionNumber} revNum The revision number.

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -30,6 +30,12 @@ const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /**
  * Controller for the active caret info for a given document.
+ *
+ * **TODO:** This class was written before it was clear that we'd want all the
+ * sub-parts of a file to be managed as lists of OT-friendly changes. You'll see
+ * a bunch of comments and `throw`s in the code here which stub out the parts
+ * which are defined in terms of that model, which is not _yet_ implemented in
+ * this class.
  */
 export default class CaretControl extends BaseControl {
   /**
@@ -113,6 +119,30 @@ export default class CaretControl extends BaseControl {
     // `update()` it will always turn into an appropriate new snapshot.
     return new CaretChange(
       snapshot.revNum + 1, [CaretOp.op_beginSession(caret)], lastActive);
+  }
+
+  /**
+   * Stubbed out because this class isn't yet fully OT-friendly. **TODO:** This
+   * method should be removed, allowing the superclass's implementation to run.
+   */
+  async appendChange() {
+    throw Errors.wtf('Not yet fully OT-friendly.');
+  }
+
+  /**
+   * Stubbed out because this class isn't yet fully OT-friendly. **TODO:** This
+   * method should be removed, allowing the superclass's implementation to run.
+   */
+  async getChangeRange() {
+    throw Errors.wtf('Not yet fully OT-friendly.');
+  }
+
+  /**
+   * Stubbed out because this class isn't yet fully OT-friendly. **TODO:** This
+   * method should be removed, allowing the superclass's implementation to run.
+   */
+  async getComposedChanges() {
+    throw Errors.wtf('Not yet fully OT-friendly.');
   }
 
   /**
@@ -426,10 +456,33 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
+   * {string} `StoragePath` string which stores the current revision number for
+   * the portion of the document controlled by this class.
+   */
+  static get _impl_revisionNumberPath() {
+    // **TODO:** This class doesn't behave like a nice member of OT society,
+    // yet. This should be fixed.
+    throw Errors.wtf('Not yet fully OT-friendly.');
+  }
+
+  /**
    * {class} Class (constructor function) of snapshot objects to be used with
    * instances of this class.
    */
   static get _impl_snapshotClass() {
     return CaretSnapshot;
+  }
+
+  /**
+   * Gets the `StoragePath` string corresponding to the indicated revision
+   * number, specifically for the portion of the document controlled by this
+   * class.
+   *
+   * @param {RevisionNumber} revNum_unused The revision number.
+   */
+  static _impl_pathForChange(revNum_unused) {
+    // **TODO:** This class doesn't behave like a nice member of OT society,
+    // yet. This should be fixed.
+    throw Errors.wtf('Not yet fully OT-friendly.');
   }
 }

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -24,6 +24,13 @@ describe('doc-server/BaseControl', () => {
     });
   });
 
+  describe('.deltaClass', () => {
+    it('should reflect the subclass\'s implementation', () => {
+      const result = MockControl.deltaClass;
+      assert.strictEqual(result, MockSnapshot.deltaClass);
+    });
+  });
+
   describe('.snapshotClass', () => {
     it('should reflect the subclass\'s implementation', () => {
       const result = MockControl.snapshotClass;

--- a/local-modules/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/doc-server/tests/test_BaseDataManager.js
@@ -1,0 +1,100 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Codec } from 'codec';
+import { BaseDataManager, FileAccess, ValidationStatus } from 'doc-server';
+import { TransactionSpec } from 'file-store';
+import { MockFile } from 'file-store/mocks';
+
+/** {FileAccess} Convenient instance of `FileAccess`. */
+const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+
+describe('doc-server/BaseDataManager', () => {
+  describe('.initSpec', () => {
+    it('should call through to the impl', () => {
+      const spec = new TransactionSpec();
+      class TestDataManager extends BaseDataManager {
+        get _impl_initSpec() {
+          return spec;
+        }
+      }
+
+      const dm = new TestDataManager(FILE_ACCESS);
+      assert.strictEqual(dm.initSpec, spec);
+    });
+
+    it('should reject an improper subclass choice', () => {
+      class HasBadSpec extends BaseDataManager {
+        get _impl_initSpec() {
+          return ['not a spec'];
+        }
+      }
+
+      const dm = new HasBadSpec(FILE_ACCESS);
+      assert.throws(() => dm.initSpec);
+    });
+  });
+
+  describe('afterInit()', () => {
+    it('should call through to the impl', async () => {
+      const dm = new BaseDataManager(FILE_ACCESS);
+
+      let callCount = 0;
+      dm._impl_afterInit = async () => {
+        callCount++;
+        return 'return value should be ignored';
+      };
+
+      const result = await dm.afterInit();
+      assert.strictEqual(callCount, 1);
+      assert.isUndefined(result);
+    });
+
+    it('should throw whatever error is thrown by the impl', async () => {
+      const dm = new BaseDataManager(FILE_ACCESS);
+      dm._impl_afterInit = async () => {
+        throw new Error('oy');
+      };
+
+      await assert.isRejected(dm.afterInit(), /^oy$/);
+    });
+  });
+
+  describe('validationStatus()', () => {
+    it('should call through to the impl', async () => {
+      const dm = new BaseDataManager(FILE_ACCESS);
+
+      let callCount = 0;
+      dm._impl_validationStatus = async () => {
+        callCount++;
+        return ValidationStatus.STATUS_OK;
+      };
+
+      const result = await dm.validationStatus();
+      assert.strictEqual(callCount, 1);
+      assert.strictEqual(result, ValidationStatus.STATUS_OK);
+    });
+
+    it('should throw whatever error is thrown by the impl', async () => {
+      const dm = new BaseDataManager(FILE_ACCESS);
+      dm._impl_validationStatus = async () => {
+        throw new Error('oy');
+      };
+
+      await assert.isRejected(dm.validationStatus(), /^oy$/);
+    });
+
+    it('should reject bogus impl return values', async () => {
+      const dm = new BaseDataManager(FILE_ACCESS);
+      dm._impl_validationStatus = async () => {
+        return ['not actually a validation status'];
+      };
+
+      await assert.isRejected(dm.validationStatus(), /bad_value/);
+    });
+  });
+});


### PR DESCRIPTION
The main thrust of this PR is to get `PropertyControl` actually writing changes to the file, and using those written changes (instead of just leaving stuff in memory). In order to make that change easy, I also did the following:

* Added method `PropertyDelta.compose()`, as a parallel to `BodyDelta.compose()`. We already had `PropertySnapshot.compose()`, but the meaning is _slightly_ different in that the latter always produces a document, and the former not necessarily.
* Extracted a bunch of generic OT functionality out of `BodyControl` and into `BaseControl`.
* Because it doesn't really play by the OT rules in terms of what's stored in the file, stubbed out the new methods from the last item in `CaretControl`. A future PR will rework this class to be a better OT citizen (which will simplify things a bit and enable more efficient transactions).