### PR TITLE
Link Detector

### DIFF
--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -21,6 +21,7 @@ import BodyClient from './BodyClient';
 import CaretOverlay from './CaretOverlay';
 import CaretState from './CaretState';
 import DocSession from './DocSession';
+import LinkDetector from './LinkDetector';
 import TitleClient from './TitleClient';
 
 /** {Logger} Logger for this module. */
@@ -375,6 +376,9 @@ export default class EditorComplex extends CommonBase {
       theme:    Hooks.theOne.quillThemeName('body'),
       modules:  EditorComplex._bodyModuleConfig
     });
+
+    LinkDetector.addKeybindings(titleQuill);
+    LinkDetector.addKeybindings(bodyQuill);
 
     return [titleQuill, bodyQuill];
   }

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -101,6 +101,12 @@ export default class EditorComplex extends CommonBase {
      */
     this._clientStore = new ClientStore();
 
+    /**
+     * {CaretState} Machinery that watches for changes to the session state
+     * and updates the client redux store.
+     */
+    this._caretState = new CaretState(this);
+
     // The rest of the initialization has to happen asynchronously. In
     // particular, there is no avoiding the asynchrony in `_domSetup()`, and
     // that setup needs to be complete before we construct the Quill and
@@ -130,12 +136,6 @@ export default class EditorComplex extends CommonBase {
 
       /** {QuillProm} The Quill editor object. */
       this._bodyQuill = bodyQuill;
-
-      /**
-       * {CaretState} Machinery that watches for changes to the session state
-       * and updates the client redux store.
-       */
-      this._caretState = new CaretState(this);
 
       /** {CaretOverlay} The remote caret overlay controller. */
       this._caretOverlay = new CaretOverlay(this, authorOverlayNode);

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -108,7 +108,7 @@ export default class EditorComplex extends CommonBase {
     // make a `BodyClient` (which gets done by `_initSession()`).
     (async () => {
       // Do all of the DOM setup for the instance.
-      const [headerNode, titleNode, quillNode, authorOverlayNode] =
+      const [headerNode, titleNode, bodyNode, authorOverlayNode] =
         await this._domSetup(topNode, sessionKey.baseUrl);
 
       // The Provider component wraps our React application and makes the
@@ -122,34 +122,18 @@ export default class EditorComplex extends CommonBase {
         headerNode
       );
 
-      // Makes a clone of the default config with the additional binding of
-      // the "enter" key to our special handler. **TODO:** This is way more
-      // verbose and precarious than it ought to be. We should fix it to be
-      // less icky.
-      const titleModuleConfig = Object.assign({}, EditorComplex._titleModuleConfig);
-      titleModuleConfig.keyboard = Object.assign({},
-        titleModuleConfig.keyboard,
-        { onEnter: this.titleOnEnter.bind(this) });
+      // Construct the `QuillProm` instances.
+      const [titleQuill, bodyQuill] = this._quillSetup(titleNode, bodyNode);
 
       /** {QuillProm} The Quill editor object for the document title. */
-      this._titleQuill = new QuillProm(titleNode, {
-        readOnly: false,
-        strict:   true,
-        theme:    Hooks.theOne.quillThemeName('title'),
-        modules:  titleModuleConfig
-      });
+      this._titleQuill = titleQuill;
 
       /** {QuillProm} The Quill editor object. */
-      this._bodyQuill = new QuillProm(quillNode, {
-        readOnly: true,
-        strict:   true,
-        theme:    Hooks.theOne.quillThemeName('body'),
-        modules:  EditorComplex._bodyModuleConfig
-      });
+      this._bodyQuill = bodyQuill;
 
       /**
-       * {CaretState} Machinery that watches for changes to the
-       * session state and updates the client redux store.
+       * {CaretState} Machinery that watches for changes to the session state
+       * and updates the client redux store.
        */
       this._caretState = new CaretState(this);
 
@@ -280,8 +264,8 @@ export default class EditorComplex extends CommonBase {
    *
    * @param {Element} topNode The top DOM node for the complex.
    * @param {string} baseUrl Base URL of the server.
-   * @returns {array<Element>} Array of `[quillNode, authorOverlayNode]`, for
-   *   immediate consumption by the constructor.
+   * @returns {array<Element>} Array of `[headerNode, titleNode, bodyNode,
+   *   authorOverlayNode]`, for immediate consumption by the constructor.
    */
   async _domSetup(topNode, baseUrl) {
     // Validate the top node, and give it the right CSS style.
@@ -336,26 +320,63 @@ export default class EditorComplex extends CommonBase {
     topNode.appendChild(titleNode);
 
     // Make the node for the document body section. The most prominent part of
-    // this section is the `<div>` managed by Quill. In addition, this is where
-    // the author overlay goes.
+    // this section is the `<div>` managed by the Quill instance for the
+    // document body. In addition, this is where the author overlay goes.
 
+    const bodyOuterNode = document.createElement('div');
+    bodyOuterNode.classList.add('bayou-body');
+    topNode.appendChild(bodyOuterNode);
+
+    // Make the `<div>` that actually ends up getting controlled by Quill for
+    // the body.
     const bodyNode = document.createElement('div');
-    bodyNode.classList.add('bayou-body');
-    topNode.appendChild(bodyNode);
-
-    // Make the `<div>` that actually ends up getting controlled by Quill.
-    const quillNode = document.createElement('div');
-    quillNode.classList.add('bayou-editor');
-    bodyNode.appendChild(quillNode);
+    bodyNode.classList.add('bayou-editor');
+    bodyOuterNode.appendChild(bodyNode);
 
     // Make the author overlay node. **Note:** The wacky namespace URL is
     // required. Without it, the `<svg>` element is actually left uninterpreted.
     const authorOverlayNode =
       document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     authorOverlayNode.classList.add('bayou-author-overlay');
-    bodyNode.appendChild(authorOverlayNode);
+    bodyOuterNode.appendChild(authorOverlayNode);
 
-    return [headerNode, titleNode, quillNode, authorOverlayNode];
+    return [headerNode, titleNode, bodyNode, authorOverlayNode];
+  }
+
+  /**
+   * Creates and returns the `QuillProm` instances to use with this complex.
+   *
+   * @param {Element} titleNode The `<div>` for title content.
+   * @param {Element} bodyNode The `<div>` for body content.
+   * @returns {array<QuillProm>} Array of the form `[titleQuill, bodyQuill]`.
+   */
+  _quillSetup(titleNode, bodyNode) {
+    // Makes a clone of the default config with the additional binding of
+    // the "enter" key to our special handler. **TODO:** This is way more
+    // verbose and precarious than it ought to be. We should fix it to be
+    // less icky.
+    const titleModuleConfig = Object.assign({}, EditorComplex._titleModuleConfig);
+    titleModuleConfig.keyboard = Object.assign({},
+      titleModuleConfig.keyboard,
+      { onEnter: this.titleOnEnter.bind(this) });
+
+    /** {QuillProm} The Quill editor object for the document title. */
+    const titleQuill = new QuillProm(titleNode, {
+      readOnly: false,
+      strict:   true,
+      theme:    Hooks.theOne.quillThemeName('title'),
+      modules:  titleModuleConfig
+    });
+
+    /** {QuillProm} The Quill editor object. */
+    const bodyQuill = new QuillProm(bodyNode, {
+      readOnly: true,
+      strict:   true,
+      theme:    Hooks.theOne.quillThemeName('body'),
+      modules:  EditorComplex._bodyModuleConfig
+    });
+
+    return [titleQuill, bodyQuill];
   }
 
   /**

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -1,0 +1,74 @@
+import { BayouKeyboard } from 'quill-util';
+import { ImageEmbed } from 'ui-embeds';
+
+// Originally imported from <https://gist.github.com/dperini/729294>, by
+// Diego Perini and licensed under the MIT License.
+const OPTIONAL_PROTOCOL_URL_REGEXP = /((?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?/i;
+
+/**
+ * Detector of URLs typed / pasted into a Quill document.
+ */
+export default class LinkDetector {
+  /**
+   * Adds a keyboard binding to the Quill editor for basic link detection.
+   *
+   * @param {Quill} quill the Quill editor to add the binding to.
+   */
+  static addKeybindings(quill) {
+    const linkBinding = function (range, context) {
+      const matches = [];
+
+      // Gather all the link so we can later pull out just the last one. We're
+      // not actually replacing anything here, but this is so much tidier than
+      // `/regex/.exec()` calls in a loop. If a given link doesn't have a
+      // protocol then the Quill Link format will treat it as a relative path
+      // off the current host. So, if there is no protocol then assume HTTP.
+      context.prefix.replace(OPTIONAL_PROTOCOL_URL_REGEXP, (matchedText, protocol) => {
+        matches.push({
+          regexMatch: matchedText,
+          link:       protocol ? matchedText : `http://${matchedText}`
+        });
+      });
+
+      const lastMatch = matches.pop();
+      const index = range.index - lastMatch.regexMatch.length;
+
+      if (LinkDetector.isImageUrl(lastMatch.regexMatch)) {
+        const value = { url: lastMatch.link };
+
+        this.quill.deleteText(index, lastMatch.regexMatch.length);
+        this.quill.insertEmbed(index, ImageEmbed.blotName, value);
+      } else {
+        this.quill.formatText(index, lastMatch.regexMatch.length, 'link', lastMatch.link, 'user');
+      }
+
+      return true;
+    };
+
+    quill.keyboard.addBinding(
+      { key: BayouKeyboard.KEYMAP.SPACE },
+      { prefix: OPTIONAL_PROTOCOL_URL_REGEXP },
+      linkBinding);
+
+    quill.keyboard.addBinding(
+      { key: BayouKeyboard.KEYMAP.ENTER },
+      { prefix: OPTIONAL_PROTOCOL_URL_REGEXP },
+      linkBinding);
+  }
+
+  /**
+   * Indiates whether or not the given URL names an image, as determined by file
+   * extension.
+   *
+   * @param {string} url URL to inspect.
+   * @returns {boolean} `true` iff `url` names an image.
+   */
+  static isImageUrl(url) {
+    const link = new URL(url);
+    let extension = link.pathname.split('.').pop();
+
+    extension = extension && extension.toLowerCase();
+
+    return ['gif', 'jpg', 'jpeg', 'png', 'svg'].includes(extension);
+  }
+}

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -2,8 +2,11 @@ import { BayouKeyboard } from 'quill-util';
 import { ImageEmbed } from 'ui-embeds';
 
 // Originally imported from <https://gist.github.com/dperini/729294>, by
-// Diego Perini and licensed under the MIT License.
-const OPTIONAL_PROTOCOL_URL_REGEXP = /((?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?/i;
+// Diego Perini and licensed under the MIT License. **TODO:** Consider using a
+// newer implementation, such as the Node module `url-regex`
+// <https://github.com/kevva/url-regex>, which is based on the same gist.
+const OPTIONAL_PROTOCOL_URL_REGEXP =
+  /((?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?/i;
 
 /**
  * Detector of URLs typed / pasted into a Quill document.

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -64,8 +64,8 @@ export default class LinkDetector {
   }
 
   /**
-   * Indiates whether or not the given URL names an image, as determined by file
-   * extension.
+   * Indicates whether or not the given URL names an image, as determined by
+   * file extension.
    *
    * @param {string} url URL to inspect.
    * @returns {boolean} `true` iff `url` names an image.

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -17,7 +17,7 @@ const OPTIONAL_PROTOCOL_URL_REGEXP =
  */
 export default class LinkDetector {
   /**
-   * Adds a keyboard binding to the Quill editor for basic link detection.
+   * Adds keyboard bindings to the Quill editor for basic link detection.
    *
    * @param {Quill} quill the Quill editor to add the binding to.
    */

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -1,3 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
 import { BayouKeyboard } from 'quill-util';
 import { ImageEmbed } from 'ui-embeds';
 

--- a/local-modules/doc-client/package.json
+++ b/local-modules/doc-client/package.json
@@ -15,6 +15,7 @@
     "see-all": "local",
     "state-machine": "local",
     "typecheck": "local",
+    "ui-embeds": "local",
     "ui-header": "local",
     "util-client": "local",
     "util-common": "local"


### PR DESCRIPTION
This PR adds key bindings to our Quill instances which detect non-marked-up URLs, converting them into links or image embeds (depending on the file suffix of the URL).

This was based on a Slack-internal class by @meatime, which I cleaned up for export.