### PR TITLE
Continuous server sync of the title field

### DIFF
--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -45,18 +45,6 @@ export default class TitleClient extends CommonBase {
    * Starts handling bidirectional updates.
    */
   async start() {
-    // **TODO:** Needs to be implemented nontrivially. This just gets a snapshot
-    // of the property at start time and never listens for updates coming from
-    // the server.
-    try {
-      const initialValue = await this._propertyClient.get('title');
-      this._quillContents = initialValue;
-      this._pushUpdate();
-    } catch (e) {
-      // Probably that the property wasn't found, which is no big deal.
-      this._log.warn('Trouble getting initial title value.', e);
-    }
-
     // Start noticing when the local client changes the title.
     this._syncLoop();
   }

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -50,7 +50,7 @@ export default class TitleClient extends CommonBase {
     // the server.
     try {
       const initialValue = await this._propertyClient.get('title');
-      this._quill.setText(initialValue);
+      this._quillContents = initialValue;
       this._pushUpdate();
     } catch (e) {
       // Probably that the property wasn't found, which is no big deal.
@@ -58,7 +58,7 @@ export default class TitleClient extends CommonBase {
     }
 
     // Start noticing when the local client changes the title.
-    this._pusherLoop();
+    this._syncLoop();
   }
 
   /**
@@ -87,36 +87,81 @@ export default class TitleClient extends CommonBase {
     return false;
   }
 
+  /** {string} Current Quill title field contents. */
+  get _quillContents() {
+    // **TODO:** This should be a call to `getContents()` so we have a marked-up
+    // delta and not just flat text.
+    return this._quill.getText();
+  }
+
+  /** @param {string} string New Quill title field contents. */
+  set _quillContents(string) {
+    // **TODO:** This should be a call to `setContents()` so we have a marked-up
+    // delta and not just flat text.
+    return this._quill.setText(string);
+  }
+
   /**
-   * Loop which listens for events indicating that the title Quill lost focus,
-   * using them to drive updates.
+   * Loop which synchronizes the title between Quill, the server, and the Redux
+   * store.
+   *
+   * **TODO:** This very likely wants to use {@link StateMachine}. As it stands,
+   * the interactions between the pieces are confusing and surprising, and a
+   * carefully thought-out state machine might help make things more
+   * understandable.
    */
-  async _pusherLoop() {
+  async _syncLoop() {
     let currentEvent = this._quill.currentEvent;
 
     for (;;) {
-      const event = await currentEvent.nextOf(QuillEvents.SELECTION_CHANGE);
-      const { range } = QuillEvents.propsOf(event);
+      const currentContents = this._quillContents;
 
-      if (range === null) {
-        this._pushUpdate();
+      if (this._quill.getSelection() === null) {
+        // The title field doesn't have focus, so we should wait for changes
+        // coming from the server, but also stop waiting should the selection
+        // change (meaning that the title field probably got focus). What's
+        // going on here is that we wrap each of the two possible calls in a
+        // result object that lets us trivially distinguish which one happened.
+        const got = await Promise.race([
+          (async () => {
+            const event = await currentEvent.nextOf(QuillEvents.SELECTION_CHANGE);
+            return { event };
+          })(),
+          (async () => {
+            const value =
+              await this._docSession.propertyClient.getUpdate('title', currentContents);
+            return { value };
+          })()
+        ]);
+
+        const { event, value } = got;
+        if (value !== undefined) {
+          this._quill.setText(value);
+          await this._pushUpdate();
+        } else {
+          currentEvent = event;
+        }
+      } else {
+        // The title field has focus. Wait for it to lose focus, then grab the
+        // contents and push it as an update.
+        const event     = await currentEvent.nextOf(QuillEvents.SELECTION_CHANGE);
+        const { range } = QuillEvents.propsOf(event);
+        if (range === null) {
+          await this._pushUpdate();
+        }
+        currentEvent = event;
       }
-
-      currentEvent = event;
     }
   }
 
   /**
    * Performs a push of the local title state to Redux and to the server.
    */
-  _pushUpdate() {
-    // **TODO:** This should be a call to `getContents()` so we have a marked-up
-    // delta and not just flat text.
-    const text = this._quill.getText();
+  async _pushUpdate() {
+    const text = this._quillContents;
 
-    // **TODO:** This is an async call, and its response (which could be an
-    // exception) needs to be handled.
-    this._docSession.propertyClient.set('title', text);
+    // **TODO:** Probably want to handle exceptions from this call.
+    await this._docSession.propertyClient.set('title', text);
 
     // Update the Redux store.
     const store  = this._editorComplex.clientStore;

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -125,15 +125,28 @@ export default class PropertySnapshot extends BaseSnapshot {
    * @returns {Property} Corresponding property.
    */
   get(name) {
-    TString.identifier(name);
+    const found = this.getOrNull(name);
 
-    const p = this._properties.get(name);
-
-    if (p) {
-      return p.props.property;
+    if (found) {
+      return found;
     }
 
     throw Errors.bad_use(`No such property: ${name}`);
+  }
+
+  /**
+   * Gets the property for the given name, if any.
+   *
+   * @param {string} name Property name.
+   * @returns {Property|null} Corresponding property, , or `null` if there is
+   *   none.
+   */
+  getOrNull(name) {
+    TString.identifier(name);
+
+    const found = this._properties.get(name);
+
+    return found ? found.props.property : null;
   }
 
   /**

--- a/local-modules/doc-common/Timeouts.js
+++ b/local-modules/doc-common/Timeouts.js
@@ -1,0 +1,55 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TInt } from 'typecheck';
+import { UtilityClass } from 'util-common';
+
+/**
+ * Utility class that just holds common timeout-related constants and utility
+ * functions.
+ */
+export default class Timeouts extends UtilityClass {
+  /**
+   * {Int} The maximum valid timeout, in msec. This value is picked so as to
+   * avoid "promise pileup" on code which issues requests which end up getting
+   * dropped / ignored, only to reissue new ones. (For the most part, this
+   * tactic lets us avoid worrying about canceling calls.)
+   */
+  static get MAX_TIMEOUT_MSEC() {
+    return 60 * 1000; // One minute.
+  }
+
+  /**
+   * {Int} The minimum valid timeout, in msec. This value is picked so that
+   * "eager" code won't wait too long for a timeout, while still avoiding
+   * spinning the system to death.
+   */
+  static get MIN_TIMEOUT_MSEC() {
+    return 1000; // One second.
+  }
+
+  /**
+   * Clamps a timeout value to the defined range. Also accepts `null`, which
+   * gets converted to the maximum value.
+   *
+   * @param {Int|null} timeoutMsec Client-supplied timeout value. If non-`null`,
+   *   must be a non-negative integer.
+   * @returns {Int} In-range timeout value.
+   */
+  static clamp(timeoutMsec) {
+    if (timeoutMsec === null) {
+      return Timeouts.MAX_TIMEOUT_MSEC;
+    }
+
+    TInt.nonNegative(timeoutMsec);
+
+    if (timeoutMsec < Timeouts.MIN_TIMEOUT_MSEC) {
+      return Timeouts.MIN_TIMEOUT_MSEC;
+    } else if (timeoutMsec > Timeouts.MAX_TIMEOUT_MSEC) {
+      return Timeouts.MAX_TIMEOUT_MSEC;
+    }
+
+    return timeoutMsec;
+  }
+}

--- a/local-modules/doc-common/index.js
+++ b/local-modules/doc-common/index.js
@@ -24,6 +24,7 @@ import PropertyChange from './PropertyChange';
 import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 import PropertySnapshot from './PropertySnapshot';
+import Timeouts from './Timeouts';
 import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
@@ -65,6 +66,7 @@ export {
   PropertyDelta,
   PropertyOp,
   PropertySnapshot,
+  Timeouts,
   Timestamp,
   RevisionNumber
 };

--- a/local-modules/doc-common/tests/test_Timeouts.js
+++ b/local-modules/doc-common/tests/test_Timeouts.js
@@ -1,0 +1,76 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Timeouts } from 'doc-common';
+
+describe('doc-common/Timeouts', () => {
+  describe('.MAX_TIMEOUT_MSEC', () => {
+    it('should be an integer', () => {
+      const max = Timeouts.MAX_TIMEOUT_MSEC;
+      assert.isTrue(Number.isSafeInteger(max));
+    });
+
+    it('should be greater than the minimum', () => {
+      const max = Timeouts.MAX_TIMEOUT_MSEC;
+      const min = Timeouts.MIN_TIMEOUT_MSEC;
+      assert.isTrue(max > min);
+    });
+  });
+
+  describe('.MIN_TIMEOUT_MSEC', () => {
+    it('should be a positive integer', () => {
+      const min = Timeouts.MIN_TIMEOUT_MSEC;
+      assert.isTrue(Number.isSafeInteger(min));
+      assert.isAtLeast(min, 0);
+    });
+  });
+
+  describe('clamp()', () => {
+    it('should convert `null` to the maximum', () => {
+      assert.strictEqual(Timeouts.clamp(null), Timeouts.MAX_TIMEOUT_MSEC);
+    });
+
+    it('should accept in-range integers as-is', () => {
+      const min = Timeouts.MIN_TIMEOUT_MSEC;
+      const max = Timeouts.MAX_TIMEOUT_MSEC;
+
+      for (let i = min; i < max; i += 1234) {
+        assert.strictEqual(Timeouts.clamp(i), i);
+      }
+
+      assert.strictEqual(Timeouts.clamp(max), max);
+    });
+
+    it('should clamp too-low whole numbers to the minimum', () => {
+      const min = Timeouts.MIN_TIMEOUT_MSEC;
+
+      for (let i = 0; i < min; i += 37) {
+        assert.strictEqual(Timeouts.clamp(i), min);
+      }
+    });
+
+    it('should clamp too-high integers to the maximum', () => {
+      const max = Timeouts.MAX_TIMEOUT_MSEC;
+
+      for (let i = max + 1; i < (max * 100); i += 1234567) {
+        assert.strictEqual(Timeouts.clamp(i), max);
+      }
+    });
+
+    it('should reject negative numbers', () => {
+      assert.throws(() => Timeouts.clamp(-1));
+      assert.throws(() => Timeouts.clamp(-0.01));
+      assert.throws(() => Timeouts.clamp(-123));
+    });
+
+    it('should reject non-numbers that are not `null`', () => {
+      assert.throws(() => Timeouts.clamp(undefined));
+      assert.throws(() => Timeouts.clamp(false));
+      assert.throws(() => Timeouts.clamp('123'));
+    });
+  });
+});

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -119,9 +119,11 @@ export default class BodyControl extends BaseControl {
       // Wait for the file to change (or for the storage layer to time out), and
       // then iterate to see if in fact the change updated the document revision
       // number.
+
       const fc   = this.fileCodec;
       const ops  = [fc.op_whenPathNot(Paths.BODY_REVISION_NUMBER, currentRevNum)];
       const spec = new TransactionSpec(...ops);
+
       try {
         await fc.transact(spec);
       } catch (e) {
@@ -131,7 +133,7 @@ export default class BodyControl extends BaseControl {
         }
 
         // It's a timeout, so just fall through and iterate.
-        this.log.info('Storage layer timeout in `getChangeAfter`.');
+        this.log.info('Storage layer timeout in `getChangeAfter()`.');
       }
 
       // Update what we think of as the current revision number, and iterate to

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -104,18 +104,16 @@ export default class BodyControl extends BaseControl {
    *   was determined just before this method was called, and which should be
    *   treated as the actually-current revision number at the start of this
    *   method.
-   * @returns {BodyChange} Delta and associated information. Though the
-   *   superclass allows it, this method never returns `null`.
+   * @returns {BodyChange} Change with respect to the revision indicated by
+   *   `baseRevNum`. Though the superclass allows it, this method never returns
+   *   `null`.
    */
   async _impl_getChangeAfter(baseRevNum, currentRevNum) {
     for (;;) {
       if (baseRevNum < currentRevNum) {
         // The document's revision is in fact newer than the base, so we can now
-        // form and return a result. Compose all the deltas from the revision
-        // after the base through and including the current revision.
-        const delta = await this.getComposedChanges(
-          BodyDelta.EMPTY, baseRevNum + 1, currentRevNum + 1);
-        return new BodyChange(currentRevNum, delta);
+        // stop waiting and return a result.
+        break;
       }
 
       // Wait for the file to change (or for the storage layer to time out), and
@@ -131,6 +129,7 @@ export default class BodyControl extends BaseControl {
           // It's _not_ a timeout, so we should propagate the error.
           throw e;
         }
+
         // It's a timeout, so just fall through and iterate.
         this.log.info('Storage layer timeout in `getChangeAfter`.');
       }
@@ -139,6 +138,19 @@ export default class BodyControl extends BaseControl {
       // try again.
       currentRevNum = await this.currentRevNum();
     }
+
+    // There are two possible ways to calculate the result, namely (1) compose
+    // all the changes that were made after `baseRevNum`, or (2) calculate the
+    // OT diff between `baseRevNum` and `currentRevNum`. We're doing the former
+    // here, because the usual case is one or two small deltas being made to a
+    // document of (to a first approximation) unbounded size, making the
+    // composition option clearly preferable. **TODO:** Heuristically figure out
+    // when option (2) would be more profitable.
+
+    const delta = await this.getComposedChanges(
+      BodyDelta.EMPTY, baseRevNum + 1, currentRevNum + 1);
+
+    return new BodyChange(currentRevNum, delta);
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -84,9 +84,9 @@ export default class PropertyControl extends BaseControl {
    *   or earlier.
    * @param {Int} currentRevNum The instantaneously-current revision number that
    *   was determined just before this method was called.
-   * @returns {PropertyChange|null} Change with respect to the revision
-   *   indicated by `baseRevNum`, or `null` to indicate that the revision was
-   *   not available as a base.
+   * @returns {PropertyChange} Change with respect to the revision indicated by
+   *   `baseRevNum`. Though the superclass allows it, this method never returns
+   *   `null`.
    */
   async _impl_getChangeAfter(baseRevNum, currentRevNum) {
     // Just spin (with delays) waiting for a change. **TODO:** Wait specifically
@@ -102,6 +102,13 @@ export default class PropertyControl extends BaseControl {
       await Delay.resolve(2000);
       currentRevNum = await this.currentRevNum();
     }
+
+    // There are two possible ways to calculate the result, namely (1) compose
+    // all the changes that were made after `baseRevNum`, or (2) calculate the
+    // OT diff between `baseRevNum` and `currentRevNum`. We're doing the latter
+    // here, because it's a little simpler and because (as of this writing at
+    // least) there isn't actually that much data stored as properties. (N.b.,
+    // `BodyControl` does the (1) tactic.)
 
     const oldSnapshot = await this.getSnapshot(baseRevNum);
     const newSnapshot = await this.getSnapshot(currentRevNum);

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BodyDelta } from 'doc-common';
-import { EventSource } from 'promise-util';
+import { ChainedEvent, EventSource } from 'promise-util';
 import { TString } from 'typecheck';
 import { Errors, Functor, ObjectUtil, UtilityClass } from 'util-common';
 
@@ -41,7 +41,7 @@ export default class QuillEvents extends UtilityClass {
   }
 
   /**
-   * Emits a `ChainableEvent` on the given `EventSource`, based on the payload
+   * Emits a `ChainedEvent` on the given `EventSource`, based on the payload
    * of a Quill event callback. This "fixes" the payload (via
    * {@link #fixPayload}) so that the various values adhere to the `doc-client`
    * contract.
@@ -50,7 +50,7 @@ export default class QuillEvents extends UtilityClass {
    * @param {Functor} payload Original Quill event payload, where the functor
    *   name is the name of the original event, and the functor arguments are the
    *   arguments as originally passed to the event handler callback.
-   * @returns {ChainableEvent} The emitted event.
+   * @returns {ChainedEvent} The emitted event.
    */
   static emitQuillPayload(source, payload) {
     EventSource.check(source);
@@ -93,10 +93,10 @@ export default class QuillEvents extends UtilityClass {
   }
 
   /**
-   * Gets the payload of the given event or event payload as an object with
+   * Gets the payload of the given event or event payload, as an object with
    * named properties.
    *
-   * @param {ChainableEvent|Functor} eventOrPayload Event or event payload in
+   * @param {ChainedEvent|Functor} eventOrPayload Event or event payload in
    *   question.
    * @returns {object} The properties of `event`'s payload, in convenient named
    *   form.
@@ -104,7 +104,7 @@ export default class QuillEvents extends UtilityClass {
   static propsOf(eventOrPayload) {
     const payload = (eventOrPayload instanceof Functor)
       ? eventOrPayload
-      : eventOrPayload.payload;
+      : ChainedEvent.check(eventOrPayload).payload;
     const name = payload.name;
 
     switch (name) {


### PR DESCRIPTION
This PR continues the property unstubbening, with the end result that now the client-side title field actually gets pulled from the server when the server updates it (unlike before where it would read it once on startup and then only ever push to it). The fixes spanned both client and server sides.

As before, this all is _still_ not without jank. One day at a time!