### PR TITLE
A few more logger tweaks

### DIFF
--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -124,8 +124,8 @@ export default class RecentSink extends BaseSink {
       tag = '[time]';
       body = `${utcString} ${chalk.dim.bold('/')} ${localString}`;
     } else {
-      const level = (log.level === 'info') ? '' : ` ${log.level}`;
-      tag = `[${log.tag}${level}]`;
+      const levelStr = (log.level === 'info') ? '' : ` ${log.level}`;
+      tag = `[${log.tag}${levelStr}]`;
       body = log.message;
       body = body.replace(/(^\n+)|(\n+$)/g, ''); // Trim leading and trailing newlines.
     }

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -85,7 +85,20 @@ export default class RecentSink extends BaseSink {
   get htmlContents() {
     const result = [];
 
-    result.push('<table>');
+    result.push(
+      '<style>\n' +
+      'table { width: 100vw; border-collapse: collapse; border-spacing: 0; }\n' +
+      'td { padding: 1px; margin: 0; }\n' +
+      'td:firstChild { width: 20%; }\n' +
+      'td:firstChild + td { width: 80%; }\n' +
+      'pre { white-space: pre-wrap; }\n' +
+      '</style>'
+    );
+
+    result.push(
+      '<table>' +
+      '<colgroup><col style="width:20%"><col style="width:80%"></colgroup>'
+    );
 
     for (const l of this._log) {
       result.push(RecentSink._htmlLine(l));
@@ -110,7 +123,8 @@ export default class RecentSink extends BaseSink {
       tag = '[time]';
       body = `${utcString} ${chalk.dim.bold('/')} ${localString}`;
     } else {
-      tag = `[${log.tag} ${log.level}]`;
+      const level = (log.level === 'info') ? '' : ` ${log.level}`;
+      tag = `[${log.tag}${level}]`;
       body = log.message;
     }
 
@@ -124,6 +138,6 @@ export default class RecentSink extends BaseSink {
     const tagHtml = ansiHtml(tag);
     const bodyHtml = ansiHtml(body);
 
-    return `<tr><td>${tagHtml}</td><td>${bodyHtml}</td>`;
+    return `<tr><td>${tagHtml}</td><td><pre>${bodyHtml}</pre></td>`;
   }
 }

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -87,17 +87,18 @@ export default class RecentSink extends BaseSink {
 
     result.push(
       '<style>\n' +
-      'table { width: 100vw; border-collapse: collapse; border-spacing: 0; }\n' +
-      'td { padding: 1px; margin: 0; }\n' +
-      'td:firstChild { width: 20%; }\n' +
-      'td:firstChild + td { width: 80%; }\n' +
-      'pre { white-space: pre-wrap; }\n' +
+      'table { border-collapse: collapse; border-spacing: 0; ' +
+      '  width: 90vw; margin-left: 5vw; margin-right: 5vw; }\n' +
+      'td { padding-bottom: 0.1em; padding-right: 1em; }\n' +
+      'td:first-child { width: 15%; }\n' +
+      'pre { white-space: pre-wrap; margin: 0; }\n' +
       '</style>'
     );
 
     result.push(
       '<table>' +
-      '<colgroup><col style="width:20%"><col style="width:80%"></colgroup>'
+      //'<colgroup><col style="width:20%"><col style="width:80%"></colgroup>' +
+      ''
     );
 
     for (const l of this._log) {
@@ -126,6 +127,7 @@ export default class RecentSink extends BaseSink {
       const level = (log.level === 'info') ? '' : ` ${log.level}`;
       tag = `[${log.tag}${level}]`;
       body = log.message;
+      body = body.replace(/(^\n+)|(\n+$)/g, ''); // Trim leading and trailing newlines.
     }
 
     // Color the prefix according to level.

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -189,8 +189,9 @@ export default class ServerSink extends BaseSink {
    * @returns {string} The prefix, including coloring and padding.
    */
   _makePrefix(tag, level = '') {
-    let   text   = `[${tag}${level !== '' ? ' ' : ''}${level}]`;
-    const length = text.length + 1; // `+1` for the space at the end.
+    const levelStr = ((level === 'info') || (level === '')) ? '' : ` ${level}`;
+    let   text     = `[${tag}${levelStr}]`;
+    const length   = text.length + 1; // `+1` for the space at the end.
 
     // Color the prefix according to level.
     switch (level) {

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -28,22 +28,27 @@ const PREFIX_ADJUST_INCREMENT = 4;
 export default class ServerSink extends BaseSink {
   /**
    * Registers an instance of this class as a logging sink with the main
-   * `see-all` module. Also, patches `console.log()` and friends to call through
-   * to `see-all`, such that they will ultimately log to the console via this
-   * class as well as getting logged with any other sink that's hooked up (e.g.
-   * a {@link RecentSink}).
+   * `see-all` module. Also, optionally patches `console.log()` and friends to
+   * call through to `see-all`, such that they will ultimately log to the
+   * console via this class as well as getting logged with any other sink that's
+   * hooked up (e.g. a {@link RecentSink}).
+   *
+   * @param {boolean} patchConsole If `true`, patches `console.log()` and
+   *   friends.
    */
-  static init() {
+  static init(patchConsole) {
     const origConsoleLog = console.log;
     const log = (...args) => { origConsoleLog.apply(console, args); };
 
     SeeAll.theOne.add(new ServerSink(log));
 
-    const consoleLogger = new Logger('node-console');
-    console.info  = (...args) => { consoleLogger.info(format(...args));  };
-    console.warn  = (...args) => { consoleLogger.warn(format(...args));  };
-    console.error = (...args) => { consoleLogger.error(format(...args)); };
-    console.log   = console.info;
+    if (patchConsole) {
+      const consoleLogger = new Logger('node-console');
+      console.info  = (...args) => { consoleLogger.info(format(...args));  };
+      console.warn  = (...args) => { consoleLogger.warn(format(...args));  };
+      console.error = (...args) => { consoleLogger.error(format(...args)); };
+      console.log   = console.info;
+    }
   }
 
   /**

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -95,11 +95,19 @@ describe('see-all-server/RecentSink', () => {
       }
 
       const contents = sink.htmlContents;
-      const lines = contents.match(/[^\r\n]+/g);
+      const lines    = contents.match(/[^\r\n]+/g);
 
-      // One line for each log entry, plus one more each for the <table> and
-      // </table>. This is kind of a weak test but it's better than nothing.
-      assert.strictEqual(lines.length, 1 + NUM_LINES + 1);
+      // Count the lines starting with `<tr>`. This is kind of a weak test but
+      // it's better than nothing.
+
+      let count = 0;
+      for (const l of lines) {
+        if (/^<tr>/.test(l)) {
+          count++;
+        }
+      }
+
+      assert.strictEqual(count, NUM_LINES);
     });
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -310,11 +310,6 @@ async function serverTest() {
   process.exit((failures === 0) ? 0 : 1);
 }
 
-// Initialize logging.
-
-ServerSink.init();
-new FileSink(path.resolve(Dirs.theOne.LOG_DIR, 'general.log'));
-
 process.on('unhandledRejection', (reason, promise_unused) => {
   log.error('Unhandled promise rejection:', reason);
 
@@ -340,11 +335,16 @@ process.on('uncaughtException', (error) => {
 // Dispatch to the selected top-level function.
 
 if (clientBundleMode) {
+  ServerSink.init(false);
   clientBundle();
 } else if (clientTestMode) {
+  ServerSink.init(false);
   clientTest();
 } else if (serverTestMode) {
+  ServerSink.init(false);
   serverTest();
 } else {
+  ServerSink.init(true);
+  new FileSink(path.resolve(Dirs.theOne.LOG_DIR, 'general.log'));
   run(devMode ? 'dev' : 'prod');
 }


### PR DESCRIPTION
[My time was a bit scattered yesterday, and so I poked a bit more at the logging code in between my various other agenda items, and wrapped the work up this morning.]

* On the server, patch `console.log()` and friends so that they go through our logging infrastructure (which means, e.g., they show up on the `/debug/log` endpoint and will ultimately get plumbed off-machine to somewhere interesting).
* Fix up the HTML rendering of logs in `RecentSink` (which is what the aforementioned `/debug/log` uses).
* Better economize the column-width used by the console logger prefix, by not bothering with an `info` label (it's what most logs are) and by abbreviating the other labels.