### PR TITLE
`BaseControl` and `FileOp`

### DIFF
--- a/local-modules/doc-common/mocks/index.js
+++ b/local-modules/doc-common/mocks/index.js
@@ -2,10 +2,18 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Codec } from 'codec';
+
 import MockChange from './MockChange';
 import MockDelta from './MockDelta';
 import MockOp from './MockOp';
 import MockSnapshot from './MockSnapshot';
+
+// Register classes with the API.
+Codec.theOne.registerClass(MockChange);
+Codec.theOne.registerClass(MockDelta);
+Codec.theOne.registerClass(MockOp);
+Codec.theOne.registerClass(MockSnapshot);
 
 export {
   MockChange,

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -205,6 +205,26 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * Gets a particular change to the part of the document that this instance
+   * controls. This is just a convenient shorthand for
+   * `await getChangeRange(revNum, revNum + 1)[0]`.
+   *
+   * @param {Int} revNum The revision number of the change. The result is the
+   *   change which produced that revision. E.g., `0` is a request for the first
+   *   change (the change from the empty document).
+   * @returns {BodyChange} The requested change.
+   */
+  async getChange(revNum) {
+    // We need to do this check so that the error (if there's an error) is both
+    // more prompt and more sensible than if we just deferred to
+    // `getChangeRange()`.
+    RevisionNumber.check(revNum);
+
+    const changes = await this.getChangeRange(revNum, revNum + 1);
+    return changes[0];
+  }
+
+  /**
    * Returns a document change representing a change to the portion of the file
    * controlled by this instance which has been made with respect to a given
    * revision. This returns a promptly-resolved value when `baseRevNum` is not

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -536,6 +536,30 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * {TransactionSpec} Spec for a transaction which when run will initialize the
+   * portion of the file which this class is responsible for. This
+   * implementation should be sufficient for all subclasses of this class.
+   */
+  get _impl_initSpec() {
+    const clazz = this.constructor;
+    const fc    = this.fileCodec; // Avoids boilerplate immediately below.
+
+    return new TransactionSpec(
+      // Clear out old data, if any. For example (and especially during
+      // development), there might be data in an old schema. By the time we get
+      // here, if there were anything to preserve it would have already been
+      // preserved.
+      fc.op_deletePathPrefix(clazz.pathPrefix),
+
+      // Initial revision number.
+      fc.op_writePath(clazz.revisionNumberPath, 0),
+
+      // Empty change #0.
+      fc.op_writePath(clazz.pathForChange(0), clazz.changeClass.FIRST)
+    );
+  }
+
+  /**
    * Subclass-specific implementation of `getChangeAfter()`. Subclasses must
    * override this method.
    *

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -48,26 +48,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * {TransactionSpec} Spec for a transaction which when run will initialize the
-   * portion of the file which this class is responsible for.
-   */
-  get _impl_initSpec() {
-    const fc = this.fileCodec; // Avoids boilerplate immediately below.
-
-    return new TransactionSpec(
-      // If there was any body content (e.g. and most likely data in an earlier
-      // schema, this clears it out.
-      fc.op_deletePathPrefix(Paths.BODY_PREFIX),
-
-      // Initial revision number.
-      fc.op_writePath(BodyControl.revisionNumberPath, 0),
-
-      // Empty change #0 (per documented interface).
-      fc.op_writePath(BodyControl.pathForChange(0), BodyChange.FIRST)
-    );
-  }
-
-  /**
    * Subclass-specific implementation of `afterInit()`.
    */
   async _impl_afterInit() {

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -31,23 +31,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Gets a particular change to the document. The document consists of a
-   * sequence of changes, each modifying revision N of the document to produce
-   * revision N+1.
-   *
-   * @param {Int} revNum The revision number of the change. The result is the
-   *   change which produced that revision. E.g., `0` is a request for the first
-   *   change (the change from the empty document).
-   * @returns {BodyChange} The requested change.
-   */
-  async getChange(revNum) {
-    RevisionNumber.check(revNum);
-
-    const changes = await this.getChangeRange(revNum, revNum + 1);
-    return changes[0];
-  }
-
-  /**
    * Subclass-specific implementation of `afterInit()`.
    */
   async _impl_afterInit() {

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -97,25 +97,6 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
-   * {TransactionSpec} Spec for a transaction which when run will initialize the
-   * portion of the file which this class is responsible for.
-   */
-  get _impl_initSpec() {
-    const fc = this.fileCodec; // Avoids boilerplate immediately below.
-
-    return new TransactionSpec(
-      // Clear out old data, if any.
-      fc.op_deletePathPrefix(Paths.CARET_PREFIX),
-
-      // Initial revision number.
-      fc.op_writePath(CaretControl.revisionNumberPath, 0),
-
-      // Empty change #0.
-      fc.op_writePath(CaretControl.pathForChange(0), CaretChange.FIRST)
-    );
-  }
-
-  /**
    * Subclass-specific implementation of `afterInit()`.
    */
   async _impl_afterInit() {

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -31,25 +31,6 @@ export default class PropertyControl extends BaseControl {
   }
 
   /**
-   * {TransactionSpec} Spec for a transaction which when run will initialize the
-   * portion of the file which this class is responsible for.
-   */
-  get _impl_initSpec() {
-    const fc = this.fileCodec; // Avoids boilerplate immediately below.
-
-    return new TransactionSpec(
-      // Clear out old property data, if any.
-      fc.op_deletePathPrefix(Paths.PROPERTY_PREFIX),
-
-      // Initial revision number.
-      fc.op_writePath(PropertyControl.revisionNumberPath, 0),
-
-      // Empty change #0.
-      fc.op_writePath(PropertyControl.pathForChange(0), PropertyChange.FIRST)
-    );
-  }
-
-  /**
    * Subclass-specific implementation of `afterInit()`.
    */
   async _impl_afterInit() {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -179,8 +179,8 @@ describe('doc-server/BaseControl', () => {
       assert.strictEqual(gotSpec.ops.length, 2);
       assert.lengthOf(ops1, 1);
       assert.lengthOf(ops2, 1);
-      assert.strictEqual(ops1[0].arg('storagePath'), '/mock_control/revision_number');
-      assert.strictEqual(ops2[0].arg('storagePath'), '/mock_control/revision_number');
+      assert.strictEqual(ops1[0].props.storagePath, '/mock_control/revision_number');
+      assert.strictEqual(ops2[0].props.storagePath, '/mock_control/revision_number');
     });
 
     it('should use the result of the transaction it performed', async () => {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -13,10 +13,10 @@ import { MockControl } from 'doc-server/mocks';
 import { TransactionSpec } from 'file-store';
 import { MockFile } from 'file-store/mocks';
 
-/** {FileAccess} Convenient instance of `FileAccess`. */
-const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
-
 describe('doc-server/BaseControl', () => {
+  /** {FileAccess} Convenient instance of `FileAccess`. */
+  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+
   describe('.changeClass', () => {
     it('should reflect the subclass\'s implementation', () => {
       const result = MockControl.changeClass;
@@ -146,6 +146,13 @@ describe('doc-server/BaseControl', () => {
     it('should reject non-`FileAccess` arguments', () => {
       assert.throws(() => new MockControl(null,      'boop'));
       assert.throws(() => new MockControl({ x: 10 }, 'boop'));
+    });
+  });
+
+  describe('.initSpec', () => {
+    it('should be a `TransactionSpec`', () => {
+      const result = new MockControl(FILE_ACCESS, 'florp').initSpec;
+      assert.instanceOf(result, TransactionSpec);
     });
   });
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -104,7 +104,7 @@ export default class Transactor extends CommonBase {
         throw Errors.wtf(`Missing handler for op: ${op.name}`);
       }
 
-      handler.call(this, op);
+      handler.call(this, op.props);
     }
 
     this._log.detail('Transactor done.');
@@ -139,10 +139,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkBlobAbsent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkBlobAbsent(op) {
-    const hash = op.arg('hash');
+  _op_checkBlobAbsent(props) {
+    const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) !== null) {
       throw FileStoreErrors.blob_not_absent(hash);
@@ -152,10 +152,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkBlobPresent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkBlobPresent(op) {
-    const hash = op.arg('hash');
+  _op_checkBlobPresent(props) {
+    const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) === null) {
       throw FileStoreErrors.blob_not_found(hash);
@@ -165,10 +165,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkPathAbsent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkPathAbsent(op) {
-    const storagePath = op.arg('storagePath');
+  _op_checkPathAbsent(props) {
+    const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
       throw FileStoreErrors.path_not_absent(storagePath);
@@ -178,12 +178,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkPathIs` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkPathIs(op) {
-    const storagePath  = op.arg('storagePath');
-    const expectedHash = op.arg('hash');
-    const data         = this._fileFriend.readPathOrNull(storagePath);
+  _op_checkPathIs(props) {
+    const { hash: expectedHash, storagePath } = props;
+    const data = this._fileFriend.readPathOrNull(storagePath);
 
     if (data === null) {
       throw FileStoreErrors.path_not_found(storagePath);
@@ -195,12 +194,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkPathNot` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkPathNot(op) {
-    const storagePath    = op.arg('storagePath');
-    const unexpectedHash = op.arg('hash');
-    const data           = this._fileFriend.readPathOrNull(storagePath);
+  _op_checkPathNot(props) {
+    const { hash: unexpectedHash, storagePath } = props;
+    const data = this._fileFriend.readPathOrNull(storagePath);
 
     if ((data !== null) && (data.hash === unexpectedHash)) {
       throw FileStoreErrors.path_hash_mismatch(storagePath, unexpectedHash);
@@ -210,10 +208,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `checkPathPresent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_checkPathPresent(op) {
-    const storagePath = op.arg('storagePath');
+  _op_checkPathPresent(props) {
+    const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
       throw FileStoreErrors.path_not_found(storagePath);
@@ -223,9 +221,9 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `deleteAll` operations.
    *
-   * @param {FileOp} op_unused The operation.
+   * @param {object} props_unused The operation properties.
    */
-  _op_deleteAll(op_unused) {
+  _op_deleteAll(props_unused) {
     for (const [storagePath, value_unused] of this._fileFriend.allStorage()) {
       this._updatedStorage.set(storagePath, null);
     }
@@ -234,10 +232,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `deleteBlob` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_deleteBlob(op) {
-    const hash = op.arg('hash');
+  _op_deleteBlob(props) {
+    const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) !== null) {
       this._updatedStorage.set(hash, null);
@@ -247,10 +245,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `deletePath` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_deletePath(op) {
-    const storagePath = op.arg('storagePath');
+  _op_deletePath(props) {
+    const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
       this._updatedStorage.set(storagePath, null);
@@ -260,10 +258,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `deletePathPrefix` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_deletePathPrefix(op) {
-    const prefix = op.arg('storagePath');
+  _op_deletePathPrefix(props) {
+    const { storagePath: prefix } = props;
 
     for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {
       if (StoragePath.isPrefixOrSame(prefix, storagePath)) {
@@ -276,10 +274,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `listPathPrefix` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_listPathPrefix(op) {
-    const prefix = op.arg('storagePath');
+  _op_listPathPrefix(props) {
+    const { storagePath: prefix } = props;
 
     for (const [storagePath, value_unused] of this._fileFriend.pathStorage()) {
       if (StoragePath.isPrefixOrSame(prefix, storagePath)) {
@@ -297,11 +295,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `readBlob` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_readBlob(op) {
-    const hash = op.arg('hash');
-    const data = this._fileFriend.readBlobOrNull(hash);
+  _op_readBlob(props) {
+    const { hash } = props;
+    const data     = this._fileFriend.readBlobOrNull(hash);
 
     if (data !== null) {
       // Per the `FileOp` documentation, we are only supposed to bind a result
@@ -313,11 +311,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `readPath` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_readPath(op) {
-    const storagePath = op.arg('storagePath');
-    const data        = this._fileFriend.readPathOrNull(storagePath);
+  _op_readPath(props) {
+    const { storagePath } = props;
+    const data            = this._fileFriend.readPathOrNull(storagePath);
 
     if (data !== null) {
       // Per the `FileOp` documentation, we are only supposed to bind a result
@@ -331,10 +329,10 @@ export default class Transactor extends CommonBase {
    * a single revision available, and we reject the transaction should it not be
    * the requested restriction.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_revNum(op) {
-    const revNum = op.arg('revNum');
+  _op_revNum(props) {
+    const { revNum } = props;
 
     if (this._fileFriend.revNum !== revNum) {
       throw Errors.revision_not_available(revNum);
@@ -346,20 +344,20 @@ export default class Transactor extends CommonBase {
    * because the code in `LocalFile` that calls into here already takes care
    * of timeouts.
    *
-   * @param {FileOp} op_unused The operation.
+   * @param {object} props_unused The operation properties.
    */
-  _op_timeout(op_unused) {
+  _op_timeout(props_unused) {
     // This space intentionally left blank.
   }
 
   /**
    * Handler for `whenPathAbsent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_whenPathAbsent(op) {
-    const storagePath = op.arg('storagePath');
-    const value       = this._fileFriend.readPathOrNull(storagePath);
+  _op_whenPathAbsent(props) {
+    const { storagePath } = props;
+    const value           = this._fileFriend.readPathOrNull(storagePath);
 
     if (value === null) {
       this._paths.add(storagePath);
@@ -372,12 +370,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `whenPathNot` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  async _op_whenPathNot(op) {
-    const storagePath = op.arg('storagePath');
-    const hash        = op.arg('hash');
-    const value       = this._fileFriend.readPathOrNull(storagePath);
+  async _op_whenPathNot(props) {
+    const { hash, storagePath } = props;
+    const value                 = this._fileFriend.readPathOrNull(storagePath);
 
     if ((value === null) || (value.hash !== hash)) {
       this._paths.add(storagePath);
@@ -390,11 +387,11 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `whenPathPresent` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_whenPathPresent(op) {
-    const storagePath = op.arg('storagePath');
-    const value       = this._fileFriend.readPathOrNull(storagePath);
+  _op_whenPathPresent(props) {
+    const { storagePath } = props;
+    const value           = this._fileFriend.readPathOrNull(storagePath);
 
     if (value !== null) {
       this._paths.add(storagePath);
@@ -407,10 +404,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `writeBlob` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_writeBlob(op) {
-    const value = op.arg('value');
+  _op_writeBlob(props) {
+    const { value } = props;
 
     this._updatedStorage.set(value.hash, value);
   }
@@ -418,11 +415,10 @@ export default class Transactor extends CommonBase {
   /**
    * Handler for `writePath` operations.
    *
-   * @param {FileOp} op The operation.
+   * @param {object} props The operation properties.
    */
-  _op_writePath(op) {
-    const storagePath = op.arg('storagePath');
-    const value       = op.arg('value');
+  _op_writePath(props) {
+    const { storagePath, value } = props;
 
     this._updatedStorage.set(storagePath, value);
   }

--- a/local-modules/file-store/FileCodec.js
+++ b/local-modules/file-store/FileCodec.js
@@ -81,9 +81,10 @@ export default class FileCodec extends CommonBase {
    */
   static _addFileOpConstructorMethods() {
     const proto = FileCodec.prototype;
-    for (const [category_unused, opName, ...argInfo] of FileOp.OPERATIONS) {
-      const methodName = `op_${opName}`;
-      const originalMethod = FileOp[methodName].bind(FileOp);
+    for (const name of FileOp.OPERATION_NAMES) {
+      const { args: argInfo } = FileOp.propsFromName(name);
+      const methodName        = `op_${name}`;
+      const originalMethod    = FileOp[methodName].bind(FileOp);
 
       // Figure out which arguments are buffers, if any.
       const bufferAt = [];

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -525,6 +525,24 @@ export default class FileOp extends CommonBase {
   }
 
   /**
+   * {object} The properties of this operation, as a conveniently-accessed
+   * plain object. `opName` is always bound to the operation name, and
+   * `category` to the category. Other bindings depend on the operation name.
+   * Guaranteed to be a frozen (immutable) object.
+   */
+  get props() {
+    const category = this._category;
+    const opName   = this._name;
+    const result   = { category, opName };
+
+    for (const [name, value] of this._args) {
+      result[name] = value;
+    }
+
+    return Object.freeze(result);
+  }
+
+  /**
    * Custom inspect function to provide a more succinct representation than the
    * default.
    *

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -557,12 +557,13 @@ export default class FileOp extends CommonBase {
   }
 
   /**
-   * Based on the operation `OPERATIONS`, add `static` constructor methods to
+   * Based on the set of defined operations, add `static` constructor methods to
    * this class. This method is called during class initialization. (Look at
-   * the bottome of this file for the call.)
+   * the bottom of this file for the call.)
    */
   static _addConstructorMethods() {
-    for (const [category, opName, ...argInfo] of OPERATIONS) {
+    for (const opName of FileOp.OPERATION_NAMES) {
+      const { category, args: argInfo } = FileOp.propsFromName(opName);
       const constructorMethod = (...args) => {
         if (args.length !== argInfo.length) {
           throw Errors.bad_use(`Wrong argument count for op constructor. Expected ${argInfo.length}.`);

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -481,13 +481,19 @@ export default class FileOp extends CommonBase {
       throw Errors.bad_use('Constructor is private.');
     }
 
+    // This validates `name`.
+    const opProps = FileOp.propsFromName(name);
+
+    // This both validates and modifies `args`.
+    FileOp._fixArgs(opProps, args);
+
     super();
 
     /** {object} Properties of the _operation_. */
-    this._opProps = FileOp.propsFromName(name);
+    this._opProps = opProps;
 
     /** {array<*>} Arguments to the operation. */
-    this._args = Object.freeze(args);
+    this._args = args;
 
     Object.freeze(this);
   }
@@ -560,9 +566,7 @@ export default class FileOp extends CommonBase {
    */
   static _addConstructorMethods() {
     for (const opName of FileOp.OPERATION_NAMES) {
-      const opProps = FileOp.propsFromName(opName);
       const constructorMethod = (...args) => {
-        FileOp._fixArgs(opProps, args);
         return new FileOp(KEY, opName, ...args);
       };
 

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -42,13 +42,13 @@ const TYPE_PATH      = 'Path';
 const TYPE_HASH      = 'Hash';
 const TYPE_REV_NUM   = 'RevNum';
 
-// Operation schemata. See the doc for the equivalent static property for
+// Operation schemata. See the doc for {@link FileOp#propsFromName} for
 // details.
 //
 // **Note:** The comments below aren't "real" JSDoc comments, because JSDoc
 // has no way of understanding that the elements cause methods to be generated.
 // So it goes.
-const OPERATIONS = DataUtil.deepFreeze([
+const OPERATIONS = [
   /*
    * A `checkBlobAbsent` operation. This is a prerequisite operation that
    * verifies that the file does not store a blob with the indicated hash.
@@ -261,7 +261,7 @@ const OPERATIONS = DataUtil.deepFreeze([
    * @param {FrozenBuffer} value The value to store and bind to `storagePath`.
    */
   [CAT_WRITE, 'writePath', ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]]
-]);
+];
 
 /**
  * {Map<string,object>} Map from operation name to corresponding properties
@@ -273,7 +273,7 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
   const isPush = (category === CAT_WRITE) || (category === CAT_DELETE);
 
   const props = { category, name, args, isPull, isPush };
-  return [name, Object.freeze(props)];
+  return [name, DataUtil.deepFreeze(props)];
 }));
 
 /**
@@ -358,24 +358,6 @@ export default class FileOp extends CommonBase {
     return Object.freeze([...OPERATION_MAP.keys()]);
   }
 
-  /**
-   * {array<array>} List of operation schemata. These are used to
-   * programatically define static methods on `FileOp` for constructing
-   * instances. Each element consists of three parts, as follows:
-   *
-   * * `category` &mdash; The category of the operation.
-   * * `name` &mdsah; The name of the operation.
-   * * `args` &mdash; One or more elements indicating the names and types of
-   *   the arguments to the operation. Each argument is represented as a two-
-   *   element array `[<name>, <type>]`, where `<type>` is one of the type
-   *   constants defined by this class.
-   *
-   * This value is deep frozen. Attempts to mutate it will fail.
-   */
-  static get OPERATIONS() {
-    return OPERATIONS;
-  }
-
   /** {string} Type name for a `FrozenBuffer`. */
   static get TYPE_BUFFER() {
     return TYPE_BUFFER;
@@ -409,8 +391,10 @@ export default class FileOp extends CommonBase {
    * Gets the properties associated with a given operation, by name. Properties
    * are as follows:
    *
-   * * `args: array` &mdash; Array of argument specs, same as defined by
-   *   {@link #OPERATIONS}.
+   * * `args: array` &mdash; One or more elements indicating the names and types
+   *   of the arguments to the operation. Each argument is represented as a
+   *   two-element array `[<name>, <type>]`, where `<type>` is one of the type
+   *   constants defined by this class.
    * * `category: string` &mdash; Operation category.
    * * `isPull: boolean` &mdash; Whether the operation is a pull (category
    *   `read` or `list`).

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -9,15 +9,6 @@ import { CommonBase, DataUtil, Errors, FrozenBuffer } from 'util-common';
 
 import StoragePath from './StoragePath';
 
-/**
- * {Symbol} Private key used to protect the main constructor. This is used so
- * that only the static constructor methods can use it. This makes it less
- * likely that a bogus instance will get constructed (and pretty obvious if
- * someone writes code to try to sneak around the restriction, which ought to
- * be a red flag).
- */
-const KEY = Symbol('FileOp constructor key');
-
 // Operation category constants. See docs on the static properties for details.
 const CAT_DELETE       = 'delete';
 const CAT_ENVIRONMENT  = 'environment';
@@ -471,16 +462,10 @@ export default class FileOp extends CommonBase {
    * Constructs an instance. This should not be used directly. Instead use the
    * static constructor methods defined by this class.
    *
-   * @param {object} constructorKey The private-to-this-module key that
-   *   enforces the exhortation in the method documentation above.
    * @param {string} name The operation name.
    * @param {...*} args Arguments to the operation.
    */
-  constructor(constructorKey, name, ...args) {
-    if (constructorKey !== KEY) {
-      throw Errors.bad_use('Constructor is private.');
-    }
-
+  constructor(name, ...args) {
     // This validates `name`.
     const opProps = FileOp.propsFromName(name);
 
@@ -566,11 +551,9 @@ export default class FileOp extends CommonBase {
    */
   static _addConstructorMethods() {
     for (const opName of FileOp.OPERATION_NAMES) {
-      const constructorMethod = (...args) => {
-        return new FileOp(KEY, opName, ...args);
+      FileOp[`op_${opName}`] = (...args) => {
+        return new FileOp(opName, ...args);
       };
-
-      FileOp[`op_${opName}`] = constructorMethod;
     }
   }
 

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -57,7 +57,7 @@ export default class TransactionSpec extends CommonBase {
    */
   get timeoutMsec() {
     const result = this.opsWithName('timeout')[0];
-    return (result === undefined) ? 'never' : result.arg('durMsec');
+    return (result === undefined) ? 'never' : result.props.durMsec;
   }
 
   /**

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import FileOp from './FileOp';
@@ -154,7 +153,9 @@ export default class TransactionSpec extends CommonBase {
    * @returns {array<FileOp>} Array of all such operations.
    */
   opsWithName(name) {
-    TString.nonEmpty(name);
+    // This validates the name.
+    FileOp.propsFromName(name);
+
     return this._ops.filter(op => (op.name === name));
   }
 }


### PR DESCRIPTION
Two parts of this PR, only semi-related:

* I extracted more functionality from the concrete OT control classes into `BaseControl`, and added a bit of testing for them. These were a couple pretty easy opportunities.
* I reworked the structure of `FileOp` to be both more like the OT op classes in structure. In addition, I used this as an opportunity to work on better validity checking; this class is now a template (as it were) for how we can improve the OT op classes.