### PR TITLE
Factor out file paths

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -104,6 +104,22 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * Gets the `StoragePath` string corresponding to the indicated revision
+   * number, specifically for the portion of the document controlled by this
+   * class.
+   *
+   * @param {RevisionNumber} revNum The revision number.
+   * @returns {string} The corresponding `StoragePath` string.
+   */
+  static pathForChange(revNum) {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    RevisionNumber.check(revNum);
+    return `${this.pathPrefix}/change/${revNum}`;
+  }
+
+  /**
    * Appends a new change to the document. On success, this returns `true`. On a
    * failure due to `baseRevNum` not being current at the moment of application,
    * this returns `false`. All other failures are reported via thrown errors.
@@ -133,7 +149,7 @@ export default class BaseControl extends BaseDataManager {
 
     const revNum       = change.revNum;
     const baseRevNum   = revNum - 1;
-    const changePath   = clazz._impl_pathForChange(revNum);
+    const changePath   = clazz.pathForChange(revNum);
     const revisionPath = clazz.revisionNumberPath;
 
     const fc   = this.fileCodec; // Avoids boilerplate immediately below.
@@ -289,7 +305,7 @@ export default class BaseControl extends BaseDataManager {
 
     const paths = [];
     for (let i = startInclusive; i < endExclusive; i++) {
-      paths.push(clazz._impl_pathForChange(i));
+      paths.push(clazz.pathForChange(i));
     }
 
     const fc = this.fileCodec;
@@ -603,18 +619,5 @@ export default class BaseControl extends BaseDataManager {
    */
   static get _impl_snapshotClass() {
     return this._mustOverride();
-  }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically for the portion of the document controlled by this
-   * class. Subclasses must override this.
-   *
-   * @abstract
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string.
-   */
-  static _impl_pathForChange(revNum) {
-    return this._mustOverride(revNum);
   }
 }

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -190,12 +190,18 @@ export default class BaseControl extends BaseDataManager {
    * @returns {Int} The instantaneously-current revision number.
    */
   async currentRevNum() {
-    // This method merely exists to enforce the return-type contract as
-    // specified in the method docs.
+    const clazz       = this.constructor;
+    const fc          = this.fileCodec;
+    const storagePath = clazz.revisionNumberPath;
+    const spec        = new TransactionSpec(
+      fc.op_checkPathPresent(storagePath),
+      fc.op_readPath(storagePath)
+    );
 
-    const revNum = await this._impl_currentRevNum();
+    const transactionResult = await fc.transact(spec);
 
-    return RevisionNumber.check(revNum);
+    const result = transactionResult.data.get(storagePath);
+    return RevisionNumber.check(result);
   }
 
   /**
@@ -518,17 +524,6 @@ export default class BaseControl extends BaseDataManager {
       retryTotalMsec += retryDelayMsec;
       retryDelayMsec *= UPDATE_RETRY_GROWTH_FACTOR;
     }
-  }
-
-  /**
-   * Subclass-specific implementation of `currentRevNum()`. Subclasses must
-   * override this.
-   *
-   * @abstract
-   * @returns {Int} The instantaneously-current revision number.
-   */
-  async _impl_currentRevNum() {
-    return this._mustOverride();
   }
 
   /**

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -74,6 +74,17 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * {string} `StoragePath` string which stores the current revision number for
+   * the portion of the document controlled by this class. This corresponds to
+   * the change number for the most recent change stored in the document.
+   */
+  static get revisionNumberPath() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+    return `${this.pathPrefix}/revision_number`;
+  }
+
+  /**
    * {class} Class (constructor function) of snapshot objects to be used with
    * instances of this class.
    */
