### PR TITLE
Testing again

### DIFF
--- a/local-modules/data-model-client/tests/test_DocumentState.js
+++ b/local-modules/data-model-client/tests/test_DocumentState.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { DocumentState } from 'data-model-client';
 
-describe('DocumentState', () => {
+describe('data-model-client/DocumentState', () => {
   it('should return default values when passed an undefined initial', () => {
     const reducer = DocumentState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });

--- a/local-modules/data-model-client/tests/test_DragState.js
+++ b/local-modules/data-model-client/tests/test_DragState.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { DragState } from 'data-model-client';
 
-describe('DragState', () => {
+describe('data-model-client/DragState', () => {
   it('should return default values when passed a null initial state', () => {
     const reducer = DragState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });

--- a/local-modules/data-model-client/tests/test_OwnerState.js
+++ b/local-modules/data-model-client/tests/test_OwnerState.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { OwnerState } from 'data-model-client';
 
-describe('OwnerState', () => {
+describe('data-model-client/OwnerState', () => {
   it('should return default values when passed a null initial state', () => {
     const reducer = OwnerState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });

--- a/local-modules/data-model-client/tests/test_SharingState.js
+++ b/local-modules/data-model-client/tests/test_SharingState.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { SharingState } from 'data-model-client';
 
-describe('SharingState', () => {
+describe('data-model-client/SharingState', () => {
   it('should return default values when passed a null initial state', () => {
     const reducer = SharingState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });

--- a/local-modules/testing-client/EventReporter.js
+++ b/local-modules/testing-client/EventReporter.js
@@ -106,10 +106,16 @@ export default class EventReporter extends CommonBase {
         // Handle expected/actual diffing specially. In particular, we don't
         // want to try to pass nontrivial objects across the client/server
         // boundary, so stringify them here.
+        //
+        // **Note:** As of this writing, the browser polyfill for
+        // `util.inspect()` doesn't respect `breakLength`, which means that we
+        // too often end up with single-line results for arrays and objects.
+        // **TODO:** Get this fixed upstream.
+        const inspectOpts = { depth: 8, breakLength: 10 };
         extras = {
           showDiff: true,
-          actual:   inspect(error.actual),
-          expected: inspect(error.expected)
+          actual:   inspect(error.actual,   inspectOpts),
+          expected: inspect(error.expected, inspectOpts)
         };
       }
 

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -218,6 +218,36 @@ export default class EventReceiver extends CommonBase {
   }
 
   /**
+   * Produces lines representing the differences between the given two
+   * strings.
+   *
+   * @param {string} actual String representing the actual result of a test.
+   * @param {string} expected String representing the expected result of a test.
+   * @returns {array<string>} Array of lines.
+   */
+  static _linesForDiff(actual, expected) {
+    const result = [];
+
+    function add(string = '', indent = '') {
+      const lines = string.replace(/\n$/, '').split('\n');
+
+      for (const line of lines) {
+        result.push(`${indent}${line}`);
+      }
+    }
+
+    // **TODO:** Produce a real diff.
+    add();
+    add('Actual:');
+    add(actual, '  ');
+    add();
+    add('Expected:');
+    add(expected, '  ');
+
+    return result;
+  }
+
+  /**
    * Produces a set of lines to log for a given test, _except_ for a header.
    * Always includes a blank line at the end if there are any lines at all.
    *
@@ -228,11 +258,11 @@ export default class EventReceiver extends CommonBase {
   static _linesForTest(details) {
     const result = [];
 
-    function add(string = '', indent = '') {
+    function add(string = '') {
       const lines = string.replace(/\n$/, '').split('\n');
 
-      for (const l of lines) {
-        result.push(`${indent}${l}`);
+      for (const line of lines) {
+        result.push(line);
       }
     }
 
@@ -248,13 +278,9 @@ export default class EventReceiver extends CommonBase {
 
       if (extras !== null) {
         if (extras.showDiff) {
-          // **TODO:** Produce a real diff.
-          add();
-          add('Actual:');
-          add(extras.actual, '  ');
-          add();
-          add('Expected:');
-          add(extras.expected, '  ');
+          for (const line of EventReceiver._linesForDiff(extras.actual, extras.expected)) {
+            add(line);
+          }
           delete extras.showDiff;
           delete extras.actual;
           delete extras.expected;

--- a/local-modules/testing-server/package.json
+++ b/local-modules/testing-server/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
+    "diff": "^3.4.0",
     "mocha": "^3.3.0",
     "puppeteer": "^0.11.0",
 

--- a/local-modules/util-common/tests/test_ColorSelector.js
+++ b/local-modules/util-common/tests/test_ColorSelector.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { ColorSelector } from 'util-common';
 
-describe('ColorSelector', () => {
+describe('util-common/ColorSelector', () => {
   describe('constructor()', () => {
     it('should default to a hue angle of pure red if given no seed', () => {
       const selector = new ColorSelector();
@@ -45,14 +45,14 @@ describe('ColorSelector', () => {
 
       assert.equal(colorA.hue, colorB.hue - 37);
     });
+  });
 
-    describe('nextCssColor()', () => {
-      it('should return a valid hex string representation of the RGB value of a given color', () => {
-        const selector = new ColorSelector();
-        const hex = selector.nextCssColor();
+  describe('nextCssColor()', () => {
+    it('should return a valid hex string representation of the RGB value of a given color', () => {
+      const selector = new ColorSelector();
+      const hex = selector.nextCssColor();
 
-        assert.equal(hex, '#ffbfbf');
-      });
+      assert.equal(hex, '#ffbfbf');
     });
   });
 });

--- a/local-modules/util-common/tests/test_ColorUtil.js
+++ b/local-modules/util-common/tests/test_ColorUtil.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { ColorUtil } from 'util-common';
 
-describe('ColorUtil', () => {
+describe('util-common/ColorUtil', () => {
   describe('checkCss()', () => {
     it('should accept proper strings', () => {
       function test(v) {


### PR DESCRIPTION
This PR probably represents the last major work I'll be doing on the client-side testing framework, for the time being. The main changes:

* Test reports now have a list of test failures at the bottom, making them easy to find.
* When there's a failure that includes `actual` and `expected` values, it now includes a diff in a form similar to Mocha's default.

On that last front, unfortunately the polyfill for `util.inspect()` that Webpack uses is out of date and doesn't respect the `breakLength` option, which is used to help produce more useful diffs. As it turns out, the underlying module <https://github.com/defunctzombie/node-util/> is not currently maintained, and the former maintainer is in the process of transferring its stewardship, exactly because others have run into its deficiencies as well. The upshot is that, in the short term, our diffs will kinda suck, but they might magically get better soon without much if any effort on our parts.

**Bonus:** Cleaned up some test suite names and test hierarchy, that I happened to notice were wrong.