### PR TITLE
`BaseControl` and API setup/logging

### DIFF
--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -23,14 +23,14 @@ export default class Response extends CommonBase {
    *   a non-negative integer.
    * @param {*} result Non-error result. Must be `null` if `error` is non-`null`
    *   (but note that `null` is a valid non-error result).
-   * @param {Error|null} error Error response, or `null` if there is no error.
-   *   `null` here definitively indicates that the instance is not
+   * @param {Error|null} [error = null] Error response, or `null` if there is no
+   *   error. `null` here definitively indicates that the instance is not
    *   error-bearing.
    */
-  constructor(id, result, error) {
+  constructor(id, result, error = null) {
     super();
 
-    // Validate the `error`/`result` combo.
+    // Validate the `error` / `result` combo.
     if ((result !== null) && (error !== null)) {
       throw Errors.bad_use('`result` and `error` cannot both be non-`null`.');
     }
@@ -106,7 +106,11 @@ export default class Response extends CommonBase {
    * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
-    return [this._id, this._result, this._error];
+    // Avoid returning a `null` error argument. This is ever so slightly nicer
+    // should this result be used for encoding across an API boundary.
+    return (this._error === null)
+      ? [this._id, this._result]
+      : [this._id, null, this._error];
   }
 
   /**

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -2,9 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
-import { TInt } from 'typecheck';
+import { TInt, TObject } from 'typecheck';
 import { CommonBase, ErrorUtil, Errors, Functor, InfoError } from 'util-common';
 
 import CodableError from './CodableError';
@@ -25,7 +23,7 @@ export default class Response extends CommonBase {
    *   a non-negative integer.
    * @param {*} result Non-error result. Must be `null` if `error` is non-`null`
    *   (but note that `null` is a valid non-error result).
-   * @param {*|null} error Error response, or `null` if there is no error.
+   * @param {Error|null} error Error response, or `null` if there is no error.
    *   `null` here definitively indicates that the instance is not
    *   error-bearing.
    */
@@ -47,16 +45,17 @@ export default class Response extends CommonBase {
     this._result = result;
 
     /**
-     * {CodableError|null} Error response, or `null` if this instance doesn't
-     * represent an error.
+     * {Error|null} The original error, or `null` if this is a non-error
+     * response. Intended to be used for logging.
      */
-    this._error = Response._fixError(error);
+    this._originalError = (error === null) ? null : TObject.check(error, Error);
 
     /**
-     * {array<string>|null} Error trace, or `null` if this instance doesn't
-     * represent an error.
+     * {CodableError|null} Error response, or `null` if this instance doesn't
+     * represent an error. This value is suitable for transmission across an API
+     * boundary.
      */
-    this._errorTrace = Response._fixErrorTrace(error);
+    this._error = Response._fixError(error);
 
     Object.freeze(this);
   }
@@ -71,11 +70,22 @@ export default class Response extends CommonBase {
   }
 
   /**
-   * {array<string>|null} Clean error trace (including message and causes if
-   * any), or `null` if this instance doesn't represent an error.
+   * {Error|null} The original error, or `null` if this is a non-error
+   * response. Intended to be used for logging.
    */
-  get errorTrace() {
-    return this._errorTrace;
+  get originalError() {
+    return this._originalError;
+  }
+
+  /**
+   * {array<string>|null} Clean error trace (including message and causes if
+   * any) of the original error, or `null` if this instance doesn't represent an
+   * error.
+   */
+  get originalTrace() {
+    const error = this._originalError;
+
+    return (error === null) ? null : ErrorUtil.fullTraceLines(error);
   }
 
   /** {Int} Message ID. */
@@ -115,34 +125,9 @@ export default class Response extends CommonBase {
       // Adopt the functor of the error. Lose the cause (if any), exact class
       // identity, and stack.
       return new CodableError(error.info);
-    } else if (error instanceof Error) {
+    } else {
       // Adopt the message. Lose the rest of the info.
       return new CodableError(new Functor('general_error', error.message));
     }
-
-    const message = (typeof error === 'string')
-      ? error
-      : inspect(error, { breakLength: Infinity });
-
-    return new CodableError('general_error', message);
-  }
-
-  /**
-   * Makes a cleaned-up trace from an incoming `error` argument. This returns
-   * `null` if given `null`.
-   *
-   * @param {*} error Error value.
-   * @returns {array<string>|null} Cleaned up error trace as an array of lines,
-   *   lines. Will be `[]` if this is an error-ish value with no stack, or
-   *   `null` if `error` is `null`.
-   */
-  static _fixErrorTrace(error) {
-    if (error === null) {
-      return null;
-    } else if (!(error instanceof Error)) {
-      return [];
-    }
-
-    return ErrorUtil.fullTraceLines(error);
   }
 }

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -59,8 +59,13 @@ export default class ApiLog extends CommonBase {
       endTime:      Date.now(),
       connectionId,
       ok:           !response.error,
-      msg:          msg ? msg.toLog() : null
     };
+
+    if (msg !== null) {
+      details.id      = msg.id;
+      details.target  = msg.target;
+      details.payload = msg.payload;
+    }
 
     if (details.ok) {
       details.result = response.result;

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -74,19 +74,14 @@ export default class ApiLog extends Singleton {
 
   /**
    * Logs an incoming message. This should be called just after the message was
-   * decoded off of an incoming connection. This method returns the timestamp
-   * that should be used as the `startTime` when logging the completed API call.
+   * decoded off of an incoming connection.
    *
    * @param {string} connectionId Identifier for the connection.
    * @param {object} msg Incoming message.
-   * @returns {Int} Standard msec timestamp indicating the start time of the API
-   *   call being represented here.
    */
   incomingMessage(connectionId, msg) {
     // TODO: This will ultimately need to redact some information.
     this._console.detail(`[${connectionId}] Message:`, msg.toLog());
-
-    return Date.now();
   }
 
   /**

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -42,24 +42,17 @@ export default class ApiLog extends Singleton {
    * @param {Response} response Response to the message.
    */
   fullCall(connectionId, startTime, msg, response) {
+    this._console.detail('Response:', response);
+
     if (response.error) {
       // TODO: Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
-
-      if (response.errorTrace.length === 0) {
-        this._console.error(`[${connectionId}] Error:`, response.error.message);
-      } else {
-        this._console.error(`[${connectionId}] Error.`);
-        const trace = response.errorTrace.map(line => `  ${line}`).join('\n');
-        this._console.info(trace);
-      }
+      this._console.error(`[${connectionId}] Error.`, response.originalError);
     }
 
-    this._console.detail('Response:', response);
-
-    // TODO: This will ultimately need to redact some information from `msg` and
-    // `response`.
+    // Details to log. **TODO:** This will ultimately need to redact some
+    // information from `msg` and `response`.
     const details = {
       startTime,
       endTime:      Date.now(),
@@ -71,8 +64,9 @@ export default class ApiLog extends Singleton {
     if (details.ok) {
       details.result = response.result;
     } else {
-      details.error      = response.error;
-      details.errorTrace = response.errorTrace || [];
+      // `response.originalError` per se isn't a JSON-friendly value, whereas
+      // the `originalTrace` is a plain array of strings.
+      details.error = response.originalTrace;
     }
 
     this._writeJson(details);

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import fs from 'fs';
-import path from 'path';
 
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
@@ -19,13 +18,13 @@ export default class ApiLog extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {string} path Path of API log file.
+   * @param {string} logFile Path of API log file.
    */
-  constructor() {
+  constructor(logFile) {
     super();
 
     /** {string} Path of API log file. */
-    this._path = TString.nonEmpty(path);
+    this._path = TString.nonEmpty(logFile);
 
     Object.freeze(this);
   }
@@ -79,11 +78,12 @@ export default class ApiLog extends CommonBase {
    * decoded off of an incoming connection.
    *
    * @param {string} connectionId Identifier for the connection.
+   * @param {Int} startTime Timestamp for the start of the call.
    * @param {object} msg Incoming message.
    */
-  incomingMessage(connectionId, msg) {
+  incomingMessage(connectionId, startTime, msg) {
     // TODO: This will ultimately need to redact some information.
-    log.detail(`[${connectionId}] Message:`, msg.toLog());
+    log.detail(`[${connectionId}] Message at ${startTime}:`, msg.toLog());
   }
 
   /**

--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -5,25 +5,27 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Dirs } from 'env-server';
 import { Logger } from 'see-all';
-import { Singleton } from 'util-common';
+import { TString } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+/** {Logger} Console logger. */
+const log = new Logger('api');
 
 /**
  * Singleton class that handles the logging of API calls.
  */
-export default class ApiLog extends Singleton {
+export default class ApiLog extends CommonBase {
   /**
    * Constructs an instance.
+   *
+   * @param {string} path Path of API log file.
    */
   constructor() {
     super();
 
-    /** {Logger} Console logger. */
-    this._console = new Logger('api');
-
     /** {string} Path of API log file. */
-    this._path = path.resolve(Dirs.theOne.LOG_DIR, 'api.log');
+    this._path = TString.nonEmpty(path);
 
     Object.freeze(this);
   }
@@ -42,13 +44,13 @@ export default class ApiLog extends Singleton {
    * @param {Response} response Response to the message.
    */
   fullCall(connectionId, startTime, msg, response) {
-    this._console.detail('Response:', response);
+    log.detail('Response:', response);
 
     if (response.error) {
       // TODO: Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
-      this._console.error(`[${connectionId}] Error.`, response.originalError);
+      log.error(`[${connectionId}] Error.`, response.originalError);
     }
 
     // Details to log. **TODO:** This will ultimately need to redact some
@@ -81,7 +83,7 @@ export default class ApiLog extends Singleton {
    */
   incomingMessage(connectionId, msg) {
     // TODO: This will ultimately need to redact some information.
-    this._console.detail(`[${connectionId}] Message:`, msg.toLog());
+    log.detail(`[${connectionId}] Message:`, msg.toLog());
   }
 
   /**

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -188,7 +188,7 @@ export default class Connection extends CommonBase {
     let error = null;
 
     if (msg instanceof Message) {
-      this._apiLog.incomingMessage(this._connectionId, msg);
+      this._apiLog.incomingMessage(this._connectionId, startTime, msg);
       try {
         result = await this._actOnMessage(msg);
       } catch (e) {

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ConnectionError, Message, Response } from 'api-common';
-import { Codec } from 'codec';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, Errors, Random } from 'util-common';
@@ -80,6 +79,9 @@ export default class Connection extends CommonBase {
 
     /** {ApiLog} The standard API logging handler. */
     this._apiLog = ApiLog.theOne;
+
+    /** {Codec} The codec to use. */
+    this._codec = context.codec;
 
     /** {Logger} Logger which includes the connection ID as a prefix. */
     this._log = log.withPrefix(`[${this._connectionId}]`);
@@ -182,11 +184,12 @@ export default class Connection extends CommonBase {
   async handleJsonMessage(msg) {
     msg = this._decodeMessage(msg); // Not supposed to ever throw.
 
-    const startTime = this._apiLog.incomingMessage(this._connectionId, msg);
+    const startTime = Date.now();
     let result = null;
     let error = null;
 
     if (msg instanceof Message) {
+      this._apiLog.incomingMessage(this._connectionId, msg);
       try {
         result = await this._actOnMessage(msg);
       } catch (e) {
@@ -206,7 +209,7 @@ export default class Connection extends CommonBase {
     // caller.
 
     const response = new Response(msg.id, result, error);
-    const encodedResponse = Codec.theOne.encodeJson(response);
+    const encodedResponse = this._codec.encodeJson(response);
 
     this._apiLog.fullCall(this._connectionId, startTime, msg, response);
 
@@ -241,7 +244,7 @@ export default class Connection extends CommonBase {
    */
   _decodeMessage(msg) {
     try {
-      msg = Codec.theOne.decodeJson(msg);
+      msg = this._codec.decodeJson(msg);
     } catch (error) {
       return ConnectionError.connection_nonsense(this._connectionId, error.message);
     }

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -7,7 +7,6 @@ import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, Errors, Random } from 'util-common';
 
-import ApiLog from './ApiLog';
 import BearerToken from './BearerToken';
 import MetaHandler from './MetaHandler';
 import Context from './Context';
@@ -77,8 +76,8 @@ export default class Connection extends CommonBase {
     /** {Int} Count of messages received. Used for liveness logging. */
     this._messageCount = 0;
 
-    /** {ApiLog} The standard API logging handler. */
-    this._apiLog = ApiLog.theOne;
+    /** {ApiLog} The API logger to use. */
+    this._apiLog = context.apiLog;
 
     /** {Codec} The codec to use. */
     this._codec = context.codec;

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Codec } from 'codec';
 import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
@@ -18,9 +19,10 @@ const log = new Logger('api');
 const IDLE_TIME_MSEC = 20 * 60 * 1000; // Twenty minutes.
 
 /**
- * Binding context for an API server or session therein. This is pretty much
- * just a map from IDs to `Target` instances, along with reasonably
- * straightforward accessor and update methods.
+ * Binding context for an API server or session therein. This is mostly just a
+ * map from IDs to `Target` instances, along with reasonably straightforward
+ * accessor and update methods. In addition, this is what knows which {@link
+ * Codec} to use.
  */
 export default class Context extends CommonBase {
   /**
@@ -29,10 +31,18 @@ export default class Context extends CommonBase {
   constructor() {
     super();
 
+    /** {Codec} The codec to use for connections / sessions. */
+    this._codec = Codec.theOne;
+
     /** {Map<string, Target>} The underlying map. */
     this._map = new Map();
 
     Object.freeze(this);
+  }
+
+  /** {Codec} The codec to use for connections / sessions. */
+  get codec() {
+    return this._codec;
   }
 
   /**

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -27,12 +27,14 @@ const IDLE_TIME_MSEC = 20 * 60 * 1000; // Twenty minutes.
 export default class Context extends CommonBase {
   /**
    * Constructs an instance which is initially empty.
+   *
+   * @param {Codec} codec Codec to use for all connections / sessions.
    */
-  constructor() {
+  constructor(codec) {
     super();
 
     /** {Codec} The codec to use for connections / sessions. */
-    this._codec = Codec.theOne;
+    this._codec = Codec.check(codec);
 
     /** {Map<string, Target>} The underlying map. */
     this._map = new Map();
@@ -98,7 +100,7 @@ export default class Context extends CommonBase {
    * @returns {Context} The newly-cloned instance.
    */
   clone() {
-    const result = new Context();
+    const result = new Context(this._codec);
 
     for (const t of this._map.values()) {
       result.addTarget(t);

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -7,6 +7,7 @@ import { Logger } from 'see-all';
 import { TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
+import ApiLog from './ApiLog';
 import Target from './Target';
 
 /** {Logger} Logger. */
@@ -22,24 +23,33 @@ const IDLE_TIME_MSEC = 20 * 60 * 1000; // Twenty minutes.
  * Binding context for an API server or session therein. This is mostly just a
  * map from IDs to `Target` instances, along with reasonably straightforward
  * accessor and update methods. In addition, this is what knows which {@link
- * Codec} to use.
+ * Codec} and {@link ApiLog} to use.
  */
 export default class Context extends CommonBase {
   /**
    * Constructs an instance which is initially empty.
    *
    * @param {Codec} codec Codec to use for all connections / sessions.
+   * @param {ApiLog} apiLog API logger to use.
    */
-  constructor(codec) {
+  constructor(codec, apiLog) {
     super();
 
     /** {Codec} The codec to use for connections / sessions. */
     this._codec = Codec.check(codec);
 
+    /** {ApiLog} The API logger to use. */
+    this._apiLog = ApiLog.check(apiLog);
+
     /** {Map<string, Target>} The underlying map. */
     this._map = new Map();
 
     Object.freeze(this);
+  }
+
+  /** {ApiLog} The API logger to use. */
+  get apiLog() {
+    return this._apiLog;
   }
 
   /** {Codec} The codec to use for connections / sessions. */
@@ -100,7 +110,7 @@ export default class Context extends CommonBase {
    * @returns {Context} The newly-cloned instance.
    */
   clone() {
-    const result = new Context(this._codec);
+    const result = new Context(this._codec, this._apiLog);
 
     for (const t of this._map.values()) {
       result.addTarget(t);

--- a/local-modules/api-server/index.js
+++ b/local-modules/api-server/index.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import ApiLog from './ApiLog';
 import BearerToken from './BearerToken';
 import Connection from './Connection';
 import Context from './Context';
@@ -9,4 +10,4 @@ import PostConnection from './PostConnection';
 import Target from './Target';
 import WsConnection from './WsConnection';
 
-export { BearerToken, Connection, Context, PostConnection, Target, WsConnection };
+export { ApiLog, BearerToken, Connection, Context, PostConnection, Target, WsConnection };

--- a/local-modules/api-server/package.json
+++ b/local-modules/api-server/package.json
@@ -7,7 +7,6 @@
 
       "api-common": "local",
       "codec": "local",
-      "env-server": "local",
       "hooks-server": "local",
       "promise-util": "local",
       "see-all": "local",

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
 
-import { BearerToken, Context, PostConnection, WsConnection } from 'api-server';
+import { ApiLog, BearerToken, Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
 import { Codec } from 'codec';
 import { Dirs } from 'env-server';
@@ -39,7 +39,7 @@ export default class Application {
      * {Context} All of the objects we provide access to via the API, along with
      * other objects of use to the server.
      */
-    this._context = new Context(Codec.theOne);
+    this._context = new Context(Codec.theOne, ApiLog.theOne);
     this._context.startAutomaticIdleCleanup();
 
     /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -39,7 +39,9 @@ export default class Application {
      * {Context} All of the objects we provide access to via the API, along with
      * other objects of use to the server.
      */
-    this._context = new Context(Codec.theOne, ApiLog.theOne);
+    this._context = new Context(
+      Codec.theOne,
+      new ApiLog(path.resolve(Dirs.theOne.LOG_DIR, 'api.log')));
     this._context.startAutomaticIdleCleanup();
 
     /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -35,13 +35,15 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
+    const codec = Codec.theOne;
+
     /**
      * {Context} All of the objects we provide access to via the API, along with
      * other objects of use to the server.
      */
     this._context = new Context(
-      Codec.theOne,
-      new ApiLog(path.resolve(Dirs.theOne.LOG_DIR, 'api.log')));
+      codec,
+      new ApiLog(path.resolve(Dirs.theOne.LOG_DIR, 'api.log'), codec));
     this._context.startAutomaticIdleCleanup();
 
     /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -11,6 +11,7 @@ import { promisify } from 'util';
 
 import { BearerToken, Context, PostConnection, WsConnection } from 'api-server';
 import { ClientBundle } from 'client-bundle';
+import { Codec } from 'codec';
 import { Dirs } from 'env-server';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
@@ -34,8 +35,11 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
-    /** {Context} All of the objects we provide access to via the API. */
-    this._context = new Context();
+    /**
+     * {Context} All of the objects we provide access to via the API, along with
+     * other objects of use to the server.
+     */
+    this._context = new Context(Codec.theOne);
     this._context.startAutomaticIdleCleanup();
 
     /**

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -238,7 +238,7 @@ export default class BaseControl extends BaseDataManager {
    * the current revision (that is, it is an older revision); but when
    * `baseRevNum` _is_ the current revision, the return value only resolves
    * after at least one change has been made. It is an error to request a
-   * revision that does not yet exist. For subclasses that don't keep full
+   * base revision that does not yet exist. For subclasses that don't keep full
    * history, it is also an error to request a revision that is _no longer_
    * available as a base; in this case, the error name is always
    * `revision_not_available`.
@@ -249,7 +249,8 @@ export default class BaseControl extends BaseDataManager {
    * snapshot(baseRevNum).compose(result)`.
    *
    * @param {Int} baseRevNum Revision number for the base to get a change with
-   *   respect to.
+   *   respect to. Must be no greater than the current revision number at the
+   *   time of the call.
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
    *   range as defined by {@link Timeouts}. `null` is treated as the maximum

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -38,31 +38,6 @@ export default class BodyControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `getChangeAfter()`, as required by the
-   * superclass.
-   *
-   * @param {Int} baseRevNum Revision number for the base to get a change with
-   *   respect to. Guaranteed to refer to the instantaneously-current revision
-   *   or earlier.
-   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
-   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
-   * @param {Int} currentRevNum The instantaneously-current revision number that
-   *   was determined just before this method was called, and which should be
-   *   treated as the actually-current revision number at the start of this
-   *   method.
-   * @returns {BodyChange} Change with respect to the revision indicated by
-   *   `baseRevNum`. Though the superclass allows it, this method never returns
-   *   `null`.
-   */
-  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
-    if (currentRevNum === baseRevNum) {
-      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
-    }
-
-    return this.getDiff(baseRevNum, currentRevNum);
-  }
-
-  /**
    * Underlying implementation of `getSnapshot()`, as required by the
    * superclass.
    *

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -104,29 +104,6 @@ export default class CaretControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `getChangeAfter()`, as required by the
-   * superclass.
-   *
-   * @param {Int} baseRevNum Revision number for the base to get a change with
-   *   respect to. Guaranteed to refer to the instantaneously-current revision
-   *   or earlier.
-   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
-   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
-   * @param {Int} currentRevNum The instantaneously-current revision number that
-   *   was determined just before this method was called.
-   * @returns {CaretChange} Change with respect to the revision indicated by
-   *   `baseRevNum`. Though the superclass allows it, this method never returns
-   *   `null`.
-   */
-  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
-    if (currentRevNum === baseRevNum) {
-      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
-    }
-
-    return this.getDiff(baseRevNum, currentRevNum);
-  }
-
-  /**
    * Underlying implementation of `getSnapshot()`, as required by the
    * superclass.
    *

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -38,29 +38,6 @@ export default class PropertyControl extends BaseControl {
   }
 
   /**
-   * Underlying implementation of `getChangeAfter()`, as required by the
-   * superclass.
-   *
-   * @param {Int} baseRevNum Revision number for the base to get a change with
-   *   respect to. Guaranteed to refer to the instantaneously-current revision
-   *   or earlier.
-   * @param {Int} timeoutMsec Maximum amount of time to allow in this call, in
-   *   msec. Guaranteed to be a valid value as defined by {@link Timeouts}.
-   * @param {Int} currentRevNum The instantaneously-current revision number that
-   *   was determined just before this method was called.
-   * @returns {PropertyChange} Change with respect to the revision indicated by
-   *   `baseRevNum`. Though the superclass allows it, this method never returns
-   *   `null`.
-   */
-  async _impl_getChangeAfter(baseRevNum, timeoutMsec, currentRevNum) {
-    if (currentRevNum === baseRevNum) {
-      currentRevNum = await this.whenRevNum(currentRevNum + 1, timeoutMsec);
-    }
-
-    return this.getDiff(baseRevNum, currentRevNum);
-  }
-
-  /**
    * Underlying implementation of `getSnapshot()`, as required by the
    * superclass.
    *

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.32.0
+version = 0.32.1


### PR DESCRIPTION
Two unrelated bits in this PR:

* Did the cleanup promised in my previous PR, wherein `BaseControl.getChangeAfter()` got to be super-simplified, including removing the need for subclasses to provide differentiated behavior.
* Did a round of work to make the server-side API setup more straightforward (and more testable, though I didn't actually add more formal tests). Also made the API logging log more sensible representations of the incoming messages and outgoing responses.