### PR TITLE
Refactor; implement ephemeral change management.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -84,6 +84,17 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * {boolean} Whether (`true`) or not (`false`) this instance controls an
+   * ephemeral part. This is overridden in each of the two direct subclasses of
+   * this class and should not be overridden further.
+   *
+   * @abstract
+   */
+  static get ephemeral() {
+    throw this._mustOverride();
+  }
+
+  /**
    * {string} Path prefix to use for file storage for the portion of the
    * document controlled by instances of this class.
    */
@@ -156,17 +167,6 @@ export default class BaseControl extends BaseDataManager {
 
     RevisionNumber.check(revNum);
     return `${this.changePathPrefix}/${revNum}`;
-  }
-
-  /**
-   * {boolean} Whether (`true`) or not (`false`) this instance controls an
-   * ephemeral part. This is overridden in each of the two direct subclasses of
-   * this class and should not be overridden further.
-   *
-   * @abstract
-   */
-  get ephemeral() {
-    throw this._mustOverride();
   }
 
   /**

--- a/local-modules/doc-server/BodyControl.js
+++ b/local-modules/doc-server/BodyControl.js
@@ -3,13 +3,10 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BodyChange, BodyDelta, BodySnapshot } from 'doc-common';
-import { TransactionSpec } from 'file-store';
-import { RevisionNumber } from 'ot-common';
 
 import DurableControl from './DurableControl';
 import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
-import ValidationStatus from './ValidationStatus';
 
 /**
  * Controller for a given document's body content.
@@ -84,88 +81,6 @@ export default class BodyControl extends DurableControl {
     const finalDelta = serverDelta.transform(change.delta, true);
 
     return new BodyChange(currentSnapshot.revNum + 1, finalDelta, change.timestamp, change.authorId);
-  }
-
-  /**
-   * Subclass-specific implementation of {@link #validationStatus}.
-   *
-   * @returns {string} One of the constants defined by {@link ValidationStatus}.
-   */
-  async _impl_validationStatus() {
-    let transactionResult;
-
-    // Check the revision number (mandatory) and stored snapshot (if present).
-
-    try {
-      const fc = this.fileCodec;
-      const spec = new TransactionSpec(
-        fc.op_readPath(BodyControl.revisionNumberPath),
-        fc.op_readPath(BodyControl.storedSnapshotPath)
-      );
-      transactionResult = await fc.transact(spec);
-    } catch (e) {
-      this.log.error('Major problem trying to read file!', e);
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    const data     = transactionResult.data;
-    const revNum   = data.get(BodyControl.revisionNumberPath);
-    const snapshot = data.get(BodyControl.storedSnapshotPath);
-
-    try {
-      RevisionNumber.check(revNum);
-    } catch (e) {
-      this.log.info('Corrupt document: Bogus or missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    if (snapshot) {
-      try {
-        BodyControl.snapshotClass.check(snapshot);
-      } catch (e) {
-        this.log.info('Corrupt document: Bogus stored snapshot (wrong class).');
-        return ValidationStatus.STATUS_ERROR;
-      }
-
-      if (revNum < snapshot.revNum) {
-        this.log.info('Corrupt document: Bogus stored snapshot (weird revision number).');
-        return ValidationStatus.STATUS_ERROR;
-      }
-    }
-
-    // Make sure all the changes can be read and decoded.
-
-    const MAX = DurableControl.MAX_CHANGE_READS_PER_TRANSACTION;
-    for (let i = 0; i <= revNum; i += MAX) {
-      const lastI = Math.min(i + MAX - 1, revNum);
-      try {
-        await this.getChangeRange(i, lastI + 1, false);
-      } catch (e) {
-        this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
-        return ValidationStatus.STATUS_ERROR;
-      }
-    }
-
-    // Look for changes past the stored revision number to make sure they don't
-    // exist. **TODO:** Handle the possibility that the document got a new
-    // change added to it during the course of validation.
-
-    let extraChanges;
-    try {
-      extraChanges = await this.listChangeRange(revNum + 1, revNum + 10000);
-    } catch (e) {
-      this.log.info('Corrupt document: Trouble listing changes.');
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    if (extraChanges.length !== 0) {
-      this.log.info(`Corrupt document: Detected extra changes (at least ${extraChanges.length}).`);
-      return ValidationStatus.STATUS_ERROR;
-    }
-
-    // All's well!
-
-    return ValidationStatus.STATUS_OK;
   }
 
   /**

--- a/local-modules/doc-server/DurableControl.js
+++ b/local-modules/doc-server/DurableControl.js
@@ -13,7 +13,7 @@ export default class DurableControl extends BaseControl {
    * {boolean} Whether (`true`) or not (`false`) this instance controls an
    * ephemeral part. Defined as `false` for this class.
    */
-  get ephemeral() {
+  static get ephemeral() {
     return false;
   }
 }

--- a/local-modules/doc-server/DurableControl.js
+++ b/local-modules/doc-server/DurableControl.js
@@ -7,6 +7,11 @@ import BaseControl from './BaseControl';
 /**
  * Base class for _durable_ document part controllers. Durable parts maintain
  * full change history (as opposed to _ephemeral_ parts which do not).
+ *
+ * **Note:** The actual differences in behavior between instances of this class
+ * and instances of {@link EphemeralControl} are defined in the superclass,
+ * which merely keys off of the value of the static property {@link #ephemeral}
+ * defined here.
  */
 export default class DurableControl extends BaseControl {
   /**

--- a/local-modules/doc-server/EphemeralControl.js
+++ b/local-modules/doc-server/EphemeralControl.js
@@ -15,7 +15,7 @@ export default class EphemeralControl extends BaseControl {
    * {boolean} Whether (`true`) or not (`false`) this instance controls an
    * ephemeral part. Defined as `true` for this class.
    */
-  get ephemeral() {
+  static get ephemeral() {
     return true;
   }
 }

--- a/local-modules/doc-server/EphemeralControl.js
+++ b/local-modules/doc-server/EphemeralControl.js
@@ -9,6 +9,11 @@ import BaseControl from './BaseControl';
  * maintain full change history. Instead, they keep a stored snapshot of _some_
  * revision along with all subsequent changes. Every so often, the stored
  * snapshot gets updated, at which point earlier changes are able to be deleted.
+ *
+ * **Note:** The actual differences in behavior between instances of this class
+ * and instances of {@link EphemeralControl} are defined in the superclass,
+ * which merely keys off of the value of the static property {@link #ephemeral}
+ * defined here.
  */
 export default class EphemeralControl extends BaseControl {
   /**

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -425,14 +425,14 @@ describe('doc-server/BaseControl', () => {
       let gotEnd    = null;
       let gotAllow  = null;
 
-      control.getChangeRange = async (start, end, allowMissing) => {
+      control._getChangeRange = async (start, end, allowMissing) => {
         gotStart = start;
         gotEnd   = end;
         gotAllow = allowMissing;
         return ['foomp'];
       };
 
-      it('should pass appropriate arguments to `getChangeRange()`', async () => {
+      it('should pass appropriate arguments to `_getChangeRange()`', async () => {
         async function test(n) {
           await control.getChange(n);
           assert.strictEqual(gotStart, n);
@@ -445,7 +445,7 @@ describe('doc-server/BaseControl', () => {
         await test(914);
       });
 
-      it('should return the first element of the return value from `getChangeRange()`', async () => {
+      it('should return the first element of the return value from `_getChangeRange()`', async () => {
         const result = await control.getChange(123);
         assert.strictEqual(result, 'foomp');
       });
@@ -453,7 +453,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should promptly reject blatantly invalid `revNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
-      control.getChangeRange = async (start_unused, end_unused, allow_unused) => {
+      control._getChangeRange = async (start_unused, end_unused, allow_unused) => {
         throw new Error('This should not have been called.');
       };
 

--- a/local-modules/doc-server/tests/test_DurableControl.js
+++ b/local-modules/doc-server/tests/test_DurableControl.js
@@ -5,21 +5,15 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codec } from 'codec';
-import { DurableControl, FileAccess } from 'doc-server';
-import { MockFile } from 'file-store/mocks';
+import { DurableControl } from 'doc-server';
 
 describe('doc-server/DurableControl', () => {
-  /** {FileAccess} Convenient instance of `FileAccess`. */
-  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
-
   /** {class} Concrete subclass, for use in testing. */
   class SomeControl extends DurableControl { /*empty*/ }
 
   describe('.ephemeral', () => {
-    const control = new SomeControl(FILE_ACCESS, 'boop');
     it('should be `false`', () => {
-      assert.isFalse(control.ephemeral);
+      assert.isFalse(SomeControl.ephemeral);
     });
   });
 });

--- a/local-modules/doc-server/tests/test_EphemeralControl.js
+++ b/local-modules/doc-server/tests/test_EphemeralControl.js
@@ -5,21 +5,15 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codec } from 'codec';
-import { EphemeralControl, FileAccess } from 'doc-server';
-import { MockFile } from 'file-store/mocks';
+import { EphemeralControl } from 'doc-server';
 
 describe('doc-server/EphemeralControl', () => {
-  /** {FileAccess} Convenient instance of `FileAccess`. */
-  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
-
   /** {class} Concrete subclass, for use in testing. */
   class SomeControl extends EphemeralControl { /*empty*/ }
 
   describe('.ephemeral', () => {
-    const control = new SomeControl(FILE_ACCESS, 'boop');
     it('should be `true`', () => {
-      assert.isTrue(control.ephemeral);
+      assert.isTrue(SomeControl.ephemeral);
     });
   });
 });

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.32.2
+version = 0.33.0


### PR DESCRIPTION
This PR has two main bits:

* The long-awaited (by me at least) refactor of document part validation, so that it's implemented entirely in `BaseControl`, instead of having three nearly-identical implementations in the concrete OT control subclasses.
* Implements the "aging out" behavior of changes in ephemeral parts. So, `CaretControl` no longer spews an immutable and eternal trail of caret info.

With this PR, it's reasonable to say that the caret rework is finally done. This is being commemorated with a product version bump.