### PR TITLE
Durable vs. ephemeral OT parts.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -794,6 +794,9 @@ export default class BaseControl extends BaseDataManager {
 
     clazz.snapshotClass.check(snapshot);
 
+    // **TODO:** Ephemeral parts should delete changes from revisions earlier
+    // than the snapshot before some amount of "buffer" changes (to allow for
+    // some leeway in noticing changes across snapshot boundaries).
     const spec = new TransactionSpec(fc.op_writePath(path, snapshot));
 
     await fc.transact(spec);

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -38,6 +38,11 @@ const CHANGES_PER_STORED_SNAPSHOT = 100;
  * Base class for document part controllers. There is one instance of each
  * concrete subclass of this class for each actively-edited document. They are
  * all managed and hooked up via {@link FileComplex}.
+ *
+ * This class has two direct subclasses, which are both abstract,
+ * {@link DurableControl} and {@link EphemeralControl}. The only difference
+ * in behavior between the subclasses is in whether full change history is
+ * stored. See their descriptions for details.
  */
 export default class BaseControl extends BaseDataManager {
   /**
@@ -152,6 +157,17 @@ export default class BaseControl extends BaseDataManager {
 
     RevisionNumber.check(revNum);
     return `${this.changePathPrefix}/${revNum}`;
+  }
+
+  /**
+   * {boolean} Whether (`true`) or not (`false`) this instance controls an
+   * ephemeral part. This is overridden in each of the two direct subclasses of
+   * this class and should not be overridden further.
+   *
+   * @abstract
+   */
+  get ephemeral() {
+    throw this._mustOverride();
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -6,7 +6,7 @@ import { BodyChange, BodyDelta, BodySnapshot } from 'doc-common';
 import { TransactionSpec } from 'file-store';
 import { RevisionNumber } from 'ot-common';
 
-import BaseControl from './BaseControl';
+import DurableControl from './DurableControl';
 import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
 import ValidationStatus from './ValidationStatus';
@@ -14,7 +14,7 @@ import ValidationStatus from './ValidationStatus';
 /**
  * Controller for a given document's body content.
  */
-export default class BodyControl extends BaseControl {
+export default class BodyControl extends DurableControl {
   /**
    * Constructs an instance.
    *
@@ -135,7 +135,7 @@ export default class BodyControl extends BaseControl {
 
     // Make sure all the changes can be read and decoded.
 
-    const MAX = BaseControl.MAX_CHANGE_READS_PER_TRANSACTION;
+    const MAX = DurableControl.MAX_CHANGE_READS_PER_TRANSACTION;
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -7,8 +7,8 @@ import { TransactionSpec } from 'file-store';
 import { RevisionNumber, Timestamp } from 'ot-common';
 import { TInt, TString } from 'typecheck';
 
-import BaseControl from './BaseControl';
 import CaretColor from './CaretColor';
+import EphemeralControl from './EphemeralControl';
 import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
 import ValidationStatus from './ValidationStatus';
@@ -25,7 +25,7 @@ const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
  * **TODO:** Caret data should be ephemeral. As of this writing, old data will
  * never get purged from the underlying file.
  */
-export default class CaretControl extends BaseControl {
+export default class CaretControl extends EphemeralControl {
   /**
    * Constructs an instance.
    *
@@ -201,9 +201,11 @@ export default class CaretControl extends BaseControl {
       }
     }
 
-    // Make sure all the changes can be read and decoded.
+    // Make sure all the changes can be read and decoded. **TODO:** Ephemeral
+    // parts don't necessarily store any changes from before the snapshot
+    // revision. Handle that possibility.
 
-    const MAX = BaseControl.MAX_CHANGE_READS_PER_TRANSACTION;
+    const MAX = EphemeralControl.MAX_CHANGE_READS_PER_TRANSACTION;
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {

--- a/local-modules/doc-server/DurableControl.js
+++ b/local-modules/doc-server/DurableControl.js
@@ -1,0 +1,19 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseControl from './BaseControl';
+
+/**
+ * Base class for _durable_ document part controllers. Durable parts maintain
+ * full change history (as opposed to _ephemeral_ parts which do not).
+ */
+export default class DurableControl extends BaseControl {
+  /**
+   * {boolean} Whether (`true`) or not (`false`) this instance controls an
+   * ephemeral part. Defined as `false` for this class.
+   */
+  get ephemeral() {
+    return false;
+  }
+}

--- a/local-modules/doc-server/EphemeralControl.js
+++ b/local-modules/doc-server/EphemeralControl.js
@@ -1,0 +1,21 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseControl from './BaseControl';
+
+/**
+ * Base class for _ephemeral_ document part controllers. Ephemeral parts do not
+ * maintain full change history. Instead, they keep a stored snapshot of _some_
+ * revision along with all subsequent changes. Every so often, the stored
+ * snapshot gets updated, at which point earlier changes are able to be deleted.
+ */
+export default class EphemeralControl extends BaseControl {
+  /**
+   * {boolean} Whether (`true`) or not (`false`) this instance controls an
+   * ephemeral part. Defined as `true` for this class.
+   */
+  get ephemeral() {
+    return true;
+  }
+}

--- a/local-modules/doc-server/PropertyControl.js
+++ b/local-modules/doc-server/PropertyControl.js
@@ -6,7 +6,7 @@ import { PropertySnapshot } from 'doc-common';
 import { TransactionSpec } from 'file-store';
 import { RevisionNumber } from 'ot-common';
 
-import BaseControl from './BaseControl';
+import DurableControl from './DurableControl';
 import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
 import ValidationStatus from './ValidationStatus';
@@ -14,7 +14,7 @@ import ValidationStatus from './ValidationStatus';
 /**
  * Controller for the property metadata of a particular document.
  */
-export default class PropertyControl extends BaseControl {
+export default class PropertyControl extends DurableControl {
   /**
    * Constructs an instance.
    *
@@ -138,7 +138,7 @@ export default class PropertyControl extends BaseControl {
 
     // Make sure all the changes can be read and decoded.
 
-    const MAX = BaseControl.MAX_CHANGE_READS_PER_TRANSACTION;
+    const MAX = DurableControl.MAX_CHANGE_READS_PER_TRANSACTION;
     for (let i = 0; i <= revNum; i += MAX) {
       const lastI = Math.min(i + MAX - 1, revNum);
       try {

--- a/local-modules/doc-server/index.js
+++ b/local-modules/doc-server/index.js
@@ -9,6 +9,8 @@ import BodyControl from './BodyControl';
 import CaretControl from './CaretControl';
 import DocServer from './DocServer';
 import DocSession from './DocSession';
+import DurableControl from './DurableControl';
+import EphemeralControl from './EphemeralControl';
 import FileAccess from './FileAccess';
 import FileComplex from './FileComplex';
 import PropertyControl from './PropertyControl';
@@ -23,6 +25,8 @@ export {
   CaretControl,
   DocServer,
   DocSession,
+  DurableControl,
+  EphemeralControl,
   FileAccess,
   FileComplex,
   PropertyControl,

--- a/local-modules/doc-server/mocks/MockControl.js
+++ b/local-modules/doc-server/mocks/MockControl.js
@@ -2,13 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseControl } from 'doc-server';
+import { DurableControl } from 'doc-server';
 import { MockSnapshot } from 'ot-common/mocks';
 
 /**
- * Subclass of {@link BaseControl} for use in testing.
+ * Subclass of {@link DurableControl} for use in testing.
  */
-export default class MockControl extends BaseControl {
+export default class MockControl extends DurableControl {
   constructor(fileAccess, logLabel) {
     super(fileAccess, logLabel);
 

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -8,13 +8,16 @@ import { describe, it } from 'mocha';
 import { Codec } from 'codec';
 import { Timeouts } from 'doc-common';
 import { MockChange, MockDelta, MockOp, MockSnapshot } from 'ot-common/mocks';
-import { BaseControl, FileAccess } from 'doc-server';
+import { DurableControl, FileAccess } from 'doc-server';
 import { MockControl } from 'doc-server/mocks';
 import { Errors as FileErrors, TransactionSpec } from 'file-store';
 import { MockFile } from 'file-store/mocks';
 import { Timestamp } from 'ot-common';
 import { Errors, FrozenBuffer } from 'util-common';
 
+// **Note:** Even though these tests are written in terms of `DurableControl`
+// and a subclass thereof, they are limited to testing behavior which is common
+// to all control classes. This is why it is labeled as being for `BaseControl`.
 describe('doc-server/BaseControl', () => {
   /** {FileAccess} Convenient instance of `FileAccess`. */
   const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
@@ -47,7 +50,7 @@ describe('doc-server/BaseControl', () => {
     });
 
     it('should reject an improper subclass choice', () => {
-      class HasBadPrefix extends BaseControl {
+      class HasBadPrefix extends DurableControl {
         static get _impl_pathPrefix() {
           return '//invalid/path_string!';
         }
@@ -57,7 +60,7 @@ describe('doc-server/BaseControl', () => {
     });
 
     it('should only ever ask the subclass once', () => {
-      class GoodControl extends BaseControl {
+      class GoodControl extends DurableControl {
         static get _impl_pathPrefix() {
           this.count++;
           return '/blort';
@@ -82,7 +85,7 @@ describe('doc-server/BaseControl', () => {
     });
 
     it('should reject an improper subclass choice', () => {
-      class HasBadSnapshot extends BaseControl {
+      class HasBadSnapshot extends DurableControl {
         static get _impl_snapshotClass() {
           return Object;
         }
@@ -92,7 +95,7 @@ describe('doc-server/BaseControl', () => {
     });
 
     it('should only ever ask the subclass once', () => {
-      class GoodControl extends BaseControl {
+      class GoodControl extends DurableControl {
         static get _impl_snapshotClass() {
           this.count++;
           return MockSnapshot;

--- a/local-modules/doc-server/tests/test_DurableControl.js
+++ b/local-modules/doc-server/tests/test_DurableControl.js
@@ -1,0 +1,25 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Codec } from 'codec';
+import { DurableControl, FileAccess } from 'doc-server';
+import { MockFile } from 'file-store/mocks';
+
+describe('doc-server/DurableControl', () => {
+  /** {FileAccess} Convenient instance of `FileAccess`. */
+  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+
+  /** {class} Concrete subclass, for use in testing. */
+  class SomeControl extends DurableControl { /*empty*/ }
+
+  describe('.ephemeral', () => {
+    const control = new SomeControl(FILE_ACCESS, 'boop');
+    it('should be `false`', () => {
+      assert.isFalse(control.ephemeral);
+    });
+  });
+});

--- a/local-modules/doc-server/tests/test_EphemeralControl.js
+++ b/local-modules/doc-server/tests/test_EphemeralControl.js
@@ -1,0 +1,25 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Codec } from 'codec';
+import { EphemeralControl, FileAccess } from 'doc-server';
+import { MockFile } from 'file-store/mocks';
+
+describe('doc-server/DurableControl', () => {
+  /** {FileAccess} Convenient instance of `FileAccess`. */
+  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+
+  /** {class} Concrete subclass, for use in testing. */
+  class SomeControl extends EphemeralControl { /*empty*/ }
+
+  describe('.ephemeral', () => {
+    const control = new SomeControl(FILE_ACCESS, 'boop');
+    it('should be `true`', () => {
+      assert.isTrue(control.ephemeral);
+    });
+  });
+});

--- a/local-modules/doc-server/tests/test_EphemeralControl.js
+++ b/local-modules/doc-server/tests/test_EphemeralControl.js
@@ -9,7 +9,7 @@ import { Codec } from 'codec';
 import { EphemeralControl, FileAccess } from 'doc-server';
 import { MockFile } from 'file-store/mocks';
 
-describe('doc-server/DurableControl', () => {
+describe('doc-server/EphemeralControl', () => {
   /** {FileAccess} Convenient instance of `FileAccess`. */
   const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
 

--- a/local-modules/file-store-local/tests/test_LocalFileStore.js
+++ b/local-modules/file-store-local/tests/test_LocalFileStore.js
@@ -1,9 +1,0 @@
-// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
-// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
-// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
-
-import { describe, it } from 'mocha';
-
-describe('file-store-local/LocalFileStore', () => {
-  it('needs a way to be tested');
-});


### PR DESCRIPTION
This PR introduces a nascent distinction between "durable" and "ephemeral" parts of a document. The former keep full change history, while the latter do not. The stuff you most likely think of as _being_ the document are classified as "durable," while active metadata — most notably in the short term, the caret / session info — is "ephemeral."

As of this PR, new abstract subclasses of `BaseControl` are in place, and each of the concrete subclasses has gotten a new superclass as appropriate. However, there is as yet no difference in implemented behavior between the two categories. That will come soon!