### PR TITLE
More `BaseControl` functionality.

### DIFF
--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -78,18 +78,7 @@ export default class BodyControl extends BaseControl {
       }
     }
 
-    // There are two possible ways to calculate the result, namely (1) compose
-    // all the changes that were made after `baseRevNum`, or (2) calculate the
-    // OT diff between `baseRevNum` and `currentRevNum`. We're doing the former
-    // here, because the usual case is one or two small deltas being made to a
-    // document of (to a first approximation) unbounded size, making the
-    // composition option clearly preferable. **TODO:** Heuristically figure out
-    // when option (2) would be more profitable.
-
-    const delta = await this.getComposedChanges(
-      BodyDelta.EMPTY, baseRevNum + 1, currentRevNum + 1, false);
-
-    return new BodyChange(currentRevNum, delta);
+    return this.getDiff(baseRevNum, currentRevNum);
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -4,7 +4,6 @@
 
 import { BodyChange, BodyDelta, BodySnapshot, RevisionNumber } from 'doc-common';
 import { TransactionSpec } from 'file-store';
-import { Errors } from 'util-common';
 
 import BaseControl from './BaseControl';
 import Paths from './Paths';
@@ -57,25 +56,7 @@ export default class BodyControl extends BaseControl {
    */
   async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
     if (currentRevNum === baseRevNum) {
-      // The current revision is the same as the base, so we have to wait for
-      // the file to change (or for the storage layer to time out), and then
-      // check to see if in fact the revision number was changed.
-
-      const fc   = this.fileCodec;
-      const spec = new TransactionSpec(
-        fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(BodyControl.revisionNumberPath, currentRevNum));
-
-      // If this returns normally (doesn't throw), then we know it wasn't due
-      // to hitting the timeout. And if it _is_ a timeout, then the exception
-      // that's thrown is exactly what should be reported upward.
-      await fc.transact(spec);
-
-      // Verify that the revision number went up. It's a bug if it didn't.
-      currentRevNum = await this.currentRevNum();
-      if (currentRevNum <= baseRevNum) {
-        throw Errors.wtf(`Revision number should have gone up. Instead was ${baseRevNum} then ${currentRevNum}.`);
-      }
+      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
     }
 
     return this.getDiff(baseRevNum, currentRevNum);

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -7,7 +7,6 @@ import {
 } from 'doc-common';
 import { TransactionSpec } from 'file-store';
 import { TInt, TString } from 'typecheck';
-import { Errors } from 'util-common';
 
 import BaseControl from './BaseControl';
 import CaretColor from './CaretColor';
@@ -121,25 +120,7 @@ export default class CaretControl extends BaseControl {
    */
   async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
     if (currentRevNum === baseRevNum) {
-      // The current revision is the same as the base, so we have to wait for
-      // the file to change (or for the storage layer to time out), and then
-      // check to see if in fact the revision number was changed.
-
-      const fc   = this.fileCodec;
-      const spec = new TransactionSpec(
-        fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(CaretControl.revisionNumberPath, currentRevNum));
-
-      // If this returns normally (doesn't throw), then we know it wasn't due
-      // to hitting the timeout. And if it _is_ a timeout, then the exception
-      // that's thrown is exactly what should be reported upward.
-      await fc.transact(spec);
-
-      // Verify that the revision number went up. It's a bug if it didn't.
-      currentRevNum = await this.currentRevNum();
-      if (currentRevNum <= baseRevNum) {
-        throw Errors.wtf(`Revision number should have gone up. Instead was ${baseRevNum} then ${currentRevNum}.`);
-      }
+      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
     }
 
     return this.getDiff(baseRevNum, currentRevNum);

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -142,17 +142,7 @@ export default class CaretControl extends BaseControl {
       }
     }
 
-    // There are two possible ways to calculate the result, namely (1) compose
-    // all the changes that were made after `baseRevNum`, or (2) calculate the
-    // OT diff between `baseRevNum` and `currentRevNum`. We're doing the latter
-    // here, because it's a little simpler and because (as of this writing at
-    // least) there isn't actually that much data stored as properties. (N.b.,
-    // `BodyControl` does the (1) tactic.)
-
-    const oldSnapshot = await this.getSnapshot(baseRevNum);
-    const newSnapshot = await this.getSnapshot(currentRevNum);
-
-    return oldSnapshot.diff(newSnapshot);
+    return this.getDiff(baseRevNum, currentRevNum);
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -76,17 +76,7 @@ export default class PropertyControl extends BaseControl {
       }
     }
 
-    // There are two possible ways to calculate the result, namely (1) compose
-    // all the changes that were made after `baseRevNum`, or (2) calculate the
-    // OT diff between `baseRevNum` and `currentRevNum`. We're doing the latter
-    // here, because it's a little simpler and because (as of this writing at
-    // least) there isn't actually that much data stored as properties. (N.b.,
-    // `BodyControl` does the (1) tactic.)
-
-    const oldSnapshot = await this.getSnapshot(baseRevNum);
-    const newSnapshot = await this.getSnapshot(currentRevNum);
-
-    return oldSnapshot.diff(newSnapshot);
+    return this.getDiff(baseRevNum, currentRevNum);
   }
 
   /**

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -4,7 +4,6 @@
 
 import { PropertyChange, PropertyDelta, PropertySnapshot, RevisionNumber } from 'doc-common';
 import { TransactionSpec } from 'file-store';
-import { Errors } from 'util-common';
 
 import BaseControl from './BaseControl';
 import Paths from './Paths';
@@ -55,25 +54,7 @@ export default class PropertyControl extends BaseControl {
    */
   async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
     if (currentRevNum === baseRevNum) {
-      // The current revision is the same as the base, so we have to wait for
-      // the file to change (or for the storage layer to time out), and then
-      // check to see if in fact the revision number was changed.
-
-      const fc   = this.fileCodec;
-      const spec = new TransactionSpec(
-        fc.op_timeout(timeoutMsec),
-        fc.op_whenPathNot(PropertyControl.revisionNumberPath, currentRevNum));
-
-      // If this returns normally (doesn't throw), then we know it wasn't due
-      // to hitting the timeout. And if it _is_ a timeout, then the exception
-      // that's thrown is exactly what should be reported upward.
-      await fc.transact(spec);
-
-      // Verify that the revision number went up. It's a bug if it didn't.
-      currentRevNum = await this.currentRevNum();
-      if (currentRevNum <= baseRevNum) {
-        throw Errors.wtf(`Revision number should have gone up. Instead was ${baseRevNum} then ${currentRevNum}.`);
-      }
+      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
     }
 
     return this.getDiff(baseRevNum, currentRevNum);

--- a/local-modules/doc-server/mocks/MockControl.js
+++ b/local-modules/doc-server/mocks/MockControl.js
@@ -15,6 +15,10 @@ export default class MockControl extends BaseControl {
     this.revNum = 0;
   }
 
+  _impl_getSnapshot(revNum) {
+    return new MockSnapshot(revNum, [[`snap_${revNum}`]]);
+  }
+
   static get _impl_pathPrefix() {
     return '/mock_control';
   }


### PR DESCRIPTION
This PR extracts two common methods out of the concrete OT control classes into `BaseControl`. These two methods are, approximately, two halves of the functionality defined by `getChangeAfter()`. Unlike the un-factored code, the new methods are reasonably covered by unit tests.

**Note:** As of this PR, each of the concrete OT classes has an identical implementation of `_impl_getChangeAfter()`, based on the two extracted methods. This all will be factored out — the main `getChangeAfter()` implementation will get completely rewritten — in a future PR.