### PR TITLE
Simplify API client setup.

### DIFF
--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -167,7 +167,7 @@ export default class ApiClient extends CommonBase {
         // Successful auth.
         this._log.info('Authed:', id);
         this._pendingAuths.delete(id); // It's no longer pending.
-        return this._targets.addTarget(id);
+        return this._targets.add(id);
       } catch (error) {
         // Trouble along the way. Clean out the pending auth, and propagate the
         // error.

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -378,7 +378,8 @@ export default class ApiClient extends CommonBase {
     this._nextId          = 0;
     this._callbacks       = {};
     this._pendingMessages = [];
-    this._targets.reset();
+    this._targets.clear();
+    this._targets.add('meta'); // The one guaranteed target.
   }
 
   /**

--- a/local-modules/api-client/ApiClient.js
+++ b/local-modules/api-client/ApiClient.js
@@ -73,9 +73,9 @@ export default class ApiClient extends CommonBase {
 
     /**
      * {TargetMap} Map of names to target proxies. See {@link
-     * TargetMap#constructor} for details about the second argument.
+     * TargetMap#constructor} for details about the argument.
      */
-    this._targets = new TargetMap(this, this._send.bind(this));
+    this._targets = new TargetMap(this._send.bind(this));
 
     /**
      * {Map<string, Promise<Proxy>>} Map from target IDs to promises of their

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -2,7 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TFunction, TString } from 'typecheck';
+import { TargetId } from 'api-common';
+import { TFunction } from 'typecheck';
 import { CommonBase, Errors, Functor } from 'util-common';
 
 /** {Set<string>} Set of methods which never get proxied. */
@@ -51,7 +52,7 @@ export default class TargetHandler extends CommonBase {
     this._sendMessage = TFunction.checkCallable(sendMessage);
 
     /** {string} The ID of the target. */
-    this._targetId = TString.nonEmpty(targetId);
+    this._targetId = TargetId.check(targetId);
 
     /**
      * {Map<string, function>} Cached method call handlers, as a map from name

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TFunction, TString } from 'typecheck';
 import { CommonBase, Errors, Functor } from 'util-common';
 
 /** {Set<string>} Set of methods which never get proxied. */
@@ -47,10 +48,10 @@ export default class TargetHandler extends CommonBase {
     super();
 
     /** {function} Function to call to send a message. */
-    this._sendMessage = sendMessage;
+    this._sendMessage = TFunction.checkCallable(sendMessage);
 
     /** {string} The ID of the target. */
-    this._targetId = targetId;
+    this._targetId = TString.nonEmpty(targetId);
 
     /**
      * {Map<string, function>} Cached method call handlers, as a map from name

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -27,29 +27,24 @@ export default class TargetHandler extends CommonBase {
   /**
    * Makes a proxy that is handled by an instance of this class.
    *
-   * @param {ApiClient} apiClient The client to forward calls to.
    * @param {function} sendMessage Function to call to send a message. See
    *   {@link TargetMap#constructor} for an explanation.
    * @param {string} targetId The ID of the target to call on.
    * @returns {Proxy} An appropriately-constructed proxy object.
    */
-  static makeProxy(apiClient, sendMessage, targetId) {
-    return new Proxy(Object.freeze({}), new TargetHandler(apiClient, sendMessage, targetId));
+  static makeProxy(sendMessage, targetId) {
+    return new Proxy(Object.freeze({}), new TargetHandler(sendMessage, targetId));
   }
 
   /**
    * Constructs an instance.
    *
-   * @param {ApiClient} apiClient The client to forward calls to.
    * @param {function} sendMessage Function to call to send a message. See
    *   {@link TargetMap#constructor} for an explanation.
    * @param {string} targetId The ID of the target to call on.
    */
-  constructor(apiClient, sendMessage, targetId) {
+  constructor(sendMessage, targetId) {
     super();
-
-    /** {ApiClient} The client to forward calls to. */
-    this._apiClient = apiClient;
 
     /** {function} Function to call to send a message. */
     this._sendMessage = sendMessage;

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -58,7 +58,7 @@ export default class TargetHandler extends CommonBase {
      */
     this._methods = new Map();
 
-    Object.seal(this);
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -166,7 +166,7 @@ export default class TargetMap extends CommonBase {
       throw Errors.bad_use(`Already bound: ${id}`);
     }
 
-    const result = TargetHandler.makeProxy(this._apiClient, this._sendMessage, id);
+    const result = TargetHandler.makeProxy(this._sendMessage, id);
     this._targets.set(id, result);
     return result;
   }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -73,7 +73,7 @@ export default class TargetMap extends CommonBase {
   get(id) {
     const result = this.getOrNull(id);
 
-    if (!result) {
+    if (result === null) {
       throw Errors.bad_use(`No such target: ${id}`);
     }
 
@@ -89,7 +89,7 @@ export default class TargetMap extends CommonBase {
    *   bound to a target.
    */
   getOrNull(id) {
-    TString.check(id);
+    TString.nonEmpty(id);
     return this._targets.get(id) || null;
   }
 }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -5,7 +5,6 @@
 import { TFunction, TString } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
-import ApiClient from './ApiClient';
 import TargetHandler from './TargetHandler';
 
 /**
@@ -18,18 +17,14 @@ export default class TargetMap extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {ApiClient} apiClient The client to forward calls to.
    * @param {function} sendMessage Function to call to send a message. This is
-   *   bound to the private `_send()` method on `apiClient`. (This arrangement
-   *   is done, instead of making a public `send()` method on `ApiClient`, to
-   *   make it clear that the right way to send messages is via the exposed
-   *   proxies.)
+   *   bound to the private `_send()` method on an instance of
+   *   {@link ApiClient}. (This arrangement is done, instead of making a public
+   *   `send()` method on {@link ApiClient}, so as to make it clear that the
+   *   right way to send messages is via the exposed proxies.)
    */
-  constructor(apiClient, sendMessage) {
+  constructor(sendMessage) {
     super();
-
-    /** {ApiClient} The client to forward calls to. */
-    this._apiClient = ApiClient.check(apiClient);
 
     /** {function} Function to call to send a message. */
     this._sendMessage = TFunction.checkCallable(sendMessage);

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -40,7 +40,8 @@ export default class TargetMap extends CommonBase {
 
   /**
    * Creates and binds a proxy for the target with the given ID. Returns the
-   * so-created proxy.
+   * so-created proxy. It is an error to try to add the same `id` more than
+   * once (except if {@link #clear} is called in the mean time).
    *
    * @param {string} id Target ID.
    * @returns {Proxy} The newly-bound proxy.
@@ -63,7 +64,8 @@ export default class TargetMap extends CommonBase {
   }
 
   /**
-   * Gets the proxy for the target with the given ID.
+   * Gets the proxy for the target with the given ID. It is an error to pass an
+   * `id` that is not bound.
    *
    * @param {string} id The target ID.
    * @returns {Proxy} The corresponding proxy.

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -51,6 +51,23 @@ export default class TargetMap extends CommonBase {
   }
 
   /**
+   * Creates and binds a proxy for the target with the given ID. Returns the
+   * so-created proxy.
+   *
+   * @param {string} id Target ID.
+   * @returns {Proxy} The newly-bound proxy.
+   */
+  addTarget(id) {
+    if (this.getOrNull(id) !== null) {
+      throw Errors.bad_use(`Already bound: ${id}`);
+    }
+
+    const result = TargetHandler.makeProxy(this._sendMessage, id);
+    this._targets.set(id, result);
+    return result;
+  }
+
+  /**
    * Performs a challenge-response authorization for a given key. When the
    * returned promise resolves successfully, that means that the corresponding
    * target (that is, the target with id `key.id`) can be accessed without
@@ -99,7 +116,7 @@ export default class TargetMap extends CommonBase {
         // Successful auth.
         log.info('Authed:', id);
         this._pendingAuths.delete(id); // It's no longer pending.
-        return this._addTarget(id);
+        return this.addTarget(id);
       } catch (error) {
         // Trouble along the way. Clean out the pending auth, and propagate the
         // error.
@@ -151,23 +168,6 @@ export default class TargetMap extends CommonBase {
     this._pendingAuths = new Map();
 
     // Set up the standard initial map contents.
-    this._addTarget('meta');
-  }
-
-  /**
-   * Creates and binds a proxy for the target with the given ID. Returns the
-   * so-created proxy.
-   *
-   * @param {string} id Target ID.
-   * @returns {Proxy} The newly-bound proxy.
-   */
-  _addTarget(id) {
-    if (this.getOrNull(id) !== null) {
-      throw Errors.bad_use(`Already bound: ${id}`);
-    }
-
-    const result = TargetHandler.makeProxy(this._sendMessage, id);
-    this._targets.set(id, result);
-    return result;
+    this.addTarget('meta');
   }
 }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -2,7 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TFunction, TString } from 'typecheck';
+import { TargetId } from 'api-common';
+import { TFunction } from 'typecheck';
 import { CommonBase, Errors } from 'util-common';
 
 import TargetHandler from './TargetHandler';
@@ -89,7 +90,7 @@ export default class TargetMap extends CommonBase {
    *   bound to a target.
    */
   getOrNull(id) {
-    TString.nonEmpty(id);
+    TargetId.check(id);
     return this._targets.get(id) || null;
   }
 }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -50,7 +50,7 @@ export default class TargetMap extends CommonBase {
    * @param {string} id Target ID.
    * @returns {Proxy} The newly-bound proxy.
    */
-  addTarget(id) {
+  add(id) {
     if (this.getOrNull(id) !== null) {
       throw Errors.bad_use(`Already bound: ${id}`);
     }
@@ -98,6 +98,6 @@ export default class TargetMap extends CommonBase {
     this._pendingAuths = new Map();
 
     // Set up the standard initial map contents.
-    this.addTarget('meta');
+    this.add('meta');
   }
 }

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -36,11 +36,11 @@ export default class TargetMap extends CommonBase {
 
     /**
      * {Map<string, TargetHandler>} The targets being provided, as a map from ID
-     * to proxy. Initialized in `reset()`.
+     * to proxy.
      */
-    this._targets = null;
+    this._targets = new Map();
 
-    this.reset();
+    Object.freeze(this);
   }
 
   /**
@@ -58,6 +58,13 @@ export default class TargetMap extends CommonBase {
     const result = TargetHandler.makeProxy(this._sendMessage, id);
     this._targets.set(id, result);
     return result;
+  }
+
+  /**
+   * Clears out the targets of this instance.
+   */
+  clear() {
+    this._targets.clear();
   }
 
   /**
@@ -87,17 +94,5 @@ export default class TargetMap extends CommonBase {
   getOrNull(id) {
     TString.check(id);
     return this._targets.get(id) || null;
-  }
-
-  /**
-   * Resets the targets of this instance. This is used during instance init
-   * as well as when a connection gets reset.
-   */
-  reset() {
-    this._targets      = new Map();
-    this._pendingAuths = new Map();
-
-    // Set up the standard initial map contents.
-    this.add('meta');
   }
 }

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -7,6 +7,8 @@ import { inspect } from 'util';
 import { TString } from 'typecheck';
 import { CommonBase, Errors, URL } from 'util-common';
 
+import TargetId from './TargetId';
+
 /**
  * Base class for access keys. An access key consists of information for
  * accessing a network-accessible resource, along with functionality for
@@ -36,8 +38,8 @@ export default class BaseKey extends CommonBase {
    *   superfluous, this can be passed as `*` (a literal asterisk). This is
    *   _not_ allowed to have URL-level "auth" info (e.g.,
    *   `http://user:pass@example.com/`).
-   * @param {string} id Key / resource identifier. This must be a string of at
-   *   least 8 characters.
+   * @param {string} id Key / resource identifier. This must be a `TargetId` of
+   *   at least 8 characters.
    */
   constructor(url, id) {
     super();
@@ -50,7 +52,7 @@ export default class BaseKey extends CommonBase {
     this._url = url;
 
     /** {string} Key / resource identifier. */
-    this._id = TString.minLen(id, 8);
+    this._id = TargetId.minLen(id, 8);
   }
 
   /**

--- a/local-modules/api-common/Message.js
+++ b/local-modules/api-common/Message.js
@@ -2,8 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TString } from 'typecheck';
+import { TInt } from 'typecheck';
 import { CommonBase, Functor } from 'util-common';
+
+import TargetId from './TargetId';
 
 /**
  * The main "envelope" of a message being sent from client to server to requrest
@@ -26,7 +28,7 @@ export default class Message extends CommonBase {
     this._id = TInt.nonNegative(id);
 
     /** {string} ID of the target object. */
-    this._target = TString.nonEmpty(target);
+    this._target = TargetId.check(target);
 
     /**
      * {Functor} The name of the method to call and the arguments to call it

--- a/local-modules/api-common/TargetId.js
+++ b/local-modules/api-common/TargetId.js
@@ -1,0 +1,57 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from 'typecheck';
+import { Errors, UtilityClass } from 'util-common';
+
+/** {RegExp} Regular expression which matches valid target IDs. */
+const VALID_TARGET_ID_REGEX = /^[-_a-zA-Z0-9]{1,64}$/;
+
+/**
+ * Type representation of target IDs. The values themselves are always just
+ * strings. This is just where the type checker code lives.
+ *
+ * A "target ID" is a string identifier which "names" an object at an API
+ * boundary. There are both "well-known" IDs (most notably `meta`) as well as
+ * programatically-generated IDs (e.g. for specific files).
+ *
+ * Syntactically, a target ID must be a string of consisting of ASCII-range
+ * alphanumerics, underscore (`_`), or dash (`-`), which is no longer than 64
+ * characters.
+ */
+export default class TargetId extends UtilityClass {
+  /**
+   * Checks a value of type `TargetId`.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value`.
+   */
+  static check(value) {
+    try {
+      return TString.check(value, VALID_TARGET_ID_REGEX);
+    } catch (e) {
+      // Throw a higher-fidelity error.
+      throw Errors.bad_value(value, TargetId);
+    }
+  }
+
+  /**
+   * Checks a value of type `TargetId` which must furthermore have a minimum
+   * length as given.
+   *
+   * @param {*} value Value to check.
+   * @param {Int} minLen The minimum length.
+   * @returns {string} `value`.
+   */
+  static minLen(value, minLen) {
+    try {
+      TString.check(value, VALID_TARGET_ID_REGEX);
+      TString.minLen(value, minLen);
+      return value;
+    } catch (e) {
+      // Throw a higher-fidelity error.
+      throw Errors.bad_value(value, TargetId, `length >= ${minLen}`);
+    }
+  }
+}

--- a/local-modules/api-common/index.js
+++ b/local-modules/api-common/index.js
@@ -10,6 +10,7 @@ import ConnectionError from './ConnectionError';
 import Message from './Message';
 import Response from './Response';
 import SplitKey from './SplitKey';
+import TargetId from './TargetId';
 
 // Register classes for encoding / decoding.
 Codec.theOne.registerClass(CodableError);
@@ -17,4 +18,4 @@ Codec.theOne.registerClass(Message);
 Codec.theOne.registerClass(Response);
 Codec.theOne.registerClass(SplitKey);
 
-export { BaseKey, CodableError, ConnectionError, Message, Response, SplitKey };
+export { BaseKey, CodableError, ConnectionError, Message, Response, SplitKey, TargetId };

--- a/local-modules/api-common/tests/test_TargetId.js
+++ b/local-modules/api-common/tests/test_TargetId.js
@@ -1,0 +1,116 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { TargetId } from 'api-common';
+
+describe('api-common/TargetId', () => {
+  describe('check()', () => {
+    it('should accept valid ids', () => {
+      function test(value) {
+        assert.strictEqual(TargetId.check(value), value);
+      }
+
+      test('a');
+      test('z');
+      test('AZ');
+      test('0123456789');
+      test('-x-y-');
+      test('_X_Y_');
+
+      for (let len = 10; len <= 64; len++) {
+        test('x'.repeat(len));
+      }
+    });
+
+    it('should reject strings with invalid characters', () => {
+      function test(value) {
+        assert.throws(() => TargetId.check(value), /bad_value/);
+      }
+
+      test('!');
+      test(' ');
+      test('%');
+      test('what is happening?');
+    });
+
+    it('should reject the empty string', () => {
+      assert.throws(() => TargetId.check(''), /bad_value/);
+    });
+
+    it('should reject too-long strings', () => {
+      for (let i = 65; i < 100; i++) {
+        assert.throws(() => TargetId.check('x'.repeat(i)), /bad_value/);
+      }
+    });
+
+    it('should reject non-strings', () => {
+      function test(value) {
+        assert.throws(() => TargetId.check(value), /bad_value/);
+      }
+
+      test(null);
+      test(undefined);
+      test(true);
+      test(123);
+      test(new Map());
+    });
+  });
+
+  describe('minLen()', () => {
+    it('should accept valid ids', () => {
+      function test(value, minLen) {
+        assert.strictEqual(TargetId.minLen(value, minLen), value);
+      }
+
+      test('abc', 1);
+      test('xyz', 3);
+      test('0123456789', 5);
+    });
+
+    it('should reject strings with invalid characters', () => {
+      function test(value) {
+        assert.throws(() => TargetId.minLen(value, 5), /bad_value/);
+      }
+
+      test('!abcd');
+      test(' abcd');
+      test('%abcd');
+      test('what is happening?');
+    });
+
+    it('should reject too-short strings', () => {
+      function test(value, minLen) {
+        assert.throws(() => TargetId.minLen(value, minLen), /bad_value/);
+      }
+
+      test('', 1);
+      test('', 10);
+      test('a', 2);
+      test('a', 3);
+      test('a', 30);
+      test('ab', 3);
+    });
+
+    it('should reject too-long strings', () => {
+      for (let i = 65; i < 100; i++) {
+        assert.throws(() => TargetId.minLen('x'.repeat(i), 10), /bad_value/);
+      }
+    });
+
+    it('should reject non-strings', () => {
+      function test(value) {
+        assert.throws(() => TargetId.check(value, 2), /bad_value/);
+      }
+
+      test(null);
+      test(undefined);
+      test(true);
+      test(123);
+      test(new Map());
+    });
+  });
+});

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -142,24 +142,4 @@ export default class MetaHandler {
   ping() {
     return true;
   }
-
-  /**
-   * Gets the schema(ta) for the given object(s), by ID. This returns an object
-   * that maps each given ID to its corresponding schema. It is only valid to
-   * pass IDs for uncontrolled (no authorization required) resources.
-   *
-   * @param {...string} ids IDs of the object to inquire about.
-   * @returns {object} An object mapping each of the `ids` to its corresponding
-   *   schema.
-   */
-  schemaFor(...ids) {
-    const result = {};
-
-    for (const id of ids) {
-      const target = this._connection.context.getUncontrolled(id);
-      result[id] = target.schema.propertiesObject;
-    }
-
-    return result;
-  }
 }

--- a/local-modules/api-server/tests/test_BearerToken.js
+++ b/local-modules/api-server/tests/test_BearerToken.js
@@ -7,12 +7,12 @@ import { describe, it } from 'mocha';
 
 import { BearerToken } from 'api-server';
 
-const SECRET_TOKEN = 'Setec Astronomy Setec Astronomy ';
+const SECRET_TOKEN = 'Setec-Astronomy-Setec-Astronomy-';
 
 describe('api-server/BearerToken', () => {
   describe('constructor(secret)', () => {
     it('should reject secrets with length < 32', () => {
-      assert.throws(() => new BearerToken('Setec Astronomy'));
+      assert.throws(() => new BearerToken('Setec-Astronomy'));
     });
 
     it('should return a frozen instane of BearerToken', () => {
@@ -32,26 +32,26 @@ describe('api-server/BearerToken', () => {
   });
 
   describe('sameToken(other)', () => {
-    it('should return false when passed null', () => {
+    it('should return false when passed `null`', () => {
       const token = new BearerToken(SECRET_TOKEN);
 
       assert.isFalse(token.sameToken(null));
     });
 
-    it('should return false when passed undefined', () => {
+    it('should return false when passed `undefined`', () => {
       const token = new BearerToken(SECRET_TOKEN);
 
       assert.isFalse(token.sameToken(undefined));
     });
 
-    it('should return false when passed a token with a different secret key', () => {
+    it('should return `false` when passed a token with a different secret key', () => {
       const token = new BearerToken(SECRET_TOKEN);
       const other = new BearerToken('abcdefghijklmnopqrstuvwxyz012345');
 
       assert.isFalse(token.sameToken(other));
     });
 
-    it('should return true when passed a token with the same secret key', () => {
+    it('should return `true` when passed a token with the same secret key', () => {
       const token = new BearerToken(SECRET_TOKEN);
       const other = new BearerToken(SECRET_TOKEN);
 
@@ -60,7 +60,7 @@ describe('api-server/BearerToken', () => {
   });
 
   describe('sameArrays(array1, array2)', () => {
-    it('should reject arrays that are different lengths', () => {
+    it('should return `false` given arrays that are different lengths', () => {
       const token1 = new BearerToken(SECRET_TOKEN);
       const token2 = new BearerToken(SECRET_TOKEN);
       const token3 = new BearerToken(SECRET_TOKEN);
@@ -84,7 +84,7 @@ describe('api-server/BearerToken', () => {
       assert.throws(() => BearerToken.sameArrays(array1, array2));
     });
 
-    it('should accept identical arrays of BearerTokens', () => {
+    it('should return `true` given identically-constructed arrays of BearerTokens', () => {
       const token1 = new BearerToken(SECRET_TOKEN);
       const token2 = new BearerToken(SECRET_TOKEN);
       const token3 = new BearerToken(SECRET_TOKEN);

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -121,7 +121,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('checkIdentifier()', () => {
+  describe('identifier()', () => {
     it('accepts identifier strings', () => {
       function test(value) {
         assert.strictEqual(TString.identifier(value), value);
@@ -181,7 +181,7 @@ describe('typecheck/TString', () => {
     });
   });
 
-  describe('checkLabel()', () => {
+  describe('label()', () => {
     it('accepts label strings', () => {
       function test(value) {
         assert.strictEqual(TString.label(value), value);


### PR DESCRIPTION
The main thing in this PR is chopping out all the schema-related code in `api-client`. Early on, I thought it would be useful, but that has not turned out to be the case. It wasn't really hurting anything by being there, but it did make the code a bit more complicated than it needed to be.

While I was in the territory, I went ahead and tightened up the salient type checking, including adding a meaningful restriction to what constitutes a valid "target ID."