@@ -123,7 +134,7 @@ export default class BaseControl extends BaseDataManager {
     const revNum       = change.revNum;
     const baseRevNum   = revNum - 1;
     const changePath   = clazz._impl_pathForChange(revNum);
-    const revisionPath = clazz._impl_revisionNumberPath;
+    const revisionPath = clazz.revisionNumberPath;
 
     const fc   = this.fileCodec; // Avoids boilerplate immediately below.
     const spec = new TransactionSpec(
@@ -581,17 +592,6 @@ export default class BaseControl extends BaseDataManager {
    * @abstract
    */
   static get _impl_pathPrefix() {
-    return this._mustOverride();
-  }
-
-  /**
-   * {string} `StoragePath` string which stores the current revision number for
-   * the portion of the document controlled by this class. Subclasses must
-   * override this.
-   *
-   * @abstract
-   */
-  static get _impl_revisionNumberPath() {
     return this._mustOverride();
   }
 

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseSnapshot, RevisionNumber, Timeouts } from 'doc-common';
-import { Errors as FileStoreErrors, TransactionSpec } from 'file-store';
+import { Errors as FileStoreErrors, StoragePath, TransactionSpec } from 'file-store';
 import { Delay } from 'promise-util';
 import { TFunction } from 'typecheck';
 import { Errors } from 'util-common';
@@ -52,6 +52,25 @@ export default class BaseControl extends BaseDataManager {
     // **Note:** `this` in the context of a static method is the class, not an
     // instance.
     return this.snapshotClass.deltaClass;
+  }
+
+  /**
+   * {string} Path prefix to use for file storage for the portion of the
+   * document controlled by instances of this class.
+   */
+  static get pathPrefix() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+
+    if (!this._pathPrefix) {
+      // Call the `_impl` and verify the result.
+      const prefix = this._impl_pathPrefix;
+
+      StoragePath.check(prefix);
+      this._pathPrefix = prefix;
+    }
+
+    return this._pathPrefix;
   }
 
   /**
@@ -552,6 +571,17 @@ export default class BaseControl extends BaseDataManager {
    */
   async _impl_update(baseSnapshot, change, expectedSnapshot) {
     return this._mustOverride(baseSnapshot, change, expectedSnapshot);
+  }
+
+  /**
+   * {string} `StoragePath` prefix string to use for file storage for the
+   * portion of the document controlled by instances of this class. Subclasses
+   * must override override this.
+   *
+   * @abstract
+   */
+  static get _impl_pathPrefix() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -63,7 +63,7 @@ export default class BodyControl extends BaseControl {
       fc.op_writePath(BodyControl.revisionNumberPath, 0),
 
       // Empty change #0 (per documented interface).
-      fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST)
+      fc.op_writePath(BodyControl.pathForChange(0), BodyChange.FIRST)
     );
   }
 
@@ -319,7 +319,7 @@ export default class BodyControl extends BaseControl {
       const fc  = this.fileCodec;
       const ops = [];
       for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(Paths.forBodyChange(i)));
