### PR TITLE
Improve document validation. New file op.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -262,6 +262,7 @@ export default class BaseControl extends BaseDataManager {
    * @returns {BodyChange} The requested change.
    */
   async getChange(revNum) {
+    RevisionNumber.check(revNum); // So we know we can `+1` without weirdness.
     const changes = await this.getChangeRange(revNum, revNum + 1, false);
 
     return changes[0];
@@ -342,6 +343,7 @@ export default class BaseControl extends BaseDataManager {
 
     RevisionNumber.check(startInclusive);
     RevisionNumber.min(endExclusive, startInclusive);
+    TBoolean.check(allowMissing);
 
     if ((endExclusive - startInclusive) > BaseControl.MAX_CHANGE_READS_PER_TRANSACTION) {
       // The calling code (in this class) should have made sure we weren't

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -139,7 +139,7 @@ export default class BodyControl extends BaseControl {
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {
-        await this.getChangeRange(i, lastI + 1);
+        await this.getChangeRange(i, lastI + 1, false);
       } catch (e) {
         this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
         return ValidationStatus.STATUS_ERROR;
@@ -147,7 +147,8 @@ export default class BodyControl extends BaseControl {
     }
 
     // Look for changes past the stored revision number to make sure they don't
-    // exist.
+    // exist. **TODO:** Handle the possibility that the document got a new
+    // change added to it during the course of validation.
 
     let extraChanges;
     try {

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -146,25 +146,19 @@ export default class BodyControl extends BaseControl {
       }
     }
 
-    // Look for a few changes past the stored revision number to make sure
-    // they're empty.
+    // Look for changes past the stored revision number to make sure they don't
+    // exist.
 
+    let extraChanges;
     try {
-      const fc  = this.fileCodec;
-      const ops = [];
-      for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(BodyControl.pathForChange(i)));
-      }
-      const spec = new TransactionSpec(...ops);
-      transactionResult = await fc.transact(spec);
+      extraChanges = await this.listChangeRange(revNum + 1, revNum + 10000);
     } catch (e) {
-      this.log.info('Corrupt document: Weird empty-change read failure.');
+      this.log.info('Corrupt document: Trouble listing changes.');
       return ValidationStatus.STATUS_ERROR;
     }
 
-    // In a valid doc, the loop body won't end up executing at all.
-    for (const storagePath of transactionResult.data.keys()) {
-      this.log.info('Corrupt document. Extra change at path:', storagePath);
+    if (extraChanges.length !== 0) {
+      this.log.info(`Corrupt document: Detected extra changes (at least ${extraChanges.length}).`);
       return ValidationStatus.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -162,12 +162,13 @@ export default class CaretControl extends BaseControl {
   async _impl_validationStatus() {
     let transactionResult;
 
-    // Check the revision number.
+    // Check the revision number (mandatory) and stored snapshot (if present).
 
     try {
       const fc = this.fileCodec;
       const spec = new TransactionSpec(
-        fc.op_readPath(CaretControl.revisionNumberPath)
+        fc.op_readPath(CaretControl.revisionNumberPath),
+        fc.op_readPath(CaretControl.storedSnapshotPath)
       );
       transactionResult = await fc.transact(spec);
     } catch (e) {
@@ -175,14 +176,29 @@ export default class CaretControl extends BaseControl {
       return ValidationStatus.STATUS_ERROR;
     }
 
-    const data   = transactionResult.data;
-    const revNum = data.get(CaretControl.revisionNumberPath);
+    const data     = transactionResult.data;
+    const revNum   = data.get(CaretControl.revisionNumberPath);
+    const snapshot = data.get(CaretControl.storedSnapshotPath);
 
     try {
       RevisionNumber.check(revNum);
     } catch (e) {
       this.log.info('Corrupt document: Bogus or missing revision number.');
       return ValidationStatus.STATUS_ERROR;
+    }
+
+    if (snapshot) {
+      try {
+        CaretControl.snapshotClass.check(snapshot);
+      } catch (e) {
+        this.log.info('Corrupt document: Bogus stored snapshot (wrong class).');
+        return ValidationStatus.STATUS_ERROR;
+      }
+
+      if (revNum < snapshot.revNum) {
+        this.log.info('Corrupt document: Bogus stored snapshot (weird revision number).');
+        return ValidationStatus.STATUS_ERROR;
+      }
     }
 
     // Make sure all the changes can be read and decoded.

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -214,25 +214,19 @@ export default class CaretControl extends BaseControl {
       }
     }
 
-    // Look for a few changes past the stored revision number to make sure
-    // they're empty.
+    // Look for changes past the stored revision number to make sure they don't
+    // exist.
 
+    let extraChanges;
     try {
-      const fc  = this.fileCodec;
-      const ops = [];
-      for (let i = revNum + 1; i <= (revNum + 10); i++) {
-        ops.push(fc.op_readPath(CaretControl.pathForChange(i)));
-      }
-      const spec = new TransactionSpec(...ops);
-      transactionResult = await fc.transact(spec);
+      extraChanges = await this.listChangeRange(revNum + 1, revNum + 10000);
     } catch (e) {
-      this.log.info('Corrupt document: Weird empty-change read failure.');
+      this.log.info('Corrupt document: Trouble listing changes.');
       return ValidationStatus.STATUS_ERROR;
     }
 
-    // In a valid doc, the loop body won't end up executing at all.
-    for (const storagePath of transactionResult.data.keys()) {
-      this.log.info('Corrupt document. Extra change at path:', storagePath);
+    if (extraChanges.length !== 0) {
+      this.log.info(`Corrupt document: Detected extra changes (at least ${extraChanges.length}).`);
       return ValidationStatus.STATUS_ERROR;
     }
 

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -207,7 +207,7 @@ export default class CaretControl extends BaseControl {
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {
-        await this.getChangeRange(i, lastI + 1);
+        await this.getChangeRange(i, lastI + 1, false);
       } catch (e) {
         this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
         return ValidationStatus.STATUS_ERROR;
@@ -215,7 +215,8 @@ export default class CaretControl extends BaseControl {
     }
 
     // Look for changes past the stored revision number to make sure they don't
-    // exist.
+    // exist. **TODO:** Handle the possibility that the document got a new
+    // change added to it during the course of validation.
 
     let extraChanges;
     try {

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -142,7 +142,7 @@ export default class PropertyControl extends BaseControl {
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {
-        await this.getChangeRange(i, lastI + 1);
+        await this.getChangeRange(i, lastI + 1, false);
       } catch (e) {
         this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
         return ValidationStatus.STATUS_ERROR;
@@ -150,7 +150,8 @@ export default class PropertyControl extends BaseControl {
     }
 
     // Look for changes past the stored revision number to make sure they don't
-    // exist.
+    // exist. **TODO:** Handle the possibility that the document got a new
+    // change added to it during the course of validation.
 
     let extraChanges;
     try {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -455,7 +455,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        assert.isRejected(control.getChange(value), /^bad_value/);
+        await assert.isRejected(control.getChange(value), /^bad_value/);
       }
 
       await test(undefined);
@@ -595,7 +595,7 @@ describe('doc-server/BaseControl', () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
 
       async function test(base, newer) {
-        assert.isRejected(control.getDiff(base, newer), /^bad_value/);
+        await assert.isRejected(control.getDiff(base, newer), /^bad_value/);
       }
 
       await test(undefined, 10);

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -420,10 +420,12 @@ describe('doc-server/BaseControl', () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       let gotStart  = null;
       let gotEnd    = null;
+      let gotAllow  = null;
 
-      control.getChangeRange = async (start, end) => {
+      control.getChangeRange = async (start, end, allowMissing) => {
         gotStart = start;
         gotEnd   = end;
+        gotAllow = allowMissing;
         return ['foomp'];
       };
 
@@ -432,6 +434,7 @@ describe('doc-server/BaseControl', () => {
           await control.getChange(n);
           assert.strictEqual(gotStart, n);
           assert.strictEqual(gotEnd,   n + 1);
+          assert.isFalse(gotAllow);
         }
 
         await test(0);
@@ -447,7 +450,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should promptly reject blatantly invalid `revNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control.getChangeRange = async (start_unused, end_unused) => {
+      control.getChangeRange = async (start_unused, end_unused, allow_unused) => {
         throw new Error('This should not have been called.');
       };
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -309,6 +309,22 @@ export default class Transactor extends CommonBase {
   }
 
   /**
+   * Handler for `listPathRange` operations.
+   *
+   * @param {object} props The operation properties.
+   */
+  _op_listPathRange(props) {
+    const { storagePath, startInclusive, endExclusive } = props;
+
+    for (let i = startInclusive; i < endExclusive; i++) {
+      const fullPath = `${storagePath}/${i}`;
+      if (this._fileFriend.readPathOrNull(fullPath) !== null) {
+        this._paths.add(fullPath);
+      }
+    }
+  }
+
+  /**
    * Handler for `readBlob` operations.
    *
    * @param {object} props The operation properties.

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -171,6 +171,24 @@ const OPERATIONS = [
   [CAT_LIST, 'listPathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
+   * A `listPathRange` operation. This is a read operation that retrieves a
+   * list of all paths immediately under the given prefix whose final components
+   * are in the form of whole numbers within the indicated range, if any. If
+   * there are no such paths, the result is an empty list.
+   *
+   * @param {string} storagePath The storage path prefix under which to look.
+   * @param {Int} startInclusive The start of the range to look for (inclusive).
+   *   Must be `>= 0`.
+   * @param {Int} endExclusive The end of the range to look for (exclusive).
+   *   Must be `>= 0`. If it is `<= startInclusive` then the operation will
+   *   result in an empty list (as it would be an empty range).
+   */
+  [
+    CAT_LIST, 'listPathRange',
+    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
+  ],
+
+  /*
    * A `readBlob` operation. This is a read operation that retrieves the full
    * value of the indicated blob (identified by hash), if any. If there is no
    * so-identified blob in the file, then the hash is _not_ represented in the

--- a/local-modules/file-store/StoragePath.js
+++ b/local-modules/file-store/StoragePath.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TArray, TString } from 'typecheck';
+import { TArray, TInt, TString } from 'typecheck';
 import { Errors, UtilityClass } from 'util-common';
 
 /**
@@ -86,6 +86,26 @@ export default class StoragePath extends UtilityClass {
     }
 
     return value;
+  }
+
+  /**
+   * Gets the index number (final path component, interpreted as a non-negative
+   * integer) given a path that ends with one. It is an error to pass a path
+   * that does not end with a valid index number.
+   *
+   * @param {string} path Path to extract from.
+   * @returns {Int} The index portion, as an integer.
+   */
+  static getIndex(path) {
+    StoragePath.check(path);
+
+    const match = path.match(/[/](0|[1-9][0-9]*)$/);
+
+    if (match === null) {
+      throw Errors.bad_value(path, StoragePath, 'with index');
+    }
+
+    return TInt.nonNegative(parseInt(match[1]));
   }
 
   /**

--- a/local-modules/file-store/tests/test_StoragePath.js
+++ b/local-modules/file-store/tests/test_StoragePath.js
@@ -139,6 +139,55 @@ describe('file-store/StoragePath', () => {
     });
   });
 
+  describe('getIndex()', () => {
+    it('should return the index from a valid index-bearing path', () => {
+      function test(value, expect) {
+        const result = StoragePath.getIndex(value);
+        assert.strictEqual(result, expect, value);
+      }
+
+      for (let i = 0; i < 1000; i++) {
+        if (i > 25) {
+          i += 123;
+        }
+
+        test(`/${i}`, i);
+        test(`/florp/${i}`, i);
+        test(`/a/b/c/${i}`, i);
+        test(`/a/1/c/${i}`, i);
+      }
+    });
+
+    it('should reject non-index-bearing paths', () => {
+      function test(value) {
+        assert.throws(() => StoragePath.getIndex(value), /bad_value/);
+      }
+
+      // Nothing even vaguely index-like.
+      test('/foo');
+      test('/foo/bar');
+      test('/foo/bar/baz');
+
+      // Invalid index forms.
+      test('/00');
+      test('/01');
+      test('/x/00');
+      test('/x/09');
+
+      // Last component must be the index.
+      test('/0/x');
+      test('/1/x');
+      test('/x/0/x');
+      test('/x/1/x');
+    });
+
+    it('should reject entirely invalid path arguments', () => {
+      for (const value of [...INVALID_PATHS, ...NON_STRINGS]) {
+        assert.throws(() => StoragePath.getIndex(value), /bad_value/);
+      }
+    });
+  });
+
   describe('isInstance()', () => {
     it('should return `true` for valid paths', () => {
       for (const value of VALID_PATHS) {

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -130,6 +130,11 @@ export default class EventReceiver extends CommonBase {
    */
   _handle_suite(title) {
     this._suites.push(title);
+
+    if (this._suites.length === 1) {
+      title = chalk.bold(title);
+    }
+
     this._log(`${'  '.repeat(this._suites.length)}${title}`);
   }
 


### PR DESCRIPTION
The main point of this PR is to get document validation to cover a little more territory. Specifically, it now checks that the stored snapshot (if present) is sensible. In addition, it fixes validation of existing changes which I _slightly_ broke in the last PR; immediately-previously validation would tolerate improperly-missing changes. Finally, it improves the check for extra changes.

In support of all this, I ended up adding a new file op, `listPathRange`, along with some new utility functionality in `StoragePath`. In addition, I added `BaseControl.listChangeRange()`.

The astute observer will note that we have three nearly-identical `_impl_validationStatus()` methods, one per OT control subclass. Yes, they should be merged and factored into `BaseControl`. The twist is that sometime soon the one in `CaretControl` will want to change to support ephemerality. I still don't quite know how that's going to shake out. So, in the mean time I'm going to endure the duplication.