### PR TITLE
Logging again

### DIFF
--- a/local-modules/api-server/ApiLog.js
+++ b/local-modules/api-server/ApiLog.js
@@ -55,7 +55,7 @@ export default class ApiLog extends CommonBase {
       // TODO: Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
-      log.error(`[${connectionId}] Error.`, response.originalError);
+      log.withAddedContext(connectionId).error('Error.', response.originalError);
     }
 
     // Details to log. **TODO:** This will ultimately need to redact some
@@ -94,7 +94,7 @@ export default class ApiLog extends CommonBase {
    */
   incomingMessage(connectionId, startTime, msg) {
     // TODO: This will ultimately need to redact some information.
-    log.detail(`[${connectionId}] Message at ${startTime}:`, msg.toLog());
+    log.withAddedContext(connectionId).detail(`Message at ${startTime}:`, msg.toLog());
   }
 
   /**

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -83,7 +83,7 @@ export default class Connection extends CommonBase {
     this._codec = context.codec;
 
     /** {Logger} Logger which includes the connection ID as a prefix. */
-    this._log = log.withPrefix(`[${this._connectionId}]`);
+    this._log = log.withAddedContext(this._connectionId);
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -34,7 +34,7 @@ export default class DocSession extends CommonBase {
     this._key = BaseKey.check(key);
 
     /** {Logger} Logger specific to this document's ID. */
-    this._log = log.withPrefix(`[${key.id}]`);
+    this._log = log.withAddedContext(key.id);
 
     /**
      * {ApiClient|null} API client instance. Set to non-`null` in the getter

--- a/local-modules/doc-server/BaseComplexMember.js
+++ b/local-modules/doc-server/BaseComplexMember.js
@@ -30,7 +30,7 @@ export default class BaseComplexMember extends CommonBase {
     this._logLabel = TString.check(logLabel);
 
     /** {Logger} Logger to use with this instance. Includes the log label. */
-    this._log = fileAccess.log.withPrefix(`[${logLabel}]`);
+    this._log = fileAccess.log.withAddedContext(logLabel);
   }
 
   /** {Codec} Codec instance to use with the underlying file. */

--- a/local-modules/doc-server/CaretControl.js
+++ b/local-modules/doc-server/CaretControl.js
@@ -190,7 +190,7 @@ export default class CaretControl extends EphemeralControl {
     for (const [sessionId, caret] of snapshot.entries()) {
       if (minTime.compareTo(caret.lastActive) > 0) {
         // Too old!
-        this.log.info(`[${sessionId}] Became inactive.`);
+        this.log.withAddedContext(sessionId).info('Became inactive.');
         newSnapshot = newSnapshot.withoutSession(sessionId);
       }
     }
@@ -229,7 +229,7 @@ export default class CaretControl extends EphemeralControl {
         snapshot.withoutSession(sessionId).withRevNum(snapshot.revNum + 1);
       const change =
         snapshot.diff(newSnapshot).withTimestamp(Timestamp.now());
-      this.log.info(`[${sessionId}] Local session has ended.`);
+      this.log.withAddedContext(sessionId).info('Local session has ended.');
 
       try {
         await this.update(change);
@@ -237,11 +237,11 @@ export default class CaretControl extends EphemeralControl {
         // Probably a timeout after losing too many races. Though it's
         // log-worthy, it's not a showstopper. The session will ultimately get
         // cleaned up by the idle timeout.
-        this.log.warn(`[${sessionId}] Error while reaping.`, e);
+        this.log.withAddedContext(sessionId).warn('Error while reaping.', e);
       }
     } else {
       // Some other server probably got to it first.
-      this.log.info(`[${sessionId}] Asked to reap session that was already gone.`);
+      this.log.withAddedContext(sessionId).info('Asked to reap session that was already gone.');
     }
   }
 

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -86,7 +86,7 @@ export default class DocServer extends Singleton {
         }
         // The weak reference is dead. We'll fall through and construct a new
         // result.
-        log.info(`[${docId}] Cached complex was gc'ed.`);
+        log.withAddedContext(docId).info('Cached complex was gc\'ed.');
       }
     }
 
@@ -123,7 +123,7 @@ export default class DocServer extends Singleton {
 
     // Store the the promise for the result in the cache, and return it.
 
-    log.info(`[${docId}] About to construct complex.`);
+    log.withAddedContext(docId).info('About to construct complex.');
     this._complexes.set(docId, resultPromise);
     return resultPromise;
   }

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -50,7 +50,7 @@ export default class DocSession extends CommonBase {
     this._propertyControl = fileComplex.propertyControl;
 
     /** {Logger} Logger for this session. */
-    this._log = fileComplex.log.withPrefix(`[${sessionId}]`);
+    this._log = fileComplex.log.withAddedContext(sessionId);
   }
 
   /**

--- a/local-modules/doc-server/FileAccess.js
+++ b/local-modules/doc-server/FileAccess.js
@@ -27,10 +27,6 @@ export default class FileAccess extends CommonBase {
    *   the usual one. This is only meant to be used for unit testing.
    */
   constructor(codec, file, logger = null) {
-    if (logger !== null) {
-      BaseLogger.check(logger);
-    }
-
     super();
 
     /** {Codec} Codec instance to use. */
@@ -40,7 +36,8 @@ export default class FileAccess extends CommonBase {
     this._file = BaseFile.check(file);
 
     /** {BaseLogger} Logger for this instance. */
-    this._log = (logger || log).withPrefix(`[${file.id}]`);
+    this._log =
+      ((logger === null) ? log : BaseLogger.check(logger)).withAddedContext(file.id);
 
     /** {FileCodec} File-codec wrapper to use. */
     this._fileCodec = new FileCodec(file, codec);

--- a/local-modules/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/doc-server/tests/test_BaseComplexMember.js
@@ -42,7 +42,7 @@ describe('doc-server/BaseComplexMember', () => {
       result.log.info('florp', 'like');
       const got = log.record[0];
 
-      assert.deepEqual(got, ['info', '[file-id]', '[boop]', 'florp', 'like']);
+      assert.deepEqual(got, ['info', 'florp', 'like']);
     });
   });
 });

