### PR TITLE
Cleanup in `file-store` and `doc-common`.

### DIFF
--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -691,7 +691,7 @@ export default class BodyClient extends StateMachine {
     // state to Quill's current state) composed with the correction to that
     // delta which when applied brings the client's state into alignment with
     // the server's state.
-    const correctedDelta = delta.compose(dCorrection);
+    const correctedDelta = delta.compose(dCorrection, false);
 
     if (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) === null) {
       // Thanfully, the local user hasn't made any other changes while we
@@ -801,7 +801,7 @@ export default class BodyClient extends StateMachine {
         break;
       }
 
-      delta = (delta === null) ? props.delta : delta.compose(props.delta);
+      delta = (delta === null) ? props.delta : delta.compose(props.delta, false);
     }
 
     // Remember that we consumed all these changes.

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -113,6 +113,23 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
+   * Composes another instance on top of this one, to produce a new instance.
+   * This operation works equally whether or not `this` is a document delta.
+   *
+   * @param {BaseDelta} other The delta to compose. Must be an instance of the
+   *   same concrete class as `this`.
+   * @returns {BodyDelta} Result of composition. Is always an instance of the
+   *   same concrete class as `this`.
+   */
+  compose(other) {
+    this.constructor.check(other);
+
+    const result = this._impl_compose(other);
+
+    return this.constructor.check(result);
+  }
+
+  /**
    * "Deconstructs" this instance, returning an array of arguments which is
    * suitable for passing to the constructor of this class.
    *
@@ -235,6 +252,19 @@ export default class BaseDelta extends CommonBase {
    */
   toCodecArgs() {
     return this.deconstruct();
+  }
+
+  /**
+   * Main implementation of {@link #compose}. Subclasses must fill this in.
+   *
+   * @abstract
+   * @param {BaseDelta} other Delta to compose with this instance. Guaranteed
+   *   to be an instance of the same concrete class as `this`.
+   * @returns {BaseDelta} Composed result. Must be an instance of the same
+   *   concrete class as `this`.
+   */
+  _impl_compose(other) {
+    return this._mustOverride(other);
   }
 
   /**

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -264,6 +264,7 @@ export default class BaseSnapshot extends CommonBase {
    * @returns {BaseDelta|array} Delta which represents the composed document
    *   contents. Must be an instance of the `deltaClass` as defined by the
    *   subclass or an array of operations that can be used to produce same.
+   *   Must represent a _document_ delta.
    */
   _impl_composeWithDelta(delta) {
     return this._mustOverride(delta);

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -124,7 +124,7 @@ export default class BaseSnapshot extends CommonBase {
       return this.withRevNum(change.revNum);
     }
 
-    return new this.constructor(change.revNum, this._impl_composeWithDelta(delta));
+    return new this.constructor(change.revNum, this.contents.compose(delta, true));
   }
 
   /**
@@ -250,24 +250,6 @@ export default class BaseSnapshot extends CommonBase {
     return (revNum === this._revNum)
       ? this
       : new this.constructor(revNum, this._contents);
-  }
-
-  /**
-   * Main implementation of {@link #compose}, as defined by the subclass. Takes
-   * a delta (not a change instance), and produces a document delta (not a
-   * snapshot).
-   *
-   * @abstract
-   * @param {BaseDelta} delta Difference to compose with this instance's
-   *   contents. Guaranteed to be an instance of the `deltaClass` as defined
-   *   by the subclass.
-   * @returns {BaseDelta|array} Delta which represents the composed document
-   *   contents. Must be an instance of the `deltaClass` as defined by the
-   *   subclass or an array of operations that can be used to produce same.
-   *   Must represent a _document_ delta.
-   */
-  _impl_composeWithDelta(delta) {
-    return this._mustOverride(delta);
   }
 
   /**

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -59,24 +59,6 @@ export default class BodyDelta extends BaseDelta {
   }
 
   /**
-   * Composes another instance on top of this one, to produce a new instance.
-   * This operation works equally whether or not `this` is a document delta.
-   *
-   * @param {BodyDelta} other The delta to compose.
-   * @returns {BodyDelta} Result of composition.
-   */
-  compose(other) {
-    BodyDelta.check(other);
-
-    // Use Quill's implementation.
-    const quillThis   = this.toQuillForm();
-    const quillOther  = other.toQuillForm();
-    const quillResult = quillThis.compose(quillOther);
-
-    return BodyDelta.fromQuillForm(quillResult);
-  }
-
-  /**
    * Computes the difference between this instance and another, where both must
    * be document (from-empty) deltas. The return value is a delta which can be
    * `compose()`d with this instance to produce the delta passed in here as an
@@ -145,6 +127,21 @@ export default class BodyDelta extends BaseDelta {
     const quillThis   = this.toQuillForm();
     const quillOther  = other.toQuillForm();
     const quillResult = quillThis.transform(quillOther, thisIsFirst);
+
+    return BodyDelta.fromQuillForm(quillResult);
+  }
+
+  /**
+   * Main implementation of {@link #compose}.
+   *
+   * @param {BodyDelta} other Delta to compose with this instance.
+   * @returns {BodyDelta} Composed result.
+   */
+  _impl_compose(other) {
+    // Use Quill's implementation.
+    const quillThis   = this.toQuillForm();
+    const quillOther  = other.toQuillForm();
+    const quillResult = quillThis.compose(quillOther);
 
     return BodyDelta.fromQuillForm(quillResult);
   }

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -62,7 +62,8 @@ export default class BodyDelta extends BaseDelta {
    * Computes the difference between this instance and another, where both must
    * be document (from-empty) deltas. The return value is a delta which can be
    * `compose()`d with this instance to produce the delta passed in here as an
-   * argument. That is, `newerDelta == this.compose(this.diff(newerDelta))`.
+   * argument. That is, `newerDelta == this.compose(this.diff(newerDelta),
+   * true)`.
    *
    * **Note:** The parameter name `newer` is meant to be suggestive of the
    * typical use case for this method, but strictly speaking there does not have
@@ -105,7 +106,9 @@ export default class BodyDelta extends BaseDelta {
    * such as:
    *
    * ```javascript
-   * document.compose(change1).compose(change1.transform(change2, true))
+   * document
+   *   .compose(change1, false)
+   *   .compose(change1.transform(change2, true), false)
    * ```
    *
    * **Note:** This operation only makes sense when both `this` and `other` are
@@ -135,9 +138,12 @@ export default class BodyDelta extends BaseDelta {
    * Main implementation of {@link #compose}.
    *
    * @param {BodyDelta} other Delta to compose with this instance.
+   * @param {boolean} wantDocument_unused Whether the result of the operation
+   *   should be a document delta. (Unused because there is no difference in
+   *   behavior needed for this class.)
    * @returns {BodyDelta} Composed result.
    */
-  _impl_compose(other) {
+  _impl_compose(other, wantDocument_unused) {
     // Use Quill's implementation.
     const quillThis   = this.toQuillForm();
     const quillOther  = other.toQuillForm();

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -34,7 +34,7 @@ export default class BodySnapshot extends BaseSnapshot {
    *   contents.
    */
   _impl_composeWithDelta(delta) {
-    return this.contents.compose(delta);
+    return this.contents.compose(delta, true);
   }
 
   /**

--- a/local-modules/doc-common/BodySnapshot.js
+++ b/local-modules/doc-common/BodySnapshot.js
@@ -25,19 +25,6 @@ export default class BodySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Main implementation of {@link #compose}. Takes a delta (not a change
-   * instance), and produces a document delta (not a snapshot).
-   *
-   * @param {BodyDelta} delta Difference to compose with this instance's
-   *   contents.
-   * @returns {BodyDelta} Delta which represents the composed document
-   *   contents.
-   */
-  _impl_composeWithDelta(delta) {
-    return this.contents.compose(delta, true);
-  }
-
-  /**
    * Main implementation of {@link #diff}, which produces a delta (not a
    * change).
    *

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -208,7 +208,7 @@ export default class Caret extends CommonBase {
    * Calculates the difference from a given caret to this one. The return
    * value is a delta which can be composed with this instance to produce the
    * snapshot passed in here as an argument. That is, `newerCaret ==
-   * this.compose(this.diff(newerCaret))`.
+   * this.compose(this.diff(newerCaret), true)`.
    *
    * **Note:** The word `newer` in the argument name is meant to be suggestive
    * of typical usage of this method, but there is no actual requirement that

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -19,9 +19,11 @@ export default class CaretDelta extends BaseDelta {
    * Main implementation of {@link #compose}.
    *
    * @param {CaretDelta} other Delta to compose with this instance.
+   * @param {boolean} wantDocument Whether the result of the operation should be
+   *   a document delta.
    * @returns {CaretDelta} Composed result.
    */
-  _impl_compose(other) {
+  _impl_compose(other, wantDocument) {
     // Map from each session to an array of ops which apply to it.
     const sessions = new Map();
 
@@ -39,10 +41,15 @@ export default class CaretDelta extends BaseDelta {
         }
 
         case CaretOp.END_SESSION: {
-          // Clear out the session; same reason as `BEGIN_SESSION` above. We
-          // _do_ keep the op, because the fact of a deletion needs to be part
-          // of the final composed result.
-          sessions.set(opProps.sessionId, [op]);
+          if (wantDocument) {
+            // Document deltas don't remember session deletions.
+            sessions.delete(opProps.sessionId);
+          } else {
+            // Clear out the session; same reason as `BEGIN_SESSION` above. We
+            // _do_ keep the op, because the fact of a deletion needs to be part
+            // of the final composed result.
+            sessions.set(opProps.sessionId, [op]);
+          }
           break;
         }
 

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -16,15 +16,12 @@ import CaretOp from './CaretOp';
  */
 export default class CaretDelta extends BaseDelta {
   /**
-   * Composes another instance on top of this one, to produce a new instance.
-   * This operation works equally whether or not `this` is a document delta.
+   * Main implementation of {@link #compose}.
    *
-   * @param {PropertyDelta} other The delta to compose.
-   * @returns {PropertyDelta} Result of composition.
+   * @param {CaretDelta} other Delta to compose with this instance.
+   * @returns {CaretDelta} Composed result.
    */
-  compose(other) {
-    CaretDelta.check(other);
-
+  _impl_compose(other) {
     // Map from each session to an array of ops which apply to it.
     const sessions = new Map();
 

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -232,44 +232,7 @@ export default class CaretSnapshot extends BaseSnapshot {
    *   contents.
    */
   _impl_composeWithDelta(delta) {
-    const newCarets = new Map(this._carets);
-
-    for (const op of delta.ops) {
-      const props = op.props;
-
-      switch (props.opName) {
-        case CaretOp.BEGIN_SESSION: {
-          const caret = props.caret;
-          newCarets.set(caret.sessionId, op);
-          break;
-        }
-
-        case CaretOp.SET_FIELD: {
-          const sessionId = props.sessionId;
-          const caretOp   = newCarets.get(sessionId);
-
-          if (!caretOp) {
-            throw Errors.bad_use(`Cannot update nonexistent caret: ${sessionId}`);
-          }
-
-          const caret = caretOp.props.caret.compose(new CaretDelta([op]));
-          newCarets.set(sessionId, CaretOp.op_beginSession(caret));
-          break;
-        }
-
-        case CaretOp.END_SESSION: {
-          const sessionId = props.sessionId;
-          newCarets.delete(sessionId);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird caret op: ${props.opName}`);
-        }
-      }
-    }
-
-    return new CaretDelta([...newCarets.values()]);
+    return this.contents.compose(delta, true);
   }
 
   /**

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -219,23 +219,6 @@ export default class CaretSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Main implementation of {@link #compose}. Takes a delta (not a change
-   * instance), and produces a document delta (not a snapshot).
-   *
-   * **Note:** It is an error if `delta` contains an `op_setField` to a caret
-   * that either does not exist in `this` or was not first introduced with an
-   * `op_beginSession`.
-   *
-   * @param {CaretDelta} delta Difference to compose with this instance's
-   *   contents.
-   * @returns {CaretDelta} Delta which represents the composed document
-   *   contents.
-   */
-  _impl_composeWithDelta(delta) {
-    return this.contents.compose(delta, true);
-  }
-
-  /**
    * Main implementation of {@link #diff}, which produces a delta (not a
    * change).
    *

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -19,9 +19,11 @@ export default class PropertyDelta extends BaseDelta {
    * Main implementation of {@link #compose}.
    *
    * @param {PropertyDelta} other Delta to compose with this instance.
+   * @param {boolean} wantDocument Whether the result of the operation should be
+   *   a document delta.
    * @returns {PropertyDelta} Composed result.
    */
-  _impl_compose(other) {
+  _impl_compose(other, wantDocument) {
     const props = new Map();
 
     // Add / replace the ops, first from `this` and then from `other`, as a
@@ -31,16 +33,30 @@ export default class PropertyDelta extends BaseDelta {
     for (const op of [...this.ops, ...other.ops]) {
       const opProps = op.props;
 
-      let name;
       switch (opProps.opName) {
-        case PropertyOp.SET_PROPERTY:    { name = opProps.property.name; break; }
-        case PropertyOp.DELETE_PROPERTY: { name = opProps.name;          break; }
+        case PropertyOp.SET_PROPERTY: {
+          props.set(opProps.property.name, op);
+          break;
+        }
+
+        case PropertyOp.DELETE_PROPERTY: {
+          if (wantDocument) {
+            // Document deltas don't remember property deletions; they simply
+            // don't have the property in question.
+            props.delete(opProps.name);
+          } else {
+            // For non-document results, we need to remember properties that are
+            // deleted (by `this` or `other`), so that the deletion is part of
+            // the result delta.
+            props.set(opProps.name, op);
+          }
+          break;
+        }
+
         default: {
           throw Errors.wtf(`Weird op name: ${opProps.opName}`);
         }
       }
-
-      props.set(name, op);
     }
 
     return new PropertyDelta([...props.values()]);

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -16,15 +16,12 @@ import PropertyOp from './PropertyOp';
  */
 export default class PropertyDelta extends BaseDelta {
   /**
-   * Composes another instance on top of this one, to produce a new instance.
-   * This operation works equally whether or not `this` is a document delta.
+   * Main implementation of {@link #compose}.
    *
-   * @param {PropertyDelta} other The delta to compose.
-   * @returns {PropertyDelta} Result of composition.
+   * @param {PropertyDelta} other Delta to compose with this instance.
+   * @returns {PropertyDelta} Composed result.
    */
-  compose(other) {
-    PropertyDelta.check(other);
-
+  _impl_compose(other) {
     const props = new Map();
 
     // Add / replace the ops, first from `this` and then from `other`, as a

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -209,29 +209,7 @@ export default class PropertySnapshot extends BaseSnapshot {
    *   contents.
    */
   _impl_composeWithDelta(delta) {
-    const newProps = new Map(this._properties.entries());
-
-    for (const op of delta.ops) {
-      const opProps = op.props;
-
-      switch (opProps.opName) {
-        case PropertyOp.SET_PROPERTY: {
-          newProps.set(opProps.property.name, op);
-          break;
-        }
-
-        case PropertyOp.DELETE_PROPERTY: {
-          newProps.delete(opProps.name);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
-        }
-      }
-    }
-
-    return new PropertyDelta([...newProps.values()]);
+    return this.contents.compose(delta, true);
   }
 
   /**

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -200,19 +200,6 @@ export default class PropertySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Main implementation of {@link #compose}. Takes a delta (not a change
-   * instance), and produces a document delta (not a snapshot).
-   *
-   * @param {PropertyDelta} delta Difference to compose with this instance's
-   *   contents.
-   * @returns {PropertyDelta} Delta which represents the composed document
-   *   contents.
-   */
-  _impl_composeWithDelta(delta) {
-    return this.contents.compose(delta, true);
-  }
-
-  /**
    * Main implementation of {@link #diff}, which produces a delta (not a
    * change).
    *

--- a/local-modules/doc-common/mocks/MockDelta.js
+++ b/local-modules/doc-common/mocks/MockDelta.js
@@ -28,6 +28,19 @@ export default class MockDelta extends BaseDelta {
     return [new MockOp('yes')];
   }
 
+  _impl_compose(other, wantDocument) {
+    let resultName = wantDocument ? 'composed_doc' : 'composed_not_doc';
+    const op0 = this.ops[0];
+
+    if (op0 && op0.name.startsWith(resultName)) {
+      // The first op gets a `_` suffix on its name for each additional
+      // composition.
+      resultName = op0.name + '_';
+    }
+
+    return new MockDelta([new MockOp(resultName), ...other.ops]);
+  }
+
   _impl_isDocument() {
     const op0 = this.ops[0];
 

--- a/local-modules/doc-common/mocks/MockSnapshot.js
+++ b/local-modules/doc-common/mocks/MockSnapshot.js
@@ -16,10 +16,6 @@ export default class MockSnapshot extends BaseSnapshot {
     Object.freeze(this);
   }
 
-  _impl_composeWithDelta(delta) {
-    return this.contents.compose(delta, true);
-  }
-
   _impl_diffAsDelta(newerSnapshot) {
     return [new MockOp('diff_delta'), newerSnapshot.contents.ops[0]];
   }

--- a/local-modules/doc-common/mocks/MockSnapshot.js
+++ b/local-modules/doc-common/mocks/MockSnapshot.js
@@ -17,16 +17,7 @@ export default class MockSnapshot extends BaseSnapshot {
   }
 
   _impl_composeWithDelta(delta) {
-    let resultName = 'composed_delta';
-    const op0 = this.contents.ops[0];
-
-    if (op0 && op0.name.startsWith(resultName)) {
-      // The first op gets a `_` suffix on its name for each additional
-      // composition.
-      resultName = op0.name + '_';
-    }
-
-    return [new MockOp(resultName), ...delta.ops];
+    return this.contents.compose(delta, true);
   }
 
   _impl_diffAsDelta(newerSnapshot) {

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -118,7 +118,7 @@ describe('doc-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composed_delta'), new MockOp('change_op')]);
+        [new MockOp('composed_doc'), new MockOp('change_op')]);
     });
 
     it('should return `this` given a same-`revNum` empty-`delta` change', () => {
@@ -168,7 +168,7 @@ describe('doc-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composed_delta_'), new MockOp('change_op2')]);
+        [new MockOp('composed_doc_'), new MockOp('change_op2')]);
     });
 
     it('should return `this` given same-`revNum` empty-`delta` changes', () => {

--- a/local-modules/doc-common/tests/test_BaseSnapshot.js
+++ b/local-modules/doc-common/tests/test_BaseSnapshot.js
@@ -108,7 +108,7 @@ describe('doc-common/BaseSnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('should call through to the impl and wrap the result in a new instance', () => {
+    it('should call through to the delta and wrap the result in a new instance', () => {
       const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
       const change = new MockChange(20, [new MockOp('change_op')]);
       const result = snap.compose(change);
@@ -157,7 +157,7 @@ describe('doc-common/BaseSnapshot', () => {
   });
 
   describe('composeAll()', () => {
-    it('should call through to the impl and wrap the result in a new instance', () => {
+    it('should call through to the delta and wrap the result in a new instance', () => {
       const snap    = new MockSnapshot(10, [new MockOp('some_op')]);
       const change1 = new MockChange(21, [new MockOp('change_op1')]);
       const change2 = new MockChange(22, [new MockOp('change_op2')]);

--- a/local-modules/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/doc-common/tests/test_BodyDelta.js
@@ -112,15 +112,19 @@ describe('doc-common/BodyDelta', () => {
 
   describe('compose()', () => {
     it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
-      const result = BodyDelta.EMPTY.compose(BodyDelta.EMPTY);
-      assert.instanceOf(result, BodyDelta);
-      assert.deepEqual(result.ops, []);
+      const result1 = BodyDelta.EMPTY.compose(BodyDelta.EMPTY, false);
+      assert.instanceOf(result1, BodyDelta);
+      assert.deepEqual(result1.ops, []);
+
+      const result2 = BodyDelta.EMPTY.compose(BodyDelta.EMPTY, true);
+      assert.instanceOf(result2, BodyDelta);
+      assert.deepEqual(result2.ops, []);
     });
 
     it('should reject calls when `other` is not an instance of the class', () => {
       const delta = BodyDelta.EMPTY;
       const other = 'blort';
-      assert.throws(() => delta.compose(other));
+      assert.throws(() => delta.compose(other, true));
     });
   });
 
@@ -160,7 +164,7 @@ describe('doc-common/BodyDelta', () => {
 
       describe(label, () => {
         it('should produce the expected composition', () => {
-          const result = origDoc.compose(change);
+          const result = origDoc.compose(change, true);
           assert.instanceOf(result, BodyDelta);
           assert.deepEqual(result.ops, newDoc.ops);
         });
@@ -173,7 +177,7 @@ describe('doc-common/BodyDelta', () => {
 
         it('should produce the new doc when composing the orig doc with the diff', () => {
           const diff   = origDoc.diff(newDoc);
-          const result = origDoc.compose(diff);
+          const result = origDoc.compose(diff, true);
           assert.instanceOf(result, BodyDelta);
           assert.deepEqual(result.ops, newDoc.ops);
         });

--- a/local-modules/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/doc-common/tests/test_CaretDelta.js
@@ -16,7 +16,7 @@ describe('doc-common/CaretDelta', () => {
     function test(ops1, ops2, expectOps) {
       const d1     = new CaretDelta(ops1);
       const d2     = new CaretDelta(ops2);
-      const result = d1.compose(d2);
+      const result = d1.compose(d2, false);
 
       assert.strictEqual(result.ops.length, expectOps.length);
 
@@ -40,17 +40,21 @@ describe('doc-common/CaretDelta', () => {
     }
 
     it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
-      const result = CaretDelta.EMPTY.compose(CaretDelta.EMPTY);
-      assert.instanceOf(result, CaretDelta);
-      assert.deepEqual(result.ops, []);
+      const result1 = CaretDelta.EMPTY.compose(CaretDelta.EMPTY, false);
+      assert.instanceOf(result1, CaretDelta);
+      assert.deepEqual(result1.ops, []);
+
+      const result2 = CaretDelta.EMPTY.compose(CaretDelta.EMPTY, true);
+      assert.instanceOf(result2, CaretDelta);
+      assert.deepEqual(result2.ops, []);
     });
 
     it('should reject calls when `other` is not an instance of the class', () => {
       const delta = CaretDelta.EMPTY;
 
-      assert.throws(() => delta.compose('blort'));
-      assert.throws(() => delta.compose(null));
-      assert.throws(() => delta.compose(new MockDelta([])));
+      assert.throws(() => delta.compose('blort', true));
+      assert.throws(() => delta.compose(null, true));
+      assert.throws(() => delta.compose(new MockDelta([]), true));
     });
 
     describe('`endSession` preceded by anything for that session', () => {

--- a/local-modules/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/doc-common/tests/test_CaretDelta.js
@@ -12,7 +12,7 @@ import { MockDelta } from 'doc-common/mocks';
 
 describe('doc-common/CaretDelta', () => {
   describe('compose()', () => {
-    // Common tester for all of `compose()`.
+    // Common tester for `compose()` when passing `false` for `wantDocuent`.
     function test(ops1, ops2, expectOps) {
       const d1     = new CaretDelta(ops1);
       const d2     = new CaretDelta(ops2);
@@ -55,6 +55,19 @@ describe('doc-common/CaretDelta', () => {
       assert.throws(() => delta.compose('blort', true));
       assert.throws(() => delta.compose(null, true));
       assert.throws(() => delta.compose(new MockDelta([]), true));
+    });
+
+    it('should not include session ends when `wantDocument` is `true`', () => {
+      const op1    = CaretOp.op_beginSession(new Caret('aaa'));
+      const op2    = CaretOp.op_beginSession(new Caret('bbb'));
+      const op3    = CaretOp.op_beginSession(new Caret('ccc'));
+      const op4    = CaretOp.op_endSession('bbb');
+      const op5    = CaretOp.op_endSession('ddd');
+      const d1     = new CaretDelta([op1, op2]);
+      const d2     = new CaretDelta([op3, op4, op5]);
+      const result = d1.compose(d2, true);
+
+      assert.sameMembers(result.ops, [op1, op3]);
     });
 
     describe('`endSession` preceded by anything for that session', () => {

--- a/local-modules/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/doc-common/tests/test_PropertyDelta.js
@@ -80,24 +80,28 @@ describe('doc-common/PropertyDelta', () => {
 
   describe('compose()', () => {
     it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
-      const result = PropertyDelta.EMPTY.compose(PropertyDelta.EMPTY);
-      assert.instanceOf(result, PropertyDelta);
-      assert.deepEqual(result.ops, []);
+      const result1 = PropertyDelta.EMPTY.compose(PropertyDelta.EMPTY, false);
+      assert.instanceOf(result1, PropertyDelta);
+      assert.deepEqual(result1.ops, []);
+
+      const result2 = PropertyDelta.EMPTY.compose(PropertyDelta.EMPTY, true);
+      assert.instanceOf(result2, PropertyDelta);
+      assert.deepEqual(result2.ops, []);
     });
 
     it('should reject calls when `other` is not an instance of the class', () => {
       const delta = PropertyDelta.EMPTY;
 
-      assert.throws(() => delta.compose('blort'));
-      assert.throws(() => delta.compose(null));
-      assert.throws(() => delta.compose(new MockDelta([])));
+      assert.throws(() => delta.compose('blort', false));
+      assert.throws(() => delta.compose(null, false));
+      assert.throws(() => delta.compose(new MockDelta([]), false));
     });
 
     it('should result in no more than one op per named property, with `other` taking precedence', () => {
       function test(ops1, ops2, expectOps) {
         const d1     = new PropertyDelta(ops1);
         const d2     = new PropertyDelta(ops2);
-        const result = d1.compose(d2);
+        const result = d1.compose(d2, false);
 
         assert.strictEqual(result.ops.length, expectOps.length);
 

--- a/local-modules/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/doc-common/tests/test_PropertyDelta.js
@@ -140,6 +140,19 @@ describe('doc-common/PropertyDelta', () => {
       test([op1, op5], [op6],      [op1, op6]);
       test([op1, op5], [op7],      [op5, op7]);
     });
+
+    it('should not include deletions when `wantDocument` is `true`', () => {
+      const op1    = PropertyOp.op_setProperty('aaa', '111');
+      const op2    = PropertyOp.op_setProperty('bbb', '222');
+      const op3    = PropertyOp.op_setProperty('ccc', '333');
+      const op4    = PropertyOp.op_deleteProperty('bbb');
+      const op5    = PropertyOp.op_deleteProperty('ddd');
+      const d1     = new PropertyDelta([op1, op2]);
+      const d2     = new PropertyDelta([op3, op4, op5]);
+      const result = d1.compose(d2, true);
+
+      assert.sameMembers(result.ops, [op1, op3]);
+    });
   });
 
   describe('equals()', () => {

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -391,7 +391,7 @@ export default class BaseControl extends BaseDataManager {
       const end = Math.min(i + MAX, endExclusive);
       const changes = await this.getChangeRange(i, end);
       for (const c of changes) {
-        result = result.compose(c.delta);
+        result = result.compose(c.delta, false);
       }
     }
 

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -124,7 +124,7 @@ export default class BodyControl extends BaseControl {
     // when option (2) would be more profitable.
 
     const delta = await this.getComposedChanges(
-      BodyDelta.EMPTY, baseRevNum + 1, currentRevNum + 1);
+      BodyDelta.EMPTY, baseRevNum + 1, currentRevNum + 1, false);
 
     return new BodyChange(currentRevNum, delta);
   }
@@ -208,7 +208,7 @@ export default class BodyControl extends BaseControl {
     // (1)
 
     const dServer = await this.getComposedChanges(
-      BodyDelta.EMPTY, rBase.revNum + 1, rCurrent.revNum + 1);
+      BodyDelta.EMPTY, rBase.revNum + 1, rCurrent.revNum + 1, false);
 
     // (2)
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -234,7 +234,7 @@ export default class CaretControl extends BaseControl {
     // to return to the caller.
 
     const finalContents = await this.getComposedChanges(
-      expectedSnapshot.contents, baseSnapshot.revNum + 1, current.revNum + 1);
+      expectedSnapshot.contents, baseSnapshot.revNum + 1, current.revNum + 1, true);
 
     if (finalContents.equals(current.contents)) {
       // The changes after the base either overwrote or included the contents of

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -166,7 +166,7 @@ export default class PropertyControl extends BaseControl {
     // to return to the caller.
 
     const finalContents = await this.getComposedChanges(
-      expectedSnapshot.contents, baseSnapshot.revNum + 1, current.revNum + 1);
+      expectedSnapshot.contents, baseSnapshot.revNum + 1, current.revNum + 1, true);
 
     if (finalContents.equals(current.contents)) {
       // The changes after the base either overwrote or included the contents of

--- a/local-modules/doc-server/SnapshotManager.js
+++ b/local-modules/doc-server/SnapshotManager.js
@@ -26,9 +26,6 @@ export default class SnapshotManager extends CommonBase {
      */
     this._control = BaseControl.check(control);
 
-    /** {class} The change class used by {@link #_control}. */
-    this._changeClass = control.constructor.changeClass;
-
     /** {class} The delta class used by {@link #_control}. */
     this._deltaClass = control.constructor.deltaClass;
 
@@ -107,9 +104,8 @@ export default class SnapshotManager extends CommonBase {
     const baseArgs = (base === null)
       ? [this._deltaClass.EMPTY, 0]
       : [base.contents,          base.revNum + 1];
-    const contents = this._control.getComposedChanges(...baseArgs, revNum + 1);
-    const change   = new this._changeClass(revNum, await contents);
-    const result   = this._snapshotClass.EMPTY.compose(change);
+    const contents = this._control.getComposedChanges(...baseArgs, revNum + 1, true);
+    const result   = new this._snapshotClass(revNum, await contents);
 
     if (base === null) {
       const endRev = (revNum === 0) ? '' : ` .. c${revNum}`;

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -149,7 +149,7 @@ describe('doc-server/BaseControl', () => {
     });
   });
 
-  describe.only('currentRevNum()', () => {
+  describe('currentRevNum()', () => {
     it('should perform an appropriate transaction, and use the result', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(Codec.theOne, file);

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -169,7 +169,7 @@ describe('doc-server/BaseControl', () => {
       const ops1 = gotSpec.opsWithName('checkPathPresent');
       const ops2 = gotSpec.opsWithName('readPath');
 
-      assert.strictEqual(gotSpec.size, 2);
+      assert.strictEqual(gotSpec.ops.length, 2);
       assert.lengthOf(ops1, 1);
       assert.lengthOf(ops2, 1);
       assert.strictEqual(ops1[0].arg('storagePath'), '/mock_control/revision_number');

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -602,7 +602,7 @@ describe('doc-server/BaseControl', () => {
     assert.deepEqual(gotBase, new MockSnapshot(6, [new MockOp('x', 6)]));
     assert.strictEqual(gotChange, change);
     assert.deepEqual(gotExpected,
-      new MockSnapshot(7, [new MockOp('composed_delta'), new MockOp('abc')]));
+      new MockSnapshot(7, [new MockOp('composed_doc'), new MockOp('abc')]));
 
     assert.instanceOf(result, MockChange);
     assert.deepEqual(result, new MockChange(14, [new MockOp('q')]));

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -587,38 +587,7 @@ export default class FileOp extends CommonBase {
         const argMap = new Map();
         for (let i = 0; i < argInfo.length; i++) {
           const [name, type] = argInfo[i];
-          let arg = args[i];
-          switch (type) {
-            case TYPE_BUFFER: {
-              FrozenBuffer.check(arg);
-              break;
-            }
-            case TYPE_DUR_MSEC: {
-              TInt.nonNegative(arg);
-              break;
-            }
-            case TYPE_HASH: {
-              if (arg instanceof FrozenBuffer) {
-                arg = arg.hash;
-              } else {
-                FrozenBuffer.checkHash(arg);
-              }
-              break;
-            }
-            case TYPE_PATH: {
-              StoragePath.check(arg);
-              break;
-            }
-            case TYPE_REV_NUM: {
-              TInt.nonNegative(arg);
-              break;
-            }
-            default: {
-              // Indicates a bug in this class.
-              throw Errors.wtf(`Weird \`type\` constant: ${type}`);
-            }
-          }
-
+          const arg          = FileOp._typeCheck(args[i], type);
           argMap.set(name, arg);
         }
 
@@ -627,6 +596,56 @@ export default class FileOp extends CommonBase {
 
       FileOp[`op_${opName}`] = constructorMethod;
     }
+  }
+
+  /**
+   * Checks that the given value has the given type, as defined by this class.
+   * Returns the value to use as an argument, which _might_ be different than
+   * the one passed in. Throws an error if the type check fails.
+   *
+   * @param {*} value Value to check.
+   * @param {string} type Expected type, in the form of a `TYPE_*` string as
+   *   defined by this class.
+   * @returns {*} The value to use.
+   */
+  static _typeCheck(value, type) {
+    switch (type) {
+      case TYPE_BUFFER: {
+        FrozenBuffer.check(value);
+        break;
+      }
+
+      case TYPE_DUR_MSEC: {
+        TInt.nonNegative(value);
+        break;
+      }
+
+      case TYPE_HASH: {
+        if (value instanceof FrozenBuffer) {
+          value = value.hash;
+        } else {
+          FrozenBuffer.checkHash(value);
+        }
+        break;
+      }
+
+      case TYPE_PATH: {
+        StoragePath.check(value);
+        break;
+      }
+
+      case TYPE_REV_NUM: {
+        TInt.nonNegative(value);
+        break;
+      }
+
+      default: {
+        // Indicates a bug in this class.
+        throw Errors.wtf(`Weird \`type\` constant: ${type}`);
+      }
+    }
+
+    return value;
   }
 }
 

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TInt, TString } from 'typecheck';
 import { CommonBase, DataUtil, Errors, FrozenBuffer } from 'util-common';
 
@@ -536,6 +538,38 @@ export default class FileOp extends CommonBase {
     }
 
     return result;
+  }
+
+  /**
+   * Custom inspect function to provide a more succinct representation than the
+   * default.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth, opts) {
+    const clazz   = this.constructor;
+    const nameStr = `${clazz.name}.op_${this.name}`;
+
+    if (depth < 0) {
+      return `${nameStr}(...)`;
+    }
+
+    // Set up the inspection opts so that recursive `inspect()` calls respect
+    // the topmost requested depth.
+    const subOpts = (opts.depth === null)
+      ? opts
+      : Object.assign({}, opts, { depth: opts.depth - 1 });
+
+    const result = [nameStr];
+    for (const [name, type_unused] of FileOp.propsFromName(this.name).args) {
+      result.push((result.length === 1) ? '(' : ', ');
+      result.push(inspect(this.arg(name), subOpts));
+    }
+    result.push(')');
+
+    return result.join('');
   }
 
   /**

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -43,15 +43,12 @@ export default class TransactionSpec extends CommonBase {
   }
 
   /**
-   * {Iterator<FileOp>} An iterator for the operations to perform. The
-   * operations are yielded by the iterator in category-sorted order, as
-   * documented by `FileOp`.
-   *
-   * **Note:** This is an iterator and not (say) an array so as to make it
-   * obvious that the contents are immutable.
+   * {array<FileOp>} An iterator for the operations to perform. The operations
+   * are in category-sorted order, as documented by `FileOp`. This value is
+   * always immutable.
    */
   get ops() {
-    return this._ops.values();
+    return this._ops;
   }
 
   /** {Int} The number of operations in this instance. */

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -45,15 +45,10 @@ export default class TransactionSpec extends CommonBase {
   /**
    * {array<FileOp>} An iterator for the operations to perform. The operations
    * are in category-sorted order, as documented by `FileOp`. This value is
-   * always immutable.
+   * always frozen (immutable).
    */
   get ops() {
     return this._ops;
-  }
-
-  /** {Int} The number of operations in this instance. */
-  get size() {
-    return this._ops.length;
   }
 
   /**

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -1,0 +1,140 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { it } from 'mocha';
+import { inspect } from 'util';
+
+import { FileOp } from 'file-store';
+import { Errors, FrozenBuffer, UtilityClass } from 'util-common';
+
+/**
+ * Test helper utility class for constructing valid arrays of ops which cover
+ * all op types.
+ */
+export default class FileOpMaker extends UtilityClass {
+  /**
+   * Makes a valid ops array of the given length. All ops in the result are of
+   * the same type.
+   *
+   * @param {Int} length Desired length.
+   * @returns {array<FileOp>} Appropriately-constructed array of ops.
+   */
+  static makeLength(length) {
+    const ops = [];
+
+    for (let i = 0; i < length; i++) {
+      ops.push(FileOp.op_checkPathPresent(`/blort/${i}`));
+    }
+
+    return ops;
+  }
+
+  /**
+   * Makes an op with the given name. The second argument is to allow for
+   * different values, without introducing nondeterminism.
+   *
+   * @param {string} name Op name, as defined by {@link FileOp}.
+   * @param {Int} n Non-negative integer, to provide something to derive a
+   *   unique value from.
+   * @returns {FileOp} Appropriate op.
+   */
+  static makeOp(name, n) {
+    const schema = FileOp.propsFromName(name);
+    const args   = [];
+
+    for (const [name_unused, type] of schema.args) {
+      args.push(FileOpMaker._makeValue(type, n));
+    }
+
+    return FileOp[`op_${name}`](...args);
+  }
+
+  /**
+   * Makes a valid array with one of each op type _except_ wait ops, and at
+   * least the given number each of ops of type `push` and `pull`.
+   *
+   * @param {Int} count How many of each `push` and `pull` op to include.
+   * @returns {array<FileOp>} Appropriately-constructed array of ops.
+   */
+  static makePushPull(count) {
+    const ops = [];
+
+    for (const name of FileOp.OPERATION_NAMES) {
+      const schema = FileOp.propsFromName(name);
+      if (schema.category === FileOp.CAT_WAIT) {
+        continue;
+      }
+
+      const n = (schema.isPush || schema.isPull) ? count : 1;
+      for (let i = 0; i < n; i++) {
+        ops.push(FileOpMaker.makeOp(name, i));
+      }
+    }
+
+    return ops;
+  }
+
+  /**
+   * Performs a series of `it()` test cases with various valid arrays of ops
+   * passed to an inner test function.
+   *
+   * @param {function} testFunction Test function to call. It is passed a valid
+   *   array of ops as a single argument.
+   */
+  static testCases(testFunction) {
+    function test(value, label = null) {
+      if (label === null) {
+        label = inspect(value);
+      }
+
+      it(`works with: ${label}`, () => {
+        testFunction(value);
+      });
+    }
+
+    test([]);
+    test(FileOpMaker.makeLength(1));
+    test(FileOpMaker.makeLength(2));
+    test(FileOpMaker.makeLength(10));
+    test(FileOpMaker.makeLength(50),  '(length 50)');
+    test(FileOpMaker.makeLength(123), '(length 123)');
+    test(FileOpMaker.makePushPull(1));
+    test(FileOpMaker.makePushPull(2), '(push-pull 2)');
+    test(FileOpMaker.makePushPull(5), '(push-pull 5)');
+  }
+
+  /**
+   * Makes a value of the given type. The second argument is to allow for
+   * different values, without introducing nondeterminism.
+   *
+   * @param {string} type Value type, as defined by {@link FileOp}.
+   * @param {Int} n Non-negative integer, to provide something to derive a
+   *   unique value from.
+   * @returns {*} Appropriate value.
+   */
+  static _makeValue(type, n) {
+    switch (type) {
+      case FileOp.TYPE_BUFFER: {
+        return FrozenBuffer.coerce(`buffer_${n}`);
+      }
+      case FileOp.TYPE_DUR_MSEC: {
+        return n * 1234;
+      }
+      case FileOp.TYPE_HASH: {
+        const buf = FrozenBuffer.coerce(`buffer_hash_${n}`);
+        return buf.hash;
+      }
+      case FileOp.TYPE_PATH: {
+        return `/path/${n}`;
+      }
+      case FileOp.TYPE_REV_NUM: {
+        return n;
+      }
+      default: {
+        // Indicates a bug in this class.
+        throw Errors.wtf(`Weird \`type\` constant: ${type}`);
+      }
+    }
+  }
+}

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -51,7 +51,7 @@ export default class FileOpMaker extends UtilityClass {
   }
 
   /**
-   * Makes a valid array with one of each op type _except_ wait ops, and at
+   * Makes a valid array with one of each op name _except_ wait ops, and at
    * least the given number each of ops of type `push` and `pull`.
    *
    * @param {Int} count How many of each `push` and `pull` op to include.
@@ -67,6 +67,31 @@ export default class FileOpMaker extends UtilityClass {
       }
 
       const n = (schema.isPush || schema.isPull) ? count : 1;
+      for (let i = 0; i < n; i++) {
+        ops.push(FileOpMaker.makeOp(name, i));
+      }
+    }
+
+    return ops;
+  }
+
+  /**
+   * Makes a valid array with one of each op name _except_ push and pull ops,
+   * and at least the given number each of ops of type `wait`.
+   *
+   * @param {Int} count How many of each `wait` op to include.
+   * @returns {array<FileOp>} Appropriately-constructed array of ops.
+   */
+  static makeWait(count) {
+    const ops = [];
+
+    for (const name of FileOp.OPERATION_NAMES) {
+      const schema = FileOp.propsFromName(name);
+      if (schema.isPush || schema.isPull) {
+        continue;
+      }
+
+      const n = (schema.category === FileOp.CAT_WAIT) ? count : 1;
       for (let i = 0; i < n; i++) {
         ops.push(FileOpMaker.makeOp(name, i));
       }
@@ -103,6 +128,9 @@ export default class FileOpMaker extends UtilityClass {
     test(FileOpMaker.makePushPull(1));
     test(FileOpMaker.makePushPull(2), '(push-pull 2)');
     test(FileOpMaker.makePushPull(5), '(push-pull 5)');
+    test(FileOpMaker.makeWait(1));
+    test(FileOpMaker.makeWait(2), '(wait 2)');
+    test(FileOpMaker.makeWait(5), '(wait 5)');
   }
 
   /**

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { it } from 'mocha';
+import { describe } from 'mocha';
 import { inspect } from 'util';
 
 import { FileOp } from 'file-store';
@@ -76,8 +76,8 @@ export default class FileOpMaker extends UtilityClass {
   }
 
   /**
-   * Performs a series of `it()` test cases with various valid arrays of ops
-   * passed to an inner test function.
+   * Performs a series of `describe()` test cases with various valid arrays of
+   * ops passed to an inner test function.
    *
    * @param {function} testFunction Test function to call. It is passed a valid
    *   array of ops as a single argument.
@@ -88,7 +88,8 @@ export default class FileOpMaker extends UtilityClass {
         label = inspect(value);
       }
 
-      it(`works with: ${label}`, () => {
+      describe(`for ops: ${label}`, () => {
+        value = Object.freeze(value);
         testFunction(value);
       });
     }


### PR DESCRIPTION
This PR consists of various bits of cleanup, which are either (a) opportunities I noticed while working on the code over the last week or so, or (b) cleanups of messes I _caused_ over the last week or so. Highlights:

* Simplified `TransactionSpec` a bit, and added a bunch of tests for it.
* Extracted a base `compose()` method into `BaseDelta`. This made it possible to remove all of the `_impl_composeWithDelta()` methods on `BaseSnapshot` and its subclasses.
* Added a second argument to `BaseDelta.compose()`, `wantDocument`, which indicates whether or not the result should be a document delta. Added the same argument to `BaseControl.getComposedChanges()`. This all made it possible to undo a workaround I added earlier.
