### PR TITLE
All about timeouts

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -6,7 +6,7 @@ import { BaseKey, CodableError, ConnectionError, Message, Response } from 'api-c
 import { Codec } from 'codec';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
-import { CommonBase, InfoError, WebsocketCodes } from 'util-common';
+import { CommonBase, WebsocketCodes } from 'util-common';
 
 import TargetMap from './TargetMap';
 

--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { Functor, InfoError } from 'util-common';
 
 /**
@@ -24,6 +26,27 @@ export default class CodableError extends InfoError {
    */
   constructor(info) {
     super(Functor.check(info));
+  }
+
+  /**
+   * Custom inspector function, as called by `util.inspect()`. This just returns
+   * the info portion instead of also including the stack trace, since the stack
+   * trace is meaningless on instances of this class (will typically just
+   * indicate that there is an object graph that's in the middle of being
+   * decoded).
+   *
+   * @param {Int} depth_unused Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth_unused, opts) {
+    // Set up the inspection opts so that recursive calls respect the topmost
+    // requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+    return `${this.constructor.name}: ${inspect(this.info, subOpts)}`;
   }
 
   /**

--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -4,7 +4,7 @@
 
 import { inspect } from 'util';
 
-import { Functor, InfoError } from 'util-common';
+import { InfoError } from 'util-common';
 
 /**
  * Error which can be encoded and decoded across an API boundary.
@@ -19,19 +19,25 @@ export default class CodableError extends InfoError {
   }
 
   /**
-   * Constructs an instance. Arguments are the same as for `InfoError` except
-   * that an initial "cause" argument is not allowed.
+   * Constructs an instance. Arguments are the same as for {@link InfoError}.
    *
-   * @param {Functor} info Error info.
+   * **Note:** If a `cause` argument is given, the constructed instance will
+   * convert it to an instance of this class if it isn't given as one.
+   *
+   * @param {...*} args Construction arguments.
    */
-  constructor(info) {
-    super(Functor.check(info));
+  constructor(...args) {
+    if (args[0] instanceof Error) {
+      args[0] = CodableError._fixError(args[0]);
+    }
+
+    super(...args);
   }
 
   /**
    * Custom inspector function, as called by `util.inspect()`. This just returns
    * the info portion instead of also including the stack trace, since the stack
-   * trace is meaningless on instances of this class (will typically just
+   * trace is meaningless on instances of this class (they will typically just
    * indicate that there is an object graph that's in the middle of being
    * decoded).
    *
@@ -55,6 +61,32 @@ export default class CodableError extends InfoError {
    * @returns {array} Reconstruction arguments.
    */
   toCodecArgs() {
-    return [this.info];
+    return (this.cause === null) ? [this.info] : [this.cause, this.info];
+  }
+
+  /**
+   * "Fixes" an error so that it is an instance of this class. Returns the given
+   * value if already an appropriate instance.
+   *
+   * @param {Error} error The error to fix.
+   * @returns {CodableError} The fixed instance.
+   */
+  static _fixError(error) {
+    if (error instanceof CodableError) {
+      // No conversion necessary.
+      return error;
+    }
+
+    if (error instanceof InfoError) {
+      if (error.cause === null) {
+        return new CodableError(error.info);
+      } else {
+        return new CodableError(error.cause, error.info);
+      }
+    }
+
+    // It's an `Error` outside of the control of this system. The best we can do
+    // is re-encapsulate its `name` and `message`.
+    return new CodableError('general_error', error.name, error.message);
   }
 }

--- a/local-modules/doc-client/PropertyClient.js
+++ b/local-modules/doc-client/PropertyClient.js
@@ -149,8 +149,8 @@ export default class PropertyClient extends CommonBase {
         throw Errors.timed_out(timeoutMsec);
       }
 
-      // **TODO:** Fix this to respect the timeout, once `getChangeAfter()` can
-      // time out.
+      // **TODO:** Fix this to pass an appropriate timeout value, once
+      // `getChangeAfter()` can accept it.
       await proxy.property_getChangeAfter(snapshot.revNum);
     }
   }

--- a/local-modules/doc-client/PropertyClient.js
+++ b/local-modules/doc-client/PropertyClient.js
@@ -149,9 +149,7 @@ export default class PropertyClient extends CommonBase {
         throw Errors.timed_out(timeoutMsec);
       }
 
-      // **TODO:** Fix this to pass an appropriate timeout value, once
-      // `getChangeAfter()` can accept it.
-      await proxy.property_getChangeAfter(snapshot.revNum);
+      await proxy.property_getChangeAfter(snapshot.revNum, timeoutTime - now);
     }
   }
 }

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseSnapshot, RevisionNumber } from 'doc-common';
+import { BaseSnapshot, RevisionNumber, Timeouts } from 'doc-common';
 import { Errors as FileStoreErrors, TransactionSpec } from 'file-store';
 import { Delay } from 'promise-util';
 import { TFunction } from 'typecheck';
