### PR TITLE
Miscellaneous error-related stuff

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -3,10 +3,10 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseSnapshot, RevisionNumber } from 'doc-common';
-import { TransactionSpec } from 'file-store';
+import { Errors as FileStoreErrors, TransactionSpec } from 'file-store';
 import { Delay } from 'promise-util';
 import { TFunction } from 'typecheck';
-import { Errors, InfoError } from 'util-common';
+import { Errors } from 'util-common';
 
 import BaseDataManager from './BaseDataManager';
 
@@ -127,7 +127,7 @@ export default class BaseControl extends BaseDataManager {
     try {
       await fc.transact(spec);
     } catch (e) {
-      if ((e instanceof InfoError) && (e.name === 'path_not_empty')) {
+      if (FileStoreErrors.isPathNotEmpty(e)) {
         // This happens if and when we lose an append race, which will regularly
         // occur if there are simultaneous editors.
         this.log.info('Lost append race for revision:', revNum);
@@ -270,7 +270,7 @@ export default class BaseControl extends BaseDataManager {
 
       data = transactionResult.data;
     } catch (e) {
-      if ((e instanceof InfoError) && (e.name === 'path_not_found')) {
+      if (FileStoreErrors.isPathNotFound(e)) {
         // One of the requested revisions is no longer available. If thrown, we
         // know that at least the first one requested will be missing (because
         // we won't drop a change without also dropping its predecessors). Throw

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -129,7 +129,7 @@ export default class BodyControl extends BaseControl {
       try {
         await fc.transact(spec);
       } catch (e) {
-        if (!Errors.isTimeout(e)) {
+        if (!Errors.isTimedOut(e)) {
           // It's _not_ a timeout, so we should propagate the error.
           throw e;
         }

--- a/local-modules/doc-server/CaretStorage.js
+++ b/local-modules/doc-server/CaretStorage.js
@@ -497,7 +497,7 @@ export default class CaretStorage extends BaseComplexMember {
       const transactionResult = await fc.transact(new TransactionSpec(...ops));
       paths = transactionResult.paths;
     } catch (e) {
-      if (Errors.isTimeout(e)) {
+      if (Errors.isTimedOut(e)) {
         // Per the method doc, we convert timeout into a `false` return.
         this.log.info('Timed out while waiting for caret changes.');
         return false;

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -182,7 +182,7 @@ export default class PropertyControl extends BaseControl {
     const finalContents = await this.getComposedChanges(
       expectedSnapshot.contents, baseSnapshot.revNum + 1, current.revNum + 1);
 
-    if (finalContents.equal(current.contents)) {
+    if (finalContents.equals(current.contents)) {
       // The changes after the base either overwrote or included the contents of
       // the requested change, so there is nothing to append. We merely return a
       // diff that gets from the expected result to the already-current

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -6,10 +6,10 @@ import afs from 'async-file';
 import path from 'path';
 
 import { Codec } from 'codec';
-import { BaseFile, Errors, StoragePath } from 'file-store';
+import { BaseFile, Errors as FileStoreErrors, StoragePath } from 'file-store';
 import { Condition, Delay, Mutex } from 'promise-util';
 import { Logger } from 'see-all';
-import { FrozenBuffer, Errors as UtilErrors } from 'util-common';
+import { FrozenBuffer, Errors } from 'util-common';
 
 import Transactor from './Transactor';
 
@@ -214,11 +214,11 @@ export default class LocalFile extends BaseFile {
 
     await Promise.race([this._readStorageIfNecessary(), timeoutProm]);
     if (timeout) {
-      throw UtilErrors.timed_out(timeoutMsec);
+      throw Errors.timed_out(timeoutMsec);
     }
 
     if (!this._fileShouldExist) {
-      throw Errors.file_not_found(this.id);
+      throw FileStoreErrors.file_not_found(this.id);
     }
 
     // Construct the "file friend" object. This exposes just enough private
@@ -301,7 +301,7 @@ export default class LocalFile extends BaseFile {
       this._changeCondition.value = false;
       await Promise.race([this._changeCondition.whenTrue(), timeoutProm]);
       if (timeout) {
-        throw UtilErrors.timed_out(timeoutMsec);
+        throw Errors.timed_out(timeoutMsec);
       }
     }
 
@@ -616,7 +616,7 @@ export default class LocalFile extends BaseFile {
     } else if (FrozenBuffer.isHash(storageId) || LocalFile._isInternalStorageId(storageId)) {
       baseName = storageId;
     } else {
-      throw UtilErrors.wtf('Invalid `storageId`.');
+      throw Errors.wtf('Invalid `storageId`.');
     }
 
     const fileName = `${baseName}.blob`;
@@ -660,7 +660,7 @@ export default class LocalFile extends BaseFile {
     // Trim off the directory prefix and filename suffix.
     const match = fsName.match(/([^/]+)\.[^./]*$/);
     if (match === null) {
-      throw UtilErrors.wtf('Invalid storage path.');
+      throw Errors.wtf('Invalid storage path.');
     }
     const baseName = match[1];
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Errors, StoragePath } from 'file-store';
-import { CommonBase, Errors as UtilErrors } from 'util-common';
+import { Errors as FileStoreErrors, StoragePath } from 'file-store';
+import { CommonBase, Errors } from 'util-common';
 
 /**
  * Handler for `LocalFile.transact()`. An instance of this class is constructed
@@ -101,7 +101,7 @@ export default class Transactor extends CommonBase {
 
       const handler = this[`_op_${op.name}`];
       if (!handler) {
-        throw UtilErrors.wtf(`Missing handler for op: ${op.name}`);
+        throw Errors.wtf(`Missing handler for op: ${op.name}`);
       }
 
       handler.call(this, op);
@@ -145,7 +145,7 @@ export default class Transactor extends CommonBase {
     const hash = op.arg('hash');
 
     if (this._fileFriend.readBlobOrNull(hash) !== null) {
-      throw Errors.blob_not_absent(hash);
+      throw FileStoreErrors.blob_not_absent(hash);
     }
   }
 
@@ -158,7 +158,7 @@ export default class Transactor extends CommonBase {
     const hash = op.arg('hash');
 
     if (this._fileFriend.readBlobOrNull(hash) === null) {
-      throw Errors.blob_not_found(hash);
+      throw FileStoreErrors.blob_not_found(hash);
     }
   }
 
@@ -171,7 +171,7 @@ export default class Transactor extends CommonBase {
     const storagePath = op.arg('storagePath');
 
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
-      throw Errors.path_not_absent(storagePath);
+      throw FileStoreErrors.path_not_absent(storagePath);
     }
   }
 
@@ -186,9 +186,9 @@ export default class Transactor extends CommonBase {
     const data         = this._fileFriend.readPathOrNull(storagePath);
 
     if (data === null) {
-      throw Errors.path_not_found(storagePath);
+      throw FileStoreErrors.path_not_found(storagePath);
     } else if (data.hash !== expectedHash) {
-      throw Errors.path_hash_mismatch(storagePath, expectedHash);
+      throw FileStoreErrors.path_hash_mismatch(storagePath, expectedHash);
     }
   }
 
@@ -203,7 +203,7 @@ export default class Transactor extends CommonBase {
     const data           = this._fileFriend.readPathOrNull(storagePath);
 
     if ((data !== null) && (data.hash === unexpectedHash)) {
-      throw Errors.path_hash_mismatch(storagePath, unexpectedHash);
+      throw FileStoreErrors.path_hash_mismatch(storagePath, unexpectedHash);
     }
   }
 
@@ -216,7 +216,7 @@ export default class Transactor extends CommonBase {
     const storagePath = op.arg('storagePath');
 
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
-      throw Errors.path_not_found(storagePath);
+      throw FileStoreErrors.path_not_found(storagePath);
     }
   }
 
@@ -337,7 +337,7 @@ export default class Transactor extends CommonBase {
     const revNum = op.arg('revNum');
 
     if (this._fileFriend.revNum !== revNum) {
-      throw UtilErrors.revision_not_available(revNum);
+      throw Errors.revision_not_available(revNum);
     }
   }
 
@@ -455,6 +455,6 @@ export default class Transactor extends CommonBase {
    * @param {string} name Name of the missing op.
    */
   static _missingOp(name) {
-    throw UtilErrors.wtf(`Missing op implementation: ${name}`);
+    throw Errors.wtf(`Missing op implementation: ${name}`);
   }
 }

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -86,4 +86,24 @@ export default class Errors extends UtilityClass {
     StoragePath.check(storagePath);
     return new InfoError('path_not_found', storagePath);
   }
+
+  /**
+   * Indicates whether or not the given error is a `path_not_empty`.
+   *
+   * @param {Error} error Error in question.
+   * @returns {boolean} `true` iff it represents a `path_not_empty`.
+   */
+  static isPathNotEmpty(error) {
+    return InfoError.hasName(error, 'path_not_empty');
+  }
+
+  /**
+   * Indicates whether or not the given error is a `path_not_found`.
+   *
+   * @param {Error} error Error in question.
+   * @returns {boolean} `true` iff it represents a `path_not_found`.
+   */
+  static isPathNotFound(error) {
+    return InfoError.hasName(error, 'path_not_found');
+  }
 }

--- a/local-modules/util-common/ErrorUtil.js
+++ b/local-modules/util-common/ErrorUtil.js
@@ -30,7 +30,9 @@ export default class JsonUtil extends UtilityClass {
     // with a header "line" consisting of the error name and message. ("Line" is
     // in scare quotes because it can end up containing embedded newlines.) If
     // it does, then strip it off before doing further processing.
-    const messagePrefix = `${error.name}: ${error.message}\n`;
+    const messagePrefix = (error.message === '')
+      ? `${error.name}\n`
+      : `${error.name}: ${error.message}\n`;
     if (stack.startsWith(messagePrefix)) {
       stack = stack.slice(messagePrefix.length);
     }

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -170,12 +170,12 @@ export default class Errors extends UtilityClass {
   }
 
   /**
-   * Indicates whether or not the given error is a timeout.
+   * Indicates whether or not the given error is a `timed_out`.
    *
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a timeout.
    */
-  static isTimeout(error) {
+  static isTimedOut(error) {
     return InfoError.hasName(error, 'timed_out');
   }
 

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -104,6 +104,14 @@ export default class InfoError extends Error {
   }
 
   /**
+   * {string} The name of the error. This is expected by the default `Error`
+   * implementation.
+   */
+  get name() {
+    return this.constructor.name;
+  }
+
+  /**
    * Custom inspector function, as called by `util.inspect()`. This just returns
    * implementation is similar to the default `Error` inspector, except that
    * this one formats the first line in a nicer way given the structured error
@@ -153,7 +161,7 @@ export default class InfoError extends Error {
    * @returns {string} String form of this instance.
    */
   toString() {
-    return `${this.constructor.name}:${this._info}`;
+    return `${this.constructor.name}: ${this._info}`;
   }
 
   /**


### PR DESCRIPTION
This is a hodge-podge of error-related tweaks and fixes:

* Make the timeout error predicate's name match the error name.
* Add a couple more error predicates.
* Make `util-common.Errors` "win" any `import` name collisions.
* Tweak `InfoError` to be closer to the default `Error` interface.
* Redo `ErrorUtil.stackLines()` to be a bit better-positioned to handle Safari (though it still doesn't quite get there; there's a `TODO` in the code).
* Use `ErrorUtil.stackLines()` when logging `error()` and `warn()` to the server console.

**Bonus:** Fix a method name in `PropertyControl`. (I didn't catch the error before, because the code in question is hard to intentionally activate. Yes, needs more unit test coverage.)
