### PR TITLE
More test harness consolidation

### DIFF
--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -149,7 +149,7 @@ const webpackOptions = {
       {
         test: /[/]client-tests$/,
         use: [{
-          loader: 'client-tests-loader'
+          loader: 'client-tests-loader/load'
         }]
       },
 

--- a/local-modules/client-bundle/ClientBundle.js
+++ b/local-modules/client-bundle/ClientBundle.js
@@ -149,7 +149,7 @@ const webpackOptions = {
       {
         test: /[/]client-tests$/,
         use: [{
-          loader: 'client-tests-loader/load'
+          loader: 'testing-server/loadClientTests'
         }]
       },
 

--- a/local-modules/client-bundle/package.json
+++ b/local-modules/client-bundle/package.json
@@ -5,10 +5,10 @@
   "dependencies": {
     "memory-fs": "^0.4.1",
 
-    "client-tests-loader": "local",
     "compiler-dependencies": "local",
     "env-server": "local",
     "see-all": "local",
+    "testing-server": "local",
     "util-common": "local"
   }
 }

--- a/local-modules/client-tests-loader/package.json
+++ b/local-modules/client-tests-loader/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "client-tests-loader",
-  "version": "1.0.0",
-
-  "dependencies": {
-    "testing-server": "local"
-  }
-}

--- a/local-modules/compiler-dependencies/package.json
+++ b/local-modules/compiler-dependencies/package.json
@@ -16,6 +16,6 @@
     "style-loader": "^0.18.2",
     "ts-loader": "^2.0.3",
     "typescript": "^2.1.4",
-    "webpack": "^3.4.1"
+    "webpack": "^3.10.0"
   }
 }

--- a/local-modules/testing-client/client-tests
+++ b/local-modules/testing-client/client-tests
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 The contents of this file don't matter. Its name triggers special-case logic
-in `client-bundle` which in turn calls on `client-tests-loader` to build
-a dynamic module that references all of the client test code.
+in the Webpack config defined in `client-bundle`, which in turn calls on
+`testing-server.ClientTestsLoader.load()` to build a dynamic module that
+references all of the client test code.

--- a/local-modules/testing-server/ClientTestsLoader.js
+++ b/local-modules/testing-server/ClientTestsLoader.js
@@ -2,11 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TestFiles } from 'testing-server';
 import { UtilityClass } from 'util-common';
 
+import TestFiles from './TestFiles';
+
 /**
- * Webpack loader for the client test files.
+ * Webpack loader for the client test files. This gets imported by Webpack via
+ * the file `loadClientTests.js`.
  */
 export default class ClientTestsLoader extends UtilityClass {
   /**

--- a/local-modules/testing-server/loadClientTests.js
+++ b/local-modules/testing-server/loadClientTests.js
@@ -4,7 +4,8 @@
 
 import ClientTestsLoader from './ClientTestsLoader';
 
-// This module is used by Webpack, which makes specific requirements about what
-// is exported by loaders. This is why we have a simple `export default` here
-// instead of the more usual (for this project) set of named `export {...}`s.
+// This file is imported directly by Webpack as a loader. Webpack makes specific
+// requirements about what is exported by loader modules, which is why we have a
+// simple `export default` of a function here, instead of the more usual (for
+// this project) arrangement.
 export default ClientTestsLoader.load;


### PR DESCRIPTION
This PR merges the `client-tests-loader` module into `testing-server`. Having a separate module was more obfuscatory than elucidative.

**Bonus:** Updated the Webpack dependency.