### PR TITLE
Store occasional snapshots

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -92,6 +92,17 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * {string} `StoragePath` string which stores the base snapshot for the
+   * portion of the document controlled by this class. Not all subclasses use
+   * this path.
+   */
+  static get snapshotPath() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+    return `${this.pathPrefix}/snapshot`;
+  }
+
+  /**
    * {class} Class (constructor function) of snapshot objects to be used with
    * instances of this class.
    */

--- a/scripts/module-lifecycle
+++ b/scripts/module-lifecycle
@@ -69,6 +69,7 @@ while true; do
             ;;
         -?*)
             echo "Unknown option: $1" 1>&2
+            argError=1
             ;;
         *)  # Default case: No more options, break out of the loop.
             break;


### PR DESCRIPTION
This PR adds code to the base OT control to read and write a "stored snapshot" slot per document part, along with code to in fact perform a write every N changes (N == 100 for now) and code to read it when booting up (instead of always composing snapshots starting from revision 0).

This should help improve startup performance for docs that are "long in the tooth" and it also is a necessary prerequisite for defining "ephemeral" document parts that don't keep their full change history. (Carets are notably the intended first use case of this, but there is likely at least one other need.)

**Bonus:** Added a missing `argError=1` line to a script.