+        ops.push(fc.op_readPath(BodyControl.pathForChange(i)));
       }
       const spec = new TransactionSpec(...ops);
       transactionResult = await fc.transact(spec);

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -76,24 +76,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `currentRevNum()`, as required by the
-   * superclass.
-   *
-   * @returns {Int} The instantaneously-current revision number.
-   */
-  async _impl_currentRevNum() {
-    const fc          = this.fileCodec;
-    const storagePath = BodyControl.revisionNumberPath;
-    const spec        = new TransactionSpec(
-      fc.op_checkPathPresent(storagePath),
-      fc.op_readPath(storagePath)
-    );
-
-    const transactionResult = await fc.transact(spec);
-    return transactionResult.data.get(storagePath);
-  }
-
-  /**
    * Underlying implementation of `getChangeAfter()`, as required by the
    * superclass.
    *

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -340,6 +340,14 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
+   * {string} `StoragePath` prefix string to use for file storage for the
+   * portion of the document controlled by instances of this class.
+   */
+  static get _impl_pathPrefix() {
+    return Paths.BODY_PREFIX;
+  }
+
+  /**
    * {string} `StoragePath` string which stores the current revision number for
    * the portion of the document controlled by this class.
    */

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -354,16 +354,4 @@ export default class BodyControl extends BaseControl {
   static get _impl_snapshotClass() {
     return BodySnapshot;
   }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically for the portion of the document controlled by this
-   * class.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string.
-   */
-  static _impl_pathForChange(revNum) {
-    return Paths.forBodyChange(revNum);
-  }
 }

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -60,7 +60,7 @@ export default class BodyControl extends BaseControl {
       fc.op_deletePathPrefix(Paths.BODY_PREFIX),
 
       // Initial revision number.
-      fc.op_writePath(Paths.BODY_REVISION_NUMBER, 0),
+      fc.op_writePath(BodyControl.revisionNumberPath, 0),
 
       // Empty change #0 (per documented interface).
       fc.op_writePath(Paths.forBodyChange(0), BodyChange.FIRST)
@@ -83,7 +83,7 @@ export default class BodyControl extends BaseControl {
    */
   async _impl_currentRevNum() {
     const fc          = this.fileCodec;
-    const storagePath = Paths.BODY_REVISION_NUMBER;
+    const storagePath = BodyControl.revisionNumberPath;
     const spec        = new TransactionSpec(
       fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)
@@ -119,7 +119,7 @@ export default class BodyControl extends BaseControl {
       const fc   = this.fileCodec;
       const spec = new TransactionSpec(
         fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(Paths.BODY_REVISION_NUMBER, currentRevNum));
+        fc.op_whenPathNot(BodyControl.revisionNumberPath, currentRevNum));
 
       // If this returns normally (doesn't throw), then we know it wasn't due
       // to hitting the timeout. And if it _is_ a timeout, then the exception
@@ -276,7 +276,7 @@ export default class BodyControl extends BaseControl {
     try {
       const fc = this.fileCodec;
       const spec = new TransactionSpec(
-        fc.op_readPath(Paths.BODY_REVISION_NUMBER)
+        fc.op_readPath(BodyControl.revisionNumberPath)
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
@@ -285,7 +285,7 @@ export default class BodyControl extends BaseControl {
     }
 
     const data   = transactionResult.data;
-    const revNum = data.get(Paths.BODY_REVISION_NUMBER);
+    const revNum = data.get(BodyControl.revisionNumberPath);
 
     if (!revNum) {
       this.log.info('Corrupt document: Missing revision number.');
@@ -345,14 +345,6 @@ export default class BodyControl extends BaseControl {
    */
   static get _impl_pathPrefix() {
     return Paths.BODY_PREFIX;
-  }
-
-  /**
-   * {string} `StoragePath` string which stores the current revision number for
-   * the portion of the document controlled by this class.
-   */
-  static get _impl_revisionNumberPath() {
-    return Paths.BODY_REVISION_NUMBER;
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -449,6 +449,14 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
+   * {string} `StoragePath` prefix string to use for file storage for the
+   * portion of the document controlled by instances of this class.
+   */
+  static get _impl_pathPrefix() {
+    return Paths.CARET_PREFIX;
+  }
+
+  /**
    * {string} `StoragePath` string which stores the current revision number for
    * the portion of the document controlled by this class.
    */

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -108,7 +108,7 @@ export default class CaretControl extends BaseControl {
       fc.op_deletePathPrefix(Paths.CARET_PREFIX),
 
       // Initial revision number.
-      fc.op_writePath(Paths.CARET_REVISION_NUMBER, 0),
+      fc.op_writePath(CaretControl.revisionNumberPath, 0),
 
       // Empty change #0.
       fc.op_writePath(Paths.forCaretChange(0), CaretChange.FIRST)
@@ -131,7 +131,7 @@ export default class CaretControl extends BaseControl {
    */
   async _impl_currentRevNum() {
     const fc          = this.fileCodec;
-    const storagePath = Paths.CARET_REVISION_NUMBER;
+    const storagePath = CaretControl.revisionNumberPath;
     const spec        = new TransactionSpec(
       fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)
@@ -165,7 +165,7 @@ export default class CaretControl extends BaseControl {
       const fc   = this.fileCodec;
       const spec = new TransactionSpec(
         fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(Paths.CARET_REVISION_NUMBER, currentRevNum));
+        fc.op_whenPathNot(CaretControl.revisionNumberPath, currentRevNum));
 
       // If this returns normally (doesn't throw), then we know it wasn't due
       // to hitting the timeout. And if it _is_ a timeout, then the exception
@@ -293,7 +293,7 @@ export default class CaretControl extends BaseControl {
     try {
       const fc = this.fileCodec;
       const spec = new TransactionSpec(
-        fc.op_readPath(Paths.CARET_REVISION_NUMBER)
+        fc.op_readPath(CaretControl.revisionNumberPath)
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
@@ -302,7 +302,7 @@ export default class CaretControl extends BaseControl {
     }
 
     const data   = transactionResult.data;
-    const revNum = data.get(Paths.CARET_REVISION_NUMBER);
+    const revNum = data.get(CaretControl.revisionNumberPath);
 
     if (!revNum) {
       this.log.info('Corrupt document: Missing revision number.');
@@ -454,14 +454,6 @@ export default class CaretControl extends BaseControl {
    */
   static get _impl_pathPrefix() {
     return Paths.CARET_PREFIX;
-  }
-
-  /**
-   * {string} `StoragePath` string which stores the current revision number for
-   * the portion of the document controlled by this class.
-   */
-  static get _impl_revisionNumberPath() {
-    return Paths.CARET_REVISION_NUMBER;
   }
 
   /**

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -124,24 +124,6 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `currentRevNum()`, as required by the
-   * superclass.
-   *
-   * @returns {Int} The instantaneously-current revision number.
-   */
-  async _impl_currentRevNum() {
-    const fc          = this.fileCodec;
-    const storagePath = CaretControl.revisionNumberPath;
-    const spec        = new TransactionSpec(
-      fc.op_checkPathPresent(storagePath),
-      fc.op_readPath(storagePath)
-    );
-
-    const transactionResult = await fc.transact(spec);
-    return transactionResult.data.get(storagePath);
-  }
-
-  /**
    * Underlying implementation of `getChangeAfter()`, as required by the
    * superclass.
    *

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -111,7 +111,7 @@ export default class CaretControl extends BaseControl {
       fc.op_writePath(CaretControl.revisionNumberPath, 0),
 
       // Empty change #0.
-      fc.op_writePath(Paths.forCaretChange(0), CaretChange.FIRST)
+      fc.op_writePath(CaretControl.pathForChange(0), CaretChange.FIRST)
     );
   }
 
@@ -336,7 +336,7 @@ export default class CaretControl extends BaseControl {
       const fc  = this.fileCodec;
       const ops = [];
       for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(Paths.forCaretChange(i)));
+        ops.push(fc.op_readPath(CaretControl.pathForChange(i)));
       }
       const spec = new TransactionSpec(...ops);
       transactionResult = await fc.transact(spec);

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -465,18 +465,6 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically for the portion of the document controlled by this
-   * class.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string.
-   */
-  static _impl_pathForChange(revNum) {
-    return Paths.forCaretChange(revNum);
-  }
-
-  /**
    * Picks a color to use for a new session.
    *
    * @param {string} sessionId The ID for the new session (used as a

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { RevisionNumber } from 'doc-common';
 import { UtilityClass } from 'util-common';
 
 /**
@@ -18,19 +17,9 @@ export default class Paths extends UtilityClass {
     return '/body';
   }
 
-  /** {string} `StoragePath` prefix string for document changes. */
-  static get BODY_CHANGE_PREFIX() {
-    return `${Paths.BODY_PREFIX}/change`;
-  }
-
   /** {string} `StoragePath` prefix string for caret information. */
   static get CARET_PREFIX() {
     return '/caret';
-  }
-
-  /** {string} `StoragePath` prefix string for caret changes. */
-  static get CARET_CHANGE_PREFIX() {
-    return `${Paths.CARET_PREFIX}/change`;
   }
 
   /**
@@ -40,55 +29,8 @@ export default class Paths extends UtilityClass {
     return '/prop';
   }
 
-  /** {string} `StoragePath` prefix string for property changes. */
-  static get PROPERTY_CHANGE_PREFIX() {
-    return `${Paths.PROPERTY_PREFIX}/change`;
-  }
-
   /** {string} `StoragePath` string for the file schema (format) version. */
   static get SCHEMA_VERSION() {
     return '/schema_version';
-  }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically to store the document change that results in that
-   * revision.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string for document
-   *   change storage.
-   */
-  static forBodyChange(revNum) {
-    RevisionNumber.check(revNum);
-    return `${Paths.BODY_CHANGE_PREFIX}/${revNum}`;
-  }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically to store the caret change that results in that
-   * revision.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string for caret change
-   *   storage.
-   */
-  static forCaretChange(revNum) {
-    RevisionNumber.check(revNum);
-    return `${Paths.CARET_CHANGE_PREFIX}/${revNum}`;
-  }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically to store the property data change that results in that
-   * revision.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string for property
-   *   change storage.
-   */
-  static forPropertyChange(revNum) {
-    RevisionNumber.check(revNum);
-    return `${Paths.PROPERTY_CHANGE_PREFIX}/${revNum}`;
   }
 }

--- a/local-modules/doc-server/Paths.js
+++ b/local-modules/doc-server/Paths.js
@@ -23,14 +23,6 @@ export default class Paths extends UtilityClass {
     return `${Paths.BODY_PREFIX}/change`;
   }
 
-  /**
-   * {string} `StoragePath` string for the body content revision number.
-   * This corresponds to the highest change number.
-   */
-  static get BODY_REVISION_NUMBER() {
-    return `${Paths.BODY_PREFIX}/revision_number`;
-  }
-
   /** {string} `StoragePath` prefix string for caret information. */
   static get CARET_PREFIX() {
     return '/caret';
@@ -39,14 +31,6 @@ export default class Paths extends UtilityClass {
   /** {string} `StoragePath` prefix string for caret changes. */
   static get CARET_CHANGE_PREFIX() {
     return `${Paths.CARET_PREFIX}/change`;
-  }
-
-  /**
-   * {string} `StoragePath` string for the caret revision number. This
-   * corresponds to the highest change number.
-   */
-  static get CARET_REVISION_NUMBER() {
-    return `${Paths.CARET_PREFIX}/revision_number`;
   }
 
   /**
@@ -59,14 +43,6 @@ export default class Paths extends UtilityClass {
   /** {string} `StoragePath` prefix string for property changes. */
   static get PROPERTY_CHANGE_PREFIX() {
     return `${Paths.PROPERTY_PREFIX}/change`;
-  }
-
-  /**
-   * {string} `StoragePath` string for the property data revision number. This
-   * corresponds to the highest change number.
-   */
-  static get PROPERTY_REVISION_NUMBER() {
-    return `${Paths.PROPERTY_PREFIX}/revision_number`;
   }
 
   /** {string} `StoragePath` string for the file schema (format) version. */

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -303,16 +303,4 @@ export default class PropertyControl extends BaseControl {
   static get _impl_snapshotClass() {
     return PropertySnapshot;
   }
-
-  /**
-   * Gets the `StoragePath` string corresponding to the indicated revision
-   * number, specifically for the portion of the document controlled by this
-   * class.
-   *
-   * @param {RevisionNumber} revNum The revision number.
-   * @returns {string} The corresponding `StoragePath` string.
-   */
-  static _impl_pathForChange(revNum) {
-    return Paths.forPropertyChange(revNum);
-  }
 }

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -58,24 +58,6 @@ export default class PropertyControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `currentRevNum()`, as required by the
-   * superclass.
-   *
-   * @returns {Int} The instantaneously-current revision number.
-   */
-  async _impl_currentRevNum() {
-    const fc          = this.fileCodec;
-    const storagePath = PropertyControl.revisionNumberPath;
-    const spec        = new TransactionSpec(
-      fc.op_checkPathPresent(storagePath),
-      fc.op_readPath(storagePath)
-    );
-
-    const transactionResult = await fc.transact(spec);
-    return transactionResult.data.get(storagePath);
-  }
-
-  /**
    * Underlying implementation of `getChangeAfter()`, as required by the
    * superclass.
    *

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -45,7 +45,7 @@ export default class PropertyControl extends BaseControl {
       fc.op_writePath(PropertyControl.revisionNumberPath, 0),
 
       // Empty change #0.
-      fc.op_writePath(Paths.forPropertyChange(0), PropertyChange.FIRST)
+      fc.op_writePath(PropertyControl.pathForChange(0), PropertyChange.FIRST)
     );
   }
 
@@ -268,7 +268,7 @@ export default class PropertyControl extends BaseControl {
       const fc  = this.fileCodec;
       const ops = [];
       for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(Paths.forPropertyChange(i)));
+        ops.push(fc.op_readPath(PropertyControl.pathForChange(i)));
       }
       const spec = new TransactionSpec(...ops);
       transactionResult = await fc.transact(spec);

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -42,7 +42,7 @@ export default class PropertyControl extends BaseControl {
       fc.op_deletePathPrefix(Paths.PROPERTY_PREFIX),
 
       // Initial revision number.
-      fc.op_writePath(Paths.PROPERTY_REVISION_NUMBER, 0),
+      fc.op_writePath(PropertyControl.revisionNumberPath, 0),
 
       // Empty change #0.
       fc.op_writePath(Paths.forPropertyChange(0), PropertyChange.FIRST)
@@ -65,7 +65,7 @@ export default class PropertyControl extends BaseControl {
    */
   async _impl_currentRevNum() {
     const fc          = this.fileCodec;
-    const storagePath = Paths.PROPERTY_REVISION_NUMBER;
+    const storagePath = PropertyControl.revisionNumberPath;
     const spec        = new TransactionSpec(
       fc.op_checkPathPresent(storagePath),
       fc.op_readPath(storagePath)
@@ -99,7 +99,7 @@ export default class PropertyControl extends BaseControl {
       const fc   = this.fileCodec;
       const spec = new TransactionSpec(
         fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(Paths.PROPERTY_REVISION_NUMBER, currentRevNum));
+        fc.op_whenPathNot(PropertyControl.revisionNumberPath, currentRevNum));
 
       // If this returns normally (doesn't throw), then we know it wasn't due
       // to hitting the timeout. And if it _is_ a timeout, then the exception
@@ -225,7 +225,7 @@ export default class PropertyControl extends BaseControl {
     try {
       const fc = this.fileCodec;
       const spec = new TransactionSpec(
-        fc.op_readPath(Paths.PROPERTY_REVISION_NUMBER)
+        fc.op_readPath(PropertyControl.revisionNumberPath)
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
@@ -234,7 +234,7 @@ export default class PropertyControl extends BaseControl {
     }
 
     const data   = transactionResult.data;
-    const revNum = data.get(Paths.PROPERTY_REVISION_NUMBER);
+    const revNum = data.get(PropertyControl.revisionNumberPath);
 
     if (!revNum) {
       this.log.info('Corrupt document: Missing revision number.');
@@ -294,14 +294,6 @@ export default class PropertyControl extends BaseControl {
    */
   static get _impl_pathPrefix() {
     return Paths.PROPERTY_PREFIX;
-  }
-
-  /**
-   * {string} `StoragePath` string which stores the current revision number for
-   * the portion of the document controlled by this class.
-   */
-  static get _impl_revisionNumberPath() {
-    return Paths.PROPERTY_REVISION_NUMBER;
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -289,6 +289,14 @@ export default class PropertyControl extends BaseControl {
   }
 
   /**
+   * {string} `StoragePath` prefix string to use for file storage for the
+   * portion of the document controlled by instances of this class.
+   */
+  static get _impl_pathPrefix() {
+    return Paths.PROPERTY_PREFIX;
+  }
+
+  /**
    * {string} `StoragePath` string which stores the current revision number for
    * the portion of the document controlled by this class.
    */

--- a/local-modules/doc-server/mocks/MockControl.js
+++ b/local-modules/doc-server/mocks/MockControl.js
@@ -15,6 +15,10 @@ export default class MockControl extends BaseControl {
     this.revNum = 0;
   }
 
+  static get _impl_pathPrefix() {
+    return '/mock_control';
+  }
+
   static get _impl_snapshotClass() {
     return MockSnapshot;
   }

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -31,6 +31,41 @@ describe('doc-server/BaseControl', () => {
     });
   });
 
+  describe('.pathPrefix', () => {
+    it('should reflect the subclass\'s implementation', () => {
+      const result = MockControl.pathPrefix;
+      assert.strictEqual(result, '/mock_control');
+    });
+
+    it('should reject an improper subclass choice', () => {
+      class HasBadPrefix extends BaseControl {
+        static get _impl_pathPrefix() {
+          return '//invalid/path_string!';
+        }
+      }
+
+      assert.throws(() => HasBadPrefix.pathPrefix);
+    });
+
+    it('should only ever ask the subclass once', () => {
+      class GoodControl extends BaseControl {
+        static get _impl_pathPrefix() {
+          this.count++;
+          return '/blort';
+        }
+      }
+
+      GoodControl.count = 0;
+      assert.strictEqual(GoodControl.pathPrefix, '/blort');
+      assert.strictEqual(GoodControl.pathPrefix, '/blort');
+      assert.strictEqual(GoodControl.pathPrefix, '/blort');
+      assert.strictEqual(GoodControl.pathPrefix, '/blort');
+      assert.strictEqual(GoodControl.pathPrefix, '/blort');
+
+      assert.strictEqual(GoodControl.count, 1);
+    });
+  });
+
   describe('.snapshotClass', () => {
     it('should reflect the subclass\'s implementation', () => {
       const result = MockControl.snapshotClass;

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -193,9 +193,9 @@ describe('doc-server/BaseControl', () => {
   });
 
   describe('getChangeAfter()', () => {
-    it('should call through to `_impl_currentRevNum()` before anything else', async () => {
+    it('should call through to `currentRevNum()` before anything else', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         throw new Error('Oy!');
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum_unused) => {
@@ -205,9 +205,9 @@ describe('doc-server/BaseControl', () => {
       await assert.isRejected(control.getChangeAfter(0), /^Oy!/);
     });
 
-    it('should check the validity of `baseRevNum` against the response from `_impl_currentRevNum()`', async () => {
+    it('should check the validity of `baseRevNum` against the response from `currentRevNum()`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum_unused) => {
@@ -219,7 +219,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject blatantly invalid `baseRevNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum_unused) => {
@@ -243,7 +243,7 @@ describe('doc-server/BaseControl', () => {
       let gotTimeout = null;
 
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec, currentRevNum_unused) => {
@@ -268,7 +268,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should return back a valid non-`null` subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum, timeoutMsec_unused, currentRevNum) => {
@@ -284,7 +284,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should convert a `null` subclass response to a `revision_not_available` error', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum_unused) => {
@@ -296,7 +296,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject a non-change subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
 
@@ -317,7 +317,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject a change response that has a `timestamp`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum) => {
@@ -329,7 +329,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject a change response that has an `authorId`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getChangeAfter = async (baseRevNum_unused, timeoutMsec_unused, currentRevNum) => {
@@ -341,9 +341,9 @@ describe('doc-server/BaseControl', () => {
   });
 
   describe('getSnapshot()', () => {
-    it('should call through to `_impl_currentRevNum()` before anything else', async () => {
+    it('should call through to `currentRevNum()` before anything else', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         throw new Error('Oy!');
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -354,9 +354,9 @@ describe('doc-server/BaseControl', () => {
       await assert.isRejected(control.getSnapshot(), /^Oy!/);
     });
 
-    it('should check the validity of a non-`null` `revNum` against the response from `_impl_currentRevNum()`', async () => {
+    it('should check the validity of a non-`null` `revNum` against the response from `currentRevNum()`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -368,7 +368,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject blatantly invalid `revNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -389,7 +389,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should return back a valid non-`null` subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getSnapshot = async (revNum) => {
@@ -404,7 +404,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should use the returned `currentRevNum` when `revNum` is passed asa `null`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 37;
       };
       control._impl_getSnapshot = async (revNum) => {
@@ -419,7 +419,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should convert a `null` subclass response to a `revision_not_available` error', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -431,7 +431,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject a non-snapshot subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         return 10;
       };
 
@@ -453,7 +453,7 @@ describe('doc-server/BaseControl', () => {
   describe('update()', () => {
     it('should reject non-change arguments', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -476,7 +476,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject change arguments with invalid fields', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -499,7 +499,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should accept an empty change without calling through to the impl', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control._impl_currentRevNum = async () => {
+      control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
       };
       control._impl_getSnapshot = async (revNum_unused) => {
@@ -527,7 +527,7 @@ describe('doc-server/BaseControl', () => {
 
   it('should reject a too-large `revNum` in valid nontrivial cases', async () => {
     const control = new MockControl(FILE_ACCESS, 'boop');
-    control._impl_currentRevNum = async () => {
+    control.currentRevNum = async () => {
       return 10;
     };
     control._impl_getSnapshot = async (revNum) => {
@@ -548,7 +548,7 @@ describe('doc-server/BaseControl', () => {
     let gotChange   = 'x';
     let gotExpected = 'x';
 
-    control._impl_currentRevNum = async () => {
+    control.currentRevNum = async () => {
       return 10;
     };
     control._impl_getSnapshot = async (revNum) => {
@@ -579,7 +579,7 @@ describe('doc-server/BaseControl', () => {
     const control = new MockControl(FILE_ACCESS, 'boop');
     let callCount = 0;
 
-    control._impl_currentRevNum = async () => {
+    control.currentRevNum = async () => {
       return 10;
     };
     control._impl_getSnapshot = async (revNum) => {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -101,6 +101,34 @@ describe('doc-server/BaseControl', () => {
     });
   });
 
+  describe('pathForChange()', () => {
+    it('should return an appropriate path given a valid argument', () => {
+      function test(value) {
+        const expect = `${MockControl.pathPrefix}/change/${value}`;
+        assert.strictEqual(MockControl.pathForChange(value), expect);
+      }
+
+      test(0);
+      test(1);
+      test(10);
+      test(100000914);
+    });
+
+    it('should reject invalid arguments', () => {
+      function test(value) {
+        assert.throws(() => MockControl.pathForChange(value), /bad_value/);
+      }
+
+      test(-1);
+      test(0.01);
+      test(null);
+      test(undefined);
+      test(false);
+      test([10]);
+      test(new Map());
+    });
+  });
+
   describe('constructor()', () => {
     it('should accept a `FileAccess` and reflect it in the inherited getters', () => {
       const fa     = FILE_ACCESS;

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -54,6 +54,11 @@ export default class TransactionSpec extends CommonBase {
     return this._ops.values();
   }
 
+  /** {Int} The number of operations in this instance. */
+  get size() {
+    return this._ops.length;
+  }
+
   /**
    * {Int|'never'} The timeout duration in milliseconds, or the string `'never'`
    * if this transaction specifies no timeout.


### PR DESCRIPTION
This PR is the first work on taking real advantage of the now-parallel arrangement of all the OT parts in a document. Specifically:

* Get rid of all the boilerplate path construction code, in favor of just having a well-defined prefix per part (defined as `_impl_pathPrefix`) along with code in `BaseControl` to get specific paths under that prefix.
* Factor out a single implementation of `BaseControl.currentRevNum()` instead of having nearly-identical duplicate code in the three OT classes.
* Add test code for all the new stuff in `BaseControl`. Much of this is adding coverage for stuff that wasn't covered at all before (a/o/t just rejiggering tests to cover the same territory as before).