--- a/local-modules/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/doc-server/tests/test_BaseComplexMember.js
@@ -42,7 +42,7 @@ describe('doc-server/BaseComplexMember', () => {
       result.log.info('florp', 'like');
       const got = log.record[0];
 
-      assert.deepEqual(got, ['info', 'florp', 'like']);
+      assert.deepEqual(got, ['info', ['file-id', 'boop'], 'florp', 'like']);
     });
   });
 });

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -124,7 +124,7 @@ export default class LocalFile extends BaseFile {
     this._revNumCodec = Codec.theOne;
 
     /** {Logger} Logger specific to this file's ID. */
-    this._log = log.withPrefix(`[${fileId}]`);
+    this._log = log.withAddedContext(fileId);
 
     this._log.info('Path:', this._storageDir);
   }

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -72,8 +72,8 @@ export default class ClientSink extends BaseSink {
    * @param {LogRecord} logRecord Log record, which must be for a time.
    */
   _logTime(logRecord) {
-    const { tag, message } = logRecord;
-    console.log(`%c[${tag}] %c${message[0]} %c${message[1]} %c${message[2]}`,
+    const { message, tag: { main } } = logRecord;
+    console.log(`%c[${main}] %c${message[0]} %c${message[1]} %c${message[2]}`,
       'color: #999; font-weight: bold',
       'color: #66a; font-weight: bold',
       'color: #999; font-weight: bold',

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -96,11 +96,19 @@ export default class ClientSink extends BaseSink {
       default:      { prefixColor = '#999'; break; }
     }
 
-    return [
-      '%c%s%c',
-      `color: ${prefixColor}; font-weight: bold`,
-      logRecord.prefix,
-      '' // This empty string is for the second `%c` above; that is, reset style.
-    ];
+    let   formatStr = '%c%s';
+    const args      = [`color: ${prefixColor}; font-weight: bold`, logRecord.prefix];
+
+    if (logRecord.contextString !== null) {
+      formatStr += '%c%s';
+      args.push('color: #44e; font-weight: bold');
+      args.push(` ${logRecord.contextString}`);
+    }
+
+    // Reset the style at the end.
+    formatStr += '%c';
+    args.push('');
+
+    return [formatStr, ...args];
   }
 }

--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -97,7 +97,7 @@ export default class ClientSink extends BaseSink {
     }
 
     let   formatStr = '%c%s';
-    const args      = [`color: ${prefixColor}; font-weight: bold`, logRecord.prefix];
+    const args      = [`color: ${prefixColor}; font-weight: bold`, logRecord.prefixString];
 
     if (logRecord.contextString !== null) {
       formatStr += '%c%s';

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -33,7 +33,9 @@ export default class FileSink extends BaseSink {
    * @param {LogRecord} logRecord The record to write.
    */
   _impl_sinkLog(logRecord) {
-    const { level, tag, timeMsec } = logRecord;
+    const { level, tag: { main, context }, timeMsec } = logRecord;
+    const tag = [main, ...context];
+
     this._writeJson({ timeMsec, level, tag, message: logRecord.messageString });
   }
 

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -113,7 +113,7 @@ export default class RecentSink extends BaseSink {
    */
   static _htmlLine(logRecord) {
     const level   = logRecord.level;
-    let   prefix  = logRecord.prefix;
+    let   prefix  = logRecord.prefixString;
     const context = logRecord.contextString || '';
 
     let   body;

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -47,8 +47,10 @@ export default class RecentSink extends BaseSink {
       'table { border-collapse: collapse; border-spacing: 0; ' +
       '  width: 90vw; margin-left: 5vw; margin-right: 5vw; }\n' +
       'tr:nth-child(even) { background-color: #f8f8f8; }\n' +
-      'td { padding-bottom: 0.2em; padding-left: 0.5em; }\n' +
-      'td:first-child { width: 15%; vertical-align: top; padding-right: 1em; ' +
+      'td { vertical-align: top; padding-bottom: 0.2em; padding-left: 0.5em; }\n' +
+      'td:first-child { width: 12%; padding-right: 1em; ' +
+      '  border-right-color: #ddd; border-right-width: 1pt; border-right-style: solid }\n' +
+      'td:nth-child(2) { width: 15%; padding-right: 1em; ' +
       '  border-right-color: #ddd; border-right-width: 1pt; border-right-style: solid }\n' +
       'pre { white-space: pre-wrap; margin: 0; }'
     );
@@ -110,8 +112,10 @@ export default class RecentSink extends BaseSink {
    * @returns {string} HTML string form for the entry.
    */
   static _htmlLine(logRecord) {
-    const level  = logRecord.level;
-    let   prefix = logRecord.prefix;
+    const level   = logRecord.level;
+    let   prefix  = logRecord.prefix;
+    const context = logRecord.contextString || '';
+
     let   body;
 
     if (logRecord.isTime()) {
@@ -142,9 +146,10 @@ export default class RecentSink extends BaseSink {
       default:      { prefix = chalk.dim.bold(prefix);    break; }
     }
 
-    const prefixHtml = ansiHtml(escapeHtml(prefix));
-    const bodyHtml   = ansiHtml(escapeHtml(body));
+    const prefixHtml  = ansiHtml(escapeHtml(prefix));
+    const contextHtml = ansiHtml(escapeHtml(chalk.blue.dim.bold(context)));
+    const bodyHtml    = ansiHtml(escapeHtml(body));
 
-    return `<tr><td>${prefixHtml}</td><td><pre>${bodyHtml}</pre></td>`;
+    return `<tr><td>${prefixHtml}</td><td>${contextHtml}</td><td><pre>${bodyHtml}</pre></td>`;
   }
 }

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -159,7 +159,7 @@ export default class ServerSink extends BaseSink {
    */
   _makePrefix(logRecord) {
     let   text   = logRecord.prefix;
-    const length = text.length + 1; // `+1` for the space at the end.
+    //const length = text.length + 1; // `+1` for the space at the end.
 
     // Color the prefix according to level.
     switch (logRecord.level) {
@@ -167,6 +167,16 @@ export default class ServerSink extends BaseSink {
       case 'warn':  { text = chalk.yellow.bold(text); break; }
       default:      { text = chalk.dim.bold(text);    break; }
     }
+
+    // If there's context, color it and append it.
+    if (logRecord.contextString !== null) {
+      text += ` ${chalk.hex('#44e').bold(logRecord.contextString)}`;
+    }
+
+    // **Note:** `stringLength()` takes into account the fact that ANSI color
+    // escapes don't add to the visual-length of a string. `+1` to guarantee at
+    // least one space of padding.
+    const length = stringLength(text) + 1;
 
     // Update the prefix length instance variables. What we're doing here is
     // adjusting the prefix area to be wider when we discover a prefix which

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -158,7 +158,7 @@ export default class ServerSink extends BaseSink {
    * @returns {string} The prefix, including coloring and padding.
    */
   _makePrefix(logRecord) {
-    let   text   = logRecord.prefix;
+    let   text   = logRecord.prefixString;
     //const length = text.length + 1; // `+1` for the space at the end.
 
     // Color the prefix according to level.

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -50,7 +50,7 @@ describe('see-all-server/RecentSink', () => {
         assert.strictEqual(lr.timeMsec, 12345 + i);
         assert.strictEqual(lr.stack, 'yay-stack');
         assert.strictEqual(lr.level, 'info');
-        assert.strictEqual(lr.tag, 'blort');
+        assert.strictEqual(lr.tag.main, 'blort');
         assert.deepEqual(lr.message, [`florp ${i}`]);
       }
     });

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -5,20 +5,23 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { LogRecord } from 'see-all';
+import { LogRecord, LogTag } from 'see-all';
 import { RecentSink } from 'see-all-server';
+
+/** {LogTag} Handy instance. */
+const LOG_TAG = new LogTag('blort-tag');
 
 describe('see-all-server/RecentSink', () => {
   describe('log()', () => {
     it('should log a regular item as given', () => {
       const sink = new RecentSink(1);
 
-      sink.sinkLog(new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar', 'baz'));
+      sink.sinkLog(new LogRecord(90909, 'yay-stack', 'error', LOG_TAG, 'bar', 'baz'));
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
       assert.deepEqual(contents[0],
-        new LogRecord(90909, 'yay-stack', 'error', 'foo', 'bar baz'));
+        new LogRecord(90909, 'yay-stack', 'error', LOG_TAG, 'bar baz'));
     });
 
     it('should log a time record as given', () => {
@@ -39,7 +42,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
+        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
       }
 
       const contents = sink.contents;
@@ -50,7 +53,7 @@ describe('see-all-server/RecentSink', () => {
         assert.strictEqual(lr.timeMsec, 12345 + i);
         assert.strictEqual(lr.stack, 'yay-stack');
         assert.strictEqual(lr.level, 'info');
-        assert.strictEqual(lr.tag.main, 'blort');
+        assert.strictEqual(lr.tag, LOG_TAG);
         assert.deepEqual(lr.message, [`florp ${i}`]);
       }
     });
@@ -66,7 +69,7 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(MAX_AGE);
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(timeForLine(i), 'yay-stack', 'info', 'blort', 'florp'));
+        sink.sinkLog(new LogRecord(timeForLine(i), 'yay-stack', 'info', LOG_TAG, 'florp'));
       }
 
       sink.sinkLog(LogRecord.forTime(FINAL_TIME));
@@ -89,7 +92,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', 'blort', 'florp', i));
+        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
       }
 
       const contents = sink.htmlContents;

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -68,7 +68,7 @@ export default class AllSinks extends Singleton {
    * time, and calls `sinkLog(logRecord)` on each of the registered sinks.
    *
    * @param {string} level Severity level.
-   * @param {string} tag Name of the component associated with the message.
+   * @param {LogTag} tag Component and context.
    * @param {...*} message Message to log.
    */
   log(level, tag, ...message) {

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -102,23 +102,6 @@ export default class BaseLogger extends CommonBase {
 
   /**
    * Constructs and returns a wrapper for this instance which prefixes each
-   * log with the given additional arguments.
-   *
-   * @param {...*} prefix Values to use as a prefix for all logged messages.
-   * @returns {BaseLogger} A new logger which prefixes logs as indicated.
-   */
-  withPrefix(...prefix) {
-    const result = new BaseLogger();
-
-    result._impl_log = (level, message) => {
-      this.log(level, ...prefix, ...message);
-    };
-
-    return result;
-  }
-
-  /**
-   * Constructs and returns a wrapper for this instance which prefixes each
    * log with the results of calling the given prefix-generator function. The
    * function is called with no arguments and is expected to return an array.
    * The results of that call are used as the first message arguments to the

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -6,6 +6,7 @@ import { CommonBase, Errors } from 'util-common';
 
 import LogRecord from './LogRecord';
 import LogStream from './LogStream';
+import LogTag from './LogTag';
 
 
 /**
@@ -101,8 +102,23 @@ export default class BaseLogger extends CommonBase {
   }
 
   /**
-   * Actual logging implementation. Subclasses must override this to do
-   * something appropriate.
+   * Constructs and returns an instance just like this one, except with a tag
+   * that has the given additional context.
+   *
+   * @param {...string} context Additional context strings. Each must be valid
+   *   per the definition of context in {@link LogTag}.
+   * @returns {BaseLogger} An appropriately-constructed instance of this class.
+   */
+  withAddedContext(...context) {
+    for (const c of context) {
+      LogTag.checkContextString(c);
+    }
+
+    return this._impl_withAddedContext(...context);
+  }
+
+  /**
+   * Subclass-specific logging implementation.
    *
    * @abstract
    * @param {string} level Severity level. Guaranteed to be a valid level.
@@ -110,5 +126,17 @@ export default class BaseLogger extends CommonBase {
    */
   _impl_log(level, message) {
     this._mustOverride(level, message);
+  }
+
+  /**
+   * Subclass-specific context adder.
+   *
+   * @abstract
+   * @param {...string} context Additional context strings. Guaranteed to be
+   *   valid.
+   * @returns {BaseLogger} An appropriately-constructed instance of this class.
+   */
+  _impl_withAddedContext(...context) {
+    this._mustOverride(context);
   }
 }

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -101,27 +101,6 @@ export default class BaseLogger extends CommonBase {
   }
 
   /**
-   * Constructs and returns a wrapper for this instance which prefixes each
-   * log with the results of calling the given prefix-generator function. The
-   * function is called with no arguments and is expected to return an array.
-   * The results of that call are used as the first message arguments to the
-   * ultimate logging calls.
-   *
-   * @param {function} prefixGenerator Function to generate prefix arguments.
-   * @returns {BaseLogger} A new logger which prefixes logs as indicated.
-   */
-  withDynamicPrefix(prefixGenerator) {
-    const result = new BaseLogger();
-
-    result._impl_log = (level, message) => {
-      const prefix = prefixGenerator();
-      this.log(level, ...prefix, ...message);
-    };
-
-    return result;
-  }
-
-  /**
    * Actual logging implementation. Subclasses must override this to do
    * something appropriate.
    *

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -166,6 +166,19 @@ export default class LogRecord extends CommonBase {
     Object.freeze(this);
   }
 
+  /**
+   * {string|null} The standard-form context string for this instance, or `null`
+   * if there is no context.
+   */
+  get contextString() {
+    const context = this.tag.context;
+
+    return (context.length === 0)
+      ? null
+      : `[${context.join(' ')}]`;
+  }
+
+
   /** {string} Severity level. */
   get level() {
     return this._level;
@@ -219,13 +232,10 @@ export default class LogRecord extends CommonBase {
    * instance.
    */
   get prefix() {
-    const { level, tag: { main, context } } = this;
+    const { level, tag: { main } } = this;
     const levelStr = (level === 'info') ? '' : ` ${level[0].toUpperCase()}`;
-    const contextStr = (context.length === 0)
-      ? ''
-      : ` ${context.join(':')}`;
 
-    return `[${main}${levelStr}]${contextStr}`;
+    return `[${main}${levelStr}]`;
   }
 
   /**

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -223,7 +223,7 @@ export default class LogRecord extends CommonBase {
     const levelStr = (level === 'info') ? '' : ` ${level[0].toUpperCase()}`;
     const contextStr = (context.length === 0)
       ? ''
-      : ` ${context.join('/')}`;
+      : ` ${context.join(':')}`;
 
     return `[${main}${levelStr}]${contextStr}`;
   }

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -231,7 +231,7 @@ export default class LogRecord extends CommonBase {
    * {string} The standard-form prefix string for the level and tag of this
    * instance.
    */
-  get prefix() {
+  get prefixString() {
     const { level, tag: { main } } = this;
     const levelStr = (level === 'info') ? '' : ` ${level[0].toUpperCase()}`;
 

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -134,8 +134,8 @@ export default class LogRecord extends CommonBase {
    *   caused this instance to be created. or `null` if that information is not
    *   available.
    * @param {string} level Severity level.
-   * @param {LogTag|string} tag Tag (component name and optional context)
-   *   associated with the message.
+   * @param {LogTag} tag Tag (component name and optional context) associated
+   *   with the message.
    * @param {...*} message Message to log.
    */
   constructor(timeMsec, stack, level, tag, ...message) {
@@ -154,8 +154,11 @@ export default class LogRecord extends CommonBase {
     /** {string} Severity level. */
     this._level = LogRecord.validateLevel(level);
 
-    /** {LogTag} Name of the component associated with the message. */
-    this._tag = (tag instanceof LogTag) ? tag : new LogTag(TString.label(tag));
+    /**
+     * {LogTag} Tag (component name and optional context) associated with the
+     * message.
+     */
+    this._tag = LogTag.check(tag);
 
     /** {array<*>} Message to log. */
     this._message = message;

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -45,7 +45,7 @@ export default class LogRecord extends CommonBase {
     const utcString   = LogRecord._utcTimeString(date);
     const localString = LogRecord._localTimeString(date);
 
-    return new LogRecord(timeMsec, null, 'info', 'time',
+    return new LogRecord(timeMsec, null, 'info', LogTag.TIME,
       utcString, '/', localString);
   }
 
@@ -270,7 +270,7 @@ export default class LogRecord extends CommonBase {
   isTime() {
     // The first check (the tag) is probably sufficient, but it probably can't
     // hurt to be a little pickier.
-    return (this._tag.main === 'time')
+    return (this._tag === LogTag.TIME)
       && (this._message.length === 3)
       && (this._message[1] === '/');
   }

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -7,6 +7,8 @@ import { inspect } from 'util';
 import { TInt, TString } from 'typecheck';
 import { CommonBase, ErrorUtil, Errors } from 'util-common';
 
+import LogTag from './LogTag';
+
 /** {array<string>} Array of valid severity levels. */
 const LEVELS_ARRAY = Object.freeze(['debug', 'error', 'warn', 'info', 'detail']);
 
@@ -132,7 +134,8 @@ export default class LogRecord extends CommonBase {
    *   caused this instance to be created. or `null` if that information is not
    *   available.
    * @param {string} level Severity level.
-   * @param {string} tag Name of the component associated with the message.
+   * @param {LogTag|string} tag Tag (component name and optional context)
+   *   associated with the message.
    * @param {...*} message Message to log.
    */
   constructor(timeMsec, stack, level, tag, ...message) {
@@ -151,8 +154,8 @@ export default class LogRecord extends CommonBase {
     /** {string} Severity level. */
     this._level = LogRecord.validateLevel(level);
 
-    /** {string} Name of the component associated with the message. */
-    this._tag = TString.label(tag);
+    /** {LogTag} Name of the component associated with the message. */
+    this._tag = (tag instanceof LogTag) ? tag : new LogTag(TString.label(tag));
 
     /** {array<*>} Message to log. */
     this._message = message;
@@ -213,10 +216,13 @@ export default class LogRecord extends CommonBase {
    * instance.
    */
   get prefix() {
-    const { level, tag } = this;
+    const { level, tag: { main, context } } = this;
     const levelStr = (level === 'info') ? '' : ` ${level[0].toUpperCase()}`;
+    const contextStr = (context.length === 0)
+      ? ''
+      : ` ${context.join('/')}`;
 
-    return `[${tag}${levelStr}]`;
+    return `[${main}${levelStr}]${contextStr}`;
   }
 
   /**
@@ -228,7 +234,7 @@ export default class LogRecord extends CommonBase {
     return this._stack;
   }
 
-  /** {string} Name of the component associated with the message. */
+  /** {LogTag} Tag (component name and context). */
   get tag() {
     return this._tag;
   }
@@ -264,7 +270,7 @@ export default class LogRecord extends CommonBase {
   isTime() {
     // The first check (the tag) is probably sufficient, but it probably can't
     // hurt to be a little pickier.
-    return (this._tag === 'time')
+    return (this._tag.main === 'time')
       && (this._message.length === 3)
       && (this._message[1] === '/');
   }

--- a/local-modules/see-all/LogTag.js
+++ b/local-modules/see-all/LogTag.js
@@ -6,6 +6,12 @@ import { TArray, TString } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 /**
+ * {LogTag|null} Instance to use when logging timestamp "punctuation."
+ * Initialized in {@link #TIME}.
+ */
+let TIME = null;
+
+/**
  * Structured "tag" information for log records. Each instance consists of a
  * main tag and zero or more additional "context" strings. The main tag is
  * typically a high-level system component of some sort, e.g. and typically a
@@ -13,6 +19,15 @@ import { CommonBase } from 'util-common';
  * by the component being so represented).
  */
 export default class LogTag extends CommonBase {
+  /** {LogTag} Instance to use when logging timestamp "punctuation." */
+  static get TIME() {
+    if (TIME === null) {
+      TIME = new LogTag('time');
+    }
+
+    return TIME;
+  }
+
   /**
    * Validates a context string. This will throw an error given an invalid
    * value.

--- a/local-modules/see-all/LogTag.js
+++ b/local-modules/see-all/LogTag.js
@@ -1,0 +1,67 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray, TString } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+/**
+ * Structured "tag" information for log records. Each instance consists of a
+ * main tag and zero or more additional "context" strings. The main tag is
+ * typically a high-level system component of some sort, e.g. and typically a
+ * module. The context strings, if any, are specific to the main tag (defined
+ * by the component being so represented).
+ */
+export default class LogTag extends CommonBase {
+  /**
+   * Validates a context string. This will throw an error given an invalid
+   * value.
+   *
+   * @param {*} value Alleged context string.
+   * @returns {string} `value`, if it is valid.
+   */
+  static checkContextString(value) {
+    return TString.maxLen(value, 25);
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} main Main tag. Must be a "label" string.
+   * @param {...string} context Context strings. Each must be no longer
+   *   than 25 characters.
+   */
+  constructor(main, ...context) {
+    super();
+
+    /** {string} Main tag. */
+    this._main = TString.label(main);
+
+    /** {array<string>} Context strings. */
+    this._context =
+      Object.freeze(TArray.check(context, LogTag.checkContextString));
+
+    Object.freeze(this);
+  }
+
+  /** {string} Main tag. */
+  get main() {
+    return this._main;
+  }
+
+  /** {array<string>} Context strings. Always a frozen array. */
+  get context() {
+    return this._context;
+  }
+
+  /**
+   * Constructs an instance just like this one, except with additional context
+   * strings.
+   *
+   * @param {...string} context Additional context strings.
+   * @returns {LogTag} An appropriately-constructed instance.
+   */
+  withAddedContext(...context) {
+    return new LogTag(this._main, ...this._context, ...context);
+  }
+}

--- a/local-modules/see-all/Logger.js
+++ b/local-modules/see-all/Logger.js
@@ -63,17 +63,6 @@ export default class Logger extends BaseLogger {
   }
 
   /**
-   * Constructs and returns an instance just like this one, except with a tag
-   * that has the given additional context.
-   *
-   * @param {...string} context Additional context strings.
-   * @returns {LogTag} An appropriately-constructed instance.
-   */
-  withAddedContext(...context) {
-    return new Logger(this._tag.withAddedContext(...context));
-  }
-
-  /**
    * Actual logging implementation, as specified by the superclass.
    *
    * @param {string} level Severity level. Guaranteed to be a valid level.
@@ -87,5 +76,17 @@ export default class Logger extends BaseLogger {
     }
 
     AllSinks.theOne.log(level, this._tag, ...message);
+  }
+
+  /**
+   * Subclass-specific context adder.
+   *
+   * @abstract
+   * @param {...string} context Additional context strings. Guaranteed to be
+   *   valid.
+   * @returns {BaseLogger} An appropriately-constructed instance of this class.
+   */
+  _impl_withAddedContext(...context) {
+    return new Logger(this._tag.withAddedContext(...context));
   }
 }

--- a/local-modules/see-all/Logger.js
+++ b/local-modules/see-all/Logger.js
@@ -44,8 +44,9 @@ export default class Logger extends BaseLogger {
   /**
    * Constructs an instance.
    *
-   * @param {string} tag Component tag to associate with messages logged by this
-   *   instance.
+   * @param {LogTag|string} tag Tag to use with messages logged by this
+   *   instance. If passed as a string, this constructor automatically creates
+   *   a corresponding {@link LogTag} instance (with no extra context strings).
    * @param {boolean} [enableDetail = false] Whether or not to produce logs at
    *   the `detail` level.
    */
@@ -53,12 +54,23 @@ export default class Logger extends BaseLogger {
     super();
 
     /** {LogTag} The module / subsystem (plus context) tag. */
-    this._tag = new LogTag(tag);
+    this._tag = (tag instanceof LogTag) ? tag : new LogTag(tag);
 
     /** {boolean} Whether logging is enabled for the `detail` level. */
     this._enableDetail = TBoolean.check(enableDetail);
 
     Object.freeze(this);
+  }
+
+  /**
+   * Constructs and returns an instance just like this one, except with a tag
+   * that has the given additional context.
+   *
+   * @param {...string} context Additional context strings.
+   * @returns {LogTag} An appropriately-constructed instance.
+   */
+  withAddedContext(...context) {
+    return new Logger(this._tag.withAddedContext(...context));
   }
 
   /**

--- a/local-modules/see-all/Logger.js
+++ b/local-modules/see-all/Logger.js
@@ -2,10 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TBoolean, TString } from 'typecheck';
+import { TBoolean } from 'typecheck';
 
-import BaseLogger from './BaseLogger';
 import AllSinks from './AllSinks';
+import BaseLogger from './BaseLogger';
+import LogTag from './LogTag';
 
 /**
  * Logger which associates a tag (typically a subsystem or module name) and a
@@ -51,8 +52,8 @@ export default class Logger extends BaseLogger {
   constructor(tag, enableDetail = false) {
     super();
 
-    /** {string} The module / subsystem tag. */
-    this._tag = TString.nonEmpty(tag);
+    /** {LogTag} The module / subsystem (plus context) tag. */
+    this._tag = new LogTag(tag);
 
     /** {boolean} Whether logging is enabled for the `detail` level. */
     this._enableDetail = TBoolean.check(enableDetail);

--- a/local-modules/see-all/index.js
+++ b/local-modules/see-all/index.js
@@ -6,7 +6,8 @@ import BaseLogger from './BaseLogger';
 import BaseSink from './BaseSink';
 import LogRecord from './LogRecord';
 import LogStream from './LogStream';
+import LogTag from './LogTag';
 import Logger from './Logger';
 import SeeAll from './SeeAll';
 
-export { BaseLogger, BaseSink, LogRecord, LogStream, Logger, SeeAll };
+export { BaseLogger, BaseSink, LogRecord, LogStream, LogTag, Logger, SeeAll };

--- a/local-modules/see-all/mocks/MockLogger.js
+++ b/local-modules/see-all/mocks/MockLogger.js
@@ -18,12 +18,6 @@ export default class MockLogger extends BaseLogger {
     this.record = [];
   }
 
-  // **TODO:** Arguably ought to do something better.
-  withAddedContext(...context_unused) {
-    // Ignore it.
-    return this;
-  }
-
   /**
    * Actual logging implementation. Subclasses must override this to do
    * something appropriate.
@@ -34,5 +28,10 @@ export default class MockLogger extends BaseLogger {
    */
   _impl_log(level, message) {
     this.record.push([level, ...message]);
+  }
+
+  _impl_withAddedContext(...context_unused) {
+    // Ignore it. **TODO:** Arguably ought to do something better.
+    return this;
   }
 }

--- a/local-modules/see-all/mocks/MockLogger.js
+++ b/local-modules/see-all/mocks/MockLogger.js
@@ -15,7 +15,7 @@ export default class MockLogger extends BaseLogger {
     super();
 
     /** {array<string>} Context to log per item. */
-    this._context = [];
+    this._context = Object.freeze([]);
 
     /** {array<array>} Array of logged items. */
     this._record = [];
@@ -28,7 +28,7 @@ export default class MockLogger extends BaseLogger {
   }
 
   _impl_log(level, message) {
-    this.record.push([level, ...message]);
+    this.record.push([level, this._context, ...message]);
   }
 
   _impl_withAddedContext(...context) {
@@ -37,7 +37,7 @@ export default class MockLogger extends BaseLogger {
     // Make the result (a) have additional context, and (b) point its `record`
     // at this instance.
 
-    result._context = [...this._context, ...context];
+    result._context = Object.freeze([...this._context, ...context]);
     result._record  = this._record;
 
     return result;

--- a/local-modules/see-all/mocks/MockLogger.js
+++ b/local-modules/see-all/mocks/MockLogger.js
@@ -14,24 +14,32 @@ export default class MockLogger extends BaseLogger {
   constructor() {
     super();
 
+    /** {array<string>} Context to log per item. */
+    this._context = [];
+
     /** {array<array>} Array of logged items. */
-    this.record = [];
+    this._record = [];
+
+    Object.seal(this);
   }
 
-  /**
-   * Actual logging implementation. Subclasses must override this to do
-   * something appropriate.
-   *
-   * @abstract
-   * @param {string} level Severity level. Guaranteed to be a valid level.
-   * @param {array} message Array of arguments to log.
-   */
+  get record() {
+    return this._record;
+  }
+
   _impl_log(level, message) {
     this.record.push([level, ...message]);
   }
 
-  _impl_withAddedContext(...context_unused) {
-    // Ignore it. **TODO:** Arguably ought to do something better.
-    return this;
+  _impl_withAddedContext(...context) {
+    const result = new MockLogger();
+
+    // Make the result (a) have additional context, and (b) point its `record`
+    // at this instance.
+
+    result._context = [...this._context, ...context];
+    result._record  = this._record;
+
+    return result;
   }
 }

--- a/local-modules/see-all/mocks/MockLogger.js
+++ b/local-modules/see-all/mocks/MockLogger.js
@@ -18,6 +18,12 @@ export default class MockLogger extends BaseLogger {
     this.record = [];
   }
 
+  // **TODO:** Arguably ought to do something better.
+  withAddedContext(...context_unused) {
+    // Ignore it.
+    return this;
+  }
+
   /**
    * Actual logging implementation. Subclasses must override this to do
    * something appropriate.

--- a/local-modules/see-all/tests/test_BaseLogger.js
+++ b/local-modules/see-all/tests/test_BaseLogger.js
@@ -59,26 +59,4 @@ describe('see-all/BaseLogger', () => {
       assert.deepEqual(logger.record, [['info', 'blort']]);
     });
   });
-
-  describe('withDynamicPrefix()', () => {
-    it('returns a logger which operates as expected', () => {
-      let count = 0;
-      function prefunc() {
-        count++;
-        return [count, 'x'];
-      }
-
-      const logger = new MockLogger();
-      const prefixer = logger.withDynamicPrefix(prefunc);
-
-      prefixer.info('one');
-      prefixer.info('two');
-      prefixer.info('three');
-      assert.deepEqual(logger.record, [
-        ['info', 1, 'x', 'one'],
-        ['info', 2, 'x', 'two'],
-        ['info', 3, 'x', 'three'],
-      ]);
-    });
-  });
 });

--- a/local-modules/see-all/tests/test_BaseLogger.js
+++ b/local-modules/see-all/tests/test_BaseLogger.js
@@ -17,7 +17,7 @@ describe('see-all/BaseLogger', () => {
       const logger = new MockLogger();
       logger.log('info', 'blort', 7);
 
-      assert.deepEqual(logger.record, [['info', 'blort', 7]]);
+      assert.deepEqual(logger.record, [['info', [], 'blort', 7]]);
     });
 
     it('rejects invalid `level` arguments', () => {
@@ -33,14 +33,14 @@ describe('see-all/BaseLogger', () => {
           const logger = new MockLogger();
           logger[level](1, 2, 3);
 
-          assert.deepEqual(logger.record, [[level, 1, 2, 3]]);
+          assert.deepEqual(logger.record, [[level, [], 1, 2, 3]]);
         });
 
         it('accepts a call with no arguments', () => {
           const logger = new MockLogger();
           logger[level]();
 
-          assert.deepEqual(logger.record, [[level]]);
+          assert.deepEqual(logger.record, [[level, []]]);
         });
       });
     }
@@ -56,7 +56,7 @@ describe('see-all/BaseLogger', () => {
       const stream = logger.streamFor('info');
 
       stream.write('blort');
-      assert.deepEqual(logger.record, [['info', 'blort']]);
+      assert.deepEqual(logger.record, [['info', [], 'blort']]);
     });
   });
 });

--- a/local-modules/see-all/tests/test_BaseLogger.js
+++ b/local-modules/see-all/tests/test_BaseLogger.js
@@ -60,16 +60,6 @@ describe('see-all/BaseLogger', () => {
     });
   });
 
-  describe('withPrefix()', () => {
-    it('returns a logger which operates as expected', () => {
-      const logger = new MockLogger();
-      const prefixer = logger.withPrefix('goodness', 'gracious');
-
-      prefixer.info('sakes', 'alive');
-      assert.deepEqual(logger.record, [['info', 'goodness', 'gracious', 'sakes', 'alive']]);
-    });
-  });
-
   describe('withDynamicPrefix()', () => {
     it('returns a logger which operates as expected', () => {
       let count = 0;

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { LogRecord } from 'see-all';
+import { LogRecord, LogTag } from 'see-all';
 
 describe('see-all/LogRecord', () => {
   describe('.LEVELS', () => {
@@ -49,8 +49,10 @@ describe('see-all/LogRecord', () => {
 
   describe('messageString()', () => {
     it('operates as expected', () => {
+      const LOG_TAG = new LogTag('whee');
+
       function test(expected, ...message) {
-        const lr = new LogRecord(0, 'some-stack-trace', 'info', 'blort', ...message);
+        const lr = new LogRecord(0, 'some-stack-trace', 'info', LOG_TAG, ...message);
         const got = lr.messageString;
         assert.strictEqual(got, expected);
       }

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -7,9 +7,6 @@ import { describe, it } from 'mocha';
 
 import { LogRecord } from 'see-all';
 
-// This class is tested via its subclass `MockLogger`, which records all calls
-// made to `_impl_log()`.
-
 describe('see-all/LogRecord', () => {
   describe('.LEVELS', () => {
     it('is a frozen array of at least four elements', () => {

--- a/local-modules/see-all/tests/test_LogStream.js
+++ b/local-modules/see-all/tests/test_LogStream.js
@@ -37,7 +37,7 @@ describe('see-all/LogStream', () => {
 
       ls.write('florp');
       ls.write('plorple\n');
-      assert.deepEqual(logger.record, [['info', 'florp'], ['info', 'plorple\n']]);
+      assert.deepEqual(logger.record, [['info', [], 'florp'], ['info', [], 'plorple\n']]);
     });
   });
 
@@ -47,7 +47,7 @@ describe('see-all/LogStream', () => {
       const ls = new LogStream(logger, 'debug');
 
       ls.write('florp', 'not-actually-a-valid-encoding');
-      assert.deepEqual(logger.record, [['debug', 'florp']]);
+      assert.deepEqual(logger.record, [['debug', [], 'florp']]);
     });
   });
 
@@ -72,7 +72,7 @@ describe('see-all/LogStream', () => {
       const ls = new LogStream(logger, 'error');
 
       ls.write(Buffer.from('😅', 'utf8'));
-      assert.deepEqual(logger.record, [['error', '😅']]);
+      assert.deepEqual(logger.record, [['error', [], '😅']]);
     });
   });
 
@@ -82,7 +82,7 @@ describe('see-all/LogStream', () => {
       const ls = new LogStream(logger, 'warn');
 
       ls.write(Buffer.from('😅', 'utf8'), 'ascii');
-      assert.deepEqual(logger.record, [['warn', '😅']]);
+      assert.deepEqual(logger.record, [['warn',  [], '😅']]);
     });
   });
 
@@ -92,7 +92,7 @@ describe('see-all/LogStream', () => {
       const ls = new LogStream(logger, 'info');
 
       ls.end('zorch');
-      assert.deepEqual(logger.record, [['info', 'zorch']]);
+      assert.deepEqual(logger.record, [['info',  [], 'zorch']]);
     });
   });
 
@@ -102,7 +102,7 @@ describe('see-all/LogStream', () => {
       const ls = new LogStream(logger, 'debug');
 
       ls.end('splat', 'not-actually-a-valid-encoding');
-      assert.deepEqual(logger.record, [['debug', 'splat']]);
+      assert.deepEqual(logger.record, [['debug',  [], 'splat']]);
     });
   });
 

--- a/local-modules/see-all/tests/test_LogTag.js
+++ b/local-modules/see-all/tests/test_LogTag.js
@@ -1,0 +1,75 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { LogTag } from 'see-all';
+
+describe('see-all/LogTag', () => {
+  describe('checkContextString()', () => {
+    it('accepts valid strings', () => {
+      function test(value) {
+        assert.strictEqual(LogTag.checkContextString(value), value);
+      }
+
+      test(''); // Maybe shouldn't be valid, but in fact it is right now.
+      test('a');
+      test('ab');
+      test('abc');
+      test('blort foo!');
+      test('1234567890123456789012345');
+    });
+
+    it('rejects invalid values', () => {
+      function test(level) {
+        assert.throws(() => { LogTag.checkContextString(level); });
+      }
+
+      test('12345678901234567890123456'); // Too long.
+      test(null);
+      test(undefined);
+      test(123);
+      test({ a: 10 });
+    });
+  });
+
+  describe('constructor', () => {
+    it('accepts valid main tags', () => {
+      function test(main) {
+        const lt = new LogTag(main);
+        assert.strictEqual(lt.main, main);
+      }
+
+      test('a');
+      test('florp');
+      test('florp-zorch');
+      test('__florp__');
+    });
+
+    it('accepts valid context strings', () => {
+      function test(...context) {
+        const lt = new LogTag('x', ...context);
+        assert.isArray(lt.context);
+        assert.isFrozen(lt.context);
+        assert.deepEqual(lt.context, context);
+      }
+
+      test();
+      test('a');
+      test('a', 'b');
+      test('a', 'b', 'c');
+      test('florp-like', 'timeline_sideways', 'x y z');
+    });
+  });
+
+  describe('withAddedContext()', () => {
+    it('adds the indicated context', () => {
+      const lt = new LogTag('x', 'foo', 'bar');
+      const result = lt.withAddedContext('zorch', 'florp');
+
+      assert.deepEqual(result.context, ['foo', 'bar', 'zorch', 'florp']);
+    });
+  });
+});

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -82,6 +82,22 @@ export default class TString extends UtilityClass {
   }
 
   /**
+   * Checks a value of type `String`, which must furthermore have no more than a
+   * given number of characters.
+   *
+   * @param {*} value Value to check.
+   * @param {number} maxLen Maximum allowed length (inclusive).
+   * @returns {string} `value`.
+   */
+  static maxLen(value, maxLen) {
+    if ((typeof value !== 'string') || (value.length > maxLen)) {
+      throw Errors.bad_value(value, String, `value.length <= ${maxLen}`);
+    }
+
+    return value;
+  }
+
+  /**
    * Checks a value of type `String`, which must furthermore have at least a
    * given number of characters.
    *

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -244,6 +244,101 @@ describe('typecheck/TString', () => {
     });
   });
 
+  describe('maxLen()', () => {
+    it('accepts short-enough strings', () => {
+      function test(value, len) {
+        assert.strictEqual(TString.maxLen(value, len), value);
+      }
+
+      test('', 0);
+      test('', 1);
+      test('', 10);
+      test('a', 1);
+      test('a', 2);
+      test('a', 100);
+      test('fooblort', 8);
+      test('fooblort', 80);
+    });
+
+    it('rejects too-long strings', () => {
+      function test(value, len) {
+        Assert.throwsInfo(
+          () => { TString.maxLen(value, len); },
+          'bad_value',
+          [inspect(value), 'String', `value.length <= ${len}`]);
+      }
+
+      test('a',   0);
+      test('ab',  0);
+      test('ab',  1);
+      test('abc', 0);
+      test('abc', 1);
+      test('abc', 2);
+    });
+
+    it('rejects non-strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.maxLen(value, 123); },
+          'bad_value',
+          [inspect(value), 'String', 'value.length <= 123']);
+      }
+
+      for (const v of NON_STRING_CASES) {
+        test(v);
+      }
+    });
+  });
+
+  describe('minLen()', () => {
+    it('accepts long-enough strings', () => {
+      function test(value, len) {
+        assert.strictEqual(TString.minLen(value, len), value);
+      }
+
+      test('', 0);
+      test('a', 0);
+      test('a', 1);
+      test('ab', 0);
+      test('ab', 1);
+      test('ab', 2);
+      test('fooblort', 7);
+      test('fooblort', 8);
+    });
+
+    it('rejects too-short strings', () => {
+      function test(value, len) {
+        Assert.throwsInfo(
+          () => { TString.minLen(value, len); },
+          'bad_value',
+          [inspect(value), 'String', `value.length >= ${len}`]);
+      }
+
+      test('',    1);
+      test('',    10);
+      test('a',   2);
+      test('a',   3);
+      test('ab',  3);
+      test('ab',  4);
+      test('abc', 4);
+      test('abc', 5);
+      test('abc', 123);
+    });
+
+    it('rejects non-strings', () => {
+      function test(value) {
+        Assert.throwsInfo(
+          () => { TString.minLen(value, 1); },
+          'bad_value',
+          [inspect(value), 'String', 'value.length >= 1']);
+      }
+
+      for (const v of NON_STRING_CASES) {
+        test(v);
+      }
+    });
+  });
+
   describe('nonEmpty()', () => {
     it('should return the provided value if it is a string with length >= 1', () => {
       const value = 'This better work!';


### PR DESCRIPTION
I expect that this PR is the last major chunk of work on logging infrastructure for a while. The main change is that all of the "context" bits that get included in some log lines are now treated as their own thing instead of getting lumped in with the message arguments. This lets them get marked up reasonably distinctively in the console (both client and server) and in the rendering of the `/debug/log` endpoint; and it lets them get collated sensibly in the structured file log (which is a series of newline-delimited JSON objects).