### PR TITLE
Test dependencies. Server test reporting.

### DIFF
--- a/local-modules/deps-testing/README.md
+++ b/local-modules/deps-testing/README.md
@@ -1,0 +1,5 @@
+deps-testing
+============
+
+This module just serves as a single location to hold dependencies related to
+the (unit / integration) testing tooling.

--- a/local-modules/deps-testing/index.js
+++ b/local-modules/deps-testing/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// This module serves only to hold common external dependencies. There is
+// nothing to export.
+export {};

--- a/local-modules/deps-testing/package.json
+++ b/local-modules/deps-testing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "deps-testing",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "chai": "^4.1.0",
+    "chai-as-promised": "^7.1.1",
+    "diff": "^3.4.0",
+    "mocha": "^3.3.0"
+  }
+}

--- a/local-modules/mocha-client-shim/package.json
+++ b/local-modules/mocha-client-shim/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
 
   "dependencies": {
-    "mocha": "^3.3.0",
-
+    "deps-testing": "local",
     "util-common": "local"
   }
 }

--- a/local-modules/testing-client/EventReporter.js
+++ b/local-modules/testing-client/EventReporter.js
@@ -2,160 +2,56 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { format, inspect } from 'util';
-
-import { CommonBase, ErrorUtil } from 'util-common';
+import { BaseReporter } from 'testing-common';
 
 /**
  * Mocha reporter, similar to its built-in "JSON stream" reporter, but
  * specifically tailored to emit exactly the right info for collection on our
  * server side. See {@link testing-server.EventReceiver} for the consuming code.
  */
