### PR TITLE
`deconstruct()`

### DIFF
--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -37,7 +37,7 @@ export default class CodableError extends InfoError {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return (this.cause === null) ? [this.info] : [this.cause, this.info];

--- a/local-modules/api-common/CodableError.js
+++ b/local-modules/api-common/CodableError.js
@@ -35,6 +35,15 @@ export default class CodableError extends InfoError {
   }
 
   /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  deconstruct() {
+    return (this.cause === null) ? [this.info] : [this.cause, this.info];
+  }
+
+  /**
    * Custom inspector function, as called by `util.inspect()`. This just returns
    * the info portion instead of also including the stack trace, since the stack
    * trace is meaningless on instances of this class (they will typically just
@@ -53,15 +62,6 @@ export default class CodableError extends InfoError {
       : Object.assign({}, opts, { depth: opts.depth - 1 });
 
     return `${this.constructor.name}: ${inspect(this.info, subOpts)}`;
-  }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return (this.cause === null) ? [this.info] : [this.cause, this.info];
   }
 
   /**

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -40,7 +40,7 @@ export default class Message extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return [this._id, this._target, this._payload];

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -38,11 +38,11 @@ export default class Message extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
+   * Gets reconstruction arguments for this instance.
    *
    * @returns {array} Reconstruction arguments.
    */
-  toCodecArgs() {
+  deconstruct() {
     return [this._id, this._target, this._payload];
   }
 

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -91,11 +91,11 @@ export default class Response extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
+   * Gets reconstruction arguments for this instance.
    *
    * @returns {array} Reconstruction arguments.
    */
-  toCodecArgs() {
+  deconstruct() {
     return [this._id, this._result, this._error];
   }
 

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -93,7 +93,7 @@ export default class Response extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return [this._id, this._result, this._error];

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -70,11 +70,11 @@ export default class SplitKey extends BaseKey {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
+   * Gets reconstruction arguments for this instance.
    *
    * @returns {array} Reconstruction arguments.
    */
-  toCodecArgs() {
+  deconstruct() {
     return [this.url, this.id, this._secret];
   }
 

--- a/local-modules/api-common/SplitKey.js
+++ b/local-modules/api-common/SplitKey.js
@@ -72,7 +72,7 @@ export default class SplitKey extends BaseKey {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return [this.url, this.id, this._secret];

--- a/local-modules/codec/Codec.js
+++ b/local-modules/codec/Codec.js
@@ -120,11 +120,11 @@ export default class Codec extends Singleton {
    *
    * * Objects that are instances of classes (that is, have constructor
    *   functions) are allowed, as long as they at least bind a method
-   *   `toCodecArgs()`. In addition, if they have a static `CODEC_TAG` property
+   *   `deconstruct()`. In addition, if they have a static `CODEC_TAG` property
    *   then that is used as the tag (class name) in encoded form. The encoded
    *   form is an array with the first element being the value tag (typically
    *   the class name) and the rest of the elements whatever was returned by
-   *  `toCodecArgs()`.
+   *  `deconstruct()`.
    *
    * * All other objects are rejected.
    *

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -109,12 +109,12 @@ export default class ItemCodec extends CommonBase {
    */
   static fromClass(clazz) {
     TFunction.checkClass(clazz);
-    TFunction.checkCallable(clazz.prototype.toCodecArgs);
+    TFunction.checkCallable(clazz.prototype.deconstruct);
 
     const tag = clazz.CODEC_TAG || clazz.name;
 
     const encode = (value, subEncode) => {
-      const payload = TArray.check(value.toCodecArgs());
+      const payload = TArray.check(value.deconstruct());
       return payload.map(subEncode);
     };
 

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -52,7 +52,7 @@ export default class Registry extends CommonBase {
 
   /**
    * Registers a class to be accepted for codec use. To be valid, a class must
-   * define an instance method `toCodecArgs()`. In addition, it can optionally
+   * define an instance method `deconstruct()`. In addition, it can optionally
    * define a static property `CODEC_TAG` as a replacement for its class name
    * for use as the tag when encoding.
    *

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -103,7 +103,7 @@ export default class SpecialCodecs extends UtilityClass {
    * @returns {array<*>} Encoded form.
    */
   static _functorEncode(value, subEncode) {
-    return [value.name, ...(value.args)].map(subEncode);
+    return value.deconstruct().map(subEncode);
   }
 
   /** {ItemCodec} Codec used for coding plain objects. */

--- a/local-modules/codec/mocks/MockCodable.js
+++ b/local-modules/codec/mocks/MockCodable.js
@@ -15,7 +15,7 @@ export default class MockCodable {
     this.args        = args;
   }
 
-  toCodecArgs() {
+  deconstruct() {
     return ['fake argument', 0, 1, 2];
   }
 }

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -10,7 +10,7 @@ import { MockCodable } from 'codec/mocks';
 import { FrozenBuffer } from 'util-common';
 
 class NoCodecTag {
-  toCodecArgs() {
+  deconstruct() {
     return 'NoCodecTag!';
   }
 }
@@ -80,13 +80,13 @@ describe('api-common/Codec.encode*()', () => {
       assert.throws(() => encodeData(noCodecTag));
     });
 
-    it('should reject objects with no toCodecArgs() method', () => {
+    it('should reject objects with no `deconstruct()` method', () => {
       const noToCodecArgs = new NoToCodecArgs();
 
       assert.throws(() => encodeData(noToCodecArgs));
     });
 
-    it('should accept objects with an CODEC_TAG property and toCodecArgs() method', () => {
+    it('should accept objects with an CODEC_TAG property and `deconstruct()` method', () => {
       const fakeObject = new MockCodable();
 
       assert.doesNotThrow(() => encodeData(fakeObject));

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -20,13 +20,13 @@ class RegistryTestClass {
     return 'RegistryTestClass';
   }
 
-  toCodecArgs() {
+  deconstruct() {
     return ['fake argument', 0, 1, 2];
   }
 }
 
 class NoCodecTag {
-  toCodecArgs() {
+  deconstruct() {
     return 'NoCodecTag!';
   }
 }
@@ -49,7 +49,7 @@ describe('api-common/Registry', () => {
       assert.doesNotThrow(() => reg.registerClass(NoCodecTag));
     });
 
-    it('should reject a class without `toCodecArgs()`', () => {
+    it('should reject a class without `deconstruct()`', () => {
       const reg = new Registry();
       assert.throws(() => reg.registerClass(NoToCodecArgs));
     });

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -147,7 +147,7 @@ export default class BaseChange extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     // **Note:** `[0]` on the `delta` argument is because `deconstruct()`

--- a/local-modules/doc-common/BaseChange.js
+++ b/local-modules/doc-common/BaseChange.js
@@ -145,11 +145,11 @@ export default class BaseChange extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
+   * Gets reconstruction arguments for this instance.
    *
    * @returns {array} Reconstruction arguments.
    */
-  toCodecArgs() {
+  deconstruct() {
     // **Note:** `[0]` on the `delta` argument is because `deconstruct()`
     // returns an _array_ of arguments which can be used to reconstruct an
     // instance, and we know in this case that deltas always deconstruct to a

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -212,29 +212,6 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
-   * Custom inspector function, as called by `util.inspect()`.
-   *
-   * @param {Int} depth Current inspection depth.
-   * @param {object} opts Inspection options.
-   * @returns {string} The inspection string form of this instance.
-   */
-  [inspect.custom](depth, opts) {
-    if (depth < 0) {
-      return `${this.constructor.name} [...]`;
-    }
-
-    // Set up the inspection opts so that recursive calls respect the topmost
-    // requested depth.
-    const subOpts = (opts.depth === null)
-      ? opts
-      : Object.assign({}, opts, { depth: opts.depth - 1 });
-
-    const body = inspect(this._ops, subOpts);
-
-    return `${this.constructor.name} ${body}`;
-  }
-
-  /**
    * Returns `true` iff this instance has the form of a "document," or put
    * another way, iff it is valid to compose with an instance which represents
    * an empty snapshot. The details of what makes an instance a document vary

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
 import { TArray, TBoolean, TFunction } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
@@ -162,13 +160,12 @@ export default class BaseDelta extends CommonBase {
    * `opClass` gets to be implied instead of redundantly encoded.
    *
    * @returns {array<array<*>>} Array of array of operation-construction
-   *   arguments. The result is always a deeply-frozen array.
+   *   arguments.
    */
   deconstruct() {
     const ops = this._ops.map(op => op.deconstruct());
 
-    Object.freeze(ops);
-    return Object.freeze([ops]);
+    return [ops];
   }
 
   /**

--- a/local-modules/doc-common/BaseDelta.js
+++ b/local-modules/doc-common/BaseDelta.js
@@ -262,15 +262,6 @@ export default class BaseDelta extends CommonBase {
   }
 
   /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return this.deconstruct();
-  }
-
-  /**
    * Main implementation of {@link #compose}. Subclasses must fill this in.
    *
    * @abstract

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -69,29 +69,4 @@ export default class BaseOp extends CommonBase {
     return (this.constructor === other.constructor)
       && this._payload.equals(other._payload);
   }
-
-  /**
-   * Custom inspector function, as called by `util.inspect()`.
-   *
-   * @param {Int} depth Current inspection depth.
-   * @param {object} opts Inspection options.
-   * @returns {string} The inspection string form of this instance.
-   */
-  [inspect.custom](depth, opts) {
-    if (depth < 0) {
-      return `${this.constructor.name}:...`;
-    }
-
-    // Set up the inspection opts so that recursive calls respect the topmost
-    // requested depth.
-    const subOpts = (opts.depth === null)
-      ? opts
-      : Object.assign({}, opts, { depth: opts.depth - 1 });
-
-    const payload = inspect(this._payload, subOpts);
-
-    // Since the payload is a functor -- which has a custom inspect renderer --
-    // the result here looks like `FlorpOp:some_op_name(arg, arg)`.
-    return `${this.constructor.name}:${payload}`;
-  }
 }

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -94,13 +94,4 @@ export default class BaseOp extends CommonBase {
     // the result here looks like `FlorpOp:some_op_name(arg, arg)`.
     return `${this.constructor.name}:${payload}`;
   }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return this.deconstruct();
-  }
 }

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -38,14 +38,12 @@ export default class BaseOp extends CommonBase {
   }
 
   /**
-   * "Deconstructs" this instance, returning an array which is suitable for
-   * passing to the constructor of this class.
+   * Gets reconstruction arguments for this instance.
    *
-   * @returns {array<*>} Reconstruction arguments. The result is always deeply
-   * frozen.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
-    return Object.freeze([this._payload.name, ...this._payload.args]);
+    return [this._payload.name, ...this._payload.args];
   }
 
   /**

--- a/local-modules/doc-common/BaseOp.js
+++ b/local-modules/doc-common/BaseOp.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
 import { CommonBase, Functor } from 'util-common';
 
 /**

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -154,6 +154,19 @@ export default class BaseSnapshot extends CommonBase {
   }
 
   /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  deconstruct() {
+    // **Note:** `[0]` on the `delta` argument is because `deconstruct()`
+    // returns an _array_ of arguments which can be used to reconstruct an
+    // instance, and we know in this case that deltas always deconstruct to a
+    // single-element array (because the constructor only accepts one argument).
+    return [this._revNum, this._contents.deconstruct()[0]];
+  }
+
+  /**
    * Calculates the difference from a given snapshot to this one. The return
    * value is a change which can be composed with this instance to produce the
    * snapshot passed in here as an argument. That is, roughly speaking,
@@ -207,19 +220,6 @@ export default class BaseSnapshot extends CommonBase {
     return (this.constructor === other.constructor)
       && (this._revNum === other._revNum)
       && this._contents.equals(other._contents);
-  }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    // **Note:** `[0]` on the `delta` argument is because `deconstruct()`
-    // returns an _array_ of arguments which can be used to reconstruct an
-    // instance, and we know in this case that deltas always deconstruct to a
-    // single-element array (because the constructor only accepts one argument).
-    return [this._revNum, this._contents.deconstruct()[0]];
   }
 
   /**

--- a/local-modules/doc-common/BaseSnapshot.js
+++ b/local-modules/doc-common/BaseSnapshot.js
@@ -156,7 +156,7 @@ export default class BaseSnapshot extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     // **Note:** `[0]` on the `delta` argument is because `deconstruct()`

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -205,6 +205,21 @@ export default class Caret extends CommonBase {
   }
 
   /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  deconstruct() {
+    // Convert the `_fields` map to a plain object for the purpose of coding.
+    const fields = {};
+    for (const [k, v] of this._fields) {
+      fields[k] = v;
+    }
+
+    return [this._sessionId, fields];
+  }
+
+  /**
    * Calculates the difference from a given caret to this one. The return
    * value is a delta which can be composed with this instance to produce the
    * snapshot passed in here as an argument. That is, `newerCaret ==
@@ -284,21 +299,6 @@ export default class Caret extends CommonBase {
     }
 
     return true;
-  }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    // Convert the `_fields` map to a plain object for the purpose of coding.
-    const fields = {};
-    for (const [k, v] of this._fields) {
-      fields[k] = v;
-    }
-
-    return [this._sessionId, fields];
   }
 
   /**

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -207,7 +207,7 @@ export default class Caret extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     // Convert the `_fields` map to a plain object for the purpose of coding.

--- a/local-modules/doc-common/Property.js
+++ b/local-modules/doc-common/Property.js
@@ -42,7 +42,7 @@ export default class Property extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return [this._name, this._value];

--- a/local-modules/doc-common/Property.js
+++ b/local-modules/doc-common/Property.js
@@ -40,6 +40,15 @@ export default class Property extends CommonBase {
   }
 
   /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  deconstruct() {
+    return [this._name, this._value];
+  }
+
+  /**
    * Compares this to another value, for equality.
    *
    * @param {*} other Value to compare to.
@@ -55,14 +64,5 @@ export default class Property extends CommonBase {
 
     return (this._name === other._name)
       && DataUtil.equalData(this._value, other._value);
-  }
-
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return [this._name, this._value];
   }
 }

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -120,15 +120,6 @@ export default class Timestamp extends CommonBase {
     Object.freeze(this);
   }
 
-  /**
-   * Converts this instance to codec reconstruction arguments.
-   *
-   * @returns {array} Reconstruction arguments.
-   */
-  toCodecArgs() {
-    return [this._secs, this._usecs];
-  }
-
   /** {Int} The number of seconds since the Unix Epoch. */
   get secs() {
     return this._secs;
@@ -207,6 +198,15 @@ export default class Timestamp extends CommonBase {
     } else {
       return 1;
     }
+  }
+
+  /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array} Reconstruction arguments.
+   */
+  deconstruct() {
+    return [this._secs, this._usecs];
   }
 
   /**

--- a/local-modules/doc-common/Timestamp.js
+++ b/local-modules/doc-common/Timestamp.js
@@ -203,7 +203,7 @@ export default class Timestamp extends CommonBase {
   /**
    * Gets reconstruction arguments for this instance.
    *
-   * @returns {array} Reconstruction arguments.
+   * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
     return [this._secs, this._usecs];

--- a/local-modules/doc-common/tests/test_BaseDelta.js
+++ b/local-modules/doc-common/tests/test_BaseDelta.js
@@ -165,11 +165,11 @@ describe('doc-common/BaseDelta', () => {
   });
 
   describe('deconstruct()', () => {
-    it('should return a deep-frozen data value', () => {
+    it('should return a data value', () => {
       const delta  = new MockDelta([['a', 1, 2, 3, [4, 5, 6]], ['b', { x: ['y'] }]]);
       const result = delta.deconstruct();
 
-      assert.isTrue(DataUtil.isDeepFrozen(result));
+      assert.isTrue(DataUtil.isData(result));
     });
 
     it('should return an array of length one, which contains an array-of-arrays', () => {

--- a/local-modules/doc-common/tests/test_BaseOp.js
+++ b/local-modules/doc-common/tests/test_BaseOp.js
@@ -90,12 +90,12 @@ describe('doc-common/BaseOp', () => {
   });
 
   describe('deconstruct()', () => {
-    it('should return a deep-frozen array data value', () => {
+    it('should return an array data value', () => {
       const op     = new MockOp('blort', ['florp', 'like'], { timeline: 'sideways' });
       const result = op.deconstruct();
 
       assert.isArray(result);
-      assert.isTrue(DataUtil.isDeepFrozen(result));
+      assert.isTrue(DataUtil.isData(result));
     });
 
     it('should return a value which successfully round-trips from and to constructor arguments', () => {

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -57,6 +57,16 @@ export default class Functor {
   }
 
   /**
+   * "Deconstructs" this instance, returning an array which is suitable for
+   * passing to the constructor of this class.
+   *
+   * @returns {array<*>} Reconstruction arguments.
+   */
+  deconstruct() {
+    return [this._name, ...this._args];
+  }
+
+  /**
    * Custom inspector function, as called by `util.inspect()`.
    *
    * @param {Int} depth Current inspection depth.

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -57,8 +57,7 @@ export default class Functor {
   }
 
   /**
-   * "Deconstructs" this instance, returning an array which is suitable for
-   * passing to the constructor of this class.
+   * Gets reconstruction arguments for this instance.
    *
    * @returns {array<*>} Reconstruction arguments.
    */

--- a/scripts/lint
+++ b/scripts/lint
@@ -36,6 +36,9 @@ showHelp=0
 # Option for the output directory, if any.
 outDirOpt=()
 
+# Option for the overlay source directory, if any.
+overlayDirOpt=()
+
 while (( $# != 0 )); do
     opt="$1"
     if [[ ${opt} == '--' ]]; then
@@ -45,7 +48,9 @@ while (( $# != 0 )); do
             || ${opt} == '-h' ]]; then
         showHelp=1
     elif [[ ${opt} =~ ^--out= ]]; then
-        outDirOpt="${opt}"
+        outDirOpt=("${opt}")
+    elif [[ ${opt} =~ ^--overlay= ]]; then
+        overlayDirOpt=("${opt}")
     elif [[ ${opt} =~ ^- ]]; then
         echo "Unknown option: ${opt}" 1>&2
         argError=1
@@ -65,12 +70,14 @@ fi
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--out=<dir>] [--] [<file-or-dir> ...]"
+    echo "${progName} [--out=<dir>] [--overlay=<dir>] [--] [<file-or-dir> ...]"
     echo '  Run the linter on the indicated files or directories. With nothing'
     echo '  specified, runs over the entire project.'
     echo ''
     echo '  --out=<dir>'
     echo '    Place output (built linter tool) in directory <dir>.'
+    echo '  --overlay=<dir>'
+    echo '    Find overlay source in directory <dir>.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -89,7 +96,7 @@ fi
 
 lintDir="${outDir}/linter"
 
-"${progDir}/build" "${outDirOpt[@]}" --linter || exit 1
+"${progDir}/build" "${outDirOpt[@]}" "${overlayDirOpt[@]}" --linter || exit 1
 
 "${lintDir}/node_modules/.bin/eslint" \
     --cache --cache-location "${lintDir}/cache" \

--- a/scripts/lint
+++ b/scripts/lint
@@ -39,6 +39,9 @@ outDirOpt=()
 # Option for the overlay source directory, if any.
 overlayDirOpt=()
 
+# Overlay source directory, if any.
+overlayDir=''
+
 while (( $# != 0 )); do
     opt="$1"
     if [[ ${opt} == '--' ]]; then
@@ -49,7 +52,8 @@ while (( $# != 0 )); do
         showHelp=1
     elif [[ ${opt} =~ ^--out= ]]; then
         outDirOpt=("${opt}")
-    elif [[ ${opt} =~ ^--overlay= ]]; then
+    elif [[ ${opt} =~ ^--overlay=(.*) ]]; then
+        overlayDir="${BASH_REMATCH[1]}"
         overlayDirOpt=("${opt}")
     elif [[ ${opt} =~ ^- ]]; then
         echo "Unknown option: ${opt}" 1>&2
@@ -65,6 +69,9 @@ unset opt
 args=("$@")
 if (( ${#args[@]} == 0 )); then
     args=("${baseDir}")
+    if [[ ${overlayDir} != '' ]]; then
+        args+=("${overlayDir}")
+    fi
 fi
 
 if (( ${showHelp} || ${argError} )); then
@@ -72,7 +79,8 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo "${progName} [--out=<dir>] [--overlay=<dir>] [--] [<file-or-dir> ...]"
     echo '  Run the linter on the indicated files or directories. With nothing'
-    echo '  specified, runs over the entire project.'
+    echo '  specified, runs over the entire project (including overlay source'
+    echo '  if indicated).'
     echo ''
     echo '  --out=<dir>'
     echo '    Place output (built linter tool) in directory <dir>.'


### PR DESCRIPTION
This PR finishes work I started a few weeks ago to turn the codec-specific `toCodecArgs()` method into a general `deconstruct()` method. Highlights include adding a generalized `inspect()` implementation for classes that implement `deconstruct()` and the removal of a lot of now-redundant code.

**Bonus:** Stop ignoring overlay source during the build step when `lint`ing.