### PR TITLE
Remove separate "missing" check.

### DIFF
--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -109,15 +109,10 @@ export default class BodyControl extends BaseControl {
     const data   = transactionResult.data;
     const revNum = data.get(BodyControl.revisionNumberPath);
 
-    if (!revNum) {
-      this.log.info('Corrupt document: Missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
     try {
       RevisionNumber.check(revNum);
     } catch (e) {
-      this.log.info('Corrupt document: Bogus revision number.');
+      this.log.info('Corrupt document: Bogus or missing revision number.');
       return ValidationStatus.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -179,15 +179,10 @@ export default class CaretControl extends BaseControl {
     const data   = transactionResult.data;
     const revNum = data.get(CaretControl.revisionNumberPath);
 
-    if (!revNum) {
-      this.log.info('Corrupt document: Missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
     try {
       RevisionNumber.check(revNum);
     } catch (e) {
-      this.log.info('Corrupt document: Bogus revision number.');
+      this.log.info('Corrupt document: Bogus or missing revision number.');
       return ValidationStatus.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -112,15 +112,10 @@ export default class PropertyControl extends BaseControl {
     const data   = transactionResult.data;
     const revNum = data.get(PropertyControl.revisionNumberPath);
 
-    if (!revNum) {
-      this.log.info('Corrupt document: Missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
     try {
       RevisionNumber.check(revNum);
     } catch (e) {
-      this.log.info('Corrupt document: Bogus revision number.');
+      this.log.info('Corrupt document: Bogus or missing revision number.');
       return ValidationStatus.STATUS_ERROR;
     }
 


### PR DESCRIPTION
As originally written, it failed on legit revision number `0`, but also it didn't really serve a useful purpose to have that extra code, when the following code effectively included the same check.