-export default class EventReporter extends CommonBase {
+export default class EventReporter extends BaseReporter {
   /**
    * Constructs an instance.
    *
    * @param {mocha.Runner} runner The Mocha test driver.
-   * @param {*} options_unused Options as originally passed to the `Mocha`
-   *   constructor.
+   * @param {*} options Options as originally passed to the `Mocha` constructor.
    */
-  constructor(runner, options_unused) {
-    super();
-
-    /** {Int} Current depth of suites. */
-    this._suiteDepth = 0;
-
-    /**
-     * {array<string>} Ongoing collected console output, reset for each test.
-     */
-    this._console = [];
-
-    /** {function} Original value of `console.log`. */
-    this._originalLog = console.log; // eslint-disable-line no-console
-
-    runner.on('test', () => {
-      console.log = this._log.bind(this); // eslint-disable-line no-console
-      this._console = [];
-    });
-
-    runner.on('test end', () => {
-      console.log = this._originalLog; // eslint-disable-line no-console
-    });
-
-    runner.on('suite', (suite) => {
-      // Don't emit an event for the anonymous top-level suite.
-      if (this._suiteDepth !== 0) {
-        this._emit('suiteStart', suite.title);
-      }
-
-      this._suiteDepth++;
-    });
-
-    runner.on('suite end', () => {
-      this._suiteDepth--;
-      this._emit((this._suiteDepth === 0) ? 'allDone' : 'suiteEnd');
-    });
-
-    runner.on('pending', (test) => {
-      this._emitResult(test, 'pending');
-    });
-
-    runner.on('pass', (test) => {
-      this._emitResult(test, 'pass');
-    });
-
-    runner.on('fail', (test, error) => {
-      this._emitResult(test, 'fail', error);
-    });
+  constructor(runner, options) {
+    super(runner, options);
   }
 
   /**
-   * Emits a test result.
-   *
-   * @param {mocha.Test} test The test that was run.
-   * @param {string} status Its success status.
-   * @param {*} [error = null] Cause of failure, if any.
+   * Handles an `allDone` event.
    */
-  _emitResult(test, status, error = null) {
-    let speed = 'fast';
-    if (test.duration > test.slow()) {
-      speed = 'slow';
-    } else if (test.duration > (test.slow() / 2)) {
-      speed = 'medium';
-    }
-
-    if (error !== null) {
-      // Get a trace of the error without any extra properties (as those get
-      // pulled out separately, below).
-      const pureError = new Error(error.message);
-      pureError.name  = error.name;
-      pureError.stack = error.stack;
-      const fullTrace = ErrorUtil.fullTrace(pureError);
-
-      // Trim off the part of the stack trace that looks like the test harness.
-      // Specifically, Mocha (as of this writing) has a method
-      // `Test.Runnable.run` which calls a function `callFn`. If this ever
-      // changes, then this trimming code will need to be updated.
-      const trace = fullTrace.replace(/\n +callFn[^\n]+\n +Test\.Runnable\.run[^]*$/, '\n');
-
-      // Unit test errors often have interesting auxiliary info. Collect such
-      // info separately.
-
-      let extras = null;
-
-      if (error.showDiff) {
-        // Handle expected/actual diffing specially. In particular, we want to
-        // make the diffing code not have to worry about stringifying (and it's
-        // also good that we don't maintain references to stateful objects,
-        // _and_ this code is also used when transporting test results between
-        // client and server), so we stringify here.
-        //
-        // **Note:** As of this writing, the browser polyfill for
-        // `util.inspect()` doesn't respect `breakLength`, which means that we
-        // too often end up with single-line results for arrays and objects.
-        const inspectOpts = { depth: 8, breakLength: 10 };
-        extras = {
-          showDiff: true,
-          actual:   inspect(error.actual,   inspectOpts),
-          expected: inspect(error.expected, inspectOpts)
-        };
-      }
-
-      const skipExtras = ['name', 'message', 'stack', 'showDiff', 'actual', 'expected'];
-      for (const name of Object.getOwnPropertyNames(error)) {
-        if (skipExtras.includes(name)) {
-          continue;
-        } else if (extras === null) {
-          extras = {};
-        }
-
-        extras[name] = error[name];
-      }
-
-      error = { trace, extras };
-    }
-
-    // **Note:** The payload here ends up getting consumed in
-    // {@link testing-server.TestCollector}.
-    this._emit('testResult', {
-      title:    test.title,
-      console:  this._console,
-      duration: test.duration || 0,
-      error,
-      status,
-      speed
-    });
+  _impl_allDone() {
+    this._emit('allDone');
   }
 
   /**
-   * Replacement for `console.log()` which is active when a test is running.
+   * Handles a `suiteStart` event.
    *
-   * @param {...*} args Original arguments to `console.log()`.
+   * @param {string} title The suite title.
    */
-  _log(...args) {
-    this._originalLog(...args);
-    this._console.push(format(...args));
+  _impl_suiteStart(title) {
+    this._emit('suiteStart', title);
   }
+
+  /**
+   * Handles a `suiteEnd` event.
+   */
+  _impl_suiteEnd() {
+    this._emit('suiteEnd');
+  }
+
+  /**
+   * Handles a `testResult` event.
+   *
+   * @param {object} details Ad-hoc plain object with test details.
+   */
+  _impl_testResult(details) {
+    this._emit('testResult', details);
+  }
+
 
   /**
    * Emit an event for consumption by the ultimate test reporter. Each emitted

--- a/local-modules/testing-client/EventReporter.js
+++ b/local-modules/testing-client/EventReporter.js
@@ -9,7 +9,7 @@ import { CommonBase, ErrorUtil } from 'util-common';
 /**
  * Mocha reporter, similar to its built-in "JSON stream" reporter, but
  * specifically tailored to emit exactly the right info for collection on our
- * server side. See {@link testing-server.ClientTests} for the consuming code.
+ * server side. See {@link testing-server.EventReceiver} for the consuming code.
  */
 export default class EventReporter extends CommonBase {
   /**
@@ -45,7 +45,7 @@ export default class EventReporter extends CommonBase {
     runner.on('suite', (suite) => {
       // Don't emit an event for the anonymous top-level suite.
       if (this._suiteDepth !== 0) {
-        this._emit('suite', suite.title);
+        this._emit('suiteStart', suite.title);
       }
 
       this._suiteDepth++;
@@ -53,7 +53,7 @@ export default class EventReporter extends CommonBase {
 
     runner.on('suite end', () => {
       this._suiteDepth--;
-      this._emit((this._suiteDepth === 0) ? 'done' : 'suiteEnd');
+      this._emit((this._suiteDepth === 0) ? 'allDone' : 'suiteEnd');
     });
 
     runner.on('pending', (test) => {
@@ -133,7 +133,9 @@ export default class EventReporter extends CommonBase {
       error = { trace, extras };
     }
 
-    this._emit('test', {
+    // **Note:** The payload here ends up getting consumed in
+    // {@link testing-server.TestCollector}.
+    this._emit('testResult', {
       title:    test.title,
       console:  this._console,
       duration: test.duration || 0,

--- a/local-modules/testing-client/EventReporter.js
+++ b/local-modules/testing-client/EventReporter.js
@@ -52,13 +52,12 @@ export default class EventReporter extends BaseReporter {
     this._emit('testResult', details);
   }
 
-
   /**
-   * Emit an event for consumption by the ultimate test reporter. Each emitted
-   * event is in the form of a JSON-encoded array consisting of a string (event
-   * name) followed by zero or more event-specific arguments, preceded by the
-   * distinctive string `:::MOCHA:::` to make it easy to parse out from other
-   * console spew.
+   * Emits an event for consumption by the ultimate test reporter, by writing
+   * to the console. Each emitted event consists of an initial "sigil" of the
+   * distinctive string `:::MOCHA:::` (to make it easy to parse out from other
+   * console spew), followed by a JSON-encoded array consisting of a string
+   * (event name), finally followed by zero or more event-specific arguments.
    *
    * @param {string} name Event name.
    * @param {...*} args Event-specific arguments.

--- a/local-modules/testing-client/package.json
+++ b/local-modules/testing-client/package.json
@@ -7,6 +7,7 @@
     "see-all": "local",
     "promise-util": "local",
     "mocha-client-shim": "local",
+    "testing-common": "local",
     "util-common": "local"
   }
 }

--- a/local-modules/testing-client/package.json
+++ b/local-modules/testing-client/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
 
   "dependencies": {
-    "chai": "^4.1.0",
-    "chai-as-promised": "^7.1.1",
-
+    "deps-testing": "local",
     "see-all": "local",
     "promise-util": "local",
     "mocha-client-shim": "local",

--- a/local-modules/testing-common/BaseReporter.js
+++ b/local-modules/testing-common/BaseReporter.js
@@ -1,0 +1,209 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { format, inspect } from 'util';
+
+import { CommonBase, ErrorUtil } from 'util-common';
+
+/**
+ * Mocha reporter which "re-envisions" Mocha's various events as a simpler set
+ * of calls on abstract methods of itself. There are client- and server-specific
+ * subclasses of this class, which plumb the information in different ways,
+ * ultimately landing in an instance of {@link testing-server.TestCollector}.
+ */
+export default class BaseReporter extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {mocha.Runner} runner The Mocha test driver.
+   * @param {*} options_unused Options as originally passed to the `Mocha`
+   *   constructor.
+   */
+  constructor(runner, options_unused) {
+    super();
+
+    /** {Int} Current depth of suites. */
+    this._suiteDepth = 0;
+
+    /**
+     * {array<string>} Ongoing collected console output, reset for each test.
+     */
+    this._console = [];
+
+    /** {function} Original value of `console.log`. */
+    this._originalLog = console.log; // eslint-disable-line no-console
+
+    runner.on('test', () => {
+      console.log = this._log.bind(this); // eslint-disable-line no-console
+      this._console = [];
+    });
+
+    runner.on('test end', () => {
+      console.log = this._originalLog; // eslint-disable-line no-console
+    });
+
+    runner.on('suite', (suite) => {
+      // Don't make an `_impl_suite()` call for the anonymous top-level suite.
+      if (this._suiteDepth !== 0) {
+        this._impl_suiteStart(suite.title);
+      }
+
+      this._suiteDepth++;
+    });
+
+    runner.on('suite end', () => {
+      this._suiteDepth--;
+
+      if (this._suiteDepth === 0) {
+        this._impl_allDone();
+      } else {
+        this._impl_suiteEnd();
+      }
+    });
+
+    runner.on('pending', (test) => {
+      this._testResult(test, 'pending');
+    });
+
+    runner.on('pass', (test) => {
+      this._testResult(test, 'pass');
+    });
+
+    runner.on('fail', (test, error) => {
+      this._testResult(test, 'fail', error);
+    });
+  }
+
+  /**
+   * Handles an `allDone` event.
+   *
+   * @abstract
+   */
+  _impl_allDone() {
+    this._mustOverride();
+  }
+
+  /**
+   * Handles a `suiteStart` event.
+   *
+   * @abstract
+   * @param {string} title The suite title.
+   */
+  _impl_suiteStart(title) {
+    this._mustOverride(title);
+  }
+
+  /**
+   * Handles a `suiteEnd` event.
+   *
+   * @abstract
+   */
+  _impl_suiteEnd() {
+    this._mustOverride();
+  }
+
+  /**
+   * Handles a `testResult` event.
+   *
+   * @abstract
+   * @param {object} details Ad-hoc plain object with test details.
+   */
+  _impl_testResult(details) {
+    this._mustOverride(details);
+  }
+
+  /**
+   * Replacement for `console.log()` which is active when a test is running.
+   *
+   * @param {...*} args Original arguments to `console.log()`.
+   */
+  _log(...args) {
+    this._originalLog(...args);
+    this._console.push(format(...args));
+  }
+
+  /**
+   * Puts together a single test result, and passes it to the subclass's
+   * implementation for further handling.
+   *
+   * @param {mocha.Test} test The test that was run.
+   * @param {string} status Its success status.
+   * @param {*} [error = null] Cause of failure, if any.
+   */
+  _testResult(test, status, error = null) {
+    // `slice()` to make an independent clone.
+    const consoleSnapshot = this._console.slice();
+    const duration        = test.duration || 0;
+
+    let speed = 'fast';
+    if (duration > test.slow()) {
+      speed = 'slow';
+    } else if (duration > (test.slow() / 2)) {
+      speed = 'medium';
+    }
+
+    if (error !== null) {
+      // Get a trace of the error without any extra properties (as those get
+      // pulled out separately, below).
+      const pureError = new Error(error.message);
+      pureError.name  = error.name;
+      pureError.stack = error.stack;
+      const fullTrace = ErrorUtil.fullTrace(pureError);
+
+      // Trim off the part of the stack trace that looks like the test harness.
+      // Specifically, Mocha (as of this writing) has a method
+      // `Test.Runnable.run` which calls a function `callFn`. If this ever
+      // changes, then this trimming code will need to be updated.
+      const trace = fullTrace.replace(/\n +callFn[^\n]+\n +Test\.Runnable\.run[^]*$/, '\n');
+
+      // Unit test errors often have interesting auxiliary info. Collect such
+      // info separately.
+
+      let extras = null;
+
+      if (error.showDiff) {
+        // Handle expected/actual diffing specially. In particular, we want to
+        // make the diffing code not have to worry about stringifying (and it's
+        // also good that we don't maintain references to stateful objects,
+        // _and_ this code is also used when transporting test results between
+        // client and server), so we stringify here.
+        //
+        // **Note:** As of this writing, the browser polyfill for
+        // `util.inspect()` doesn't respect `breakLength`, which means that when
+        // running client tests, we too often end up with single-line results
+        // for arrays and objects.
+        const inspectOpts = { depth: 8, breakLength: 10 };
+        extras = {
+          showDiff: true,
+          actual:   inspect(error.actual,   inspectOpts),
+          expected: inspect(error.expected, inspectOpts)
+        };
+      }
+
+      const skipExtras = ['name', 'message', 'stack', 'showDiff', 'actual', 'expected'];
+      for (const name of Object.getOwnPropertyNames(error)) {
+        if (skipExtras.includes(name)) {
+          continue;
+        } else if (extras === null) {
+          extras = {};
+        }
+
+        extras[name] = error[name];
+      }
+
+      error = { trace, extras };
+    }
+
+    // **Note:** The payload here ultimately ends up getting consumed in
+    // {@link testing-server.TestCollector}.
+    this._impl_testResult({
+      title:    test.title,
+      console:  consoleSnapshot,
+      duration,
+      error,
+      status,
+      speed
+    });
+  }
+}

--- a/local-modules/testing-common/index.js
+++ b/local-modules/testing-common/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseReporter from './BaseReporter';
+
+export { BaseReporter };

--- a/local-modules/testing-common/package.json
+++ b/local-modules/testing-common/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "testing-common",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "util-common": "local"
+  }
+}

--- a/local-modules/testing-server/ClientTests.js
+++ b/local-modules/testing-server/ClientTests.js
@@ -33,9 +33,10 @@ export default class ClientTests extends UtilityClass {
 
     // Set up and start up headless Chrome (via Puppeteer).
 
-    const browser  = await puppeteer.launch();
-    const page     = await browser.newPage();
-    const receiver = new EventReceiver();
+    const browser   = await puppeteer.launch();
+    const page      = await browser.newPage();
+    const receiver  = new EventReceiver();
+    const collector = receiver.collector;
 
     page.on('console', (...args) => {
       // **TODO:** This doesn't quite work, because the first argument can have
@@ -76,7 +77,7 @@ export default class ClientTests extends UtilityClass {
     const startTime  = Date.now();
     let   lastStatus = startTime;
     for (;;) {
-      if (receiver.done) {
+      if (collector.done) {
         log.info('Test run is complete!');
         break;
       }
@@ -104,12 +105,12 @@ export default class ClientTests extends UtilityClass {
 
     await browser.close();
 
-    if (!receiver.done) {
+    if (!collector.done) {
       return true;
     }
 
     if (testOut) {
-      const allOutput = receiver.resultLines.join('\n');
+      const allOutput = collector.resultLines.join('\n');
 
       fs.writeFileSync(testOut, allOutput);
       // eslint-disable-next-line no-console
@@ -120,6 +121,6 @@ export default class ClientTests extends UtilityClass {
     // been flushed.
     await promisify(cb => process.stdout.write('', 'utf8', cb))();
 
-    return receiver.anyFailed;
+    return collector.anyFailed;
   }
 }

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -2,9 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { format, inspect } from 'util';
-
-import { CommonBase, ErrorUtil } from 'util-common';
+import { BaseReporter } from 'testing-common';
 
 import TestCollector from './TestCollector';
 
@@ -12,7 +10,7 @@ import TestCollector from './TestCollector';
  * Mocha reporter which uses its built-in `spec` reporter to write to the
  * console while also collecting data for eventual writing to a file.
  */
-export default class CollectingReporter extends CommonBase {
+export default class CollectingReporter extends BaseReporter {
   /**
    * Constructs an instance.
    *
@@ -20,7 +18,7 @@ export default class CollectingReporter extends CommonBase {
    * @param {*} options Options as originally passed to the `Mocha` constructor.
    */
   constructor(runner, options) {
-    super();
+    super(runner, options);
 
     // Store `this` in the array which we got passed in as a "reporter option,"
     // because Mocha has no better way to provide access to the reporter
@@ -28,58 +26,8 @@ export default class CollectingReporter extends CommonBase {
     // consumes this value.
     options.reporterOptions.holder[0] = this;
 
-    /** {Int} Current depth of suites. */
-    this._suiteDepth = 0;
-
     /** {TestCollector} Collector of all the test results. */
     this._collector = new TestCollector();
-
-    /**
-     * {array<string>} Ongoing collected console output, reset for each test.
-     */
-    this._console = [];
-
-    /** {function} Original value of `console.log`. */
-    this._originalLog = console.log; // eslint-disable-line no-console
-
-    runner.on('test', () => {
-      console.log = this._log.bind(this); // eslint-disable-line no-console
-      this._console = [];
-    });
-
-    runner.on('test end', () => {
-      console.log = this._originalLog; // eslint-disable-line no-console
-    });
-
-    runner.on('suite', (suite) => {
-      // Don't emit an event for the anonymous top-level suite.
-      if (this._suiteDepth !== 0) {
-        this._collector.suiteStart(suite.title);
-      }
-
-      this._suiteDepth++;
-    });
-
-    runner.on('suite end', () => {
-      this._suiteDepth--;
-      if (this._suiteDepth === 0) {
-        this._collector.allDone();
-      } else {
-        this._collector.suiteEnd();
-      }
-    });
-
-    runner.on('pending', (test) => {
-      this._testResult(test, 'pending');
-    });
-
-    runner.on('pass', (test) => {
-      this._testResult(test, 'pass');
-    });
-
-    runner.on('fail', (test, error) => {
-      this._testResult(test, 'fail', error);
-    });
   }
 
   /** {TestCollector} Collector of all the test results. */
@@ -88,91 +36,34 @@ export default class CollectingReporter extends CommonBase {
   }
 
   /**
-   * Sends a single test result to the collector.
-   *
-   * @param {mocha.Test} test The test that was run.
-   * @param {string} status Its success status.
-   * @param {*} [error = null] Cause of failure, if any.
+   * Handles an `allDone` event.
    */
-  _testResult(test, status, error = null) {
-    // `slice()` to make an independent clone.
-    const consoleSnapshot = this._console.slice();
-
-    let speed = 'fast';
-    if (test.duration > test.slow()) {
-      speed = 'slow';
-    } else if (test.duration > (test.slow() / 2)) {
-      speed = 'medium';
-    }
-
-    if (error !== null) {
-      // Get a trace of the error without any extra properties (as those get
-      // pulled out separately, below).
-      const pureError = new Error(error.message);
-      pureError.name  = error.name;
-      pureError.stack = error.stack;
-      const fullTrace = ErrorUtil.fullTrace(pureError);
-
-      // Trim off the part of the stack trace that looks like the test harness.
-      // Specifically, Mocha (as of this writing) has a method
-      // `Test.Runnable.run` which calls a function `callFn`. If this ever
-      // changes, then this trimming code will need to be updated.
-      const trace = fullTrace.replace(/\n +callFn[^\n]+\n +Test\.Runnable\.run[^]*$/, '\n');
-
-      // Unit test errors often have interesting auxiliary info. Collect such
-      // info separately.
-
-      let extras = null;
-
-      if (error.showDiff) {
-        // Handle expected/actual diffing specially. In particular, we want to
-        // make the diffing code not have to worry about stringifying (and it's
-        // also good that we don't maintain references to stateful objects,
-        // _and_ this code is also used when transporting test results between
-        // client and server), so we stringify here.
-        //
-        // **Note:** As of this writing, the browser polyfill for
-        // `util.inspect()` doesn't respect `breakLength`, which means that we
-        // too often end up with single-line results for arrays and objects.
-        const inspectOpts = { depth: 8, breakLength: 10 };
-        extras = {
-          showDiff: true,
-          actual:   inspect(error.actual,   inspectOpts),
-          expected: inspect(error.expected, inspectOpts)
-        };
-      }
-
-      const skipExtras = ['name', 'message', 'stack', 'showDiff', 'actual', 'expected'];
-      for (const name of Object.getOwnPropertyNames(error)) {
-        if (skipExtras.includes(name)) {
-          continue;
-        } else if (extras === null) {
-          extras = {};
-        }
-
-        extras[name] = error[name];
-      }
-
-      error = { trace, extras };
-    }
-
-    this._collector.testResult({
-      title:    test.title,
-      console:  consoleSnapshot,
-      duration: test.duration || 0,
-      error,
-      status,
-      speed
-    });
+  _impl_allDone() {
+    this._collector.allDone();
   }
 
   /**
-   * Replacement for `console.log()` which is active when a test is running.
+   * Handles a `suiteStart` event.
    *
-   * @param {...*} args Original arguments to `console.log()`.
+   * @param {string} title The suite title.
    */
-  _log(...args) {
-    this._originalLog(...args);
-    this._console.push(format(...args));
+  _impl_suiteStart(title) {
+    this._collector.suiteStart(title);
+  }
+
+  /**
+   * Handles a `suiteEnd` event.
+   */
+  _impl_suiteEnd() {
+    this._collector.suiteEnd();
+  }
+
+  /**
+   * Handles a `testResult` event.
+   *
+   * @param {object} details Ad-hoc plain object with test details.
+   */
+  _impl_testResult(details) {
+    this._collector.testResult(details);
   }
 }

--- a/local-modules/testing-server/CollectingReporter.js
+++ b/local-modules/testing-server/CollectingReporter.js
@@ -2,10 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { reporters } from 'mocha';
 import { format, inspect } from 'util';
 
 import { CommonBase, ErrorUtil } from 'util-common';
+
+import TestCollector from './TestCollector';
 
 /**
  * Mocha reporter which uses its built-in `spec` reporter to write to the
@@ -23,12 +24,15 @@ export default class CollectingReporter extends CommonBase {
 
     // Store `this` in the array which we got passed in as a "reporter option,"
     // because Mocha has no better way to provide access to the reporter
-    // instance that it constructed. See `ServerTests` in this module for the
-    // code that consumes this value.
+    // instance that it constructed. See {@link ServerTests} for the code that
+    // consumes this value.
     options.reporterOptions.holder[0] = this;
 
-    /** {array<mocha.Suite>} Current stack of active test suites. */
-    this._suites = [];
+    /** {Int} Current depth of suites. */
+    this._suiteDepth = 0;
+
+    /** {TestCollector} Collector of all the test results. */
+    this._collector = new TestCollector();
 
     /**
      * {array<string>} Ongoing collected console output, reset for each test.
@@ -37,12 +41,6 @@ export default class CollectingReporter extends CommonBase {
 
     /** {function} Original value of `console.log`. */
     this._originalLog = console.log; // eslint-disable-line no-console
-
-    /**
-     * {array<{ test, status, suites, log }>} Array of collected test results,
-     * each an ad-hoc plain object.
-     */
-    this._results = [];
 
     runner.on('test', () => {
       console.log = this._log.bind(this); // eslint-disable-line no-console
@@ -54,111 +52,118 @@ export default class CollectingReporter extends CommonBase {
     });
 
     runner.on('suite', (suite) => {
-      this._suites.push(suite);
+      // Don't emit an event for the anonymous top-level suite.
+      if (this._suiteDepth !== 0) {
+        this._collector.suiteStart(suite.title);
+      }
+
+      this._suiteDepth++;
     });
 
     runner.on('suite end', () => {
-      this._suites.pop();
+      this._suiteDepth--;
+      if (this._suiteDepth === 0) {
+        this._collector.allDone();
+      } else {
+        this._collector.suiteEnd();
+      }
     });
 
     runner.on('pending', (test) => {
-      this._addResult(test, 'pending');
+      this._testResult(test, 'pending');
     });
 
     runner.on('pass', (test) => {
-      this._addResult(test, 'pass');
+      this._testResult(test, 'pass');
     });
 
     runner.on('fail', (test, error) => {
-      this._addResult(test, 'fail', error);
+      this._testResult(test, 'fail', error);
     });
+  }
 
-    /**
-     * {object} Mocha's default `spec` reporter. This is done _after_ this
-     * instance adds its event handlers, as otherwise the `spec` console output
-     * would get collected into `_console`.
-     */
-    this._specReporter = new reporters.spec(runner);
+  /** {TestCollector} Collector of all the test results. */
+  get collector() {
+    return this._collector;
   }
 
   /**
-   * Gets a list of output lines representing the test results, suitable for
-   * writing to a file.
-   *
-   * @returns {array<string>} Output lines.
-   */
-  resultLines() {
-    const lines = [];
-    const stats = { fail: 0, pass: 0, pending: 0, total: 0 };
-
-    for (const { test, status, suites, log, error } of this._results) {
-      const testPath =
-        `${[...suites.map(s => s.title)].join(' / ')} :: ${test.title}`
-          .replace(/\n/, ' ');
-      const speed = test.speed || 'fast';
-      const speedStr = (speed === 'fast') ? '' : `, ${speed} ${test.duration}ms`;
-      const statusStr = `(${status}${speedStr})`;
-
-      lines.push(`${statusStr} ${testPath}`);
-      stats[status]++;
-      stats.total++;
-
-      let anyExtra = false;
-
-      if (log.length !== 0) {
-        anyExtra = true;
-        lines.push('');
-
-        for (const line of log) {
-          lines.push(`  ${line}`);
-        }
-      }
-
-      if (error !== null) {
-        let errLines;
-        if (error instanceof Error) {
-          errLines = ErrorUtil.fullTraceLines(error, '  ');
-        } else {
-          errLines = inspect(error).split('\n').map(line => `  ${line}`);
-        }
-
-        anyExtra = true;
-        lines.push('');
-        lines.push(...errLines);
-      }
-
-      if (anyExtra) {
-        lines.push('');
-      }
-    }
-
-    lines.push('');
-    lines.push('Summary:');
-    lines.push(`  Total:   ${stats.total}`);
-    lines.push(`  Passed:  ${stats.pass}`);
-    lines.push(`  Failed:  ${stats.fail}`);
-    lines.push(`  Pending: ${stats.pending}`);
-    lines.push('');
-    lines.push((stats.fail === 0) ? 'All good! Yay!' : 'Alas.');
-
-    return lines;
-  }
-
-  /**
-   * Adds a single test result to the accumulated list of same.
+   * Sends a single test result to the collector.
    *
    * @param {mocha.Test} test The test that was run.
    * @param {string} status Its success status.
    * @param {*} [error = null] Cause of failure, if any.
    */
-  _addResult(test, status, error = null) {
-    // `slice(1)` because we don't care about the anonymous top-level suite.
-    const suites = this._suites.slice(1);
-
+  _testResult(test, status, error = null) {
     // `slice()` to make an independent clone.
-    const log = this._console.slice();
+    const consoleSnapshot = this._console.slice();
 
-    this._results.push({ test, status, suites, log, error });
+    let speed = 'fast';
+    if (test.duration > test.slow()) {
+      speed = 'slow';
+    } else if (test.duration > (test.slow() / 2)) {
+      speed = 'medium';
+    }
+
+    if (error !== null) {
+      // Get a trace of the error without any extra properties (as those get
+      // pulled out separately, below).
+      const pureError = new Error(error.message);
+      pureError.name  = error.name;
+      pureError.stack = error.stack;
+      const fullTrace = ErrorUtil.fullTrace(pureError);
+
+      // Trim off the part of the stack trace that looks like the test harness.
+      // Specifically, Mocha (as of this writing) has a method
+      // `Test.Runnable.run` which calls a function `callFn`. If this ever
+      // changes, then this trimming code will need to be updated.
+      const trace = fullTrace.replace(/\n +callFn[^\n]+\n +Test\.Runnable\.run[^]*$/, '\n');
+
+      // Unit test errors often have interesting auxiliary info. Collect such
+      // info separately.
+
+      let extras = null;
+
+      if (error.showDiff) {
+        // Handle expected/actual diffing specially. In particular, we want to
+        // make the diffing code not have to worry about stringifying (and it's
+        // also good that we don't maintain references to stateful objects,
+        // _and_ this code is also used when transporting test results between
+        // client and server), so we stringify here.
+        //
+        // **Note:** As of this writing, the browser polyfill for
+        // `util.inspect()` doesn't respect `breakLength`, which means that we
+        // too often end up with single-line results for arrays and objects.
+        const inspectOpts = { depth: 8, breakLength: 10 };
+        extras = {
+          showDiff: true,
+          actual:   inspect(error.actual,   inspectOpts),
+          expected: inspect(error.expected, inspectOpts)
+        };
+      }
+
+      const skipExtras = ['name', 'message', 'stack', 'showDiff', 'actual', 'expected'];
+      for (const name of Object.getOwnPropertyNames(error)) {
+        if (skipExtras.includes(name)) {
+          continue;
+        } else if (extras === null) {
+          extras = {};
+        }
+
+        extras[name] = error[name];
+      }
+
+      error = { trace, extras };
+    }
+
+    this._collector.testResult({
+      title:    test.title,
+      console:  consoleSnapshot,
+      duration: test.duration || 0,
+      error,
+      status,
+      speed
+    });
   }
 
   /**

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -251,7 +251,7 @@ export default class EventReceiver extends CommonBase {
     let firstRangeMark = true;
     function fixLine(line) {
       // This is similar to (but not quite identical to) what Mocha implements
-      // in `reporters/Base.unifiedDiff()` (which isn't actually an expored
+      // in `reporters/Base.unifiedDiff()` (which isn't actually an exported
       // method, alas).
       if (line[0] === '+') {
         return chalk.green(line);

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -23,19 +23,9 @@ export default class EventReceiver extends CommonBase {
     this._nonTestLines = [];
   }
 
-  /** {boolean} Whether or not there were any test failures. */
-  get anyFailed() {
-    return this._collector.anyFailed;
-  }
-
   /** {TestCollector} Collector of all the test results. */
   get collector() {
     return this._collector;
-  }
-
-  /** {boolean} Whether or not we have received the `done` event. */
-  get done() {
-    return this._collector.done;
   }
 
   /**
@@ -45,14 +35,6 @@ export default class EventReceiver extends CommonBase {
    */
   get nonTestLines() {
     return this._nonTestLines;
-  }
-
-  /**
-   * {array<string>} A list of output lines representing the test results,
-   * suitable for writing to a file.
-   */
-  get resultLines() {
-    return this._collector.resultLines;
   }
 
   /**

--- a/local-modules/testing-server/EventReceiver.js
+++ b/local-modules/testing-server/EventReceiver.js
@@ -2,28 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import chalk from 'chalk';
-import { createTwoFilesPatch } from 'diff';
-import { inspect } from 'util';
-
 import { CommonBase } from 'util-common';
 
-/**
- * {object} Object that maps each possible test status to an ad-hoc set of
- * info about how to mark it up.
- */
-const TEST_STATUS_MARKUP = {
-  fail:    { char: '✖', color: chalk.red,   colorTitle: false },
-  pass:    { char: '✓', color: chalk.green, colorTitle: false },
-  pending: { char: '-', color: chalk.cyan,  colorTitle: true },
-  unknown: { char: '?', color: chalk.red,   colorTitle: true }
-};
-
-/** {object} Colors to use for non-fast speed markup. */
-const SPEED_COLOR = {
-  medium: chalk.yellow,
-  slow:   chalk.red
-};
+import TestCollector from './TestCollector';
 
 /**
  * Receiver of events sent by {@link testing-client.EventReporter}.
@@ -35,36 +16,26 @@ export default class EventReceiver extends CommonBase {
   constructor() {
     super();
 
-    /** {array<string>} Current stack of the names of active test suites. */
-    this._suites = [];
-
-    /** {array<string>} Array of collected test result lines. */
-    this._resultLines = [];
+    /** {TestCollector} Collector of all the test results. */
+    this._collector = new TestCollector();
 
     /** {array<string>} Array of non-test browser console output lines. */
     this._nonTestLines = [];
-
-    /**
-     * {array<string>} Array of reported test failures, for recapitulation at
-     * the end of the results.
-     */
-    this._failLines = [];
-
-    /** {object} Ad-hoc object with mappings for test category counts. */
-    this._stats = { fail: 0, pass: 0, pending: 0, total: 0 };
-
-    /** {boolean} Whether or not we have received the `done` event. */
-    this._done = false;
   }
 
   /** {boolean} Whether or not there were any test failures. */
   get anyFailed() {
-    return this._stats.fail !== 0;
+    return this._collector.anyFailed;
+  }
+
+  /** {TestCollector} Collector of all the test results. */
+  get collector() {
+    return this._collector;
   }
 
   /** {boolean} Whether or not we have received the `done` event. */
   get done() {
-    return this._done;
+    return this._collector.done;
   }
 
   /**
@@ -81,7 +52,7 @@ export default class EventReceiver extends CommonBase {
    * suitable for writing to a file.
    */
   get resultLines() {
-    return this._resultLines;
+    return this._collector.resultLines;
   }
 
   /**
@@ -103,251 +74,34 @@ export default class EventReceiver extends CommonBase {
   }
 
   /**
-   * Logs a test result line.
-   *
-   * @param {string} line Line to log.
+   * Handles an `allDone` event.
    */
-  _log(line) {
-    this._resultLines.push(line);
-
-    // eslint-disable-next-line no-console
-    console.log('%s', line);
+  _handle_allDone() {
+    this._collector.allDone();
   }
 
   /**
-   * Handles a `done` event.
-   */
-  _handle_done() {
-    this._done = true;
-
-    if (this._failLines.length !== 0) {
-      this._log(chalk.bold.red('Failures:'));
-      this._log('');
-
-      for (const line of this._failLines) {
-        this._log(line);
-      }
-    }
-
-    this._log('Summary:');
-    this._log(`  Total:   ${this._stats.total}`);
-    this._log(`  Passed:  ${this._stats.pass}`);
-    this._log(`  Failed:  ${this._stats.fail}`);
-    this._log(`  Pending: ${this._stats.pending}`);
-    this._log('');
-    this._log((this._stats.fail === 0) ? 'All good! Yay!' : 'Alas.');
-  }
-
-  /**
-   * Handles a `suite` event.
+   * Handles a `suiteStart` event.
    *
    * @param {string} title The suite title.
    */
-  _handle_suite(title) {
-    const topLevel = (this._suites.length === 0);
-    const prefix   = '  '.repeat(this._suites.length);
-
-    this._suites.push(title);
-
-    for (const line of EventReceiver._linesForString(title)) {
-      this._log(topLevel ? chalk.bold(line) : `${prefix}${line}`);
-    }
+  _handle_suiteStart(title) {
+    this._collector.suiteStart(title);
   }
 
   /**
    * Handles a `suiteEnd` event.
    */
   _handle_suiteEnd() {
-    this._suites.pop();
-
-    if (this._suites.length === 0) {
-      // Separate top-level suites with an extra newline.
-      this._log('');
-    }
+    this._collector.suiteEnd();
   }
 
   /**
-   * Handles a `test` event.
+   * Handles a `testResult` event.
    *
    * @param {object} details Ad-hoc plain object with test details.
    */
-  _handle_test(details) {
-    this._stats[details.status]++;
-    this._stats.total++;
-
-    const prefix     = '  '.repeat(this._suites.length);
-    const speed      = details.speed;
-    const markup     = TEST_STATUS_MARKUP[details.status] || TEST_STATUS_MARKUP.unknown;
-    const speedColor = SPEED_COLOR[speed] || chalk.gray;
-    const statusChar = markup.color(markup.char);
-    const speedStr   = (speed === 'fast')
-      ? ''
-      : '\n' + speedColor(`(${speed} ${details.duration}ms)`);
-    const titleStr   = `${statusChar} ${details.title}${speedStr}`;
-    const titleLines = EventReceiver._linesForString(titleStr);
-
-    let titlePrefix = prefix;
-    for (const line of titleLines) {
-      this._log(`${titlePrefix}${line}`);
-      titlePrefix = `${prefix}  `; // Aligns second-and-later title lines under the first.
-    }
-
-    const lines = EventReceiver._linesForTest(details);
-
-    if (lines.length !== 0) {
-      this._log('');
-      for (const line of lines) {
-        this._log(`${prefix}${line}`);
-      }
-    }
-
-    if (details.status === 'fail') {
-      let headerPrefix = '';
-
-      for (const s of this._suites) {
-        this._failLines.push(`${headerPrefix}${s}`);
-        headerPrefix += '  ';
-      }
-
-      this._failLines.push(`${headerPrefix}${details.title}`);
-      this._failLines.push('');
-
-      for (const line of lines) {
-        this._failLines.push(`  ${line}`);
-      }
-    }
-  }
-
-  /**
-   * Produces lines representing the differences between the given two
-   * strings.
-   *
-   * @param {string} actual String representing the actual result of a test.
-   * @param {string} expected String representing the expected result of a test.
-   * @returns {array<string>} Array of lines.
-   */
-  static _linesForDiff(actual, expected) {
-    const result = [];
-
-    function add(string = '') {
-      const lines = string.replace(/\n$/, '').split('\n');
-
-      for (const line of lines) {
-        result.push(line);
-      }
-    }
-
-    // Trim initial newlines and ensure exactly one final newline. (The latter
-    // is to prevent the usual "No newline" patch text from showing up.)
-
-    actual   =   actual.replace(/^\n+/, '').replace(/\n*$/, '\n');
-    expected = expected.replace(/^\n+/, '').replace(/\n*$/, '\n');
-
-    // Produce the raw patch, and filter it line-by-line into a useful result.
-
-    const patch =
-      createTwoFilesPatch('(actual)', '(expected)', actual, expected);
-
-    let firstRangeMark = true;
-    function fixLine(line) {
-      // This is similar to (but not quite identical to) what Mocha implements
-      // in `reporters/Base.unifiedDiff()` (which isn't actually an exported
-      // method, alas).
-      if (line[0] === '+') {
-        return chalk.green(line);
-      } else if (line[0] === '-') {
-        return chalk.red(line);
-      } else if (/^@@/.test(line)) {
-        if (firstRangeMark) {
-          firstRangeMark = false;
-          return '';
-        } else {
-          return '--';
-        }
-      } else if (/^==/.test(line)) {
-        return null; // The first line of a patch is a wall of `=`s.
-      } else {
-        return line;
-      }
-    }
-
-    add();
-    for (const line of EventReceiver._linesForString(patch)) {
-      const fixed = fixLine(line);
-      if (fixed !== null) {
-        add(fixed);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Produces a set of lines to log for a given test, _except_ for a header.
-   * Always includes a blank line at the end if there are any lines at all.
-   *
-   * @param {object} details Test result details.
-   * @returns {array<string>} The lines to log. Elements are guaranteed not to
-   *   have any newlines in them.
-   */
-  static _linesForTest(details) {
-    const result = [];
-
-    function add(string = '') {
-      const lines = string.replace(/\n$/, '').split('\n');
-
-      for (const line of lines) {
-        result.push(line);
-      }
-    }
-
-    if (details.console.length !== 0) {
-      add(details.console);
-      add();
-    }
-
-    if (details.error !== null) {
-      const { trace, extras } = details.error;
-
-      add(trace);
-
-      if (extras !== null) {
-        if (extras.showDiff) {
-          for (const line of EventReceiver._linesForDiff(extras.actual, extras.expected)) {
-            add(line);
-          }
-          delete extras.showDiff;
-          delete extras.actual;
-          delete extras.expected;
-        }
-
-        if (Object.keys(extras).length !== 0) {
-          add();
-          add(inspect(extras));
-        }
-      }
-
-      add();
-    }
-
-    return result;
-  }
-
-  /**
-   * Splits a string into an array of individual lines, each optionally
-   * prefixed. It also trims away string-initial and string-final newlines.
-   *
-   * @param {string} s The string to split.
-   * @param {string} [prefix = ''] Prefix for each line.
-   * @returns {array<string>} Array of lines.
-   */
-  static _linesForString(s, prefix = '') {
-    s = s.replace(/(^\n+)|(\n+$)/g, '');
-
-    const lines = s.split('\n');
-
-    return (prefix === '')
-      ? lines
-      : lines.map(line => `${prefix}${line}`);
+  _handle_testResult(details) {
+    this._collector.testResult(details);
   }
 }

--- a/local-modules/testing-server/ServerTests.js
+++ b/local-modules/testing-server/ServerTests.js
@@ -51,10 +51,12 @@ export default class ServerTests extends UtilityClass {
 
     log.info('Running server tests...');
 
-    const failures = await promisify(cb => mocha.run(f => cb(null, f)))();
+    const failures  = await promisify(cb => mocha.run(f => cb(null, f)))();
+    const reporter  = reporterHolder[0];
+    const collector = reporter.collector;
 
     if (testOut !== null) {
-      const output = reporterHolder[0].resultLines().join('\n');
+      const output = collector.resultLines.join('\n');
       fs.writeFileSync(testOut, output);
       log.info('Wrote test results to file:', testOut);
     }

--- a/local-modules/testing-server/TestCollector.js
+++ b/local-modules/testing-server/TestCollector.js
@@ -1,0 +1,336 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import chalk from 'chalk';
+import { createTwoFilesPatch } from 'diff';
+import { inspect } from 'util';
+
+import { CommonBase, Errors } from 'util-common';
+
+/**
+ * {object} Object that maps each possible test status to an ad-hoc set of
+ * info about how to mark it up.
+ */
+const TEST_STATUS_MARKUP = {
+  fail:    { char: '✖', color: chalk.red,   colorTitle: false },
+  pass:    { char: '✓', color: chalk.green, colorTitle: false },
+  pending: { char: '-', color: chalk.cyan,  colorTitle: true },
+  unknown: { char: '?', color: chalk.red,   colorTitle: true }
+};
+
+/** {object} Colors to use for non-fast speed markup. */
+const SPEED_COLOR = {
+  medium: chalk.yellow,
+  slow:   chalk.red
+};
+
+/**
+ * Collector of test results reported via public methods that closely match
+ * the Mocha test-reporting events.
+ */
+export default class TestCollector extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /** {array<string>} Current stack of the names of active test suites. */
+    this._suites = [];
+
+    /** {array<string>} Array of collected test result lines. */
+    this._resultLines = [];
+
+    /**
+     * {array<string>} Array of reported test failures, for recapitulation at
+     * the end of the results.
+     */
+    this._failLines = [];
+
+    /** {object} Ad-hoc object with mappings for test category counts. */
+    this._stats = { fail: 0, pass: 0, pending: 0, total: 0 };
+
+    /** {boolean} Whether or not we have received the `done` event. */
+    this._done = false;
+  }
+
+  /** {boolean} Whether or not there were any test failures. */
+  get anyFailed() {
+    return this._stats.fail !== 0;
+  }
+
+  /** {boolean} Whether or not we have received the `done` event. */
+  get done() {
+    return this._done;
+  }
+
+  /**
+   * {array<string>} A list of output lines representing the test results,
+   * suitable for writing to a file.
+   */
+  get resultLines() {
+    return this._resultLines;
+  }
+
+  /**
+   * Indicates that all test results have been reported. After this call is
+   * made, {@link #done} will be `true` and {@link #resultLines} will be
+   * complete.
+   */
+  allDone() {
+    if (this._done) {
+      throw Errors.bad_use('Already done!');
+    }
+
+    this._done = true;
+
+    if (this._failLines.length !== 0) {
+      this._log(chalk.bold.red('Failures:'));
+      this._log('');
+
+      for (const line of this._failLines) {
+        this._log(line);
+      }
+    }
+
+    this._log('Summary:');
+    this._log(`  Total:   ${this._stats.total}`);
+    this._log(`  Passed:  ${this._stats.pass}`);
+    this._log(`  Failed:  ${this._stats.fail}`);
+    this._log(`  Pending: ${this._stats.pending}`);
+    this._log('');
+    this._log((this._stats.fail === 0) ? 'All good! Yay!' : 'Alas.');
+  }
+
+  /**
+   * Indicates that the innermost active suite is now complete.
+   */
+  suiteEnd() {
+    if (this._suites.length === 0) {
+      throw Errors.bad_use('No active suite.');
+    }
+
+    this._suites.pop();
+
+    if (this._suites.length === 0) {
+      // Separate top-level suites with an extra newline.
+      this._log('');
+    }
+  }
+
+  /**
+   * Indicates that a new test suite has started. All subsequent suites and
+   * tests will be listed under this one, until a correspondingly-nested call
+   * to {@link #suiteEnd} is made.
+   *
+   * @param {string} title The suite title.
+   */
+  suiteStart(title) {
+    const topLevel = (this._suites.length === 0);
+    const prefix   = '  '.repeat(this._suites.length);
+
+    this._suites.push(title);
+
+    for (const line of TestCollector._linesForString(title)) {
+      this._log(topLevel ? chalk.bold(line) : `${prefix}${line}`);
+    }
+  }
+
+  /**
+   * Adds a test result to the collection.
+   *
+   * @param {object} details Ad-hoc plain object with test details.
+   */
+  testResult(details) {
+    this._stats[details.status]++;
+    this._stats.total++;
+
+    const prefix     = '  '.repeat(this._suites.length);
+    const speed      = details.speed;
+    const markup     = TEST_STATUS_MARKUP[details.status] || TEST_STATUS_MARKUP.unknown;
+    const speedColor = SPEED_COLOR[speed] || chalk.gray;
+    const statusChar = markup.color(markup.char);
+    const speedStr   = (speed === 'fast')
+      ? ''
+      : '\n' + speedColor(`(${speed} ${details.duration}ms)`);
+    const titleStr   = `${statusChar} ${details.title}${speedStr}`;
+    const titleLines = TestCollector._linesForString(titleStr);
+
+    let titlePrefix = prefix;
+    for (const line of titleLines) {
+      this._log(`${titlePrefix}${line}`);
+      titlePrefix = `${prefix}  `; // Aligns second-and-later title lines under the first.
+    }
+
+    const lines = TestCollector._linesForTest(details);
+
+    if (lines.length !== 0) {
+      this._log('');
+      for (const line of lines) {
+        this._log(`${prefix}${line}`);
+      }
+    }
+
+    if (details.status === 'fail') {
+      let headerPrefix = '';
+
+      for (const s of this._suites) {
+        this._failLines.push(`${headerPrefix}${s}`);
+        headerPrefix += '  ';
+      }
+
+      this._failLines.push(`${headerPrefix}${details.title}`);
+      this._failLines.push('');
+
+      for (const line of lines) {
+        this._failLines.push(`  ${line}`);
+      }
+    }
+  }
+
+  /**
+   * Logs a test result line.
+   *
+   * @param {string} line Line to log.
+   */
+  _log(line) {
+    this._resultLines.push(line);
+
+    // eslint-disable-next-line no-console
+    console.log('%s', line);
+  }
+
+  /**
+   * Produces lines representing the differences between the given two
+   * strings.
+   *
+   * @param {string} actual String representing the actual result of a test.
+   * @param {string} expected String representing the expected result of a test.
+   * @returns {array<string>} Array of lines.
+   */
+  static _linesForDiff(actual, expected) {
+    const result = [];
+
+    function add(string = '') {
+      const lines = string.replace(/\n$/, '').split('\n');
+
+      for (const line of lines) {
+        result.push(line);
+      }
+    }
+
+    // Trim initial newlines and ensure exactly one final newline. (The latter
+    // is to prevent the usual "No newline" patch text from showing up.)
+
+    actual   =   actual.replace(/^\n+/, '').replace(/\n*$/, '\n');
+    expected = expected.replace(/^\n+/, '').replace(/\n*$/, '\n');
+
+    // Produce the raw patch, and filter it line-by-line into a useful result.
+
+    const patch =
+      createTwoFilesPatch('(actual)', '(expected)', actual, expected);
+
+    let firstRangeMark = true;
+    function fixLine(line) {
+      // This is similar to (but not quite identical to) what Mocha implements
+      // in `reporters/Base.unifiedDiff()` (which isn't actually an exported
+      // method, alas).
+      if (line[0] === '+') {
+        return chalk.green(line);
+      } else if (line[0] === '-') {
+        return chalk.red(line);
+      } else if (/^@@/.test(line)) {
+        if (firstRangeMark) {
+          firstRangeMark = false;
+          return '';
+        } else {
+          return '--';
+        }
+      } else if (/^==/.test(line)) {
+        return null; // The first line of a patch is a wall of `=`s.
+      } else {
+        return line;
+      }
+    }
+
+    add();
+    for (const line of TestCollector._linesForString(patch)) {
+      const fixed = fixLine(line);
+      if (fixed !== null) {
+        add(fixed);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Produces a set of lines to log for a given test, _except_ for a header.
+   * Always includes a blank line at the end if there are any lines at all.
+   *
+   * @param {object} details Test result details.
+   * @returns {array<string>} The lines to log. Elements are guaranteed not to
+   *   have any newlines in them.
+   */
+  static _linesForTest(details) {
+    const result = [];
+
+    function add(string = '') {
+      const lines = string.replace(/\n$/, '').split('\n');
+
+      for (const line of lines) {
+        result.push(line);
+      }
+    }
+
+    if (details.console.length !== 0) {
+      add(details.console);
+      add();
+    }
+
+    if (details.error !== null) {
+      const { trace, extras } = details.error;
+
+      add(trace);
+
+      if (extras !== null) {
+        if (extras.showDiff) {
+          for (const line of TestCollector._linesForDiff(extras.actual, extras.expected)) {
+            add(line);
+          }
+          delete extras.showDiff;
+          delete extras.actual;
+          delete extras.expected;
+        }
+
+        if (Object.keys(extras).length !== 0) {
+          add();
+          add(inspect(extras));
+        }
+      }
+
+      add();
+    }
+
+    return result;
+  }
+
+  /**
+   * Splits a string into an array of individual lines, each optionally
+   * prefixed. It also trims away string-initial and string-final newlines.
+   *
+   * @param {string} s The string to split.
+   * @param {string} [prefix = ''] Prefix for each line.
+   * @returns {array<string>} Array of lines.
+   */
+  static _linesForString(s, prefix = '') {
+    s = s.replace(/(^\n+)|(\n+$)/g, '');
+
+    const lines = s.split('\n');
+
+    return (prefix === '')
+      ? lines
+      : lines.map(line => `${prefix}${line}`);
+  }
+}

--- a/local-modules/testing-server/TestCollector.js
+++ b/local-modules/testing-server/TestCollector.js
@@ -285,7 +285,9 @@ export default class TestCollector extends CommonBase {
     }
 
     if (details.console.length !== 0) {
-      add(details.console);
+      for (const line of details.console) {
+        add(line);
+      }
       add();
     }
 

--- a/local-modules/testing-server/package.json
+++ b/local-modules/testing-server/package.json
@@ -3,13 +3,10 @@
   "version": "1.0.0",
 
   "dependencies": {
-    "chai": "^4.1.0",
-    "chai-as-promised": "^7.1.1",
-    "diff": "^3.4.0",
-    "mocha": "^3.3.0",
     "puppeteer": "^0.11.0",
 
     "deps-ansi-color": "local",
+    "deps-testing": "local",
     "env-server": "local",
     "util-common": "local"
   }

--- a/local-modules/testing-server/package.json
+++ b/local-modules/testing-server/package.json
@@ -8,6 +8,7 @@
     "deps-ansi-color": "local",
     "deps-testing": "local",
     "env-server": "local",
+    "testing-common": "local",
     "util-common": "local"
   }
 }

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -139,7 +139,7 @@ function run-test {
     ) >> "${outPath}"
 
     if (( ${status} != 0 )); then
-        $((testErrors++))
+        (( testErrors++ ))
     fi
 }
 

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -139,7 +139,7 @@ function run-test {
     ) >> "${outPath}"
 
     if (( ${status} != 0 )); then
-        testError=1
+        $((testErrors++))
     fi
 }
 
@@ -148,8 +148,8 @@ function run-test {
 # Main script
 #
 
-# Whether any test got an error.
-testError=0
+# How many test runs reported failure.
+testErrors=0
 
 outDir="$(${progDir}/lib/out-dir-setup "${outDirOpt[@]}")"
 if (( $? != 0 )); then
@@ -183,4 +183,19 @@ for test in "${tests[@]}"; do
     esac
 done
 
-exit "${testError}"
+# Emit a summary message if more than one (set of) test(s) was run.
+if (( ${#tests[@]} > 1 )); then
+    echo ''
+    echo "${#tests[@]} test runs."
+
+    if (( ${testErrors} != 0 )); then
+        echo "${testErrors} reported at least one failure."
+        echo 'Alas.'
+    else
+        echo 'All passed. Yay!'
+    fi
+fi
+
+if (( ${testErrors} != 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
This PR is probably the last major work on the test infrastructure, for at least the time being [*]. Highlights:

* Extracted a dependencies module, `deps-testing` to hold the external testing dependencies.
* Reworked things so that our server reporter now uses the same test reporting code as the client. This means that the client and server test reports look pretty much the same, both on the console and as written to files.
* Made a couple improvements to the `run-tests` script.

[*] My previous PR alleged to be the last major work on the _client_ test infrastructure.