### PR TITLE
Logging

### DIFF
--- a/etc/bin-src/run
+++ b/etc/bin-src/run
@@ -60,7 +60,7 @@ function check-dependency {
 
 # Checks the versions of our various expected-installed dependencies.
 function check-environment-dependencies {
-    check-dependency 'Node' 'node --version' '^v[78]\.'
+    check-dependency 'Node' 'node --version' '^v[89]\.'
 }
 
 

--- a/local-modules/deps-ansi-color/package.json
+++ b/local-modules/deps-ansi-color/package.json
@@ -4,6 +4,7 @@
 
   "dependencies": {
     "ansi-html": "^0.0.7",
-    "chalk": "^2.3.0"
+    "chalk": "^2.3.0",
+    "string-length": "^2.0.0"
   }
 }

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -26,6 +26,12 @@ export default class ClientSink extends BaseSink {
    * @param {LogRecord} logRecord The record to write.
    */
   log(logRecord) {
+    if (logRecord.isTime()) {
+      // Special colorful markup for times.
+      this._logTime(logRecord);
+      return;
+    }
+
     const { level, message } = logRecord;
     const [prefixFormat, ...args] = this._makePrefix(logRecord);
     const formatStr = [prefixFormat]; // We append to this array and `args`.
@@ -61,15 +67,13 @@ export default class ClientSink extends BaseSink {
   }
 
   /**
-   * Logs the indicated time value as "punctuation" on the log.
+   * Logs the indicated time record.
    *
-   * @param {Int} nowMsec_unused Timestamp to log.
-   * @param {string} utcString String representation of the time, as UTC.
-   * @param {string} localString String representation of the time, in the local
-   *   timezone.
+   * @param {LogRecord} logRecord Log record, which must be for a time.
    */
-  time(nowMsec_unused, utcString, localString) {
-    console.log(`%c[time] %c${utcString} %c/ %c${localString}`,
+  _logTime(logRecord) {
+    const { tag, message } = logRecord;
+    console.log(`%c[${tag}] %c${message[0]} %c${message[1]} %c${message[2]}`,
       'color: #999; font-weight: bold',
       'color: #66a; font-weight: bold',
       'color: #999; font-weight: bold',
@@ -82,7 +86,7 @@ export default class ClientSink extends BaseSink {
    * string and additional arguments as appropriate.
    *
    * @param {LogRecord} logRecord The log record in question.
-   * @returns {string} The prefix.
+   * @returns {array<string>} The prefix.
    */
   _makePrefix(logRecord) {
     let prefixColor;

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -100,7 +100,7 @@ export default class ClientSink extends BaseSink {
       '%c%s%c',
       `color: ${prefixColor}; font-weight: bold`,
       logRecord.prefix,
-      ''
+      '' // This empty string is for the second `%c` above; that is, reset style.
     ];
   }
 }

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -25,7 +25,7 @@ export default class ClientSink extends BaseSink {
    *
    * @param {LogRecord} logRecord The record to write.
    */
-  log(logRecord) {
+  _impl_sinkLog(logRecord) {
     if (logRecord.isTime()) {
       // Special colorful markup for times.
       this._logTime(logRecord);

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -46,7 +46,7 @@ export default class FileSink extends BaseSink {
    *   timezone.
    */
   time(timeMsec, utcString, localString) {
-    this.log(new LogRecord(timeMsec, 'info', 'time', utcString, localString));
+    this.log(new LogRecord(timeMsec, null, 'info', 'time', utcString, localString));
   }
 
   /**

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -4,7 +4,7 @@
 
 import fs from 'fs';
 
-import { BaseSink, LogRecord, SeeAll } from 'see-all';
+import { BaseSink, SeeAll } from 'see-all';
 import { TString } from 'typecheck';
 
 /**
@@ -35,18 +35,6 @@ export default class FileSink extends BaseSink {
   log(logRecord) {
     const { level, tag, timeMsec } = logRecord;
     this._writeJson({ timeMsec, level, tag, message: logRecord.messageString });
-  }
-
-  /**
-   * Logs the indicated time value.
-   *
-   * @param {Int} timeMsec Timestamp to log.
-   * @param {string} utcString String representation of the time, as UTC.
-   * @param {string} localString String representation of the time, in the local
-   *   timezone.
-   */
-  time(timeMsec, utcString, localString) {
-    this.log(new LogRecord(timeMsec, null, 'info', 'time', utcString, localString));
   }
 
   /**

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -32,7 +32,7 @@ export default class FileSink extends BaseSink {
    *
    * @param {LogRecord} logRecord The record to write.
    */
-  log(logRecord) {
+  _impl_sinkLog(logRecord) {
     const { level, tag, timeMsec } = logRecord;
     this._writeJson({ timeMsec, level, tag, message: logRecord.messageString });
   }

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -110,8 +110,9 @@ export default class RecentSink extends BaseSink {
    * @returns {string} HTML string form for the entry.
    */
   static _htmlLine(logRecord) {
-    let prefix = logRecord.prefix;
-    let body;
+    const level  = logRecord.level;
+    let   prefix = logRecord.prefix;
+    let   body;
 
     if (logRecord.tag === 'time') {
       const [utc, local] = logRecord.message;
@@ -121,6 +122,17 @@ export default class RecentSink extends BaseSink {
     } else {
       body = logRecord.message[0];
       body = body.replace(/(^\n+)|(\n+$)/g, ''); // Trim leading and trailing newlines.
+    }
+
+    if ((level !== 'detail') && (level !== 'info')) {
+      // It's at a level that warrants a stack trace...
+      if (!logRecord.hasError()) {
+        // It doesn't otherwise have an error, so append the stack of the call
+        // site.
+        for (const line of logRecord.stack.split('\n')) {
+          body += `\n  ${line}`;
+        }
+      }
     }
 
     // Color the prefix according to level.

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -53,7 +53,7 @@ export default class RecentSink extends BaseSink {
    *   timezone.
    */
   time(timeMsec, utcString, localString) {
-    const logRecord = new LogRecord(timeMsec, 'info', 'time', utcString, localString);
+    const logRecord = new LogRecord(timeMsec, null, 'info', 'time', utcString, localString);
 
     this._log.push(logRecord);
 

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -6,7 +6,7 @@ import ansiHtml from 'ansi-html';
 import chalk from 'chalk';
 import escapeHtml from 'escape-html';
 
-import { BaseSink, LogRecord, SeeAll } from 'see-all';
+import { BaseSink, SeeAll } from 'see-all';
 import { TInt } from 'typecheck';
 
 /**
@@ -31,46 +31,6 @@ export default class RecentSink extends BaseSink {
     this._log = [];
 
     SeeAll.theOne.add(this);
-  }
-
-  /**
-   * Saves a log record to this instance.
-   *
-   * @param {LogRecord} logRecord The record to write.
-   */
-  log(logRecord) {
-    const messageString = logRecord.messageString;
-    this._log.push(logRecord.withMessage(messageString));
-  }
-
-  /**
-   * Logs the indicated time value as "punctuation" on the log. This class
-   * also uses this call to trigger cleanup of old items.
-   *
-   * @param {Int} timeMsec Timestamp to log.
-   * @param {string} utcString String representation of the time, as UTC.
-   * @param {string} localString String representation of the time, in the local
-   *   timezone.
-   */
-  time(timeMsec, utcString, localString) {
-    const logRecord = new LogRecord(timeMsec, null, 'info', 'time', utcString, localString);
-
-    this._log.push(logRecord);
-
-    // Trim the log.
-
-    const oldestMsec = timeMsec - this._maxAgeMsec;
-
-    let i;
-    for (i = 0; i < this._log.length; i++) {
-      if (this._log[i].timeMsec >= oldestMsec) {
-        break;
-      }
-    }
-
-    if (i !== 0) {
-      this._log = this._log.slice(i);
-    }
   }
 
   /** {array<object>} The saved contents of this log. */
@@ -104,6 +64,46 @@ export default class RecentSink extends BaseSink {
   }
 
   /**
+   * Saves a log record to this instance.
+   *
+   * @param {LogRecord} logRecord The record to write.
+   */
+  log(logRecord) {
+    if (logRecord.isTime()) {
+      this._logTime(logRecord);
+    } else {
+      const messageString = logRecord.messageString;
+      this._log.push(logRecord.withMessage(messageString));
+    }
+  }
+
+  /**
+   * Logs the indicated time value as "punctuation" on the log. Also, clean
+   * up old items.
+   *
+   * @param {LogRecord} logRecord The time record.
+   */
+  _logTime(logRecord) {
+    this._log.push(logRecord);
+
+    // Trim the log.
+
+    const timeMsec   = logRecord.timeMsec;
+    const oldestMsec = timeMsec - this._maxAgeMsec;
+
+    let i;
+    for (i = 0; i < this._log.length; i++) {
+      if (this._log[i].timeMsec >= oldestMsec) {
+        break;
+      }
+    }
+
+    if (i !== 0) {
+      this._log = this._log.slice(i);
+    }
+  }
+
+  /**
    * Converts the given log line to HTML.
    *
    * @param {LogRecord} logRecord Log record.
@@ -114,8 +114,8 @@ export default class RecentSink extends BaseSink {
     let   prefix = logRecord.prefix;
     let   body;
 
-    if (logRecord.tag === 'time') {
-      const [utc, local] = logRecord.message;
+    if (logRecord.isTime()) {
+      const [utc, slash_unused, local] = logRecord.message;
       const utcString = chalk.blue.bold(utc);
       const localString = chalk.blue.dim.bold(local);
       body = `${utcString} ${chalk.dim.bold('/')} ${localString}`;

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -68,7 +68,7 @@ export default class RecentSink extends BaseSink {
    *
    * @param {LogRecord} logRecord The record to write.
    */
-  log(logRecord) {
+  _impl_sinkLog(logRecord) {
     if (logRecord.isTime()) {
       this._logTime(logRecord);
     } else {

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import chalk from 'chalk';
+import stringLength from 'string-length';
 import { format } from 'util';
 
 import { BaseSink, Logger, SeeAll } from 'see-all';
@@ -118,11 +119,12 @@ export default class ServerSink extends BaseSink {
     // Measure every line. If all lines are short enough for the current
     // console, align them to the right of the prefix. If not, put the prefix on
     // its own line and produce the main content just slightly indented, under
-    // the prefix.
+    // the prefix. **Note:** `stringLength()` takes into account the fact that
+    // ANSI color escapes don't add to the visual-length of a string.
 
     const consoleWidth = ServerSink._consoleWidth();
     const maxLineWidth = lines.reduce(
-      (prev, l) => { return Math.max(prev, l.length); },
+      (prev, l) => { return Math.max(prev, stringLength(l)); },
       0);
 
     if (maxLineWidth > (consoleWidth - this._prefixLength)) {

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -90,7 +90,7 @@ export default class ServerSink extends BaseSink {
    * @param {LogRecord} logRecord The record to write.
    */
   log(logRecord) {
-    const { level, message } = logRecord;
+    const level = logRecord.level;
     const prefix = this._makePrefix(logRecord);
 
     // Make a unified string of the entire message.
@@ -104,18 +104,10 @@ export default class ServerSink extends BaseSink {
 
     if ((level !== 'detail') && (level !== 'info')) {
       // It's at a level that warrants a stack trace...
-
-      let hasError = false;
-      for (const m of message) {
-        if (m instanceof Error) {
-          hasError = true;
-          break;
-        }
-      }
-
-      if (!hasError) {
-        const stack = LogRecord.makeStack().split('\n');
-        for (const line of stack) {
+      if (!logRecord.hasError()) {
+        // It doesn't otherwise have an error, so append the stack of the call
+        // site.
+        for (const line of logRecord.stack.split('\n')) {
           lines.push(`  ${line}`);
         }
       }

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -172,7 +172,7 @@ export default class ServerSink extends BaseSink {
    *   timezone.
    */
   time(timeMsec, utcString, localString) {
-    const logRecord = new LogRecord(timeMsec, 'info', 'time', utcString, localString);
+    const logRecord = new LogRecord(timeMsec, null, 'info', 'time', utcString, localString);
     const prefix = this._makePrefix(logRecord);
 
     utcString = chalk.blue.bold(utcString);

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -90,7 +90,7 @@ export default class ServerSink extends BaseSink {
    *
    * @param {LogRecord} logRecord The record to write.
    */
-  log(logRecord) {
+  _impl_sinkLog(logRecord) {
     const level = logRecord.level;
     const prefix = this._makePrefix(logRecord);
 

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -10,7 +10,7 @@ import { RecentSink } from 'see-all-server';
 
 describe('see-all-server/RecentSink', () => {
   describe('log()', () => {
-    it('should log the item as given', () => {
+    it('should log a regular item as given', () => {
       const sink = new RecentSink(1);
 
       sink.log(new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar', 'baz'));
@@ -20,18 +20,16 @@ describe('see-all-server/RecentSink', () => {
       assert.deepEqual(contents[0],
         new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar baz'));
     });
-  });
 
-  describe('time()', () => {
-    it('should log the time as given', () => {
+    it('should log a time record as given', () => {
       const sink = new RecentSink(1);
+      const lr   = LogRecord.forTime(80808);
 
-      sink.time(80808, 'utc-time', 'local-time');
+      sink.log(lr);
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
-      assert.deepEqual(contents[0],
-        new LogRecord(80808, null, 'info', 'time', 'utc-time', 'local-time'));
+      assert.strictEqual(contents[0], lr);
     });
   });
 
@@ -71,15 +69,13 @@ describe('see-all-server/RecentSink', () => {
         sink.log(new LogRecord(timeForLine(i), 'yay-stack', 'info', 'blort', 'florp'));
       }
 
-      sink.time(FINAL_TIME, 'utc', 'local');
+      sink.log(LogRecord.forTime(FINAL_TIME));
 
       const contents = sink.contents;
 
       for (const lr of contents) {
         if (lr.tag === 'time') {
           assert.strictEqual(lr.timeMsec, FINAL_TIME);
-          assert.strictEqual(lr.message[0], 'utc');
-          assert.strictEqual(lr.message[1], 'local');
         } else {
           assert.isAtLeast(lr.timeMsec, FINAL_TIME - MAX_AGE);
         }

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -13,7 +13,7 @@ describe('see-all-server/RecentSink', () => {
     it('should log a regular item as given', () => {
       const sink = new RecentSink(1);
 
-      sink.log(new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar', 'baz'));
+      sink.sinkLog(new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar', 'baz'));
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
@@ -25,7 +25,7 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(1);
       const lr   = LogRecord.forTime(80808);
 
-      sink.log(lr);
+      sink.sinkLog(lr);
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
@@ -39,7 +39,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
+        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
       }
 
       const contents = sink.contents;
@@ -66,10 +66,10 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(MAX_AGE);
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(timeForLine(i), 'yay-stack', 'info', 'blort', 'florp'));
+        sink.sinkLog(new LogRecord(timeForLine(i), 'yay-stack', 'info', 'blort', 'florp'));
       }
 
-      sink.log(LogRecord.forTime(FINAL_TIME));
+      sink.sinkLog(LogRecord.forTime(FINAL_TIME));
 
       const contents = sink.contents;
 
@@ -89,7 +89,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
+        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
       }
 
       const contents = sink.htmlContents;

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -13,12 +13,12 @@ describe('see-all-server/RecentSink', () => {
     it('should log the item as given', () => {
       const sink = new RecentSink(1);
 
-      sink.log(new LogRecord(90909, 'error', 'foo', 'bar', 'baz'));
+      sink.log(new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar', 'baz'));
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
       assert.deepEqual(contents[0],
-        new LogRecord(90909, 'error', 'foo', 'bar baz'));
+        new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar baz'));
     });
   });
 
@@ -31,7 +31,7 @@ describe('see-all-server/RecentSink', () => {
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
       assert.deepEqual(contents[0],
-        new LogRecord(80808, 'info', 'time', 'utc-time', 'local-time'));
+        new LogRecord(80808, null, 'info', 'time', 'utc-time', 'local-time'));
     });
   });
 
@@ -41,7 +41,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(12345 + i, 'info', 'blort', 'florp', i));
+        sink.log(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
       }
 
       const contents = sink.contents;
@@ -50,6 +50,7 @@ describe('see-all-server/RecentSink', () => {
         const lr = contents[i];
 
         assert.strictEqual(lr.timeMsec, 12345 + i);
+        assert.strictEqual(lr.stack, 'yay-stack');
         assert.strictEqual(lr.level, 'info');
         assert.strictEqual(lr.tag, 'blort');
         assert.deepEqual(lr.message, [`florp ${i}`]);
@@ -67,7 +68,7 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(MAX_AGE);
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(timeForLine(i), 'info', 'blort', 'florp'));
+        sink.log(new LogRecord(timeForLine(i), 'yay-stack', 'info', 'blort', 'florp'));
       }
 
       sink.time(FINAL_TIME, 'utc', 'local');
@@ -92,7 +93,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.log(new LogRecord(12345 + i, 'info', 'blort', 'florp', i));
+        sink.log(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
       }
 
       const contents = sink.htmlContents;

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -82,7 +82,8 @@ export default class AllSinks extends Singleton {
       throw Errors.bad_use(`Overly early log call: ${details}`);
     }
 
-    const logRecord = new LogRecord(this._nowMsec(), null, level, tag, ...message);
+    const logRecord =
+      new LogRecord(this._nowMsec(), LogRecord.makeStack(), level, tag, ...message);
 
     for (const s of this._sinks) {
       s.log(logRecord);

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -65,7 +65,7 @@ export default class AllSinks extends Singleton {
 
   /**
    * Constructs a {@link LogRecord} based on the given arguments and the current
-   * time, and calls `log(logRecord)` on each of the registered sinks.
+   * time, and calls `sinkLog(logRecord)` on each of the registered sinks.
    *
    * @param {string} level Severity level.
    * @param {string} tag Name of the component associated with the message.
@@ -86,7 +86,7 @@ export default class AllSinks extends Singleton {
       new LogRecord(this._nowMsec(), LogRecord.makeStack(), level, tag, ...message);
 
     for (const s of this._sinks) {
-      s.log(logRecord);
+      s.sinkLog(logRecord);
     }
   }
 
@@ -102,7 +102,7 @@ export default class AllSinks extends Singleton {
     const logRecord = LogRecord.forTime(timeMsec);
 
     for (const s of this._sinks) {
-      s.log(logRecord);
+      s.sinkLog(logRecord);
     }
 
     this._linesSinceTime = 0;
@@ -110,7 +110,7 @@ export default class AllSinks extends Singleton {
 
   /**
    * Gets a msec timestamp representing the current time, suitable for passing
-   * as such to `sink.log()`. This will also generate `sink.time()` calls at
+   * as such to `sink.sinkLog()`. This will also generate `sink.time()` calls at
    * appropriate junctures to "punctuate" gaps.
    *
    * @returns {Int} The timestamp.

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -82,7 +82,7 @@ export default class AllSinks extends Singleton {
       throw Errors.bad_use(`Overly early log call: ${details}`);
     }
 
-    const logRecord = new LogRecord(this._nowMsec(), level, tag, ...message);
+    const logRecord = new LogRecord(this._nowMsec(), null, level, tag, ...message);
 
     for (const s of this._sinks) {
       s.log(logRecord);

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -91,6 +91,24 @@ export default class AllSinks extends Singleton {
   }
 
   /**
+   * Calls `sink.time()` on all of the logging sinks.
+   *
+   * @param {Int} timeMsec The time to pass to the sinks.
+   */
+  _callTime(timeMsec) {
+    // Note: We don't check to see if there are any sinks here. That check
+    // gets done more productively in `log()`, above.
+
+    const logRecord = LogRecord.forTime(timeMsec);
+
+    for (const s of this._sinks) {
+      s.log(logRecord);
+    }
+
+    this._linesSinceTime = 0;
+  }
+
+  /**
    * Gets a msec timestamp representing the current time, suitable for passing
    * as such to `sink.log()`. This will also generate `sink.time()` calls at
    * appropriate junctures to "punctuate" gaps.
@@ -121,51 +139,5 @@ export default class AllSinks extends Singleton {
     this._lastNow = now;
 
     return now;
-  }
-
-  /**
-   * Calls `sink.time()` on all of the logging sinks.
-   *
-   * @param {Int} nowMsec The time to pass.
-   */
-  _callTime(nowMsec) {
-    // Note: We don't check to see if there are any sinks here. That check
-    // gets done more productively in `log()`, above.
-
-    const date = new Date(nowMsec);
-    const utcString = AllSinks._utcTimeString(date);
-    const localString = AllSinks._localTimeString(date);
-
-    for (const s of this._sinks) {
-      s.time(nowMsec, utcString, localString);
-    }
-
-    this._linesSinceTime = 0;
-  }
-
-  /**
-   * Returns a string representing the given time in UTC.
-   *
-   * @param {Date} date The time, as a `Date` object.
-   * @returns {string} The corresponding UTC time string.
-   */
-  static _utcTimeString(date) {
-    // We start with the ISO string and tweak it to be a little more
-    // human-friendly.
-    const isoString = date.toISOString();
-    return isoString.replace(/T/, ' ').replace(/Z/, ' UTC');
-  }
-
-  /**
-   * Returns a string representing the given time in the local timezone.
-   *
-   * @param {Date} date The time, as a `Date` object.
-   * @returns {string} The corresponding local time string.
-   */
-  static _localTimeString(date) {
-    // We start with the local time string and cut off all everything after the
-    // actual time (timezone spew).
-    const localString = date.toTimeString();
-    return localString.replace(/ [^0-9].*$/, ' local');
   }
 }

--- a/local-modules/see-all/BaseSink.js
+++ b/local-modules/see-all/BaseSink.js
@@ -4,20 +4,44 @@
 
 import { CommonBase } from 'util-common';
 
+import LogRecord from './LogRecord';
+
 /**
- * Base class for logging sink. Subclasses must implement `log()`.
- *
- * **TODO:** This should follow the usual abstract class pattern and make the
- * methods to implement be named `_impl_*`.
+ * Base class for logging sinks (that is, a "sink" as a destination for log
+ * records). Instances of this class accept {@link LogRecord} instances and
+ * durably log them _somewhere_.
  */
 export default class BaseSink extends CommonBase {
   /**
    * Logs a record, as appropriate.
    *
-   * @abstract
-   * @param {LogRecord} logRecord The record to write.
+   * @param {LogRecord} logRecord The record to log.
    */
   log(logRecord) {
+    // **TODO:** Remove this when client sites have been updated.
+    this.sinkLog(logRecord);
+  }
+
+  /**
+   * Accepts a log record, doing whatever is appropriate per the subclass.
+   *
+   * @param {LogRecord} logRecord The record to log.
+   */
+  sinkLog(logRecord) {
+    // This method exists to (a) perform type checking, and (b) provide the
+    // usual main-vs-`_impl_` arrangement for abstract classes.
+    LogRecord.check(logRecord);
+    this._impl_sinkLog(logRecord);
+  }
+
+  /**
+   * Subclass-specific log handler.
+   *
+   * @abstract
+   * @param {LogRecord} logRecord The record to log. Guaranteed to be a valid
+   *   instance.
+   */
+  _impl_sinkLog(logRecord) {
     this._mustOverride(logRecord);
   }
 }

--- a/local-modules/see-all/BaseSink.js
+++ b/local-modules/see-all/BaseSink.js
@@ -5,7 +5,7 @@
 import { CommonBase } from 'util-common';
 
 /**
- * Base class for logging sink. Subclasses must implement `log()` and `time()`.
+ * Base class for logging sink. Subclasses must implement `log()`.
  *
  * **TODO:** This should follow the usual abstract class pattern and make the
  * methods to implement be named `_impl_*`.
@@ -19,19 +19,5 @@ export default class BaseSink extends CommonBase {
    */
   log(logRecord) {
     this._mustOverride(logRecord);
-  }
-
-  /**
-   * Logs the indicated time value as "punctuation" on the log. This class
-   * also uses this call to trigger cleanup of old items.
-   *
-   * @abstract
-   * @param {Int} timeMsec Timestamp to log.
-   * @param {string} utcString String representation of the time, as UTC.
-   * @param {string} localString String representation of the time, in the local
-   *   timezone.
-   */
-  time(timeMsec, utcString, localString) {
-    this._mustOverride(timeMsec, utcString, localString);
   }
 }

--- a/local-modules/see-all/BaseSink.js
+++ b/local-modules/see-all/BaseSink.js
@@ -13,16 +13,6 @@ import LogRecord from './LogRecord';
  */
 export default class BaseSink extends CommonBase {
   /**
-   * Logs a record, as appropriate.
-   *
-   * @param {LogRecord} logRecord The record to log.
-   */
-  log(logRecord) {
-    // **TODO:** Remove this when client sites have been updated.
-    this.sinkLog(logRecord);
-  }
-
-  /**
    * Accepts a log record, doing whatever is appropriate per the subclass.
    *
    * @param {LogRecord} logRecord The record to log.

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -78,15 +78,25 @@ export default class LogRecord extends CommonBase {
    * Constructs an instance.
    *
    * @param {Int} timeMsec Timestamp of the message.
+   * @param {string|null} stack Stack trace representing the call site which
+   *   caused this instance to be created. or `null` if that information is not
+   *   available.
    * @param {string} level Severity level.
    * @param {string} tag Name of the component associated with the message.
    * @param {...*} message Message to log.
    */
-  constructor(timeMsec, level, tag, ...message) {
+  constructor(timeMsec, stack, level, tag, ...message) {
     super();
 
     /** {Int} Timestamp of the message. */
     this._timeMsec = TInt.nonNegative(timeMsec);
+
+    /**
+     * {string|null} stack Stack trace representing the call site which caused
+     * this instance to be created. or `null` if that information is not
+     * available.
+     */
+    this._stack = TString.orNull(stack);
 
     /** {string} Severity level. */
     this._level = LogRecord.validateLevel(level);
@@ -159,6 +169,15 @@ export default class LogRecord extends CommonBase {
     return `[${tag}${levelStr}]`;
   }
 
+  /**
+   * {string|null} stack Stack trace representing the call site which caused
+   * this instance to be created. or `null` if that information is not
+   * available.
+   */
+  get stack() {
+    return this._stack;
+  }
+
   /** {string} Name of the component associated with the message. */
   get tag() {
     return this._tag;
@@ -177,7 +196,7 @@ export default class LogRecord extends CommonBase {
    * @returns {LogRecord} An appropriately-constructed instance.
    */
   withMessage(...message) {
-    const { timeMsec, level, tag } = this;
-    return new LogRecord(timeMsec, level, tag, ...message);
+    const { timeMsec, stack, level, tag } = this;
+    return new LogRecord(timeMsec, stack, level, tag, ...message);
   }
 }

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -60,6 +60,32 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
+   * Makes a stack trace for the current call site, skipping initial stack
+   * frames from this module. Results of this method are suitable for passing
+   * as the `stack` to this class's constructor.
+   *
+   * @returns {string} A stack trace.
+   */
+  static makeStack() {
+    const trace = ErrorUtil.stackLines(new Error());
+
+    let startAt;
+    for (startAt = 0; startAt < trace.length; startAt++) {
+      if (!/[/]see-all/.test(trace[startAt])) {
+        break;
+      }
+    }
+
+    // Only trim initial items if there's _some_ part of the trace that isn't in
+    // this module.
+    if (startAt < trace.length) {
+      trace.splice(0, startAt);
+    }
+
+    return trace.join('\n');
+  }
+
+  /**
    * Validates a logging severity level value. Throws an error if invalid.
    *
    * @param {string} level Severity level. Must be one of the severity level

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -215,6 +215,23 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
+   * Indicates whether any of the `message` arguments of this instance is an
+   * `Error`.
+   *
+   * @returns {boolean} `true` iff this instance's `message` contains at least
+   *   one `Error`.
+   */
+  hasError() {
+    for (const m of this._message) {
+      if (m instanceof Error) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Constructs an instance just like this one, except with `message` replaced
    * with the indicated contents.
    *

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -53,7 +53,7 @@ describe('see-all/LogRecord', () => {
   describe('messageString()', () => {
     it('operates as expected', () => {
       function test(expected, ...message) {
-        const lr = new LogRecord(0, 'info', 'blort', ...message);
+        const lr = new LogRecord(0, 'some-stack-trace', 'info', 'blort', ...message);
         const got = lr.messageString;
         assert.strictEqual(got, expected);
       }

--- a/scripts/build
+++ b/scripts/build
@@ -148,7 +148,7 @@ function check-dependency {
 # Checks the versions of our various expected-installed dependencies, notably
 # including Node and npm.
 function check-environment-dependencies {
-    check-dependency 'Node' 'node --version' '^v[78]\.'
+    check-dependency 'Node' 'node --version' '^v[89]\.'
     check-dependency 'npm' 'npm --version' '^5\.'
     check-dependency 'jq' 'jq --version' '^jq-1\.'
     check-dependency 'rsync' 'rsync --version' '.' # No actual version check.


### PR DESCRIPTION
This PR cleans up a few things in our logging infrastructure. Highlights:

* Adds a `stack` field to all log records, and uses it instead of generating stacks inside the log sinks. The original impetus for this was getting the `/debug/log` endpoint to behave consistently with respect to other loggers, and it also represents a nice simplification of logging sinks in general.

* Reworks timestamp logging. In particular, there used to be a separate method `BaseSink.time()` for logging the timestamp "punctuation" on logs, which, as with stack logging, was ad-hoc and inconsistently implemented. Now, these are logged via the same method as any other log, and the construction of the timestamp log records is done in a single place.