@@ -171,18 +171,25 @@ export default class BaseControl extends BaseDataManager {
    *
    * @param {Int} baseRevNum Revision number for the base to get a change with
    *   respect to.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BaseChange} Change with respect to the revision indicated by
    *   `baseRevNum`. Always an instance of the appropriate change class as
    *   specified by the concrete subclass of this class. The result's `revNum`
    *   is guaranteed to be at least one greater than `baseRevNum` (and could
    *   possibly be even larger). The `timestamp` and `authorId` of the result
    *   will both be `null`.
+   * @throws {Errors.timed_out} Thrown if the timeout time is reached befor a
+   *   change becomes available.
    */
-  async getChangeAfter(baseRevNum) {
+  async getChangeAfter(baseRevNum, timeoutMsec = null) {
+    timeoutMsec = Timeouts.clamp(timeoutMsec);
     const currentRevNum = await this.currentRevNum();
     RevisionNumber.maxInc(baseRevNum, currentRevNum);
 
-    const result = await this._impl_getChangeAfter(baseRevNum, currentRevNum);
+    const result = await this._impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum);
 
     if (result === null) {
       throw Errors.revision_not_available(baseRevNum);
@@ -476,6 +483,8 @@ export default class BaseControl extends BaseDataManager {
    * @param {Int} baseRevNum Revision number for the base to get a change with
    *   respect to. Guaranteed to refer to the instantaneously-current revision
    *   or earlier.
+   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
+   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
    * @param {Int} currentRevNum The instantaneously-current revision number that
    *   was determined just before this method was called, and which should be
    *   treated as the actually-current revision number at the start of this
@@ -486,8 +495,8 @@ export default class BaseControl extends BaseDataManager {
    *   class as specified by the concrete subclass of this class with `null` for
    *   both `timestamp` and `authorId`.
    */
-  async _impl_getChangeAfter(baseRevNum, currentRevNum) {
-    return this._mustOverride(baseRevNum, currentRevNum);
+  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
+    return this._mustOverride(baseRevNum, timeoutMsec, currentRevNum);
   }
 
   /**

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -189,7 +189,17 @@ export default class BaseControl extends BaseDataManager {
     const currentRevNum = await this.currentRevNum();
     RevisionNumber.maxInc(baseRevNum, currentRevNum);
 
-    const result = await this._impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum);
+    let result;
+    try {
+      result = await this._impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum);
+    } catch (e) {
+      // Note a timeout to the logs, but other than that just let the error
+      // bubble up.
+      if (Errors.isTimedOut(e)) {
+        this.log.info(`Call to \`getChangeAfter()\` timed out: ${timeoutMsec}msec`);
+      }
+      throw e;
+    }
 
     if (result === null) {
       throw Errors.revision_not_available(baseRevNum);

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -100,6 +100,8 @@ export default class BodyControl extends BaseControl {
    * @param {Int} baseRevNum Revision number for the base to get a change with
    *   respect to. Guaranteed to refer to the instantaneously-current revision
    *   or earlier.
+   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
+   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
    * @param {Int} currentRevNum The instantaneously-current revision number that
    *   was determined just before this method was called, and which should be
    *   treated as the actually-current revision number at the start of this
@@ -108,7 +110,7 @@ export default class BodyControl extends BaseControl {
    *   `baseRevNum`. Though the superclass allows it, this method never returns
    *   `null`.
    */
-  async _impl_getChangeAfter(baseRevNum, currentRevNum) {
+  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
     for (;;) {
       if (baseRevNum < currentRevNum) {
         // The document's revision is in fact newer than the base, so we can now

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -186,6 +186,8 @@ export default class CaretControl extends BaseControl {
    * @param {Int} baseRevNum Revision number for the base to get a change with
    *   respect to. Guaranteed to refer to the instantaneously-current revision
    *   or earlier.
+   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
+   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
    * @param {Int} currentRevNum_unused The instantaneously-current revision
    *   number that was determined just before this method was called. It is
    *   unused in this case because the implementation has synchronous knowledge
@@ -194,7 +196,7 @@ export default class CaretControl extends BaseControl {
    *   by `baseRevNum`, or `null` to indicate that the revision was not
    *   available as a base.
    */
-  async _impl_getChangeAfter(baseRevNum, currentRevNum_unused) {
+  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum_unused) {
     // This uses the `_impl` snapshot so that we get a `null` instead of a
     // thrown error when the revision isn't available.
     const oldSnapshot = await this._impl_getSnapshot(baseRevNum);

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -68,10 +68,14 @@ export default class DocSession extends CommonBase {
    * {@link BodyControl#getChangeAfter} for details.
    *
    * @param {Int} baseRevNum Revision number for the document.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BodyChange} Delta and associated information.
    */
-  async body_getChangeAfter(baseRevNum) {
-    return this._bodyControl.getChangeAfter(baseRevNum);
+  async body_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._bodyControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
 
   /**
@@ -131,12 +135,16 @@ export default class DocSession extends CommonBase {
    *   will form the basis for the result. If `baseRevNum` is the current
    *   revision number, this method will block until a new revision is
    *   available.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {CaretDelta} Delta from the base caret revision to a newer one.
    *   Applying this result to a `CaretSnapshot` for `baseRevNum` will produce
    *  an up-to-date snapshot.
    */
-  async caret_getChangeAfter(baseRevNum) {
-    return this._caretControl.getChangeAfter(baseRevNum);
+  async caret_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._caretControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
 
   /**
@@ -195,10 +203,14 @@ export default class DocSession extends CommonBase {
    * revision. See {@link PropertyControl#getChangeAfter} for details.
    *
    * @param {Int} baseRevNum Revision number for the document.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {PropertyChange} Delta and associated information.
    */
-  async property_getChangeAfter(baseRevNum) {
-    return this._propertyControl.getChangeAfter(baseRevNum);
+  async property_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._propertyControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -82,13 +82,15 @@ export default class PropertyControl extends BaseControl {
    * @param {Int} baseRevNum Revision number for the base to get a change with
    *   respect to. Guaranteed to refer to the instantaneously-current revision
    *   or earlier.
+   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
+   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
    * @param {Int} currentRevNum The instantaneously-current revision number that
    *   was determined just before this method was called.
    * @returns {PropertyChange} Change with respect to the revision indicated by
    *   `baseRevNum`. Though the superclass allows it, this method never returns
    *   `null`.
    */
-  async _impl_getChangeAfter(baseRevNum, currentRevNum) {
+  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
     // Wait for the revision number to change using a transaction. Iterate
     // because sometimes the transaction can return without an actual change
     // happening.

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -91,37 +91,26 @@ export default class PropertyControl extends BaseControl {
    *   `null`.
    */
   async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
-    // Wait for the revision number to change using a transaction. Iterate
-    // because sometimes the transaction can return without an actual change
-    // happening.
-    for (;;) {
-      if (baseRevNum < currentRevNum) {
-        // The document's revision is in fact newer than the base, so we can now
-        // stop waiting and return a result.
-        break;
-      }
-
-      // Wait for the file to change (or for the storage layer to time out), and
-      // then iterate to see if in fact the change updated the document revision
-      // number.
+    if (currentRevNum === baseRevNum) {
+      // The current revision is the same as the base, so we have to wait for
+      // the file to change (or for the storage layer to time out), and then
+      // check to see if in fact the revision number was changed.
 
       const fc   = this.fileCodec;
-      const ops  = [fc.op_whenPathNot(Paths.PROPERTY_REVISION_NUMBER, currentRevNum)];
-      const spec = new TransactionSpec(...ops);
+      const spec = new TransactionSpec(
+        fc.op_timeout(timeoutMsec),
+        fc.op_whenPathNot(Paths.PROPERTY_REVISION_NUMBER, currentRevNum));
 
-      try {
-        await fc.transact(spec);
-      } catch (e) {
-        if (!Errors.isTimedOut(e)) {
-          // It's _not_ a timeout, so we should propagate the error.
-          throw e;
-        }
+      // If this returns normally (doesn't throw), then we know it wasn't due
+      // to hitting the timeout. And if it _is_ a timeout, then the exception
+      // that's thrown is exactly what should be reported upward.
+      await fc.transact(spec);
 
-        // It's a timeout, so just fall through and iterate.
-        this.log.info('Storage layer timeout in `getChangeAfter()`.');
-      }
-
+      // Verify that the revision number went up. It's a bug if it didn't.
       currentRevNum = await this.currentRevNum();
+      if (currentRevNum <= baseRevNum) {
+        throw Errors.wtf(`Revision number should have gone up. Instead was ${baseRevNum} then ${currentRevNum}.`);
+      }
     }
 
     // There are two possible ways to calculate the result, namely (1) compose

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -112,7 +112,7 @@ export default class InfoError extends Error {
   }
 
   /**
-   * Custom inspector function, as called by `util.inspect()`. This just returns
+   * Custom inspector function, as called by `util.inspect()`. This
    * implementation is similar to the default `Error` inspector, except that
    * this one formats the first line in a nicer way given the structured error
    * content.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.31.0
+version = 0.31.1


### PR DESCRIPTION
This PR adds a `timeoutMsec` argument to the method `BaseControl.getChangeAfter()` and all its related incarnations. In addition, all such methods now actually time out after a configured maximum value (currently one minute) even if the client didn't ask for a timeout. This is done so that the system can't end up with a bajillion zombie calls to these methods which could otherwise end up shuffling slowly toward doom when a user simply stops editing a document.

Along with the addition of timeouts to the control classes, I also fixed all the call sites so that they deal gracefully with the inevitable timeouts that get reported back from the server.