### PR TITLE
Better error logging… again.

### DIFF
--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -53,29 +53,29 @@ export default class Response extends CommonBase {
     this._error = Response._fixError(error);
 
     /**
-     * {array<string>|null} Error stack, or `null` if this instance doesn't
-     * represent an error. In the case of an error that has no available stack
-     * info, this is an empty array (`[]`) and not `null`.
+     * {array<string>|null} Error trace, or `null` if this instance doesn't
+     * represent an error.
      */
-    this._errorStack = Response._fixErrorStack(error);
+    this._errorTrace = Response._fixErrorTrace(error);
 
     Object.freeze(this);
   }
 
   /**
    * {CodableError|null} Error result, or `null` if this instance doesn't
-   * represent an error.
+   * represent an error. This value is guaranteed to be suitable for encoding
+   * across an API boundary.
    */
   get error() {
     return this._error;
   }
 
   /**
-   * {array<string>|null} Clean error stack, or `null` if this instance doesn't
-   * represent an error.
+   * {array<string>|null} Clean error trace (including message and causes if
+   * any), or `null` if this instance doesn't represent an error.
    */
-  get errorStack() {
-    return this._errorStack;
+  get errorTrace() {
+    return this._errorTrace;
   }
 
   /** {Int} Message ID. */
@@ -128,22 +128,21 @@ export default class Response extends CommonBase {
   }
 
   /**
-   * Makes a cleaned-up stack from an incoming `error` argument. This returns
-   * `null` if given `null`. In other cases were `error` doesn't come with a
-   * stack, this returns an empty array.
+   * Makes a cleaned-up trace from an incoming `error` argument. This returns
+   * `null` if given `null`.
    *
    * @param {*} error Error value.
-   * @returns {array<string>|null} Cleaned up error stack as an array of stack
+   * @returns {array<string>|null} Cleaned up error trace as an array of lines,
    *   lines. Will be `[]` if this is an error-ish value with no stack, or
    *   `null` if `error` is `null`.
    */
-  static _fixErrorStack(error) {
+  static _fixErrorTrace(error) {
     if (error === null) {
       return null;
     } else if (!(error instanceof Error)) {
       return [];
     }
 
-    return ErrorUtil.stackLines(error);
+    return ErrorUtil.fullTraceLines(error);
   }
 }

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -46,10 +46,13 @@ export default class ApiLog extends Singleton {
       // TODO: Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
-      this._console.error(`[${connectionId}] Error:`, response.error.message);
-      if (response.errorStack.length !== 0) {
-        const stackString = response.errorStack.join('\n  ');
-        this._console.info(`Original trace:\n  ${stackString}`);
+
+      if (response.errorTrace.length === 0) {
+        this._console.error(`[${connectionId}] Error:`, response.error.message);
+      } else {
+        this._console.error(`[${connectionId}] Error.`);
+        const trace = response.errorTrace.map(line => `  ${line}`).join('\n');
+        this._console.info(trace);
       }
     }
 
@@ -69,7 +72,7 @@ export default class ApiLog extends Singleton {
       details.result = response.result;
     } else {
       details.error      = response.error;
-      details.errorStack = response.errorStack || [];
+      details.errorTrace = response.errorTrace || [];
     }
 
     this._writeJson(details);

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -265,16 +265,8 @@ export default class ServerSink extends BaseSink {
    * @returns {string} String form of `value`.
    */
   static _inspect(value) {
-    if (value instanceof Error) {
-      const lines = [value.toString()];
-
-      for (const s of ErrorUtil.stackLines(value)) {
-        lines.push(`  ${s}`);
-      }
-
-      return lines.join('\n');
-    }
-
-    return inspect(value);
+    return (value instanceof Error)
+      ? ErrorUtil.fullTrace(value)
+      : inspect(value);
   }
 }

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -117,19 +117,14 @@ export default class CollectingReporter extends CommonBase {
       if (error !== null) {
         let errLines;
         if (error instanceof Error) {
-          const msgLines   = error.toString().split('\n');
-          const stackLines = ErrorUtil.stackLines(error).map(s => `  at ${s}`);
-          errLines = [...msgLines, ...stackLines];
+          errLines = ErrorUtil.fullTraceLines(error, '  ');
         } else {
-          errLines = inspect(error).split('\n');
+          errLines = inspect(error).split('\n').map(line => `  ${line}`);
         }
 
         anyExtra = true;
         lines.push('');
-
-        for (const line of errLines) {
-          lines.push(`  ${line}`);
-        }
+        lines.push(...errLines);
       }
 
       if (anyExtra) {

--- a/local-modules/util-common/ErrorUtil.js
+++ b/local-modules/util-common/ErrorUtil.js
@@ -199,10 +199,15 @@ export default class ErrorUtil extends UtilityClass {
 
     const stack = ErrorUtil.stackLines(error, indent2);
 
+    // The message can contain multiple lines. (The name too, though that'd be
+    // pretty unusual.)
+    const message =
+      `${error.name}: ${error.message}`.split('\n').map(line => `${indent}${line}`);
+
     return {
       cause,
       lines: [
-        `${indent}${error.name}: ${error.message}`,
+        ...message,
         ...stack,
         ...extraLines
       ]

--- a/local-modules/util-common/ErrorUtil.js
+++ b/local-modules/util-common/ErrorUtil.js
@@ -46,7 +46,8 @@ export default class ErrorUtil extends UtilityClass {
   static fullTraceLines(error, indent = '') {
     TObject.check(error, Error);
 
-    const causeLine = [`${indent}caused by:`];
+    const indent2   = `${indent}  `;
+    const causeLine = [`${indent2}caused by:`];
     const traces    = [];
     let   first     = true;
 
@@ -55,7 +56,7 @@ export default class ErrorUtil extends UtilityClass {
 
       if (first) {
         first = false;
-        indent = `${indent}  `;
+        indent = indent2;
       } else {
         traces.push(causeLine);
       }
@@ -168,6 +169,7 @@ export default class ErrorUtil extends UtilityClass {
    *   `cause` to the chained cause or to `null` if there is no chained cause.
    */
   static _oneTrace(error, indent) {
+    const indent2  = `${indent}  `;
     let   cause    = null;
     const extra    = {};
     let   anyExtra = false;
@@ -190,12 +192,12 @@ export default class ErrorUtil extends UtilityClass {
 
     let extraLines;
     if (anyExtra) {
-      extraLines = inspect(extra).split('\n').map(line => `${indent}${line}`);
+      extraLines = inspect(extra).split('\n').map(line => `${indent2}${line}`);
     } else {
       extraLines = [];
     }
 
-    const stack = ErrorUtil.stackLines(error, `${indent}  `);
+    const stack = ErrorUtil.stackLines(error, indent2);
 
     return {
       cause,

--- a/local-modules/util-common/ErrorUtil.js
+++ b/local-modules/util-common/ErrorUtil.js
@@ -174,7 +174,7 @@ export default class ErrorUtil extends UtilityClass {
     const extra    = {};
     let   anyExtra = false;
 
-    const iter = new PropertyIterable(error).skipObject().skipSynthetic().skipMethods();
+    const iter = new PropertyIterable(error).skipObject().skipSynthetic().skipMethods().skipPrivate();
     for (const prop of iter) {
       const name = prop.name;
       if ((name === 'name') || (name === 'message') || (name === 'stack')) {

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -64,6 +64,18 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an addition filter that
+   * skips methods (non-synthetic function-valued properties).
+   *
+   * @returns {PropertyIterable} The new iterator.
+   */
+  skipMethods() {
+    // **Note:** If `value` is defined, the property is guaranteed not to be
+    // synthetic.
+    return this.filter(desc => !TFunction.isCallable(desc.value));
+  }
+
+  /**
+   * Gets an instance that is like this one but with an addition filter that
    * skips properties defined on the root `Object` prototype.
    *
    * @returns {PropertyIterable} The new iterator.

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -86,6 +86,16 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an addition filter that
+   * skips properties in "private" form (that is, prefixed with `_`).
+   *
+   * @returns {PropertyIterable} The new iterator.
+   */
+  skipPrivate() {
+    return this.filter(desc => !/^_/.test(desc.name));
+  }
+
+  /**
+   * Gets an instance that is like this one but with an addition filter that
    * only passes regular non-synthetic properties.
    *
    * @returns {PropertyIterable} The new iterator.

--- a/local-modules/util-common/PropertyIterable.js
+++ b/local-modules/util-common/PropertyIterable.js
@@ -71,7 +71,7 @@ export default class PropertyIterable extends CommonBase {
   skipMethods() {
     // **Note:** If `value` is defined, the property is guaranteed not to be
     // synthetic.
-    return this.filter(desc => !TFunction.isCallable(desc.value));
+    return this.filter(desc => (typeof desc.value) !== 'function');
   }
 
   /**

--- a/local-modules/util-common/tests/test_ErrorUtil.js
+++ b/local-modules/util-common/tests/test_ErrorUtil.js
@@ -21,7 +21,7 @@ describe('util-common/ErrorUtil', () => {
 
   describe('stackLines(error, indent)', () => {
     it('should return an array of strings, each with the specified indentation', () => {
-      const result = ErrorUtil.stackLines(new Error('oy'), '123');
+      const result = ErrorUtil.stackLines(new Error('oy\nyo'), '123');
 
       assert.isArray(result);
       for (const line of result) {
@@ -57,6 +57,18 @@ describe('util-common/ErrorUtil', () => {
       error3.name  = 'Foo';
       error3.cause = error2;
       test(error3, 'Foo: bar');
+    });
+
+    it('should split a multi-line name and/or message into separate result elements', () => {
+      const error = new Error('what\nis\nhappening?');
+      error.name = 'Who\nWhat';
+
+      const result = ErrorUtil.fullTraceLines(error);
+      const expect = ['Who', 'What: what', 'is', 'happening?'];
+
+      for (let i = 0; i < expect.length; i++) {
+        assert.strictEqual(result[i], expect[i]);
+      }
     });
 
     it('should have lines that indicate extra properties', () => {

--- a/local-modules/util-common/tests/test_ErrorUtil.js
+++ b/local-modules/util-common/tests/test_ErrorUtil.js
@@ -1,0 +1,147 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ErrorUtil } from 'util-common';
+
+describe('util-common/ErrorUtil', () => {
+  describe('stackLines(error)', () => {
+    it('should return an array of strings', () => {
+      const result = ErrorUtil.stackLines(new Error('oy'));
+
+      assert.isArray(result);
+      for (const line of result) {
+        assert.isString(line);
+      }
+    });
+  });
+
+  describe('stackLines(error, indent)', () => {
+    it('should return an array of strings, each with the specified indentation', () => {
+      const result = ErrorUtil.stackLines(new Error('oy'), '123');
+
+      assert.isArray(result);
+      for (const line of result) {
+        assert.isString(line);
+        assert.isTrue(line.startsWith('123'));
+      }
+    });
+  });
+
+  describe('fullTraceLines(error)', () => {
+    it('should return an array of strings', () => {
+      const result = ErrorUtil.fullTraceLines(new Error('oy'));
+
+      assert.isArray(result);
+      for (const line of result) {
+        assert.isString(line);
+      }
+    });
+
+    it('should have a first line that indicates the name and message', () => {
+      function test(value, expect) {
+        const result = ErrorUtil.fullTraceLines(value);
+        assert.strictEqual(result[0], expect);
+      }
+
+      test(new Error('oy'), 'Error: oy');
+
+      const error2 = new Error('florp');
+      error2.name  = 'Blort';
+      test(error2, 'Blort: florp');
+
+      const error3 = new Error('bar');
+      error3.name  = 'Foo';
+      error3.cause = error2;
+      test(error3, 'Foo: bar');
+    });
+
+    it('should have lines that indicate extra properties', () => {
+      function test(value, expect) {
+        const result = ErrorUtil.fullTraceLines(value);
+        let   found  = false;
+
+        for (const line of result) {
+          if (line === expect) {
+            found = true;
+            break;
+          }
+        }
+
+        assert.isTrue(found);
+      }
+
+      const error = new Error('x');
+      error.a = 10;
+      error.b = 'twenty';
+      test(error, '  { a: 10, b: \'twenty\' }');
+    });
+
+    it('should represent the cause if present', () => {
+      function test(value, ...expect) {
+        const result = ErrorUtil.fullTraceLines(value);
+        let at = 0;
+
+        for (const line of result) {
+          if (line === expect[at]) {
+            at++;
+            if (at === expect.length) {
+              break;
+            }
+          }
+        }
+
+        assert.strictEqual(at, expect.length);
+      }
+
+      const error1 = new Error('x');
+      error1.cause = new Error('y');
+      test(error1,
+        '  caused by:',
+        '  Error: y'
+      );
+
+      const error2 = new Error('x');
+      error2.florp = 'whatevs';
+      error2.cause = new Error('zorch');
+      error2.cause.name  = 'Zorch';
+      error2.cause.florp = 'like';
+      test(error2,
+        '  caused by:',
+        '  Zorch: zorch',
+        '    { florp: \'like\' }'
+      );
+
+      const error3 = new Error('quux');
+      error3.cause = error2;
+      test(error3,
+        '  caused by:',
+        '  Error: x',
+        '    { florp: \'whatevs\' }',
+        '  caused by:',
+        '  Zorch: zorch',
+        '    { florp: \'like\' }'
+      );
+    });
+  });
+
+  describe('fullTraceLines(error, indent)', () => {
+    it('should return an array of strings, each with the specified indentation', () => {
+      const error = new Error('oy');
+      error.florp = 'like';
+      error.cause = new Error('oy_cause');
+      error.cause.like = 'florp';
+
+      const result = ErrorUtil.fullTraceLines(error, '123');
+
+      assert.isArray(result);
+      for (const line of result) {
+        assert.isString(line);
+        assert.isTrue(line.startsWith('123'));
+      }
+    });
+  });
+});

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -64,6 +64,22 @@ describe('util-common/PropertyIterable', () => {
       testIteratable(iter, expectedProperties);
     });
   });
+
+  describe('iterating solely over non-methods', () => {
+    it('should iterate solely over non-methods', () => {
+      const obj = {
+        yes1: 'x',
+        yes2: 'y',
+        get yes3() { return 10; },
+        no1() { /*empty*/ },
+        no2: () => { /*empty*/ }
+      };
+      const iter = new PropertyIterable(obj).skipMethods();
+      const expectedProperties = ['yes1', 'yes2', 'yes3'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
 });
 
 /**

--- a/local-modules/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/util-common/tests/test_PropertyIterable.js
@@ -25,7 +25,7 @@ describe('util-common/PropertyIterable', () => {
     });
   });
 
-  describe('iterating soley over methods', () => {
+  describe('onlyMethods()', () => {
     it('should return just callable function elements of the object', () => {
       const iter = new PropertyIterable(TEST_OBJECT);
       const methodIter = iter.onlyMethods();
@@ -36,7 +36,7 @@ describe('util-common/PropertyIterable', () => {
     });
   });
 
-  describe('iterating over properties not defined on Object', () => {
+  describe('skipObject()', () => {
     it('should return just properties that are not part of Object', () => {
       const iter = new PropertyIterable(TEST_OBJECT);
       const nonObjectIter = iter.skipObject();
@@ -48,7 +48,7 @@ describe('util-common/PropertyIterable', () => {
     });
   });
 
-  describe('iterating solely over non-synthetic properties', () => {
+  describe('skipSynthetic()', () => {
     it('should iterate solely over non-synthetic properties', () => {
       const obj = {
         yes1: 'x',
@@ -65,7 +65,7 @@ describe('util-common/PropertyIterable', () => {
     });
   });
 
-  describe('iterating solely over non-methods', () => {
+  describe('skipMethods()', () => {
     it('should iterate solely over non-methods', () => {
       const obj = {
         yes1: 'x',
@@ -75,6 +75,23 @@ describe('util-common/PropertyIterable', () => {
         no2: () => { /*empty*/ }
       };
       const iter = new PropertyIterable(obj).skipMethods();
+      const expectedProperties = ['yes1', 'yes2', 'yes3'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
+  describe('skipPrivate()', () => {
+    it('should omit private properties', () => {
+      const obj = {
+        yes1: 'x',
+        yes2() { /*empty*/ },
+        get yes3() { return 10; },
+        _: 'no',
+        _no2: 'no',
+        get _no3() { return 10; }
+      };
+      const iter = new PropertyIterable(obj).skipPrivate();
       const expectedProperties = ['yes1', 'yes2', 'yes3'];
 
       testIteratable(iter, expectedProperties);

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,7 @@ import fs from 'fs';
 import path from 'path';
 import puppeteer from 'puppeteer';
 import minimist from 'minimist';
-import { format } from 'util';
+import { format, promisify } from 'util';
 
 import { Application } from 'app-setup';
 import { ClientBundle } from 'client-bundle';
@@ -297,6 +297,10 @@ async function clientTest() {
     // eslint-disable-next-line no-console
     console.log('Wrote test results to file:', testOut);
   }
+
+  // This ensures that `stdout` (including the `console.log()` output) has been
+  // flushed.
+  await promisify(cb => process.stdout.write('', 'utf8', cb))();
 
   process.exit(anyFailed ? 1 : 0);
 }


### PR DESCRIPTION
This PR makes some improvements to error logging, in response to deficiencies I noticed during my work over the last few days.

**Bonus:** Fixed the client test runner so that the console logs don't get cut off. (It was only happening in our CI environment, and the actual output file was getting written successfully; but was disconcerting nonetheless.)