### PR TITLE
Path ranges and change ranges.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -60,6 +60,16 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * {string} `StoragePath` prefix string for all changes stored for the portion
+   * of the document controlled by this class.
+   */
+  static get changePathPrefix() {
+    // **Note:** `this` in the context of a static method is the class, not an
+    // instance.
+    return `${this.pathPrefix}/change`;
+  }
+
+  /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class.
    */
@@ -141,7 +151,7 @@ export default class BaseControl extends BaseDataManager {
     // instance.
 
     RevisionNumber.check(revNum);
-    return `${this.pathPrefix}/change/${revNum}`;
+    return `${this.changePathPrefix}/${revNum}`;
   }
 
   /**

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -26,6 +26,13 @@ describe('doc-server/BaseControl', () => {
     });
   });
 
+  describe('.changePathPrefix', () => {
+    it('should reflect the subclass\'s implementation', () => {
+      const result = MockControl.changePathPrefix;
+      assert.strictEqual(result, '/mock_control/change');
+    });
+  });
+
   describe('.deltaClass', () => {
     it('should reflect the subclass\'s implementation', () => {
       const result = MockControl.deltaClass;

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -325,6 +325,26 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `readPathRange` operations.
+   *
+   * @param {object} props The operation properties.
+   */
+  _op_readPathRange(props) {
+    const { storagePath, startInc, endExc } = props;
+
+    for (let i = startInc; i < endExc; i++) {
+      const fullPath = `${storagePath}/${i}`;
+      const data = this._fileFriend.readPathOrNull(fullPath);
+
+      if (data !== null) {
+        // Per the `FileOp` documentation, we are only supposed to bind a result
+        // key if the path is present (stores data).
+        this._data.set(fullPath, data);
+      }
+    }
+  }
+
+  /**
    * Handler for `revNum` operations. In this implementation, we only ever have
    * a single revision available, and we reject the transaction should it not be
    * the requested restriction.

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -330,9 +330,9 @@ export default class Transactor extends CommonBase {
    * @param {object} props The operation properties.
    */
   _op_readPathRange(props) {
-    const { storagePath, startInc, endExc } = props;
+    const { storagePath, startInclusive, endExclusive } = props;
 
-    for (let i = startInc; i < endExc; i++) {
+    for (let i = startInclusive; i < endExclusive; i++) {
       const fullPath = `${storagePath}/${i}`;
       const data = this._fileFriend.readPathOrNull(fullPath);
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -272,6 +272,22 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `deletePathRange` operations.
+   *
+   * @param {object} props The operation properties.
+   */
+  _op_deletePathRange(props) {
+    const { storagePath, startInclusive, endExclusive } = props;
+
+    for (let i = startInclusive; i < endExclusive; i++) {
+      const fullPath = `${storagePath}/${i}`;
+      if (this._fileFriend.readPathOrNull(fullPath) !== null) {
+        this._updatedStorage.set(fullPath, null);
+      }
+    }
+  }
+
+  /**
    * Handler for `listPathPrefix` operations.
    *
    * @param {object} props The operation properties.

--- a/local-modules/file-store-local/tests/test_LocalFile_transact.js
+++ b/local-modules/file-store-local/tests/test_LocalFile_transact.js
@@ -287,6 +287,85 @@ describe('file-store-local/LocalFile.transact', () => {
     });
   });
 
+  describe('op deletePathRange', () => {
+    it('should succeed in deleting all in-range paths that are present', async () => {
+      const blob = new FrozenBuffer('Woo!');
+      const origPaths = [
+        '/x/a', '/x/yahhhssss', '/foo/1', '/foo/2', '/foo/10', '/foo/11', '/foo/12'
+      ];
+      const writeSpec = new TransactionSpec(...origPaths.map(p => FileOp.op_writePath(p, blob)));
+
+      async function test(start, end, expectDeleted) {
+        const file = new LocalFile('0', TempFiles.uniquePath());
+        await file.create();
+        await file.transact(writeSpec);
+
+        const spec = new TransactionSpec(FileOp.op_deletePathRange('/foo', start, end));
+        await assert.isFulfilled(file.transact(spec));
+
+        const expectPaths = new Set(origPaths);
+        for (const p of expectDeleted) {
+          expectPaths.delete(`/foo/${p}`);
+        }
+
+        const expectSpec = new TransactionSpec(
+          FileOp.op_listPathPrefix('/foo'),
+          FileOp.op_listPathPrefix('/x'));
+        const result = await file.transact(expectSpec);
+
+        assert.sameMembers([...result.paths], [...expectPaths]);
+      }
+
+      await test(1, 2, [1]);
+      await test(0, 2, [1]);
+
+      await test(2, 3, [2]);
+      await test(1, 3, [1, 2]);
+      await test(0, 3, [1, 2]);
+      await test(0, 4, [1, 2]);
+
+      await test(2, 10, [2]);
+      await test(2, 11, [2, 10]);
+      await test(2, 12, [2, 10, 11]);
+      await test(2, 13, [2, 10, 11, 12]);
+      await test(2, 14, [2, 10, 11, 12]);
+      await test(3, 14, [10, 11, 12]);
+    });
+
+    it('should succeed with an empty result given a range with no matching paths', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      await file.create();
+
+      async function test(start, end) {
+        const spec = new TransactionSpec(FileOp.op_readPathRange('/florp', start, end));
+        const transactionResult = await assert.isFulfilled(file.transact(spec));
+
+        assert.strictEqual(transactionResult.data.size, 0);
+      }
+
+      await test(0, 1);
+      await test(0, 2);
+      await test(100, 123);
+    });
+
+    it('should succeed with an empty result given an empty range', async () => {
+      const file = new LocalFile('0', TempFiles.uniquePath());
+      await file.create();
+
+      async function test(start, end) {
+        const spec = new TransactionSpec(FileOp.op_readPathRange('/florp', start, end));
+        const transactionResult = await assert.isFulfilled(file.transact(spec));
+
+        assert.strictEqual(transactionResult.data.size, 0);
+      }
+
+      await test(0, 0);
+      await test(12, 12);
+      await test(10, 9);
+      await test(5, 0);
+    });
+  });
+
   describe('op listPathPrefix', () => {
     it('should return an empty set when no results are found', async () => {
       const file = new LocalFile('0', TempFiles.uniquePath());

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -29,8 +29,9 @@ const CATEGORY_EXECUTION_ORDER = [
 // details.
 const TYPE_BUFFER    = 'Buffer';
 const TYPE_DUR_MSEC  = 'DurMsec';
-const TYPE_PATH      = 'Path';
 const TYPE_HASH      = 'Hash';
+const TYPE_INDEX     = 'Index';
+const TYPE_PATH      = 'Path';
 const TYPE_REV_NUM   = 'RevNum';
 
 // Operation schemata. See the doc for {@link FileOp#propsFromName} for
@@ -359,11 +360,6 @@ export default class FileOp extends CommonBase {
     return TYPE_DUR_MSEC;
   }
 
-  /** {string} Type name for storage paths. */
-  static get TYPE_PATH() {
-    return TYPE_PATH;
-  }
-
   /**
    * {string} Type name for hash values. Arguments of this type will also
    * accept instances of `FrozenBuffer`. When given a buffer, the constructor
@@ -371,6 +367,19 @@ export default class FileOp extends CommonBase {
    */
   static get TYPE_HASH() {
     return TYPE_HASH;
+  }
+
+  /**
+   * {string} Type name for index values, which is to say non-negative integers.
+   * These are used to with the `*Range` operations.
+   */
+  static get TYPE_INDEX() {
+    return TYPE_INDEX;
+  }
+
+  /** {string} Type name for storage paths. */
+  static get TYPE_PATH() {
+    return TYPE_PATH;
   }
 
   /** {string} Type name for revision numbers. */
@@ -585,6 +594,11 @@ export default class FileOp extends CommonBase {
         } else {
           FrozenBuffer.checkHash(value);
         }
+        break;
+      }
+
+      case TYPE_INDEX: {
+        TInt.nonNegative(value);
         break;
       }
 

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -183,6 +183,25 @@ const OPERATIONS = [
   [CAT_READ, 'readPath', ['storagePath', TYPE_PATH]],
 
   /*
+   * A `readPathRange` operation. This is a read operation that retrieves all
+   * the values for paths immediately under the given prefix whose final
+   * components are in the form of whole numbers within the indicated range, if
+   * any. Only paths that store values are represented in the result of the
+   * transaction.
+   *
+   * @param {string} storagePath The storage path prefix to read from.
+   * @param {Int} startInc The start of the range to read (inclusive). Must be
+   *   `>= 0`.
+   * @param {Int} endExc The end of the range to read (exclusive). Must be
+   *   `>= 0`. If it is `<= startInc` then the operation will have no effect (as
+   *   it would be an empty range).
+   */
+  [
+    CAT_READ, 'readPathRange',
+    ['storagePath', TYPE_PATH], ['startInc', TYPE_INDEX], ['endExc', TYPE_INDEX]
+  ],
+
+  /*
    * A `revNum` operation. This is a revision restriction that limits a
    * transaction to only be performed with respect to the indicated revision
    * number.

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -140,6 +140,25 @@ const OPERATIONS = [
   [CAT_DELETE, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
+   * A `deletePathRange` operation. This is a write operation that deletes the
+   * bindings for all paths immediately under the given prefix whose final
+   * components are in the form of whole numbers within the indicated range, if
+   * any. If there were no matching paths bound in the first place, then this
+   * operation does nothing.
+   *
+   * @param {string} storagePath The storage path prefix under which to delete.
+   * @param {Int} startInclusive The start of the range to delete (inclusive).
+   *   Must be `>= 0`.
+   * @param {Int} endExclusive The end of the range to delete (exclusive). Must
+   *   be `>= 0`. If it is `<= startInclusive` then the operation will have no
+   *   effect (as it would be an empty range).
+   */
+  [
+    CAT_DELETE, 'deletePathRange',
+    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
+  ],
+
+  /*
    * A `listPathPrefix` operation. This is a read operation that retrieves a
    * list of all paths immediately under the given prefix that store data, or
    * the path itself if it stores data directly. The resulting list can contain
@@ -193,8 +212,8 @@ const OPERATIONS = [
    * @param {Int} startInclusive The start of the range to read (inclusive).
    *   Must be `>= 0`.
    * @param {Int} endExclusive The end of the range to read (exclusive). Must be
-   *   `>= 0`. If it is `<= startInc` then the operation will have no effect (as
-   *   it would be an empty range).
+   *   `>= 0`. If it is `<= startInclusive` then the operation will have no
+   *   effect (as it would be an empty range).
    */
   [
     CAT_READ, 'readPathRange',

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -190,15 +190,15 @@ const OPERATIONS = [
    * transaction.
    *
    * @param {string} storagePath The storage path prefix to read from.
-   * @param {Int} startInc The start of the range to read (inclusive). Must be
-   *   `>= 0`.
-   * @param {Int} endExc The end of the range to read (exclusive). Must be
+   * @param {Int} startInclusive The start of the range to read (inclusive).
+   *   Must be `>= 0`.
+   * @param {Int} endExclusive The end of the range to read (exclusive). Must be
    *   `>= 0`. If it is `<= startInc` then the operation will have no effect (as
    *   it would be an empty range).
    */
   [
     CAT_READ, 'readPathRange',
-    ['storagePath', TYPE_PATH], ['startInc', TYPE_INDEX], ['endExc', TYPE_INDEX]
+    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
   ],
 
   /*

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -154,6 +154,9 @@ export default class FileOpMaker extends UtilityClass {
         const buf = FrozenBuffer.coerce(`buffer_hash_${n}`);
         return buf.hash;
       }
+      case FileOp.TYPE_INDEX: {
+        return n + 100;
+      }
       case FileOp.TYPE_PATH: {
         return `/path/${n}`;
       }


### PR DESCRIPTION
This PR adds an explicit abstraction to the file layer for handling sets of paths whose leaves are a sequence of numbers, that is, a range. Two new file ops are defined, `deletePathRange` and `readPathRange`. The latter is then used to replace more manual path creation in `BaseControl.getChangeRange()`. A future PR will use the former in the implementation of ephemeral OT parts.