### PR TITLE
Just a little more work on client-side testing.

### DIFF
--- a/local-modules/mocha-client-shim/index.js
+++ b/local-modules/mocha-client-shim/index.js
@@ -61,12 +61,18 @@ function after(...args)      { return global.after(...args);      }
 function afterEach(...args)  { return global.afterEach(...args);  }
 function before(...args)     { return global.before(...args);     }
 function beforeEach(...args) { return global.beforeEach(...args); }
-function describe(...args)   { return global.describe(...args);   }
 function context(...args)    { return global.context(...args);    }
+function describe(...args)   { return global.describe(...args);   }
 function it(...args)         { return global.it(...args);         }
 function specify(...args)    { return global.specify(...args);    }
 
+for (const func of [context, describe, it, specify]) {
+  const name = func.name;
+  func.only = (...args) => { return global[name].only(...args); };
+  func.skip = (...args) => { return global[name].skip(...args); };
+}
+
 export {
   MochaShim as Mocha,
-  after, afterEach, before, beforeEach, describe, context, it, specify
+  after, afterEach, before, beforeEach, context, describe, it, specify
 };

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -18,7 +18,7 @@ export default class EventReceiver extends CommonBase {
     this._suites = [];
 
     /** {array<string>} Array of collected test result lines. */
-    this._results = [];
+    this._resultLines = [];
 
     /** {array<string>} Array of non-test browser console output lines. */
     this._nonTestLines = [];
@@ -54,7 +54,7 @@ export default class EventReceiver extends CommonBase {
    * suitable for writing to a file.
    */
   get resultLines() {
-    return this._results;
+    return this._resultLines;
   }
 
   /**
@@ -81,7 +81,7 @@ export default class EventReceiver extends CommonBase {
    * @param {string} line Line to log.
    */
   _log(line) {
-    this._results.push(line);
+    this._resultLines.push(line);
 
     // eslint-disable-next-line no-console
     console.log('%s', line);

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -17,11 +17,11 @@ export default class EventReceiver extends CommonBase {
     /** {array<string>} Current stack of the names of active test suites. */
     this._suites = [];
 
-    /**
-     * {array<{ test, status, suites, log }>} Array of collected test results,
-     * each an ad-hoc plain object.
-     */
+    /** {array<string>} Array of collected test result lines. */
     this._results = [];
+
+    /** {array<string>} Array of non-test browser console output lines. */
+    this._nonTestLines = [];
 
     /** {object} Ad-hoc object with mappings for test category counts. */
     this._stats = { fail: 0, pass: 0, pending: 0, total: 0 };
@@ -38,6 +38,15 @@ export default class EventReceiver extends CommonBase {
   /** {boolean} Whether or not we have received the `done` event. */
   get done() {
     return this._done;
+  }
+
+  /**
+   * {array<string>} Array of non-test browser console output lines. This ends
+   * up getting used when reporting test infrastucture failures (as opposed to
+   * failures in the tests themselves).
+   */
+  get nonTestLines() {
+    return this._nonTestLines;
   }
 
   /**
@@ -58,6 +67,7 @@ export default class EventReceiver extends CommonBase {
 
     if (match === null) {
       // Not an event line.
+      this._nonTestLines.push(line);
       return;
     }
 


### PR DESCRIPTION
* Handle test harness failure instead of just hanging forever.
* Add support for `skip()` and `only()`.