### PR TITLE
Rework instance encoding.

### DIFF
--- a/client/assets/boot-from-key.js
+++ b/client/assets/boot-from-key.js
@@ -32,7 +32,7 @@
   // code we need to know the base URL, whee! So we just do the minimal bit of
   // parsing needed to get the URL and then head on our merry way.
   var key = JSON.parse(window.BAYOU_KEY);
-  var url = key[1]; // See `SplitKey.js`, the encoded form in particular.
+  var url = key.SplitKey[0]; // See `SplitKey.js`, the encoded form in particular.
   var baseUrl = ((url === '*') ? window.location : new URL(url)).origin;
 
   // Add the main JavaScript bundle to the page. Once loaded, this continues

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -29,21 +29,22 @@ import { CommonBase, Errors, ObjectUtil } from 'util-common';
  *   from `encode()` is a payload which is suitable for passing into `decode()`
  *   on the same (or equivalent) item codec.
  *
- * In most cases, the encoded payload returned by `encode()` and taken by
- * `decode()` is a plain object with a single string key binding an array. This
- * is the classic "reconstruction arguments" style of object coding, and is what
- * is done by instances produced by the `fromClass()` static method. However,
- * this system also supports two other possibilities:
+ * In most cases, the encoded payload returned by the provided `encode()`
+ * function and taken by the provided `decode()` function is an array of
+ * arbitrary values. This is the classic "reconstruction arguments" style of
+ * object coding, and is what is done by instances produced by the `fromClass()`
+ * static method. In such cases, the public {@link #encode} and {@link #decode}
+ * methods exported by this class use a plain object with a single string key
+ * binding, which binds the instance's tag string to the arguments array.
  *
- * * The encoded form is allowed to be a plain JavaScript array.
+ * This system also supports the possibility of encoding into and decoding from
+ * something other than "reconstruction arguments" form. (This is indicated by
+ * the instance using a type-based tag instead of a regular tag string.) In
+ * practice, this is used to encode simple values (e.g. numbers and literal
+ * strings) and arrays.
  *
- * * The encoded form is allowed to be a non-object value, such as a number or
- *   string.
- *
- * In these cases, the codec instance needs to be tagged with the type of the
- * value and not a class-name-like string. For the purposes of this class, the
- * value `null` is considered a distinct type from non-null object values and
- * has the type name `'null'`; and arrays have type `array`.
+ * **Note:** For the purposes of this class, `null`, arrays, plain objects, and
+ * class instances are all considered distinct types.
  */
 export default class ItemCodec extends CommonBase {
   /**

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TArray, TFunction, TString } from 'typecheck';
-import { CommonBase, Errors } from 'util-common';
+import { CommonBase, Errors, ObjectUtil } from 'util-common';
 
 /**
  * Handler for codable items of a particular class, type, or (in general) kind.
@@ -30,13 +30,12 @@ import { CommonBase, Errors } from 'util-common';
  *   on the same (or equivalent) item codec.
  *
  * In most cases, the encoded payload returned by `encode()` and taken by
- * `decode()` is an array. This is the classic "reconstruction arguments" style
- * of object coding, and is what is done by instances produced by the
- * `fromClass()` static method. However, this system also supports two other
- * possibilities:
+ * `decode()` is a plain object with a single string key binding an array. This
+ * is the classic "reconstruction arguments" style of object coding, and is what
+ * is done by instances produced by the `fromClass()` static method. However,
+ * this system also supports two other possibilities:
  *
- * * The encoded form is allowed to be a plain JavaScript object, that is, a
- *   simple mapping of string keys to arbitrary values.
+ * * The encoded form is allowed to be a plain JavaScript array.
  *
  * * The encoded form is allowed to be a non-object value, such as a number or
  *   string.
@@ -44,24 +43,40 @@ import { CommonBase, Errors } from 'util-common';
  * In these cases, the codec instance needs to be tagged with the type of the
  * value and not a class-name-like string. For the purposes of this class, the
  * value `null` is considered a distinct type from non-null object values and
- * has the type name `'null'`.
+ * has the type name `'null'`; and arrays have type `array`.
  */
 export default class ItemCodec extends CommonBase {
   /**
    * Gets the tag string (either explicit or implicit) of the given payload.
-   * This returns `null` if the payload can't possibly be valid; this is the
-   * case for empty arrays and arrays whose first element is not a string.
+   * This returns `null` if the payload can't possibly be valid.
    *
    * @param {*} payload The payload in question.
    * @returns {string|null} The tag of the payload, or `null` if it is not a
    *   valid payload.
    */
   static tagFromPayload(payload) {
-    if (Array.isArray(payload)) {
-      const tag = payload[0];
-      return ((typeof tag) === 'string') ? tag : null;
+    const type = ItemCodec.typeOf(payload);
+
+    if (type === 'object') {
+      if (!ObjectUtil.isPlain(payload)) {
+        return null;
+      }
+
+      const entries = Object.entries(payload);
+
+      if (entries.length !== 1) {
+        return null;
+      }
+
+      const [key, value] = entries[0];
+
+      if ((typeof key === 'string') && Array.isArray(value)) {
+        return key;
+      } else {
+        return null;
+      }
     } else {
-      return ItemCodec.tagFromType(ItemCodec.typeOf(payload));
+      return ItemCodec.tagFromType(type);
     }
   }
 
@@ -89,15 +104,30 @@ export default class ItemCodec extends CommonBase {
   }
 
   /**
-   * Like `typeof value`, except that `null` is treated as its own type, instead
-   * of being called an `object`.
+   * Like `typeof value`, except:
+   *
+   * * `null` is given the type `null`, instead of `object`.
+   * * Arrays are given the type `array`, instead of `object`.
+   * * Other non-plain objects (aside from functions) are given the type
+   *   `instance`.
    *
    * @param {*} value Value in question.
-   * @returns {string} Name of value's type, with the type of `null` being
-   *   `'null'`.
+   * @returns {string} Name of value's type.
    */
   static typeOf(value) {
-    return (value === null) ? 'null' : (typeof value);
+    const rawType = typeof value;
+
+    if (rawType !== 'object') {
+      return rawType;
+    } else if (value === null) {
+      return 'null';
+    } else if (Array.isArray(value)) {
+      return 'array';
+    } else if (Object.getPrototypeOf(value) !== Object.prototype) {
+      return 'instance';
+    } else {
+      return 'object';
+    }
   }
 
   /**
@@ -168,7 +198,7 @@ export default class ItemCodec extends CommonBase {
       : null;
 
     /** {string} Name of the type which identifies qualified values. */
-    this._type = (this._clazz !== null) ? 'object' : TString.check(clazzOrType);
+    this._type = (this._clazz !== null) ? 'instance' : TString.check(clazzOrType);
 
     /**
      * {function|null} Additional predicate that must be `true` of values for
@@ -276,9 +306,9 @@ export default class ItemCodec extends CommonBase {
       throw Errors.bad_value(payload, 'encoded payload');
     }
 
-    if (Array.isArray(payload)) {
-      // Strip off the tag before passing to `decode()`.
-      payload = payload.slice(1);
+    if (ObjectUtil.isPlain(payload)) {
+      // Extract the array of reconstruction arguments to pass to `_decode()`.
+      payload = Object.values(payload)[0];
     }
 
     const result = this._decode(payload, subDecode);
@@ -307,10 +337,10 @@ export default class ItemCodec extends CommonBase {
     }
 
     const encodedType = this._encodedType;
-    const result      = this._encode(value, subEncode);
+    let   result      = this._encode(value, subEncode);
 
     // Validate the result, and in the case of normal "construction arguments"
-    // arrays, add the tag as the first element of the payload.
+    // arrays, wrap it in a single-key plain object, using the tag as the key.
     if (encodedType === null) {
       try {
         TArray.check(result);
@@ -319,7 +349,7 @@ export default class ItemCodec extends CommonBase {
         throw Errors.bad_use('Invalid encoding result (not an array).');
       }
 
-      result.unshift(this._tag);
+      result = { [this._tag]: Object.freeze(result) };
     } else if (ItemCodec.typeOf(result) !== encodedType) {
       throw Errors.bad_use('Invalid encoding result: ' +
         `got type ${ItemCodec.typeOf(result)}; expected type ${encodedType}`);

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -124,10 +124,10 @@ export default class ItemCodec extends CommonBase {
       return 'null';
     } else if (Array.isArray(value)) {
       return 'array';
-    } else if (Object.getPrototypeOf(value) !== Object.prototype) {
-      return 'instance';
-    } else {
+    } else if (Object.getPrototypeOf(value) === Object.prototype) {
       return 'object';
+    } else {
+      return 'instance';
     }
   }
 

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -133,8 +133,7 @@ export default class Registry extends CommonBase {
     let clazz;
     let codecs;
 
-    if (   (valueType === 'object')
-        && (Object.getPrototypeOf(value) !== Object.prototype)) {
+    if (valueType === 'instance') {
       // The value is an instance of a class. Look up the class in the registry.
       // **Note:** We don't try to find superclass codecs. (This is an
       // intentional design choice.)
@@ -142,7 +141,7 @@ export default class Registry extends CommonBase {
       codecs = this._classToCodecs.get(clazz);
     } else {
       // The value is a non-class-instance, including possibly being a plain
-      // object (e.g., `{ florps: 10 }`) or `null`.
+      // object (e.g., `{ florps: 10 }`), an array, or `null`.
       clazz = null;
       codecs = this._typeToCodecs.get(valueType);
     }

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -82,8 +82,9 @@ export default class Registry extends CommonBase {
     // Add the codec to the appropriate reverse map.
 
     const [reverseMap, key] = (clazz === null)
-      ? [this._typeToCodecs,  codec.encodedType]
+      ? [this._typeToCodecs,  codec.type]
       : [this._classToCodecs, clazz];
+
     let codecs = reverseMap.get(key);
 
     if (!codecs) {

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -140,8 +140,11 @@ export default class SpecialCodecs extends UtilityClass {
    * @returns {object} Encoded form.
    */
   static _objectEncode(value, subEncode) {
-    return Object.entries(value).map(([k, v]) => {
-      return Object.freeze([k, subEncode(v)]);
+    // Sort the keys to avoid nondeterminism.
+    const keys = Object.keys(value).sort();
+
+    return keys.map((key) => {
+      return Object.freeze([key, subEncode(value[key])]);
     });
   }
 

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -13,7 +13,7 @@ import ItemCodec from './ItemCodec';
 export default class SpecialCodecs extends UtilityClass {
   /** {ItemCodec} Codec used for coding arrays. */
   static get ARRAY() {
-    return new ItemCodec('a', Array, this._arrayPredicate,
+    return new ItemCodec(ItemCodec.tagFromType('array'), 'array', this._arrayPredicate,
       this._arrayEncode, this._arrayDecode);
   }
 
@@ -108,7 +108,7 @@ export default class SpecialCodecs extends UtilityClass {
 
   /** {ItemCodec} Codec used for coding plain objects. */
   static get PLAIN_OBJECT() {
-    return new ItemCodec(ItemCodec.tagFromType('object'), 'object',
+    return new ItemCodec('object', 'object',
       ObjectUtil.isPlain, this._objectEncode, this._objectDecode);
   }
 
@@ -124,7 +124,7 @@ export default class SpecialCodecs extends UtilityClass {
   static _objectDecode(payload, subDecode) {
     // Iterate over all the properties in `payload`, decoding the bound values.
     const result = {};
-    for (const [k, v] of Object.entries(payload)) {
+    for (const [k, v] of payload) {
       result[k] = subDecode(v);
     }
 
@@ -140,13 +140,9 @@ export default class SpecialCodecs extends UtilityClass {
    * @returns {object} Encoded form.
    */
   static _objectEncode(value, subEncode) {
-    // Iterate over all the properties in `value`, encoding the bound values.
-    const result = {};
-    for (const [k, v] of Object.entries(value)) {
-      result[k] = subEncode(v);
-    }
-
-    return result;
+    return Object.entries(value).map(([k, v]) => {
+      return Object.freeze([k, subEncode(v)]);
+    });
   }
 
   /**

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -30,26 +30,32 @@ describe('api-common/Codec.decode*()', () => {
 
   describe('decodeData()', () => {
     it('should pass non-object values through as-is', () => {
-      assert.strictEqual(decodeData(37), 37);
-      assert.strictEqual(decodeData(true), true);
-      assert.strictEqual(decodeData(false), false);
-      assert.strictEqual(decodeData('Happy string'), 'Happy string');
-      assert.isNull(decodeData(null));
+      function test(value) {
+        assert.strictEqual(decodeData(value), value);
+      }
+
+      test(37);
+      test(true);
+      test(false);
+      test('Happy string');
+      test(null);
     });
 
-    it('should accept plain objects', () => {
-      // The tests here are of objects whose values all decode to themselves.
-      assert.deepEqual(decodeData({}), {});
-      assert.deepEqual(decodeData({ a: true, b: 'yo' }), { a: true, b: 'yo' });
+    it('should pass arrays with only data values through as-is', () => {
+      function test(value) {
+        assert.deepEqual(decodeData(value), value);
+      }
+
+      test([]);
+      test([true]);
+      test([1, false, 'x']);
+      test([[[null]]]);
     });
 
-    it('should reject arrays whose first value is not a string', () => {
-      assert.throws(() => decodeData([]));
-      assert.throws(() => decodeData([1, 2, 3, '4 5 6']));
-      assert.throws(() => decodeData([true, 2, 3, '4 5 6']));
-      assert.throws(() => decodeData([null, 2, 3, '4 5 6']));
-      assert.throws(() => decodeData([[], 2, 3, '4 5 6']));
-      assert.throws(() => decodeData([() => true, 2, 3, '4 5 6']));
+    it('should reject plain objects not in "encoded instance" form', () => {
+      assert.throws(() => decodeData({}));
+      assert.throws(() => decodeData({ a: 123 }));
+      assert.throws(() => decodeData({ foo: [], x: [] }));
     });
 
     it('should reject functions', () => {
@@ -80,7 +86,7 @@ describe('api-common/Codec.decode*()', () => {
     it('should decode as expected', () => {
       assert.strictEqual(decodeJson('null'), null);
       assert.strictEqual(decodeJson('914'), 914);
-      assert.deepEqual(decodeJson('{"a":10,"b":20}'), { a: 10, b: 20 });
+      assert.deepEqual(decodeJson('{ "object": [["a", 10], ["b", 20]] }'), { a: 10, b: 20 });
     });
   });
 
@@ -92,7 +98,7 @@ describe('api-common/Codec.decode*()', () => {
 
       assert.strictEqual(bufAndDecode('null'), null);
       assert.strictEqual(bufAndDecode('914'), 914);
-      assert.deepEqual(bufAndDecode('{"a":10,"b":20}'), { a: 10, b: 20 });
+      assert.deepEqual(bufAndDecode('{ "object": [["a", 10], ["b", 20]] }'), { a: 10, b: 20 });
     });
   });
 });

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -82,6 +82,16 @@ describe('api-common/Codec.encode*()', () => {
       test({ c: 'yay', d: [1, 2, 3] });
     });
 
+    it('should sort plain object keys in encoded form', () => {
+      const orig   = { d: [1, 2, 3], a: { c: 'cx', b: 'bx' } };
+      const expect = { object: [
+        ['a', { object: [['b', 'bx'], ['c', 'cx']] }],
+        ['d', [1, 2, 3]]]
+      };
+
+      assert.deepEqual(encodeData(orig), expect);
+    });
+
     it('should reject objects with no `deconstruct()` method', () => {
       class NoDeconstruct {
         get CODEC_TAG() {

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -25,18 +25,6 @@ class RegistryTestClass {
   }
 }
 
-class NoCodecTag {
-  deconstruct() {
-    return 'NoCodecTag!';
-  }
-}
-
-class NoToCodecArgs {
-  constructor() {
-    this.CODEC_TAG = 'NoToCodecArgs';
-  }
-}
-
 describe('api-common/Registry', () => {
   describe('register()', () => {
     it('should accept a class with all salient properties', () => {
@@ -45,13 +33,25 @@ describe('api-common/Registry', () => {
     });
 
     it('should allow classes without `CODEC_TAG`', () => {
+      class NoCodecTag {
+        deconstruct() {
+          return 'NoCodecTag!';
+        }
+      }
+
       const reg = new Registry();
       assert.doesNotThrow(() => reg.registerClass(NoCodecTag));
     });
 
     it('should reject a class without `deconstruct()`', () => {
+      class NoDeconstruct {
+        get CODEC_TAG() {
+          return 'NoDeconstruct';
+        }
+      }
+
       const reg = new Registry();
-      assert.throws(() => reg.registerClass(NoToCodecArgs));
+      assert.throws(() => reg.registerClass(NoDeconstruct));
     });
 
     it('should reject non-classes', () => {
@@ -69,7 +69,7 @@ describe('api-common/Registry', () => {
   describe('codecForPayload()', () => {
     it('should throw an error if an unregistered tag is requested', () => {
       const reg = new Registry();
-      assert.throws(() => reg.codecForPayload(['florp']));
+      assert.throws(() => reg.codecForPayload({ florp: [1, 2, 3] }));
 
       // Throws because `Symbol` wasn't a registered type.
       assert.throws(() => reg.codecForPayload(Symbol('foo')));
@@ -81,7 +81,7 @@ describe('api-common/Registry', () => {
 
       reg.registerCodec(itemCodec);
 
-      const testCodec = reg.codecForPayload(['florp']);
+      const testCodec = reg.codecForPayload({ florp: [1, 2, 3] });
       assert.strictEqual(testCodec, itemCodec);
     });
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.33.0
+version = 0.34.0


### PR DESCRIPTION
This PR has a good chance of being the last change to the JSON representation of our encoded values (which go across an API boundary and are stored in files / a db). Here's the commit message from the most interesting commit in this PR (mildly edited):

>Switch to using single-binding plain objects to represent instances. This is instead of using "tagged" arrays. 
>
>Before:
>* Instances encode as `['<tag>', <arg>, ...]`.
>* Arrays encode as `['array', <elem>, ...]` (array with literal `array` first element).
>* Plain objects self-encode.
>
>Now:
>
>* Instances encode as `{ <tag>: [<arg>, ...] }` (plain object with single binding).
>* Arrays self-encode. 
>* Plain objects encode as `{ object: [[<k>, <v>], ...] }` (literal `object` key).
>
>The new instance encoding form was inspired by how Quill represents the payloads for custom blots (it is pretty much recapitulated exactly). The impetus was that our data encodes arrays way more than it encodes plain objects, so it was a poor choice for arrays to be the encoded form of instances.

There will almost certainly be more churn in the `codec` module, but I think this is pretty much the end of the line for how we'll map our object hierarchies to and from JSON.

