### PR TITLE
String constant (particularly enum-like constant) naming conventions.

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -195,10 +195,10 @@ taking into account recent additions to the language.
   content of the related string, via one of two mappings:
 
   * The preferred way is to use a common all-caps prefix for all the constants,
-    followed by an underscore, and followed by the constant value in the same
-    casing as its value. For example, use the variable name `CODE_bakeCake` for
-    the string `"bakeCake"` and the variable name `CODE_eatCake` for `"eatCake"`
-    as part of the same enumeration.
+    followed by an underscore, and followed by the constant value in
+    `camelCase`. For example, use the variable name `CODE_bakeCake` for the
+    string `"bakeCake"` and the variable name `CODE_eatCake` for `"eatCake"` as
+    part of the same enumeration.
 
     This way is _especially_ preferred if the string values "leak" beyond the
     code, e.g., if they end up represented in databases or get transmitted
@@ -224,7 +224,9 @@ taking into account recent additions to the language.
   endeavor to do so.
 
 * Prefer `lowerCamelCase` for constant values, except if there is an external
-  dependency that requires otherwise.
+  dependency that requires otherwise. Notably, Quill event names (like many
+  Javascript event names) use `lower-kebab-case`; and many external services
+  use `lower_snake_case`.
 
 #### Other items
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -200,6 +200,10 @@ taking into account recent additions to the language.
     the string `"bakeCake"` and the variable name `CODE_eatCake` for `"eatCake"`
     as part of the same enumeration.
 
+    This way is _especially_ preferred if the string values "leak" beyond the
+    code, e.g., if they end up represented in databases or get transmitted
+    across an API boundary.
+
   * The less recommended (but still acceptable, for now) way is to convert the
     constant value to `UPPER_SNAKE_CASE` and have that be the name. For example,
     the strings of the previous example would be stored in static variables

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -225,8 +225,8 @@ taking into account recent additions to the language.
 
 * Prefer `lowerCamelCase` for constant values, except if there is an external
   dependency that requires otherwise. Notably, Quill event names (like many
-  Javascript event names) use `lower-kebab-case`; and many external services
-  use `lower_snake_case`.
+  Javascript event names) and CSS selectors use `lower-kebab-case`; and many
+  external services use `lower_snake_case`.
 
 #### Other items
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -188,13 +188,41 @@ taking into account recent additions to the language.
   Roughly speaking, you can think of this as an "instance sandwich on static
   bread."
 
-#### Other items
+#### Enumerated constants
 
-* Websockets &mdash; JavaScript has a `WebSocket` class, but when talking about
-  them in prose or in our own variable or class names, we use "websocket" (one
-  word, all lower case, though capitalized as appropriate for prose or
-  `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
-  variable that contains an instance of one (or something related).
+* Use immutable static variables to name constants instead of just using
+  quoted strings directly. The name of the variable should generally match the
+  content of the related string, via one of two mappings:
+
+  * The preferred way is to use a common all-caps prefix for all the constants,
+    followed by an underscore, and followed by the constant value in the same
+    casing as its value. For example, use the variable name `CODE_bakeCake` for
+    the string `"bakeCake"` and the variable name `CODE_eatCake` for `"eatCake"`
+    as part of the same enumeration.
+
+  * The less recommended (but still acceptable, for now) way is to convert the
+    constant value to `UPPER_SNAKE_CASE` and have that be the name. For example,
+    the strings of the previous example would be stored in static variables
+    named `BAKE_CAKE` and `EAT_CAKE` respectively.
+
+* The preferred way to define static constants is via a static getter function,
+  e.g.:
+
+  ```javascript
+  class CakeCodes {
+    static get CODE_bakeCake() { return 'bakeCake'; }
+    static get CODE_eatCake()  { return 'eatCake'; }
+    ...
+  }
+  ```
+
+  Once JavaScript gains the ability to define these in a better way, we will
+  endeavor to do so.
+
+* Prefer `lowerCamelCase` for constant values, except if there is an external
+  dependency that requires otherwise.
+
+#### Other items
 
 * Immediate-async blocks &mdash; When programming in the `async`/`await` style,
   sometimes it's useful to to "spawn" an independent thread of control which
@@ -233,3 +261,9 @@ taking into account recent additions to the language.
     ...
   }
   ```
+
+* Websockets &mdash; JavaScript has a `WebSocket` class, but when talking about
+  them in prose or in our own variable or class names, we use "websocket" (one
+  word, all lower case, though capitalized as appropriate for prose or
+  `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
+  variable that contains an instance of one (or something related).

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -209,7 +209,7 @@ taking into account recent additions to the language.
     the strings of the previous example would be stored in static variables
     named `BAKE_CAKE` and `EAT_CAKE` respectively.
 
-* The preferred way to define static constants is via a static getter function,
+* The preferred way to define static constants is via static getter functions,
   e.g.:
 
   ```javascript

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -267,3 +267,9 @@ taking into account recent additions to the language.
   word, all lower case, though capitalized as appropriate for prose or
   `camelCasing`). In addition, `ws` is a good choice for a shorthand name of a
   variable that contains an instance of one (or something related).
+
+### Exceptions to the conventions
+
+Because nobody and no scheme is perfect, there are no doubt exceptions to the
+conventions, probably inadvertently. These should be considered opportunities
+for an easy fix as opposed to being examples to emulate.

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -42,8 +42,8 @@ taking into account recent additions to the language.
   in annotations as if they were real types. The names are always capitalized.
 
 * When documenting functions marked `async`, the implicit promise returned by
-  the function should _not_ be represented in its prose or `@returns`
-  documentation. For example:
+  the function should _not_ typically be represented in its prose or `@returns`
+  documentation:
 
   ```javascript
   /**
@@ -69,6 +69,10 @@ taking into account recent additions to the language.
     return 'frobnicator';
   }
   ```
+
+  As an exception, if the asynchronous behavior warrants specific detail, it
+  is okay to describe that behavior (but still leave the `@returns` doc
+  unmarked).
 
 #### Module imports and exports
 

--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -71,7 +71,7 @@ export default class TargetHandler extends CommonBase {
    * @param {array} args_unused List of arguments passed to the call.
    */
   apply(target_unused, thisArg_unused, args_unused) {
-    throw Errors.bad_use('Unsupported proxy operation.');
+    throw Errors.badUse('Unsupported proxy operation.');
   }
 
   /**
@@ -83,7 +83,7 @@ export default class TargetHandler extends CommonBase {
    *   called, which is to say, the proxy object.
    */
   construct(target_unused, args_unused, newTarget_unused) {
-    throw Errors.bad_use('Unsupported proxy operation.');
+    throw Errors.badUse('Unsupported proxy operation.');
   }
 
   /**
@@ -142,7 +142,7 @@ export default class TargetHandler extends CommonBase {
    * @param {string} property_unused The property name.
    */
   getOwnPropertyDescriptor(target_unused, property_unused) {
-    throw Errors.bad_use('Unsupported proxy operation.');
+    throw Errors.badUse('Unsupported proxy operation.');
   }
 
   /**

--- a/local-modules/api-client/TargetMap.js
+++ b/local-modules/api-client/TargetMap.js
@@ -49,7 +49,7 @@ export default class TargetMap extends CommonBase {
    */
   add(id) {
     if (this.getOrNull(id) !== null) {
-      throw Errors.bad_use(`Already bound: ${id}`);
+      throw Errors.badUse(`Already bound: ${id}`);
     }
 
     const result = TargetHandler.makeProxy(this._sendMessage, id);
@@ -75,7 +75,7 @@ export default class TargetMap extends CommonBase {
     const result = this.getOrNull(id);
 
     if (result === null) {
-      throw Errors.bad_use(`No such target: ${id}`);
+      throw Errors.badUse(`No such target: ${id}`);
     }
 
     return result;

--- a/local-modules/api-client/tests/test_TargetHandler.js
+++ b/local-modules/api-client/tests/test_TargetHandler.js
@@ -42,7 +42,7 @@ describe('api-common/TargetHandler', () => {
 
     it('should reject a non-callable `sendMessage` argument', () => {
       function test(value) {
-        assert.throws(() => new TargetHandler(value, 'some-target-id'), /bad_value/);
+        assert.throws(() => new TargetHandler(value, 'some-target-id'), /badValue/);
       }
 
       // Classes defined with `class ...` aren't callable.
@@ -60,7 +60,7 @@ describe('api-common/TargetHandler', () => {
     it('should reject a non-id `targetId` argument', () => {
       function test(value) {
         const func = () => { /*empty*/ };
-        assert.throws(() => new TargetHandler(func, value), /bad_value/);
+        assert.throws(() => new TargetHandler(func, value), /badValue/);
       }
 
       // Strings but not valid target IDs.
@@ -81,7 +81,7 @@ describe('api-common/TargetHandler', () => {
       const func = () => { throw new Error('should not have been called'); };
       const th = new TargetHandler(func, 'some-target-id');
       const proxy = new Proxy(func, th);
-      assert.throws(() => th.apply(func, proxy, [1, 2, 3]), /bad_use/);
+      assert.throws(() => th.apply(func, proxy, [1, 2, 3]), /badUse/);
     });
   });
 
@@ -90,7 +90,7 @@ describe('api-common/TargetHandler', () => {
       const func = () => { throw new Error('should not have been called'); };
       const th = new TargetHandler(func, 'some-target-id');
       const proxy = new Proxy(func, th);
-      assert.throws(() => th.construct(func, [1, 2, 3], proxy), /bad_use/);
+      assert.throws(() => th.construct(func, [1, 2, 3], proxy), /badUse/);
     });
   });
 

--- a/local-modules/api-common/BaseKey.js
+++ b/local-modules/api-common/BaseKey.js
@@ -61,7 +61,7 @@ export default class BaseKey extends CommonBase {
    */
   get baseUrl() {
     if (this._url === '*') {
-      throw Errors.bad_use('Cannot get base of wildcard URL.');
+      throw Errors.badUse('Cannot get base of wildcard URL.');
     }
 
     return new URL(this._url).origin;

--- a/local-modules/api-common/Response.js
+++ b/local-modules/api-common/Response.js
@@ -32,7 +32,7 @@ export default class Response extends CommonBase {
 
     // Validate the `error` / `result` combo.
     if ((result !== null) && (error !== null)) {
-      throw Errors.bad_use('`result` and `error` cannot both be non-`null`.');
+      throw Errors.badUse('`result` and `error` cannot both be non-`null`.');
     }
 
     /** {Int} Message ID. */

--- a/local-modules/api-common/TargetId.js
+++ b/local-modules/api-common/TargetId.js
@@ -32,7 +32,7 @@ export default class TargetId extends UtilityClass {
       return TString.check(value, VALID_TARGET_ID_REGEX);
     } catch (e) {
       // Throw a higher-fidelity error.
-      throw Errors.bad_value(value, TargetId);
+      throw Errors.badValue(value, TargetId);
     }
   }
 
@@ -51,7 +51,7 @@ export default class TargetId extends UtilityClass {
       return value;
     } catch (e) {
       // Throw a higher-fidelity error.
-      throw Errors.bad_value(value, TargetId, `length >= ${minLen}`);
+      throw Errors.badValue(value, TargetId, `length >= ${minLen}`);
     }
   }
 }

--- a/local-modules/api-common/tests/test_TargetId.js
+++ b/local-modules/api-common/tests/test_TargetId.js
@@ -28,7 +28,7 @@ describe('api-common/TargetId', () => {
 
     it('should reject strings with invalid characters', () => {
       function test(value) {
-        assert.throws(() => TargetId.check(value), /bad_value/);
+        assert.throws(() => TargetId.check(value), /badValue/);
       }
 
       test('!');
@@ -38,18 +38,18 @@ describe('api-common/TargetId', () => {
     });
 
     it('should reject the empty string', () => {
-      assert.throws(() => TargetId.check(''), /bad_value/);
+      assert.throws(() => TargetId.check(''), /badValue/);
     });
 
     it('should reject too-long strings', () => {
       for (let i = 65; i < 100; i++) {
-        assert.throws(() => TargetId.check('x'.repeat(i)), /bad_value/);
+        assert.throws(() => TargetId.check('x'.repeat(i)), /badValue/);
       }
     });
 
     it('should reject non-strings', () => {
       function test(value) {
-        assert.throws(() => TargetId.check(value), /bad_value/);
+        assert.throws(() => TargetId.check(value), /badValue/);
       }
 
       test(null);
@@ -73,7 +73,7 @@ describe('api-common/TargetId', () => {
 
     it('should reject strings with invalid characters', () => {
       function test(value) {
-        assert.throws(() => TargetId.minLen(value, 5), /bad_value/);
+        assert.throws(() => TargetId.minLen(value, 5), /badValue/);
       }
 
       test('!abcd');
@@ -84,7 +84,7 @@ describe('api-common/TargetId', () => {
 
     it('should reject too-short strings', () => {
       function test(value, minLen) {
-        assert.throws(() => TargetId.minLen(value, minLen), /bad_value/);
+        assert.throws(() => TargetId.minLen(value, minLen), /badValue/);
       }
 
       test('', 1);
@@ -97,13 +97,13 @@ describe('api-common/TargetId', () => {
 
     it('should reject too-long strings', () => {
       for (let i = 65; i < 100; i++) {
-        assert.throws(() => TargetId.minLen('x'.repeat(i), 10), /bad_value/);
+        assert.throws(() => TargetId.minLen('x'.repeat(i), 10), /badValue/);
       }
     });
 
     it('should reject non-strings', () => {
       function test(value) {
-        assert.throws(() => TargetId.check(value, 2), /bad_value/);
+        assert.throws(() => TargetId.check(value, 2), /badValue/);
       }
 
       test(null);

--- a/local-modules/api-server/BearerToken.js
+++ b/local-modules/api-server/BearerToken.js
@@ -50,7 +50,7 @@ export default class BearerToken extends BaseKey {
     if (!Hooks.theOne.bearerTokens.isToken(secretToken)) {
       // We don't include any real detail in the error message, as that might
       // inadvertently leak a secret into the logs.
-      throw Errors.bad_value('(hidden)', 'secret token');
+      throw Errors.badValue('(hidden)', 'secret token');
     }
 
     super('*', Hooks.theOne.bearerTokens.tokenId(secretToken));

--- a/local-modules/api-server/Connection.js
+++ b/local-modules/api-server/Connection.js
@@ -159,7 +159,7 @@ export default class Connection extends CommonBase {
 
     // We _don't_ include the passed argument, as that might end up revealing
     // secret info.
-    throw Errors.bad_use('Invalid target.');
+    throw Errors.badUse('Invalid target.');
   }
 
   /**

--- a/local-modules/api-server/Context.js
+++ b/local-modules/api-server/Context.js
@@ -97,7 +97,7 @@ export default class Context extends CommonBase {
     const id = target.id;
 
     if (this._map.get(id) !== undefined) {
-      throw Errors.bad_use(`Duplicate target: \`${id}\``);
+      throw Errors.badUse(`Duplicate target: \`${id}\``);
     }
 
     this._map.set(id, target);
@@ -141,7 +141,7 @@ export default class Context extends CommonBase {
     const result = this.getOrNull(id);
 
     if (!result) {
-      throw Errors.bad_use(`Unknown target: \`${id}\``);
+      throw Errors.badUse(`Unknown target: \`${id}\``);
     }
 
     return result;
@@ -159,7 +159,7 @@ export default class Context extends CommonBase {
     const result = this.get(id);
 
     if (result.key === null) {
-      throw Errors.bad_use(`Not a controlled target: \`${id}\``);
+      throw Errors.badUse(`Not a controlled target: \`${id}\``);
     }
 
     return result;
@@ -190,7 +190,7 @@ export default class Context extends CommonBase {
     const result = this.get(id);
 
     if (result.key !== null) {
-      throw Errors.bad_use(`Unauthorized target: \`${id}\``);
+      throw Errors.badUse(`Unauthorized target: \`${id}\``);
     }
 
     return result;

--- a/local-modules/api-server/MetaHandler.js
+++ b/local-modules/api-server/MetaHandler.js
@@ -56,7 +56,7 @@ export default class MetaHandler {
     if (!challengeInfo || (response !== challengeInfo.response)) {
       // **Note:** We don't differentiate reasons for rejection (beyond type
       // checking, above), as that could reveal security-sensitive info.
-      throw Errors.bad_use('Invalid challenge pair.');
+      throw Errors.badUse('Invalid challenge pair.');
     }
 
     const id = challengeInfo.id;

--- a/local-modules/api-server/Target.js
+++ b/local-modules/api-server/Target.js
@@ -105,7 +105,7 @@ export default class Target extends CommonBase {
 
     if (schema.getDescriptor(name) !== 'method') {
       // Not in the schema, or not a method.
-      throw Errors.bad_use(`No such method: \`${this._name}.${name}\``);
+      throw Errors.badUse(`No such method: \`${this._name}.${name}\``);
     }
 
     // Listed in the schema as a method. So it exists, is public, is in

--- a/local-modules/codec/ItemCodec.js
+++ b/local-modules/codec/ItemCodec.js
@@ -304,7 +304,7 @@ export default class ItemCodec extends CommonBase {
    */
   decode(payload, subDecode) {
     if (!this.canDecode(payload)) {
-      throw Errors.bad_value(payload, 'encoded payload');
+      throw Errors.badValue(payload, 'encoded payload');
     }
 
     if (ObjectUtil.isPlain(payload)) {
@@ -315,7 +315,7 @@ export default class ItemCodec extends CommonBase {
     const result = this._decode(payload, subDecode);
 
     if (!this.canEncode(result)) {
-      throw Errors.bad_use('Invalid result from decoder.');
+      throw Errors.badUse('Invalid result from decoder.');
     }
 
     return result;
@@ -334,7 +334,7 @@ export default class ItemCodec extends CommonBase {
    */
   encode(value, subEncode) {
     if (!this.canEncode(value)) {
-      throw Errors.bad_value(value, 'encodable value');
+      throw Errors.badValue(value, 'encodable value');
     }
 
     const encodedType = this._encodedType;
@@ -347,12 +347,12 @@ export default class ItemCodec extends CommonBase {
         TArray.check(result);
       } catch (e) {
         // Throw a higher-fidelity error.
-        throw Errors.bad_use('Invalid encoding result (not an array).');
+        throw Errors.badUse('Invalid encoding result (not an array).');
       }
 
       result = { [this._tag]: Object.freeze(result) };
     } else if (ItemCodec.typeOf(result) !== encodedType) {
-      throw Errors.bad_use('Invalid encoding result: ' +
+      throw Errors.badUse('Invalid encoding result: ' +
         `got type ${ItemCodec.typeOf(result)}; expected type ${encodedType}`);
     }
 

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -74,7 +74,7 @@ export default class Registry extends CommonBase {
     const clazz = codec.clazz;
 
     if (this._tagToCodec.get(tag)) {
-      throw Errors.bad_use(`Cannot re-register tag \`${tag}\`.`);
+      throw Errors.badUse(`Cannot re-register tag \`${tag}\`.`);
     }
 
     this._tagToCodec.set(codec.tag, codec);
@@ -108,13 +108,13 @@ export default class Registry extends CommonBase {
     const tag = ItemCodec.tagFromPayload(payload);
 
     if (tag === null) {
-      throw Errors.bad_value(payload, 'encoded payload');
+      throw Errors.badValue(payload, 'encoded payload');
     }
 
     const result = this._tagToCodec.get(tag);
 
     if (!result) {
-      throw Errors.bad_use(`No codec registered with tag \`${tag}\`.`);
+      throw Errors.badUse(`No codec registered with tag \`${tag}\`.`);
     }
 
     return result;
@@ -148,21 +148,21 @@ export default class Registry extends CommonBase {
 
     if (!codecs) {
       const name = Registry._nameForError(clazz, valueType);
-      throw Errors.bad_use(`No codec registered for ${name}.`);
+      throw Errors.badUse(`No codec registered for ${name}.`);
     }
 
     const applicable = codecs.filter(c => c.canEncode(value));
     switch (applicable.length) {
       case 0: {
         const name = Registry._nameForError(clazz, valueType);
-        throw Errors.bad_use(`No applicable codec for value of ${name}.`);
+        throw Errors.badUse(`No applicable codec for value of ${name}.`);
       }
       case 1: {
         return applicable[0];
       }
       default: {
         const name = Registry._nameForError(clazz, valueType);
-        throw Errors.bad_use(`Multiple applicable codecs for value of ${name}.`);
+        throw Errors.badUse(`Multiple applicable codecs for value of ${name}.`);
       }
     }
   }

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -113,10 +113,10 @@ export default class BodyClient extends StateMachine {
     /**
      * {ChainableEvent|null} Current (most recent) local change to the document
      * made by Quill that this instance is aware of. That is,
-     * `_currentEvent.nextOf(EVENT_textChange)` (once it resolves) is the first
+     * `_currentEvent.nextOf(TYPE_textChange)` (once it resolves) is the first
      * change that this instance has not yet processed. This variable is
      * initialized by getting `_quill.currentEvent` and is generally updated by
-     * getting the next `EVENT_textChange` on it.
+     * getting the next `TYPE_textChange` on it.
      */
     this._currentEvent = null;
 
@@ -376,7 +376,7 @@ export default class BodyClient extends StateMachine {
     // The above action should have caused the Quill instance to make a change
     // which shows up on its event chain. Grab it, and verify that indeed it's
     // the change we're expecting.
-    const firstChange = firstEvent.nextOfNow(QuillEvents.EVENT_textChange);
+    const firstChange = firstEvent.nextOfNow(QuillEvents.TYPE_textChange);
 
     if (firstChange === null) {
       // This can happen if the snapshot happened to coincide with the
@@ -568,7 +568,7 @@ export default class BodyClient extends StateMachine {
     }
 
     switch (event.payload.name) {
-      case QuillEvents.EVENT_textChange: {
+      case QuillEvents.TYPE_textChange: {
         // It's a document modification. Go into state `collecting`, leaving the
         // event chain alone for now. After the prescribed amount of time, the
         // `collecting` handler will hoover up the event with any other edits
@@ -582,7 +582,7 @@ export default class BodyClient extends StateMachine {
         return;
       }
 
-      case QuillEvents.EVENT_selectionChange: {
+      case QuillEvents.TYPE_selectionChange: {
         // Consume the event, and send it onward to the caret tracker, which
         // might ultimately inform the server about it. Then go back to idling.
         if (props.range) {
@@ -703,7 +703,7 @@ export default class BodyClient extends StateMachine {
     // the server's state.
     const correctedDelta = delta.compose(dCorrection, false);
 
-    if (this._currentEvent.nextOfNow(QuillEvents.EVENT_textChange) === null) {
+    if (this._currentEvent.nextOfNow(QuillEvents.TYPE_textChange) === null) {
       // Thanfully, the local user hasn't made any other changes while we
       // were waiting for the server to get back to us, which means we can
       // cleanly apply the correction on top of Quill's current state.
@@ -771,7 +771,7 @@ export default class BodyClient extends StateMachine {
     // `EMPTY` for the old contents, because this code doesn't care about that
     // value at all
     const nextNow = this._currentEvent.withNewPayload(
-      new Functor(QuillEvents.EVENT_textChange, dNewMore, BodyDelta.EMPTY, QuillEvents.SOURCE_user));
+      new Functor(QuillEvents.TYPE_textChange, dNewMore, BodyDelta.EMPTY, QuillEvents.SOURCE_user));
 
     // Make a new head of the change chain which points at the `nextNow` we
     // just constructed above. We don't include any payload since this class
@@ -800,7 +800,7 @@ export default class BodyClient extends StateMachine {
 
     let change = this._currentEvent;
     for (;;) {
-      const nextNow = change.nextOfNow(QuillEvents.EVENT_textChange);
+      const nextNow = change.nextOfNow(QuillEvents.TYPE_textChange);
       if (nextNow === null) {
         break;
       }
@@ -841,7 +841,7 @@ export default class BodyClient extends StateMachine {
   _updateWithChange(change, quillDelta = change.delta) {
     const needQuillUpdate = !quillDelta.isEmpty();
 
-    if (   (this._currentEvent.nextOfNow(QuillEvents.EVENT_textChange) !== null)
+    if (   (this._currentEvent.nextOfNow(QuillEvents.TYPE_textChange) !== null)
         && needQuillUpdate) {
       // It is unsafe to apply the change as-is, because we know that Quill's
       // revision of the document has diverged.

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -462,7 +462,7 @@ export default class BodyClient extends StateMachine {
           this.q_gotChangeAfter(baseSnapshot, value);
         } catch (e) {
           this._pendingChangeAfter = false;
-          if (Errors.isTimedOut(e)) {
+          if (Errors.is_timedOut(e)) {
             // Emit `wantInput` in response to a timeout. If we're idling, this
             // will end up retrying the `getChangeAfter()`. In any other state,
             // it will (correctly) get ignored.

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -845,7 +845,7 @@ export default class BodyClient extends StateMachine {
         && needQuillUpdate) {
       // It is unsafe to apply the change as-is, because we know that Quill's
       // revision of the document has diverged.
-      throw Errors.bad_use('Cannot apply change due to revision skew.');
+      throw Errors.badUse('Cannot apply change due to revision skew.');
     }
 
     // Update the local snapshot.

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -113,10 +113,10 @@ export default class BodyClient extends StateMachine {
     /**
      * {ChainableEvent|null} Current (most recent) local change to the document
      * made by Quill that this instance is aware of. That is,
-     * `_currentEvent.nextOf(TEXT_CHANGE)` (once it resolves) is the first
+     * `_currentEvent.nextOf(EVENT_textChange)` (once it resolves) is the first
      * change that this instance has not yet processed. This variable is
      * initialized by getting `_quill.currentEvent` and is generally updated by
-     * getting the next `TEXT_CHANGE` on it.
+     * getting the next `EVENT_textChange` on it.
      */
     this._currentEvent = null;
 
@@ -376,7 +376,7 @@ export default class BodyClient extends StateMachine {
     // The above action should have caused the Quill instance to make a change
     // which shows up on its event chain. Grab it, and verify that indeed it's
     // the change we're expecting.
-    const firstChange = firstEvent.nextOfNow(QuillEvents.TEXT_CHANGE);
+    const firstChange = firstEvent.nextOfNow(QuillEvents.EVENT_textChange);
 
     if (firstChange === null) {
       // This can happen if the snapshot happened to coincide with the
@@ -568,7 +568,7 @@ export default class BodyClient extends StateMachine {
     }
 
     switch (event.payload.name) {
-      case QuillEvents.TEXT_CHANGE: {
+      case QuillEvents.EVENT_textChange: {
         // It's a document modification. Go into state `collecting`, leaving the
         // event chain alone for now. After the prescribed amount of time, the
         // `collecting` handler will hoover up the event with any other edits
@@ -582,7 +582,7 @@ export default class BodyClient extends StateMachine {
         return;
       }
 
-      case QuillEvents.SELECTION_CHANGE: {
+      case QuillEvents.EVENT_selectionChange: {
         // Consume the event, and send it onward to the caret tracker, which
         // might ultimately inform the server about it. Then go back to idling.
         if (props.range) {
@@ -703,7 +703,7 @@ export default class BodyClient extends StateMachine {
     // the server's state.
     const correctedDelta = delta.compose(dCorrection, false);
 
-    if (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) === null) {
+    if (this._currentEvent.nextOfNow(QuillEvents.EVENT_textChange) === null) {
       // Thanfully, the local user hasn't made any other changes while we
       // were waiting for the server to get back to us, which means we can
       // cleanly apply the correction on top of Quill's current state.
@@ -771,7 +771,7 @@ export default class BodyClient extends StateMachine {
     // `EMPTY` for the old contents, because this code doesn't care about that
     // value at all
     const nextNow = this._currentEvent.withNewPayload(
-      new Functor(QuillEvents.TEXT_CHANGE, dNewMore, BodyDelta.EMPTY, 'user'));
+      new Functor(QuillEvents.EVENT_textChange, dNewMore, BodyDelta.EMPTY, 'user'));
 
     // Make a new head of the change chain which points at the `nextNow` we
     // just constructed above. We don't include any payload since this class
@@ -800,7 +800,7 @@ export default class BodyClient extends StateMachine {
 
     let change = this._currentEvent;
     for (;;) {
-      const nextNow = change.nextOfNow(QuillEvents.TEXT_CHANGE);
+      const nextNow = change.nextOfNow(QuillEvents.EVENT_textChange);
       if (nextNow === null) {
         break;
       }
@@ -841,7 +841,7 @@ export default class BodyClient extends StateMachine {
   _updateWithChange(change, quillDelta = change.delta) {
     const needQuillUpdate = !quillDelta.isEmpty();
 
-    if (   (this._currentEvent.nextOfNow(QuillEvents.TEXT_CHANGE) !== null)
+    if (   (this._currentEvent.nextOfNow(QuillEvents.EVENT_textChange) !== null)
         && needQuillUpdate) {
       // It is unsafe to apply the change as-is, because we know that Quill's
       // revision of the document has diverged.

--- a/local-modules/doc-client/BodyClient.js
+++ b/local-modules/doc-client/BodyClient.js
@@ -771,7 +771,7 @@ export default class BodyClient extends StateMachine {
     // `EMPTY` for the old contents, because this code doesn't care about that
     // value at all
     const nextNow = this._currentEvent.withNewPayload(
-      new Functor(QuillEvents.EVENT_textChange, dNewMore, BodyDelta.EMPTY, 'user'));
+      new Functor(QuillEvents.EVENT_textChange, dNewMore, BodyDelta.EMPTY, QuillEvents.SOURCE_user));
 
     // Make a new head of the change chain which points at the `nextNow` we
     // just constructed above. We don't include any payload since this class

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -143,11 +143,11 @@ export default class CaretOverlay {
 
     for (;;) {
       // Wait for a text change.
-      currentEvent = await currentEvent.nextOf(QuillEvents.TEXT_CHANGE);
+      currentEvent = await currentEvent.nextOf(QuillEvents.EVENT_textChange);
 
       // Skip any additional text changes that have already been posted, so that
       // we won't just be slowly iterating over all changes.
-      currentEvent = currentEvent.latestOfNow(QuillEvents.TEXT_CHANGE);
+      currentEvent = currentEvent.latestOfNow(QuillEvents.EVENT_textChange);
 
       log.detail('Got local edit event.');
       this._updateDisplay();

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -143,11 +143,11 @@ export default class CaretOverlay {
 
     for (;;) {
       // Wait for a text change.
-      currentEvent = await currentEvent.nextOf(QuillEvents.EVENT_textChange);
+      currentEvent = await currentEvent.nextOf(QuillEvents.TYPE_textChange);
 
       // Skip any additional text changes that have already been posted, so that
       // we won't just be slowly iterating over all changes.
-      currentEvent = currentEvent.latestOfNow(QuillEvents.EVENT_textChange);
+      currentEvent = currentEvent.latestOfNow(QuillEvents.TYPE_textChange);
 
       log.detail('Got local edit event.');
       this._updateDisplay();

--- a/local-modules/doc-client/CaretOverlay.js
+++ b/local-modules/doc-client/CaretOverlay.js
@@ -486,19 +486,19 @@ export default class CaretOverlay {
       const props = op.props;
 
       switch (props.opName) {
-        case CaretOp.BEGIN_SESSION: {
+        case CaretOp.CODE_beginSession: {
           this._addAvatarToDefs(props.caret);
           updateDisplay = true;
           break;
         }
 
-        case CaretOp.END_SESSION: {
+        case CaretOp.CODE_endSession: {
           this._removeAvatarFromDefs(props.sessionId);
           updateDisplay = true;
           break;
         }
 
-        case CaretOp.SET_FIELD: {
+        case CaretOp.CODE_setField: {
           const sessionId = props.sessionId;
 
           if (sessionId === this._editorComplex.sessionId) {

--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -273,7 +273,7 @@ export default class EditorComplex extends CommonBase {
   async _domSetup(topNode, baseUrl) {
     // Validate the top node, and give it the right CSS style.
     if (topNode.nodeName !== 'DIV') {
-      throw Errors.bad_use('Expected `topNode` to be a `div`.');
+      throw Errors.badUse('Expected `topNode` to be a `div`.');
     }
 
     topNode.classList.add('bayou-top');

--- a/local-modules/doc-client/LinkDetector.js
+++ b/local-modules/doc-client/LinkDetector.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BayouKeyboard } from 'quill-util';
+import { BayouKeyboard, QuillEvents } from 'quill-util';
 import { FigmaEmbed, ImageEmbed } from 'ui-embeds';
 
 // Originally imported from <https://gist.github.com/dperini/729294>, by
@@ -51,7 +51,7 @@ export default class LinkDetector {
         this.quill.deleteText(index, lastMatch.regexMatch.length);
         this.quill.insertEmbed(index, FigmaEmbed.blotName, value);
       } else {
-        this.quill.formatText(index, lastMatch.regexMatch.length, 'link', lastMatch.link, 'user');
+        this.quill.formatText(index, lastMatch.regexMatch.length, 'link', lastMatch.link, QuillEvents.SOURCE_user);
       }
 
       return true;

--- a/local-modules/doc-client/PropertyClient.js
+++ b/local-modules/doc-client/PropertyClient.js
@@ -121,7 +121,7 @@ export default class PropertyClient extends CommonBase {
    *   this call. If specified, this value will be silently clamped to a
    *   system-defined range. If `null`, defaults to the maximum allowed.
    * @returns {*} New value of the property, soon after it gets changed.
-   * @throws {Error} A `timed_out` error if the property doesn't change within
+   * @throws {Error} A `timedOut` error if the property doesn't change within
    *   a reasonable period of time.
    */
   async getUpdate(name, value, timeoutMsec = null) {
@@ -146,7 +146,7 @@ export default class PropertyClient extends CommonBase {
 
       const now = Date.now();
       if (now >= timeoutTime) {
-        throw Errors.timed_out(timeoutMsec);
+        throw Errors.timedOut(timeoutMsec);
       }
 
       await proxy.property_getChangeAfter(snapshot.revNum, timeoutTime - now);

--- a/local-modules/doc-client/PropertyClient.js
+++ b/local-modules/doc-client/PropertyClient.js
@@ -47,7 +47,7 @@ export default class PropertyClient extends CommonBase {
    */
   async delete(name) {
     // The op constructor type checks its arguments.
-    const delta = new PropertyDelta([PropertyOp.op_deleteProperty(name)]);
+    const delta = new PropertyDelta([PropertyOp.op_delete(name)]);
 
     const proxy    = await this._sessionProxyPromise;
     const snapshot = await proxy.property_getSnapshot();
@@ -97,7 +97,7 @@ export default class PropertyClient extends CommonBase {
    */
   async set(name, value) {
     // The op constructor type checks its arguments.
-    const delta = new PropertyDelta([PropertyOp.op_setProperty(name, value)]);
+    const delta = new PropertyDelta([PropertyOp.op_set(name, value)]);
 
     const proxy    = await this._sessionProxyPromise;
     const snapshot = await proxy.property_getSnapshot();
@@ -126,7 +126,7 @@ export default class PropertyClient extends CommonBase {
    */
   async getUpdate(name, value, timeoutMsec = null) {
     // Use the op constructor just for its type checking.
-    PropertyOp.op_setProperty(name, value);
+    PropertyOp.op_set(name, value);
 
     timeoutMsec = Timeouts.clamp(timeoutMsec);
 

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -112,7 +112,7 @@ export default class TitleClient extends CommonBase {
         // result object that lets us trivially distinguish which one happened.
         const got = await Promise.race([
           (async () => {
-            const event = await currentEvent.nextOf(QuillEvents.EVENT_selectionChange);
+            const event = await currentEvent.nextOf(QuillEvents.TYPE_selectionChange);
             return { event };
           })(),
           (async () => {
@@ -141,7 +141,7 @@ export default class TitleClient extends CommonBase {
       } else {
         // The title field has focus. Wait for it to lose focus, then grab the
         // contents and push it as an update.
-        const event     = await currentEvent.nextOf(QuillEvents.EVENT_selectionChange);
+        const event     = await currentEvent.nextOf(QuillEvents.TYPE_selectionChange);
         const { range } = QuillEvents.propsOf(event);
         if (range === null) {
           await this._pushUpdate();

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -123,7 +123,7 @@ export default class TitleClient extends CommonBase {
             } catch (e) {
               // A timeout will just elicit a retry. Everything else is a
               // throw-worthy problem.
-              if (Errors.isTimedOut(e)) {
+              if (Errors.is_timedOut(e)) {
                 return {}; // ...so that neither `if` clause below will activate.
               }
               throw e;

--- a/local-modules/doc-client/TitleClient.js
+++ b/local-modules/doc-client/TitleClient.js
@@ -112,7 +112,7 @@ export default class TitleClient extends CommonBase {
         // result object that lets us trivially distinguish which one happened.
         const got = await Promise.race([
           (async () => {
-            const event = await currentEvent.nextOf(QuillEvents.SELECTION_CHANGE);
+            const event = await currentEvent.nextOf(QuillEvents.EVENT_selectionChange);
             return { event };
           })(),
           (async () => {
@@ -141,7 +141,7 @@ export default class TitleClient extends CommonBase {
       } else {
         // The title field has focus. Wait for it to lose focus, then grab the
         // contents and push it as an update.
-        const event     = await currentEvent.nextOf(QuillEvents.SELECTION_CHANGE);
+        const event     = await currentEvent.nextOf(QuillEvents.EVENT_selectionChange);
         const { range } = QuillEvents.propsOf(event);
         if (range === null) {
           await this._pushUpdate();

--- a/local-modules/doc-common/BodyDelta.js
+++ b/local-modules/doc-common/BodyDelta.js
@@ -48,7 +48,7 @@ export default class BodyDelta extends BaseDelta {
           // yourself looking at this error, the right thing to do is look at
           // Quill's `package.json` and update the `quill-delta` dependency in
           // this module to what you find there.
-          throw Errors.bad_use('Divergent versions of `quill-delta` package.');
+          throw Errors.badUse('Divergent versions of `quill-delta` package.');
         }
         throw e;
       }
@@ -75,9 +75,9 @@ export default class BodyDelta extends BaseDelta {
    */
   diff(newerDelta) {
     if (!this.isDocument()) {
-      throw Errors.bad_use('Called on non-document instance.');
+      throw Errors.badUse('Called on non-document instance.');
     } else if (!newerDelta.isDocument()) {
-      throw Errors.bad_value(newerDelta, BodyDelta, 'isDocument()');
+      throw Errors.badValue(newerDelta, BodyDelta, 'isDocument()');
     }
 
     // Use Quill's implementation.

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -15,25 +15,25 @@ import { DataUtil, Errors, ObjectUtil } from 'util-common';
  * forth as needed.
  */
 export default class BodyOp extends BaseOp {
-  /** {string} Operation name for "delete" operations. */
+  /** {string} Opcode constant for "delete" operations. */
   static get DELETE() {
     return 'delete';
   }
 
   /**
-   * {string} Operation name for "embed" (insert / append embedded object)
+   * {string} Opcode constant for "embed" (insert / append embedded object)
    * operations.
    */
   static get EMBED() {
     return 'embed';
   }
 
-  /** {string} Operation name for "retain" operations. */
+  /** {string} Opcode constant for "retain" operations. */
   static get RETAIN() {
     return 'retain';
   }
 
-  /** {string} Operation name for "text" (insert / append text) operations. */
+  /** {string} Opcode constant for "text" (insert / append text) operations. */
   static get TEXT() {
     return 'text';
   }

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -16,7 +16,7 @@ import { DataUtil, Errors, ObjectUtil } from 'util-common';
  */
 export default class BodyOp extends BaseOp {
   /** {string} Opcode constant for "delete" operations. */
-  static get DELETE() {
+  static get CODE_delete() {
     return 'delete';
   }
 
@@ -24,17 +24,17 @@ export default class BodyOp extends BaseOp {
    * {string} Opcode constant for "embed" (insert / append embedded object)
    * operations.
    */
-  static get EMBED() {
+  static get CODE_embed() {
     return 'embed';
   }
 
   /** {string} Opcode constant for "retain" operations. */
-  static get RETAIN() {
+  static get CODE_retain() {
     return 'retain';
   }
 
   /** {string} Opcode constant for "text" (insert / append text) operations. */
-  static get TEXT() {
+  static get CODE_text() {
     return 'text';
   }
 
@@ -101,7 +101,7 @@ export default class BodyOp extends BaseOp {
   static op_delete(count) {
     TInt.min(count, 1);
 
-    return new BodyOp(BodyOp.DELETE, count);
+    return new BodyOp(BodyOp.CODE_delete, count);
   }
 
   /**
@@ -121,7 +121,7 @@ export default class BodyOp extends BaseOp {
 
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.EMBED, type, value, ...attribArg);
+    return new BodyOp(BodyOp.CODE_embed, type, value, ...attribArg);
   }
 
   /**
@@ -138,7 +138,7 @@ export default class BodyOp extends BaseOp {
     TInt.min(count, 1);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.RETAIN, count, ...attribArg);
+    return new BodyOp(BodyOp.CODE_retain, count, ...attribArg);
   }
 
   /**
@@ -153,7 +153,7 @@ export default class BodyOp extends BaseOp {
     TString.nonEmpty(text);
     const attribArg = BodyOp._attributesArg(attributes);
 
-    return new BodyOp(BodyOp.TEXT, text, ...attribArg);
+    return new BodyOp(BodyOp.CODE_text, text, ...attribArg);
   }
 
   /**
@@ -167,22 +167,22 @@ export default class BodyOp extends BaseOp {
     const opName  = payload.name;
 
     switch (opName) {
-      case BodyOp.DELETE: {
+      case BodyOp.CODE_delete: {
         const [count] = payload.args;
         return Object.freeze({ opName, count });
       }
 
-      case BodyOp.EMBED: {
+      case BodyOp.CODE_embed: {
         const [type, value, attributes = null] = payload.args;
         return Object.freeze({ opName, type, value, attributes });
       }
 
-      case BodyOp.RETAIN: {
+      case BodyOp.CODE_retain: {
         const [count, attributes = null] = payload.args;
         return Object.freeze({ opName, count, attributes });
       }
 
-      case BodyOp.TEXT: {
+      case BodyOp.CODE_text: {
         const [text, attributes = null] = payload.args;
         return Object.freeze({ opName, text, attributes });
       }
@@ -202,7 +202,7 @@ export default class BodyOp extends BaseOp {
    */
   isInsert() {
     const opName = this._payload.name;
-    return (opName === BodyOp.TEXT) || (opName === BodyOp.EMBED);
+    return (opName === BodyOp.CODE_text) || (opName === BodyOp.CODE_embed);
   }
 
   /**
@@ -216,11 +216,11 @@ export default class BodyOp extends BaseOp {
     const props = this.props;
 
     switch (props.opName) {
-      case BodyOp.DELETE: {
+      case BodyOp.CODE_delete: {
         return { delete: props.count };
       }
 
-      case BodyOp.EMBED: {
+      case BodyOp.CODE_embed: {
         const { type, value, attributes } = props;
         const insert = { [type]: value };
 
@@ -229,7 +229,7 @@ export default class BodyOp extends BaseOp {
           : { insert };
       }
 
-      case BodyOp.RETAIN: {
+      case BodyOp.CODE_retain: {
         const { count: retain, attributes } = props;
 
         return attributes
@@ -237,7 +237,7 @@ export default class BodyOp extends BaseOp {
           : { retain };
       }
 
-      case BodyOp.TEXT: {
+      case BodyOp.CODE_text: {
         const { text: insert, attributes } = props;
 
         return attributes

--- a/local-modules/doc-common/BodyOp.js
+++ b/local-modules/doc-common/BodyOp.js
@@ -50,7 +50,7 @@ export default class BodyOp extends BaseOp {
       TObject.plain(quillOp);
     } catch (e) {
       // More specific error.
-      throw Errors.bad_value(quillOp, 'Quill delta operation');
+      throw Errors.badValue(quillOp, 'Quill delta operation');
     }
 
     const { attributes = null, delete: del, insert, retain } = quillOp;
@@ -58,7 +58,7 @@ export default class BodyOp extends BaseOp {
     const allowedSize = (attributes === null) ? 1 : 2;
     if (Object.entries(quillOp).length !== allowedSize) {
       // Extra bindings, of some sort.
-      throw Errors.bad_value(quillOp, 'Quill delta operation');
+      throw Errors.badValue(quillOp, 'Quill delta operation');
     }
 
     if (insert !== undefined) {
@@ -71,23 +71,23 @@ export default class BodyOp extends BaseOp {
         const [[key, value], ...rest] = Object.entries(insert);
         if (rest.length !== 0) {
           // Invalid form for an embed.
-          throw Errors.bad_value(quillOp, 'Quill delta operation');
+          throw Errors.badValue(quillOp, 'Quill delta operation');
         }
         return BodyOp.op_embed(key, value, attributes);
       } else {
         // Neither in text nor embed form.
-        throw Errors.bad_value(quillOp, 'Quill delta operation');
+        throw Errors.badValue(quillOp, 'Quill delta operation');
       }
     } else if (del !== undefined) {
       if (attributes !== null) {
         // Deletes can't have attributes.
-        throw Errors.bad_value(quillOp, 'Quill delta operation');
+        throw Errors.badValue(quillOp, 'Quill delta operation');
       }
       return BodyOp.op_delete(del);
     } else if (retain !== undefined) {
       return BodyOp.op_retain(retain, attributes);
     } else {
-      throw Errors.bad_value(quillOp, 'Quill delta operation');
+      throw Errors.badValue(quillOp, 'Quill delta operation');
     }
   }
 
@@ -271,7 +271,7 @@ export default class BodyOp extends BaseOp {
       return [DataUtil.deepFreeze(value)];
     } catch (e) {
       // More specific error.
-      throw Errors.bad_value(value, 'body attributes');
+      throw Errors.badValue(value, 'body attributes');
     }
   }
 }

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -191,7 +191,7 @@ export default class Caret extends CommonBase {
 
     for (const op of delta.ops) {
       const props = op.props;
-      if (props.opName !== CaretOp.SET_FIELD) {
+      if (props.opName !== CaretOp.CODE_setField) {
         throw Errors.bad_use(`Invalid operation name: ${props.opName}`);
       } else if (props.sessionId !== this.sessionId) {
         throw Errors.bad_use('Mismatched session ID.');

--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -70,14 +70,14 @@ export default class Caret extends CommonBase {
     const checker = CARET_FIELDS.get(name);
 
     if (!checker) {
-      throw Errors.bad_value(name, 'caret field name');
+      throw Errors.badValue(name, 'caret field name');
     }
 
     try {
       checker(value);
     } catch (e) {
       // Higher-fidelity error.
-      throw Errors.bad_value(value, `${name} field value`);
+      throw Errors.badValue(value, `${name} field value`);
     }
 
     return value;
@@ -123,7 +123,7 @@ export default class Caret extends CommonBase {
     }
 
     if (DEFAULT && (newFields.size !== DEFAULT._fields.size)) {
-      throw Errors.bad_use(`Missing field.`);
+      throw Errors.badUse(`Missing field.`);
     }
 
     Object.freeze(this);
@@ -192,9 +192,9 @@ export default class Caret extends CommonBase {
     for (const op of delta.ops) {
       const props = op.props;
       if (props.opName !== CaretOp.CODE_setField) {
-        throw Errors.bad_use(`Invalid operation name: ${props.opName}`);
+        throw Errors.badUse(`Invalid operation name: ${props.opName}`);
       } else if (props.sessionId !== this.sessionId) {
-        throw Errors.bad_use('Mismatched session ID.');
+        throw Errors.badUse('Mismatched session ID.');
       }
 
       fields[props.key] = props.value;
@@ -240,7 +240,7 @@ export default class Caret extends CommonBase {
     const sessionId = this.sessionId;
 
     if (sessionId !== newerCaret.sessionId) {
-      throw Errors.bad_use('Cannot `diff` carets with mismatched `sessionId`.');
+      throw Errors.badUse('Cannot `diff` carets with mismatched `sessionId`.');
     }
 
     return this.diffFields(newerCaret, sessionId);

--- a/local-modules/doc-common/CaretDelta.js
+++ b/local-modules/doc-common/CaretDelta.js
@@ -33,14 +33,14 @@ export default class CaretDelta extends BaseDelta {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case CaretOp.BEGIN_SESSION: {
+        case CaretOp.CODE_beginSession: {
           // Clear out the session except for this op, because no earlier op
           // could possibly affect the result.
           sessions.set(opProps.caret.sessionId, [op]);
           break;
         }
 
-        case CaretOp.END_SESSION: {
+        case CaretOp.CODE_endSession: {
           if (wantDocument) {
             // Document deltas don't remember session deletions.
             sessions.delete(opProps.sessionId);
@@ -53,7 +53,7 @@ export default class CaretDelta extends BaseDelta {
           break;
         }
 
-        case CaretOp.SET_FIELD: {
+        case CaretOp.CODE_setField: {
           const sessionId = opProps.sessionId;
           const ops       = sessions.get(sessionId);
           let   handled   = false;
@@ -68,12 +68,12 @@ export default class CaretDelta extends BaseDelta {
             // `BEGIN_SESSION` or `END_SESSION`, in which case we can do
             // something special.
             const op0Props = ops[0].props;
-            if (op0Props.opName === CaretOp.BEGIN_SESSION) {
+            if (op0Props.opName === CaretOp.CODE_beginSession) {
               // Integrate the new value into the caret.
               const caret = op0Props.caret.compose(new CaretDelta([op]));
               ops[0] = CaretOp.op_beginSession(caret);
               handled = true;
-            } else if (op0Props.opName === CaretOp.END_SESSION) {
+            } else if (op0Props.opName === CaretOp.CODE_endSession) {
               // We ignore set-after-end. A bit philosophical, but what does
               // it even mean to set a value on a nonexistent thing?
               handled = true;
@@ -120,7 +120,7 @@ export default class CaretDelta extends BaseDelta {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case CaretOp.BEGIN_SESSION: {
+        case CaretOp.CODE_beginSession: {
           const sessionId = opProps.caret.sessionId;
 
           if (ids.has(sessionId)) {

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -13,18 +13,18 @@ import Caret from './Caret';
  */
 export default class CaretOp extends BaseOp {
   /** {string} Opcode constant for "begin session" operations. */
-  static get BEGIN_SESSION() {
-    return 'begin_session';
+  static get CODE_beginSession() {
+    return 'beginSession';
   }
 
   /** {string} Opcode constant for "end session" operations. */
-  static get END_SESSION() {
-    return 'end_session';
+  static get CODE_endSession() {
+    return 'endSession';
   }
 
   /** {string} Opcode constant for "set field" operations. */
-  static get SET_FIELD() {
-    return 'set_field';
+  static get CODE_setField() {
+    return 'setField';
   }
 
   /**
@@ -37,7 +37,7 @@ export default class CaretOp extends BaseOp {
   static op_beginSession(caret) {
     Caret.check(caret);
 
-    return new CaretOp(CaretOp.BEGIN_SESSION, caret);
+    return new CaretOp(CaretOp.CODE_beginSession, caret);
   }
 
   /**
@@ -49,7 +49,7 @@ export default class CaretOp extends BaseOp {
   static op_endSession(sessionId) {
     TString.nonEmpty(sessionId);
 
-    return new CaretOp(CaretOp.END_SESSION, sessionId);
+    return new CaretOp(CaretOp.CODE_endSession, sessionId);
   }
 
   /**
@@ -65,7 +65,7 @@ export default class CaretOp extends BaseOp {
     TString.nonEmpty(sessionId);
     Caret.checkField(key, value);
 
-    return new CaretOp(CaretOp.SET_FIELD, sessionId, key, value);
+    return new CaretOp(CaretOp.CODE_setField, sessionId, key, value);
   }
 
   /**
@@ -79,17 +79,17 @@ export default class CaretOp extends BaseOp {
     const opName  = payload.name;
 
     switch (opName) {
-      case CaretOp.BEGIN_SESSION: {
+      case CaretOp.CODE_beginSession: {
         const [caret] = payload.args;
         return Object.freeze({ opName, caret });
       }
 
-      case CaretOp.END_SESSION: {
+      case CaretOp.CODE_endSession: {
         const [sessionId] = payload.args;
         return Object.freeze({ opName, sessionId });
       }
 
-      case CaretOp.SET_FIELD: {
+      case CaretOp.CODE_setField: {
         const [sessionId, key, value] = payload.args;
         return Object.freeze({ opName, sessionId, key, value });
       }

--- a/local-modules/doc-common/CaretOp.js
+++ b/local-modules/doc-common/CaretOp.js
@@ -12,17 +12,17 @@ import Caret from './Caret';
  * Operation which can be applied to a `Caret` or `CaretSnapshot`.
  */
 export default class CaretOp extends BaseOp {
-  /** {string} Operation name for "begin session" operations. */
+  /** {string} Opcode constant for "begin session" operations. */
   static get BEGIN_SESSION() {
     return 'begin_session';
   }
 
-  /** {string} Operation name for "end session" operations. */
+  /** {string} Opcode constant for "end session" operations. */
   static get END_SESSION() {
     return 'end_session';
   }
 
-  /** {string} Operation name for "set field" operations. */
+  /** {string} Opcode constant for "set field" operations. */
   static get SET_FIELD() {
     return 'set_field';
   }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -42,7 +42,7 @@ export default class CaretSnapshot extends BaseSnapshot {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case CaretOp.BEGIN_SESSION: {
+        case CaretOp.CODE_beginSession: {
           this._carets.set(opProps.caret.sessionId, op);
           break;
         }

--- a/local-modules/doc-common/CaretSnapshot.js
+++ b/local-modules/doc-common/CaretSnapshot.js
@@ -102,7 +102,7 @@ export default class CaretSnapshot extends BaseSnapshot {
       return found;
     }
 
-    throw Errors.bad_use(`No such session: ${sessionId}`);
+    throw Errors.badUse(`No such session: ${sessionId}`);
   }
 
   /**

--- a/local-modules/doc-common/DocumentId.js
+++ b/local-modules/doc-common/DocumentId.js
@@ -23,7 +23,7 @@ export default class DocumentId extends UtilityClass {
     if (   (typeof value !== 'string')
         || (value.length === 0)
         || !Hooks.theOne.isDocumentId(value)) {
-      throw Errors.bad_value(value, DocumentId);
+      throw Errors.badValue(value, DocumentId);
     }
 
     return value;

--- a/local-modules/doc-common/PropertyDelta.js
+++ b/local-modules/doc-common/PropertyDelta.js
@@ -34,12 +34,7 @@ export default class PropertyDelta extends BaseDelta {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case PropertyOp.SET_PROPERTY: {
-          props.set(opProps.property.name, op);
-          break;
-        }
-
-        case PropertyOp.DELETE_PROPERTY: {
+        case PropertyOp.CODE_delete: {
           if (wantDocument) {
             // Document deltas don't remember property deletions; they simply
             // don't have the property in question.
@@ -50,6 +45,11 @@ export default class PropertyDelta extends BaseDelta {
             // the result delta.
             props.set(opProps.name, op);
           }
+          break;
+        }
+
+        case PropertyOp.CODE_set: {
+          props.set(opProps.property.name, op);
           break;
         }
 
@@ -75,7 +75,7 @@ export default class PropertyDelta extends BaseDelta {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case PropertyOp.SET_PROPERTY: {
+        case PropertyOp.CODE_set: {
           const name = opProps.property.name;
 
           if (names.has(name)) {

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -13,13 +13,13 @@ import Property from './Property';
  */
 export default class PropertyOp extends BaseOp {
   /** {string} Opcode constant for "delete property" operations. */
-  static get DELETE_PROPERTY() {
-    return 'delete_property';
+  static get CODE_delete() {
+    return 'delete';
   }
 
   /** {string} Opcode constant for "set property" operations. */
-  static get SET_PROPERTY() {
-    return 'set_property';
+  static get CODE_set() {
+    return 'set';
   }
 
   /**
@@ -32,7 +32,7 @@ export default class PropertyOp extends BaseOp {
   static op_deleteProperty(name) {
     TString.identifier(name);
 
-    return new PropertyOp(PropertyOp.DELETE_PROPERTY, name);
+    return new PropertyOp(PropertyOp.CODE_delete, name);
   }
 
   /**
@@ -44,7 +44,7 @@ export default class PropertyOp extends BaseOp {
    * @returns {PropertyOp} An appropriately-constructed operation.
    */
   static op_setProperty(name, value) {
-    return new PropertyOp(PropertyOp.SET_PROPERTY, new Property(name, value));
+    return new PropertyOp(PropertyOp.CODE_set, new Property(name, value));
   }
 
   /**
@@ -58,12 +58,12 @@ export default class PropertyOp extends BaseOp {
     const opName  = payload.name;
 
     switch (opName) {
-      case PropertyOp.DELETE_PROPERTY: {
+      case PropertyOp.CODE_delete: {
         const [name] = payload.args;
         return Object.freeze({ opName, name });
       }
 
-      case PropertyOp.SET_PROPERTY: {
+      case PropertyOp.CODE_set: {
         const [property] = payload.args;
         return Object.freeze({ opName, property });
       }

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -12,12 +12,12 @@ import Property from './Property';
  * Operation which can be applied to a `PropertySnapshot`.
  */
 export default class PropertyOp extends BaseOp {
-  /** {string} Operation name for "delete property" operations. */
+  /** {string} Opcode constant for "delete property" operations. */
   static get DELETE_PROPERTY() {
     return 'delete_property';
   }
 
-  /** {string} Operation name for "set property" operations. */
+  /** {string} Opcode constant for "set property" operations. */
   static get SET_PROPERTY() {
     return 'set_property';
   }

--- a/local-modules/doc-common/PropertyOp.js
+++ b/local-modules/doc-common/PropertyOp.js
@@ -29,7 +29,7 @@ export default class PropertyOp extends BaseOp {
    *   "identifier" string.
    * @returns {PropertyOp} An appropriately-constructed operation.
    */
-  static op_deleteProperty(name) {
+  static op_delete(name) {
     TString.identifier(name);
 
     return new PropertyOp(PropertyOp.CODE_delete, name);
@@ -43,7 +43,7 @@ export default class PropertyOp extends BaseOp {
    * @param {*} value Value of the property. Must be a pure data value.
    * @returns {PropertyOp} An appropriately-constructed operation.
    */
-  static op_setProperty(name, value) {
+  static op_set(name, value) {
     return new PropertyOp(PropertyOp.CODE_set, new Property(name, value));
   }
 

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -40,7 +40,7 @@ export default class PropertySnapshot extends BaseSnapshot {
       const opProps = op.props;
 
       switch (opProps.opName) {
-        case PropertyOp.SET_PROPERTY: {
+        case PropertyOp.CODE_set: {
           this._properties.set(opProps.property.name, op);
           break;
         }

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -31,7 +31,7 @@ export default class PropertySnapshot extends BaseSnapshot {
 
     /**
      * {Map<string, PropertyOp>} Map of name to corresponding property, in the
-     * form of an `op_setProperty`.
+     * form of an `op_set`.
      */
     this._properties = new Map();
 
@@ -175,7 +175,7 @@ export default class PropertySnapshot extends BaseSnapshot {
    * @returns {PropertySnapshot} An appropriately-constructed instance.
    */
   withProperty(name, value) {
-    const op = PropertyOp.op_setProperty(name, value); // This type checks.
+    const op = PropertyOp.op_set(name, value); // This type checks.
 
     return op.equals(this._properties.get(name))
       ? this
@@ -192,7 +192,7 @@ export default class PropertySnapshot extends BaseSnapshot {
    * @returns {PropertySnapshot} An appropriately-constructed instance.
    */
   withoutProperty(name) {
-    const op = PropertyOp.op_deleteProperty(name); // This type checks.
+    const op = PropertyOp.op_delete(name); // This type checks.
 
     return this._properties.has(name)
       ? this.compose(new PropertyChange(this.revNum, [op]))
@@ -225,7 +225,7 @@ export default class PropertySnapshot extends BaseSnapshot {
     // Find properties removed from `this` when going to `newerSnapshot`.
     for (const name of this._properties.keys()) {
       if (!newerProps.get(name)) {
-        resultOps.push(PropertyOp.op_deleteProperty(name));
+        resultOps.push(PropertyOp.op_delete(name));
       }
     }
 

--- a/local-modules/doc-common/PropertySnapshot.js
+++ b/local-modules/doc-common/PropertySnapshot.js
@@ -131,7 +131,7 @@ export default class PropertySnapshot extends BaseSnapshot {
       return found;
     }
 
-    throw Errors.bad_use(`No such property: ${name}`);
+    throw Errors.badUse(`No such property: ${name}`);
   }
 
   /**

--- a/local-modules/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/doc-common/tests/test_PropertyDelta.js
@@ -39,10 +39,10 @@ describe('doc-common/PropertyDelta', () => {
     describe('valid arguments', () => {
       const values = [
         [],
-        [PropertyOp.op_setProperty('x', 'y')],
-        [PropertyOp.op_setProperty('x', ['y'])],
-        [PropertyOp.op_setProperty('x', { y: 10 })],
-        [PropertyOp.op_deleteProperty('foo')],
+        [PropertyOp.op_set('x', 'y')],
+        [PropertyOp.op_set('x', ['y'])],
+        [PropertyOp.op_set('x', { y: 10 })],
+        [PropertyOp.op_delete('foo')],
         [['set_property', 'x', 10]],
         [['delete_property', 'foo']]
       ];
@@ -115,13 +115,13 @@ describe('doc-common/PropertyDelta', () => {
         }
       }
 
-      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
-      const op2 = PropertyOp.op_setProperty('aaa', 'ccc');
-      const op3 = PropertyOp.op_setProperty('aaa', 'ddd');
-      const op4 = PropertyOp.op_setProperty('aaa', 'eee');
-      const op5 = PropertyOp.op_setProperty('bbb', 'ccc');
-      const op6 = PropertyOp.op_setProperty('bbb', 'ddd');
-      const op7 = PropertyOp.op_deleteProperty('aaa');
+      const op1 = PropertyOp.op_set('aaa', 'bbb');
+      const op2 = PropertyOp.op_set('aaa', 'ccc');
+      const op3 = PropertyOp.op_set('aaa', 'ddd');
+      const op4 = PropertyOp.op_set('aaa', 'eee');
+      const op5 = PropertyOp.op_set('bbb', 'ccc');
+      const op6 = PropertyOp.op_set('bbb', 'ddd');
+      const op7 = PropertyOp.op_delete('aaa');
 
       test([op1],      [],         [op1]);
       test([op1, op2], [],         [op2]);
@@ -142,11 +142,11 @@ describe('doc-common/PropertyDelta', () => {
     });
 
     it('should not include deletions when `wantDocument` is `true`', () => {
-      const op1    = PropertyOp.op_setProperty('aaa', '111');
-      const op2    = PropertyOp.op_setProperty('bbb', '222');
-      const op3    = PropertyOp.op_setProperty('ccc', '333');
-      const op4    = PropertyOp.op_deleteProperty('bbb');
-      const op5    = PropertyOp.op_deleteProperty('ddd');
+      const op1    = PropertyOp.op_set('aaa', '111');
+      const op2    = PropertyOp.op_set('bbb', '222');
+      const op3    = PropertyOp.op_set('ccc', '333');
+      const op4    = PropertyOp.op_delete('bbb');
+      const op5    = PropertyOp.op_delete('ddd');
       const d1     = new PropertyDelta([op1, op2]);
       const d2     = new PropertyDelta([op3, op4, op5]);
       const result = d1.compose(d2, true);
@@ -163,8 +163,8 @@ describe('doc-common/PropertyDelta', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('aaa', 'bbb')]);
-      test([PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('ccc')]);
+      test([PropertyOp.op_set('aaa', 'bbb')]);
+      test([PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_delete('ccc')]);
     });
 
     it('should return `true` when passed an identically-constructed value', () => {
@@ -176,13 +176,13 @@ describe('doc-common/PropertyDelta', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('aaa', 'bbb')]);
-      test([PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('ccc')]);
+      test([PropertyOp.op_set('aaa', 'bbb')]);
+      test([PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_delete('ccc')]);
     });
 
     it('should return `true` when equal ops are not also `===`', () => {
-      const ops1 = [PropertyOp.op_setProperty('aaa', 'bbb')];
-      const ops2 = [PropertyOp.op_setProperty('aaa', 'bbb')];
+      const ops1 = [PropertyOp.op_set('aaa', 'bbb')];
+      const ops2 = [PropertyOp.op_set('aaa', 'bbb')];
       const d1 = new PropertyDelta(ops1);
       const d2 = new PropertyDelta(ops2);
 
@@ -191,8 +191,8 @@ describe('doc-common/PropertyDelta', () => {
     });
 
     it('should return `false` when array lengths differ', () => {
-      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
-      const op2 = PropertyOp.op_deleteProperty('ccc');
+      const op1 = PropertyOp.op_set('aaa', 'bbb');
+      const op2 = PropertyOp.op_delete('ccc');
       const d1 = new PropertyDelta([op1]);
       const d2 = new PropertyDelta([op1, op2]);
 
@@ -209,11 +209,11 @@ describe('doc-common/PropertyDelta', () => {
         assert.isFalse(d2.equals(d1));
       }
 
-      const op1 = PropertyOp.op_setProperty('aaa', 'bbb');
-      const op2 = PropertyOp.op_setProperty('aaa', 'ccc');
-      const op3 = PropertyOp.op_setProperty('bbb', 'ccc');
-      const op4 = PropertyOp.op_deleteProperty('ddd');
-      const op5 = PropertyOp.op_deleteProperty('eee');
+      const op1 = PropertyOp.op_set('aaa', 'bbb');
+      const op2 = PropertyOp.op_set('aaa', 'ccc');
+      const op3 = PropertyOp.op_set('bbb', 'ccc');
+      const op4 = PropertyOp.op_delete('ddd');
+      const op5 = PropertyOp.op_delete('eee');
 
       test([op1],                     [op2]);
       test([op1, op2],                [op1, op3]);
@@ -243,12 +243,12 @@ describe('doc-common/PropertyDelta', () => {
     describe('`true` cases', () => {
       const values = [
         [],
-        [PropertyOp.op_setProperty('aaa', 'bbb')],
-        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('ccc', 'ddd')],
+        [PropertyOp.op_set('aaa', 'bbb')],
+        [PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_set('ccc', 'ddd')],
         [
-          PropertyOp.op_setProperty('aaa', 'bbb'),
-          PropertyOp.op_setProperty('ccc', 'ddd'),
-          PropertyOp.op_setProperty('eee', 'fff')
+          PropertyOp.op_set('aaa', 'bbb'),
+          PropertyOp.op_set('ccc', 'ddd'),
+          PropertyOp.op_set('eee', 'fff')
         ]
       ];
 
@@ -261,8 +261,8 @@ describe('doc-common/PropertyDelta', () => {
 
     describe('`false` cases', () => {
       const values = [
-        [PropertyOp.op_deleteProperty('xyz')],
-        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('aaa', 'ccc')]
+        [PropertyOp.op_delete('xyz')],
+        [PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_set('aaa', 'ccc')]
       ];
 
       for (const v of values) {
@@ -289,10 +289,10 @@ describe('doc-common/PropertyDelta', () => {
 
     describe('valid non-empty values', () => {
       const values = [
-        [PropertyOp.op_setProperty('aaa', 'bbb')],
-        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_setProperty('ccc', 'ddd')],
-        [PropertyOp.op_setProperty('aaa', 'bbb'), PropertyOp.op_deleteProperty('aaa')],
-        [PropertyOp.op_deleteProperty('xyz')]
+        [PropertyOp.op_set('aaa', 'bbb')],
+        [PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_set('ccc', 'ddd')],
+        [PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_delete('aaa')],
+        [PropertyOp.op_delete('xyz')]
       ];
 
       for (const v of values) {

--- a/local-modules/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/doc-common/tests/test_PropertySnapshot.js
@@ -27,10 +27,10 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('x', 'y')]);
+      test([PropertyOp.op_set('x', 'y')]);
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_setProperty('z', 'pdq')
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_set('z', 'pdq')
       ]);
     });
 
@@ -51,12 +51,12 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('x', 'y')]);
-      test([PropertyOp.op_setProperty('x', 'y'), PropertyOp.op_setProperty('z', 'pdq')]);
+      test([PropertyOp.op_set('x', 'y')]);
+      test([PropertyOp.op_set('x', 'y'), PropertyOp.op_set('z', 'pdq')]);
     });
 
     it('should produce a frozen instance', () => {
-      const snap = new PropertySnapshot(0, [PropertyOp.op_setProperty('x', 'y')]);
+      const snap = new PropertySnapshot(0, [PropertyOp.op_set('x', 'y')]);
       assert.isFrozen(snap);
     });
 
@@ -68,16 +68,16 @@ describe('doc-common/PropertySnapshot', () => {
       test([1]);
       test([
         'florp',
-        PropertyOp.op_setProperty('x', 'y')
+        PropertyOp.op_set('x', 'y')
       ]);
-      test([PropertyOp.op_deleteProperty('x')]); // Deletes aren't allowed.
+      test([PropertyOp.op_delete('x')]); // Deletes aren't allowed.
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_deleteProperty('x') // Deletes aren't allowed.
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_delete('x') // Deletes aren't allowed.
       ]);
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_setProperty('x', 'z') // Duplicate names aren't allowed.
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_set('x', 'z') // Duplicate names aren't allowed.
       ]);
     });
 
@@ -88,15 +88,15 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       // Deletes aren't allowed.
-      test([PropertyOp.op_deleteProperty('x')]);
+      test([PropertyOp.op_delete('x')]);
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_deleteProperty('x')]);
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_delete('x')]);
 
       // Duplicate names aren't allowed.
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_setProperty('x', 'z')
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_set('x', 'z')
       ]);
     });
 
@@ -124,15 +124,15 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('x', 'y')]);
+      test([PropertyOp.op_set('x', 'y')]);
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_setProperty('z', 'pdq')
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_set('z', 'pdq')
       ]);
       test([
-        PropertyOp.op_setProperty('x', 'y'),
-        PropertyOp.op_setProperty('z', 'pdq'),
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_set('x', 'y'),
+        PropertyOp.op_set('z', 'pdq'),
+        PropertyOp.op_set('florp', 'like')
       ]);
     });
   });
@@ -150,10 +150,10 @@ describe('doc-common/PropertySnapshot', () => {
       test(PropertySnapshot.EMPTY);
 
       test(new PropertySnapshot(123, PropertyDelta.EMPTY));
-      test(new PropertySnapshot(0,   [PropertyOp.op_setProperty('foo', 'bar')]));
-      test(new PropertySnapshot(37,  [PropertyOp.op_setProperty('foo', 'bar')]));
+      test(new PropertySnapshot(0,   [PropertyOp.op_set('foo', 'bar')]));
+      test(new PropertySnapshot(37,  [PropertyOp.op_set('foo', 'bar')]));
       test(new PropertySnapshot(37,
-        [PropertyOp.op_setProperty('foo', 'bar'), PropertyOp.op_setProperty('baz', 914)]));
+        [PropertyOp.op_set('foo', 'bar'), PropertyOp.op_set('baz', 914)]));
     });
 
     it('should update `revNum` given a change with a different `revNum`', () => {
@@ -166,7 +166,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should add a new property given the appropriate op', () => {
-      const op       = PropertyOp.op_setProperty('florp', 'like');
+      const op       = PropertyOp.op_set('florp', 'like');
       const snap     = new PropertySnapshot(0, []);
       const expected = new PropertySnapshot(0, [op]);
       const change   = new PropertyChange(0, [op]);
@@ -177,8 +177,8 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should update a pre-existing property given an appropriate op', () => {
-      const op       = PropertyOp.op_setProperty('florp', 'like');
-      const snap     = new PropertySnapshot(0, [PropertyOp.op_setProperty('florp', 'unlike')]);
+      const op       = PropertyOp.op_set('florp', 'like');
+      const snap     = new PropertySnapshot(0, [PropertyOp.op_set('florp', 'unlike')]);
       const expected = new PropertySnapshot(0, [op]);
       const change   = new PropertyChange(0, [op]);
       const result   = snap.compose(change);
@@ -188,8 +188,8 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should remove a property given the appropriate op', () => {
-      const snap   = new PropertySnapshot(0, [PropertyOp.op_setProperty('florp', 'like')]);
-      const change = new PropertyChange(0, [PropertyOp.op_deleteProperty('florp')]);
+      const snap   = new PropertySnapshot(0, [PropertyOp.op_set('florp', 'like')]);
+      const change = new PropertyChange(0, [PropertyOp.op_delete('florp')]);
       const result = snap.compose(change);
 
       assert.isFalse(result.has('florp'));
@@ -200,7 +200,7 @@ describe('doc-common/PropertySnapshot', () => {
   describe('diff()', () => {
     it('should produce an empty diff when passed itself', () => {
       const snap = new PropertySnapshot(914,
-        [PropertyOp.op_setProperty('a', 10), PropertyOp.op_setProperty('b', 20)]);
+        [PropertyOp.op_set('a', 10), PropertyOp.op_set('b', 20)]);
       const result = snap.diff(snap);
 
       assert.instanceOf(result, PropertyChange);
@@ -209,8 +209,8 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should result in a `revNum` diff if that in fact changes', () => {
-      const snap1 = new PropertySnapshot(123, [PropertyOp.op_setProperty('a', 10)]);
-      const snap2 = new PropertySnapshot(456, [PropertyOp.op_setProperty('a', 10)]);
+      const snap1 = new PropertySnapshot(123, [PropertyOp.op_set('a', 10)]);
+      const snap2 = new PropertySnapshot(456, [PropertyOp.op_set('a', 10)]);
       const result = snap1.diff(snap2);
 
       const composed = new PropertySnapshot(0, []).compose(result);
@@ -221,13 +221,13 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should result in a property removal if that in fact happens', () => {
       const snap1 = new PropertySnapshot(0, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30)
       ]);
       const snap2 = new PropertySnapshot(0, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('c', 30)
       ]);
       const result = snap1.diff(snap2);
 
@@ -268,22 +268,22 @@ describe('doc-common/PropertySnapshot', () => {
       }
 
       test([]);
-      test([PropertyOp.op_setProperty('x', null)]);
-      test([PropertyOp.op_setProperty('x', 10)]);
-      test([PropertyOp.op_setProperty('x', 'florp')]);
-      test([PropertyOp.op_setProperty('x', [1, 2, 3])]);
+      test([PropertyOp.op_set('x', null)]);
+      test([PropertyOp.op_set('x', 10)]);
+      test([PropertyOp.op_set('x', 'florp')]);
+      test([PropertyOp.op_set('x', [1, 2, 3])]);
       test([
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20)
       ]);
       test([
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30),
-        PropertyOp.op_setProperty('d', 40),
-        PropertyOp.op_setProperty('e', 50),
-        PropertyOp.op_setProperty('f', 60),
-        PropertyOp.op_setProperty('g', 70)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30),
+        PropertyOp.op_set('d', 40),
+        PropertyOp.op_set('e', 50),
+        PropertyOp.op_set('f', 60),
+        PropertyOp.op_set('g', 70)
       ]);
     });
   });
@@ -300,9 +300,9 @@ describe('doc-common/PropertySnapshot', () => {
       test(37, []);
       test(37, PropertyDelta.EMPTY);
       test(914, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30)
       ]);
     });
 
@@ -320,22 +320,22 @@ describe('doc-common/PropertySnapshot', () => {
       test(37, []);
       test(37, PropertyDelta.EMPTY);
       test(914, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30)
       ]);
     });
 
     it('should return `true` when identical construction ops are passed in different orders', () => {
       const snap1 = new PropertySnapshot(321, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30)
       ]);
       const snap2 = new PropertySnapshot(321, [
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('c', 30),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('c', 30),
       ]);
 
       assert.isTrue(snap1.equals(snap2));
@@ -343,14 +343,14 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should return `true` when equal property values are not also `===`', () => {
       const snap1 = new PropertySnapshot(37, [
-        PropertyOp.op_setProperty('a', [1, 2]),
-        PropertyOp.op_setProperty('b', { b: 20 }),
-        PropertyOp.op_setProperty('c', new Functor('x', [1, 2, 3]))
+        PropertyOp.op_set('a', [1, 2]),
+        PropertyOp.op_set('b', { b: 20 }),
+        PropertyOp.op_set('c', new Functor('x', [1, 2, 3]))
       ]);
       const snap2 = new PropertySnapshot(37, [
-        PropertyOp.op_setProperty('a', [1, 2]),
-        PropertyOp.op_setProperty('b', { b: 20 }),
-        PropertyOp.op_setProperty('c', new Functor('x', [1, 2, 3]))
+        PropertyOp.op_set('a', [1, 2]),
+        PropertyOp.op_set('b', { b: 20 }),
+        PropertyOp.op_set('c', new Functor('x', [1, 2, 3]))
       ]);
 
       assert.isTrue(snap1.equals(snap2));
@@ -358,8 +358,8 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return `false` when `revNum`s differ', () => {
-      const snap1 = new PropertySnapshot(123, [PropertyOp.op_setProperty('a', 10)]);
-      const snap2 = new PropertySnapshot(456, [PropertyOp.op_setProperty('a', 10)]);
+      const snap1 = new PropertySnapshot(123, [PropertyOp.op_set('a', 10)]);
+      const snap2 = new PropertySnapshot(456, [PropertyOp.op_set('a', 10)]);
 
       assert.isFalse(snap1.equals(snap2));
       assert.isFalse(snap2.equals(snap1));
@@ -367,14 +367,14 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should return `false` when a property value differs', () => {
       const snap1 = new PropertySnapshot(9, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 20),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 20),
+        PropertyOp.op_set('c', 30)
       ]);
       const snap2 = new PropertySnapshot(9, [
-        PropertyOp.op_setProperty('a', 10),
-        PropertyOp.op_setProperty('b', 22222),
-        PropertyOp.op_setProperty('c', 30)
+        PropertyOp.op_set('a', 10),
+        PropertyOp.op_set('b', 22222),
+        PropertyOp.op_set('c', 30)
       ]);
 
       assert.isFalse(snap1.equals(snap2));
@@ -397,15 +397,15 @@ describe('doc-common/PropertySnapshot', () => {
   describe('get()', () => {
     it('should return the value associated with an existing property', () => {
       function test(name, value) {
-        const op = PropertyOp.op_setProperty(name, value);
+        const op = PropertyOp.op_set(name, value);
         const snap = new PropertySnapshot(1, [
-          PropertyOp.op_setProperty('a', 1),
-          PropertyOp.op_setProperty('b', 2),
-          PropertyOp.op_setProperty('c', 3),
+          PropertyOp.op_set('a', 1),
+          PropertyOp.op_set('b', 2),
+          PropertyOp.op_set('c', 3),
           op,
-          PropertyOp.op_setProperty('X', 11),
-          PropertyOp.op_setProperty('Y', 22),
-          PropertyOp.op_setProperty('Z', 33)
+          PropertyOp.op_set('X', 11),
+          PropertyOp.op_set('Y', 22),
+          PropertyOp.op_set('Z', 33)
         ]);
 
         assert.strictEqual(snap.get(name), op.props.property);
@@ -424,7 +424,7 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should always return a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', value)]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', value)]);
 
       const result = snap.get('blort');
       assert.isTrue(DataUtil.isDeepFrozen(result.value));
@@ -432,7 +432,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should throw an error when given a name that is not bound as a property', () => {
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.throws(() => { snap.get('x'); });
     });
@@ -441,15 +441,15 @@ describe('doc-common/PropertySnapshot', () => {
   describe('getOrNull()', () => {
     it('should return the value associated with an existing property', () => {
       function test(name, value) {
-        const op = PropertyOp.op_setProperty(name, value);
+        const op = PropertyOp.op_set(name, value);
         const snap = new PropertySnapshot(1, [
-          PropertyOp.op_setProperty('a', 1),
-          PropertyOp.op_setProperty('b', 2),
-          PropertyOp.op_setProperty('c', 3),
+          PropertyOp.op_set('a', 1),
+          PropertyOp.op_set('b', 2),
+          PropertyOp.op_set('c', 3),
           op,
-          PropertyOp.op_setProperty('X', 11),
-          PropertyOp.op_setProperty('Y', 22),
-          PropertyOp.op_setProperty('Z', 33)
+          PropertyOp.op_set('X', 11),
+          PropertyOp.op_set('Y', 22),
+          PropertyOp.op_set('Z', 33)
         ]);
 
         assert.strictEqual(snap.getOrNull(name), op.props.property);
@@ -468,7 +468,7 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should always return a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', value)]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', value)]);
 
       const result = snap.getOrNull('blort');
       assert.isTrue(DataUtil.isDeepFrozen(result.value));
@@ -476,7 +476,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return `null` when given a name that is not bound as a property', () => {
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.isNull(snap.getOrNull('x'));
     });
@@ -485,11 +485,11 @@ describe('doc-common/PropertySnapshot', () => {
   describe('has()', () => {
     it('should return `true` for an existing property', () => {
       const snap = new PropertySnapshot(1, [
-        PropertyOp.op_setProperty('blort',  'zorch'),
-        PropertyOp.op_setProperty('florp',  'like'),
-        PropertyOp.op_setProperty('zilch',  null),
-        PropertyOp.op_setProperty('zip',    undefined),
-        PropertyOp.op_setProperty('zither', false)
+        PropertyOp.op_set('blort',  'zorch'),
+        PropertyOp.op_set('florp',  'like'),
+        PropertyOp.op_set('zilch',  null),
+        PropertyOp.op_set('zip',    undefined),
+        PropertyOp.op_set('zither', false)
       ]);
 
       assert.isTrue(snap.has('blort'));
@@ -501,8 +501,8 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should return `false` for a non-existent property', () => {
       const snap = new PropertySnapshot(1, [
-        PropertyOp.op_setProperty('blort', 'zorch'),
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_set('blort', 'zorch'),
+        PropertyOp.op_set('florp', 'like')
       ]);
 
       assert.isFalse(snap.has('zorch'));
@@ -538,7 +538,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `contents`', () => {
-      const delta  = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const delta  = new PropertyDelta([PropertyOp.op_set('blort', 'zorch')]);
       const snap   = new PropertySnapshot(123, []);
       const result = snap.withContents(delta);
 
@@ -555,24 +555,24 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('withProperty()', () => {
     it('should return `this` if the exact property is already in the snapshot', () => {
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.strictEqual(snap.withProperty('blort', 'zorch'), snap);
     });
 
     it('should return an appropriately-constructed instance given a new property', () => {
-      const snap     = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap     = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
       const expected = new PropertySnapshot(1, [
-        PropertyOp.op_setProperty('blort', 'zorch'),
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_set('blort', 'zorch'),
+        PropertyOp.op_set('florp', 'like')
       ]);
 
       assert.isTrue(snap.withProperty('florp', 'like').equals(expected));
     });
 
     it('should return an appropriately-constructed instance given an updated property', () => {
-      const snap     = new PropertySnapshot(2, [PropertyOp.op_setProperty('blort', 'zorch')]);
-      const expected = new PropertySnapshot(2, [PropertyOp.op_setProperty('blort', 'like')]);
+      const snap     = new PropertySnapshot(2, [PropertyOp.op_set('blort', 'zorch')]);
+      const expected = new PropertySnapshot(2, [PropertyOp.op_set('blort', 'like')]);
 
       assert.isTrue(snap.withProperty('blort', 'like').equals(expected));
     });
@@ -586,7 +586,7 @@ describe('doc-common/PropertySnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `revNum`', () => {
-      const delta  = new PropertyDelta([PropertyOp.op_setProperty('blort', 'zorch')]);
+      const delta  = new PropertyDelta([PropertyOp.op_set('blort', 'zorch')]);
       const snap   = new PropertySnapshot(123, delta);
       const result = snap.withRevNum(456);
 
@@ -603,7 +603,7 @@ describe('doc-common/PropertySnapshot', () => {
 
   describe('withoutProperty()', () => {
     it('should return `this` if there is no matching property', () => {
-      const snap = new PropertySnapshot(1, [PropertyOp.op_setProperty('blort', 'zorch')]);
+      const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.strictEqual(snap.withoutProperty('x'), snap);
       assert.strictEqual(snap.withoutProperty('y'), snap);
@@ -611,11 +611,11 @@ describe('doc-common/PropertySnapshot', () => {
 
     it('should return an appropriately-constructed instance if there is a matching property', () => {
       const snap = new PropertySnapshot(2, [
-        PropertyOp.op_setProperty('blort', 'zorch'),
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_set('blort', 'zorch'),
+        PropertyOp.op_set('florp', 'like')
       ]);
       const expected = new PropertySnapshot(2, [
-        PropertyOp.op_setProperty('florp', 'like')
+        PropertyOp.op_set('florp', 'like')
       ]);
 
       assert.isTrue(snap.withoutProperty('blort').equals(expected));

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -797,7 +797,7 @@ export default class BaseControl extends BaseDataManager {
       transactionResult = await fc.transact(spec);
     } catch (e) {
       this.log.error('Major problem trying to read file!', e);
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     const data     = transactionResult.data;
@@ -808,7 +808,7 @@ export default class BaseControl extends BaseDataManager {
       RevisionNumber.check(revNum);
     } catch (e) {
       this.log.info('Corrupt document: Bogus or missing revision number.');
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     if (snapshot) {
@@ -816,12 +816,12 @@ export default class BaseControl extends BaseDataManager {
         clazz.snapshotClass.check(snapshot);
       } catch (e) {
         this.log.info('Corrupt document: Bogus stored snapshot (wrong class).');
-        return ValidationStatus.STATUS_ERROR;
+        return ValidationStatus.STATUS_error;
       }
 
       if (revNum < snapshot.revNum) {
         this.log.info('Corrupt document: Bogus stored snapshot (weird revision number).');
-        return ValidationStatus.STATUS_ERROR;
+        return ValidationStatus.STATUS_error;
       }
     }
 
@@ -845,7 +845,7 @@ export default class BaseControl extends BaseDataManager {
         await this._getChangeRange(i, lastI + 1, true);
       } catch (e) {
         this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
-        return ValidationStatus.STATUS_ERROR;
+        return ValidationStatus.STATUS_error;
       }
     }
 
@@ -857,7 +857,7 @@ export default class BaseControl extends BaseDataManager {
         await this._getChangeRange(i, lastI + 1, false);
       } catch (e) {
         this.log.info(`Corrupt document: Bogus change in range #${i}..${lastI}.`);
-        return ValidationStatus.STATUS_ERROR;
+        return ValidationStatus.STATUS_error;
       }
     }
 
@@ -870,17 +870,17 @@ export default class BaseControl extends BaseDataManager {
       extraChanges = await this.listChangeRange(revNum + 1, revNum + 10000);
     } catch (e) {
       this.log.info('Corrupt document: Trouble listing changes.');
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     if (extraChanges.length !== 0) {
       this.log.info(`Corrupt document: Detected extra changes (at least ${extraChanges.length}).`);
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     // All's well!
 
-    return ValidationStatus.STATUS_OK;
+    return ValidationStatus.STATUS_ok;
   }
 
   /**

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -198,7 +198,7 @@ export default class BaseControl extends BaseDataManager {
     clazz.changeClass.check(change);
 
     if (change.delta.isEmpty()) {
-      throw Errors.bad_value(change, clazz.changeClass, 'non-empty');
+      throw Errors.badValue(change, clazz.changeClass, 'non-empty');
     }
 
     timeoutMsec = Timeouts.clamp(timeoutMsec);
@@ -292,7 +292,7 @@ export default class BaseControl extends BaseDataManager {
    * base revision that does not yet exist. For subclasses that don't keep full
    * history, it is also an error to request a revision that is _no longer_
    * available as a base; in this case, the error name is always
-   * `revision_not_available`.
+   * `revisionNotAvailable`.
    *
    * The return value is a change instance with respect to (that is, whose base
    * revision is) the one indicated by `baseRevNum` as passed to the method.
@@ -312,7 +312,7 @@ export default class BaseControl extends BaseDataManager {
    *   is guaranteed to be at least one greater than `baseRevNum` (and could
    *   possibly be even larger). The `timestamp` and `authorId` of the result
    *   will both be `null`.
-   * @throws {Errors.timed_out} Thrown if the timeout time is reached befor a
+   * @throws {Errors.timedOut} Thrown if the timeout time is reached befor a
    *   change becomes available.
    */
   async getChangeAfter(baseRevNum, timeoutMsec = null) {
@@ -339,7 +339,7 @@ export default class BaseControl extends BaseDataManager {
    * revision. If `startInclusive === endExclusive`, then this method returns
    * `baseDelta`. For subclasses that don't keep full change history, it is also
    * an error to request a change that is _no longer_  available; in this case,
-   * the error name is always `revision_not_available`.
+   * the error name is always `revisionNotAvailable`.
    *
    * @param {BaseDelta} baseDelta Base delta onto which the indicated deltas
    *   get composed. Must be an instance of the delta class appropriate to the
@@ -369,7 +369,7 @@ export default class BaseControl extends BaseDataManager {
       // of it here, we need to explicitly check argument validity.
 
       if (wantDocument && !baseDelta.isDocument()) {
-        throw Errors.bad_value(baseDelta, 'document delta');
+        throw Errors.badValue(baseDelta, 'document delta');
       }
 
       await this._getChangeRange(startInclusive, startInclusive, false);
@@ -448,7 +448,7 @@ export default class BaseControl extends BaseDataManager {
    * by this instance. It is an error to request a revision that does not yet
    * exist. For subclasses that don't keep full history, it is also an error to
    * request a revision that is _no longer_ available; in this case, the error
-   * name is always `revision_not_available`.
+   * name is always `revisionNotAvailable`.
    *
    * @param {Int|null} revNum Which revision to get. If passed as `null`,
    *   indicates the current (most recent) revision. **Note:** Due to the
@@ -467,7 +467,7 @@ export default class BaseControl extends BaseDataManager {
     const result = await this._impl_getSnapshot(revNum);
 
     if (result === null) {
-      throw Errors.revision_not_available(revNum);
+      throw Errors.revisionNotAvailable(revNum);
     }
 
     return this.constructor.snapshotClass.check(result);
@@ -577,13 +577,13 @@ export default class BaseControl extends BaseDataManager {
     // amiss.
     changeClass.check(change);
     if (change.timestamp === null) {
-      throw Errors.bad_value(change, changeClass, 'timestamp !== null');
+      throw Errors.badValue(change, changeClass, 'timestamp !== null');
     }
 
     const baseRevNum = change.revNum - 1;
 
     if (baseRevNum < 0) {
-      throw Errors.bad_value(change, changeClass, 'revNum >= 1');
+      throw Errors.badValue(change, changeClass, 'revNum >= 1');
     }
 
     timeoutMsec = Timeouts.clamp(timeoutMsec);
@@ -611,7 +611,7 @@ export default class BaseControl extends BaseDataManager {
       const now = Date.now();
 
       if (now >= timeoutTime) {
-        throw Errors.timed_out(timeoutMsec);
+        throw Errors.timedOut(timeoutMsec);
       }
 
       attemptCount++;
@@ -663,11 +663,11 @@ export default class BaseControl extends BaseDataManager {
     // Handles timeout (called twice, below).
     const timedOut = () => {
       // Log a message -- it's at least somewhat notable, though it does occur
-      // regularly -- and throw `timed_out` with the original timeout value. (If
+      // regularly -- and throw `timedOut` with the original timeout value. (If
       // called as a result of catching a timeout from `transact()` the timeout
       // value in the error might not be the original `timeoutMsec`.)
       this.log.info(`\`whenRevNum()\` timed out: ${timeoutMsec}msec`);
-      throw Errors.timed_out(timeoutMsec);
+      throw Errors.timedOut(timeoutMsec);
     };
 
     // Loop until the overall timeout.
@@ -973,7 +973,7 @@ export default class BaseControl extends BaseDataManager {
     if ((endExclusive - startInclusive) > MAX_CHANGE_READS_PER_TRANSACTION) {
       // The calling code (in this class) should have made sure we weren't
       // violating this restriction.
-      throw Errors.bad_use(`Too many changes requested at once: ${endExclusive - startInclusive}`);
+      throw Errors.badUse(`Too many changes requested at once: ${endExclusive - startInclusive}`);
     }
 
     // Per docs, reject a start (and implicitly an end) that would try to read
@@ -1003,7 +1003,7 @@ export default class BaseControl extends BaseDataManager {
         clazz.changeClass.check(change);
         result.push(change);
       } else if (!allowMissing) {
-        throw new Error.bad_use(`Missing change in requested range: r${i}`);
+        throw new Error.badUse(`Missing change in requested range: r${i}`);
       }
     }
 

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -220,7 +220,7 @@ export default class BaseControl extends BaseDataManager {
     try {
       await fc.transact(spec);
     } catch (e) {
-      if (FileStoreErrors.isPathNotAbsent(e) || FileStoreErrors.isPathHashMismatch(e)) {
+      if (FileStoreErrors.is_pathNotAbsent(e) || FileStoreErrors.is_pathHashMismatch(e)) {
         // One of these will get thrown if and when we lose an append race. This
         // regularly occurs when there are simultaneous editors.
         this.log.info('Lost append race for revision:', revNum);
@@ -701,7 +701,7 @@ export default class BaseControl extends BaseDataManager {
       } catch (e) {
         // For a timeout, we log and report the original timeout value. For
         // everything else, we just transparently re-throw.
-        if (Errors.isTimedOut(e)) {
+        if (Errors.is_timedOut(e)) {
           timedOut();
         }
         throw e;

--- a/local-modules/doc-server/DocSession.js
+++ b/local-modules/doc-server/DocSession.js
@@ -167,7 +167,7 @@ export default class DocSession extends CommonBase {
   /**
    * Informs the system of the client's current caret or text selection extent.
    * This should be called by clients when they notice user activity that
-   * changes the selection. More specifically, Quill's `SELECTION_CHANGED`
+   * changes the selection. More specifically, Quill's `selection-change`
    * events are expected to drive calls to this method. The `index` and `length`
    * arguments to this method have the same semantics as they have in Quill,
    * that is, they ultimately refer to an extent within a Quill `Delta`.

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -258,7 +258,7 @@ export default class FileBootstrap extends BaseDataManager {
    */
   _initCheck() {
     if (!this._initialized) {
-      throw Errors.bad_use('Must be `init()`ed before access.');
+      throw Errors.badUse('Must be `init()`ed before access.');
     }
   }
 }

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -158,7 +158,7 @@ export default class FileBootstrap extends BaseDataManager {
    */
   async _impl_validationStatus() {
     if (!(await this.file.exists())) {
-      return ValidationStatus.STATUS_NOT_FOUND;
+      return ValidationStatus.STATUS_notFound;
     }
 
     const members = [
@@ -170,12 +170,12 @@ export default class FileBootstrap extends BaseDataManager {
 
     for (const member of members) {
       const status = await member.validationStatus();
-      if (status !== ValidationStatus.STATUS_OK) {
+      if (status !== ValidationStatus.STATUS_ok) {
         return status;
       }
     }
 
-    return ValidationStatus.STATUS_OK;
+    return ValidationStatus.STATUS_ok;
   }
 
   /**
@@ -187,7 +187,7 @@ export default class FileBootstrap extends BaseDataManager {
     this.log.info('Doing bootstrap-time validation...');
     const status  = await this.validationStatus();
 
-    if (status === ValidationStatus.STATUS_OK) {
+    if (status === ValidationStatus.STATUS_ok) {
       // All's well.
       return true;
     }
@@ -197,7 +197,7 @@ export default class FileBootstrap extends BaseDataManager {
     let firstText;
 
     switch (status) {
-      case ValidationStatus.STATUS_MIGRATE: {
+      case ValidationStatus.STATUS_migrate: {
         // **TODO:** Ultimately, this code path will evolve into forward
         // migration of documents found to be in older formats. For now, we just
         // fall through to the document creation logic below, which will leave
@@ -207,15 +207,15 @@ export default class FileBootstrap extends BaseDataManager {
         break;
       }
 
-      case ValidationStatus.STATUS_RECOVER: {
-        // **TODO:** As with `STATUS_MIGRATE`, this code path will eventually
+      case ValidationStatus.STATUS_recover: {
+        // **TODO:** As with `STATUS_migrate`, this code path will eventually
         // expand into some sort of recovery mechanism.
         this.log.info('Needs recovery. (But just noting that fact for now.)');
         firstText = RECOVERY_NOTE;
         break;
       }
 
-      case ValidationStatus.STATUS_ERROR: {
+      case ValidationStatus.STATUS_error: {
         // **TODO:** Ultimately, it should be a Really Big Deal if we find
         // ourselves here. We might want to implement some form of "hail mary"
         // attempt to recover _something_ of use from the document storage.
@@ -224,7 +224,7 @@ export default class FileBootstrap extends BaseDataManager {
         break;
       }
 
-      case ValidationStatus.STATUS_NOT_FOUND: {
+      case ValidationStatus.STATUS_notFound: {
         // The file simply didn't exist.
         this.log.info('Making new file.');
         firstText = DEFAULT_TEXT;

--- a/local-modules/doc-server/SchemaHandler.js
+++ b/local-modules/doc-server/SchemaHandler.js
@@ -66,7 +66,7 @@ export default class SchemaHandler extends BaseDataManager {
       transactionResult = await fc.transact(spec);
     } catch (e) {
       this.log.error('Major problem trying to read file!', e);
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     const data          = transactionResult.data;
@@ -74,16 +74,16 @@ export default class SchemaHandler extends BaseDataManager {
 
     if (!schemaVersion) {
       this.log.info('Corrupt document: Missing schema version.');
-      return ValidationStatus.STATUS_ERROR;
+      return ValidationStatus.STATUS_error;
     }
 
     const expectSchemaVersion = this._schemaVersion;
     if (schemaVersion !== expectSchemaVersion) {
       const got = schemaVersion;
       this.log.info(`Mismatched schema version: got ${got}; expected ${expectSchemaVersion}`);
-      return ValidationStatus.STATUS_MIGRATE;
+      return ValidationStatus.STATUS_migrate;
     }
 
-    return ValidationStatus.STATUS_OK;
+    return ValidationStatus.STATUS_ok;
   }
 }

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -70,6 +70,6 @@ export default class ValidationStatus extends UtilityClass {
       }
     }
 
-    throw Errors.bad_value(value, ValidationStatus);
+    throw Errors.badValue(value, ValidationStatus);
   }
 }

--- a/local-modules/doc-server/ValidationStatus.js
+++ b/local-modules/doc-server/ValidationStatus.js
@@ -15,8 +15,8 @@ export default class ValidationStatus extends UtilityClass {
    * {string} Validation status value, which indicates an unrecoverable error in
    * interpreting the document (or document portion) data.
    */
-  static get STATUS_ERROR() {
-    return 'status_error';
+  static get STATUS_error() {
+    return 'error';
   }
 
   /**
@@ -24,32 +24,32 @@ export default class ValidationStatus extends UtilityClass {
    * document portion) is in a format that isn't directly understood, presumably
    * an older format that needs forward migration.
    */
-  static get STATUS_MIGRATE() {
-    return 'status_migrate';
+  static get STATUS_migrate() {
+    return 'migrate';
   }
 
   /**
    * {string} Validation status value, which indicates that the file does not
    * exist.
    */
-  static get STATUS_NOT_FOUND() {
-    return 'status_not_found';
+  static get STATUS_notFound() {
+    return 'notFound';
   }
 
   /**
    * {string} Validation status value, which indicates that the document (or
    * document portion) checks out as valid.
    */
-  static get STATUS_OK() {
-    return 'status_ok';
+  static get STATUS_ok() {
+    return 'ok';
   }
 
   /**
    * {string} Validation status value, which indicates that the document (or
    * document portion) has some errors but _might_ be recoverable.
    */
-  static get STATUS_RECOVER() {
-    return 'status_recover';
+  static get STATUS_recover() {
+    return 'recover';
   }
 
   /**
@@ -61,11 +61,11 @@ export default class ValidationStatus extends UtilityClass {
    */
   static check(value) {
     switch (value) {
-      case ValidationStatus.STATUS_ERROR:
-      case ValidationStatus.STATUS_MIGRATE:
-      case ValidationStatus.STATUS_NOT_FOUND:
-      case ValidationStatus.STATUS_OK:
-      case ValidationStatus.STATUS_RECOVER: {
+      case ValidationStatus.STATUS_error:
+      case ValidationStatus.STATUS_migrate:
+      case ValidationStatus.STATUS_notFound:
+      case ValidationStatus.STATUS_ok:
+      case ValidationStatus.STATUS_recover: {
         return value;
       }
     }

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -279,8 +279,8 @@ describe('doc-server/BaseControl', () => {
         await assert.eventually.strictEqual(control.appendChange(change), false);
       }
 
-      await test(FileErrors.path_hash_mismatch('/whatever', FrozenBuffer.coerce('x').hash));
-      await test(FileErrors.path_not_absent('/mock_control/change/99'));
+      await test(FileErrors.pathHashMismatch('/whatever', FrozenBuffer.coerce('x').hash));
+      await test(FileErrors.pathNotAbsent('/mock_control/change/99'));
     });
 
     it('should rethrow any transaction error other than a precondition failure', async () => {
@@ -301,7 +301,7 @@ describe('doc-server/BaseControl', () => {
         await assert.isRejected(control.appendChange(change), error);
       }
 
-      await test(FileErrors.file_not_found('x'));
+      await test(FileErrors.fileNotFound('x'));
       await test(Errors.timedOut(123456));
       await test(Errors.badValue('foo', 'bar'));
     });

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -128,7 +128,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject invalid arguments', () => {
       function test(value) {
-        assert.throws(() => MockControl.pathForChange(value), /bad_value/);
+        assert.throws(() => MockControl.pathForChange(value), /badValue/);
       }
 
       test(-1);
@@ -302,8 +302,8 @@ describe('doc-server/BaseControl', () => {
       }
 
       await test(FileErrors.file_not_found('x'));
-      await test(Errors.timed_out(123456));
-      await test(Errors.bad_value('foo', 'bar'));
+      await test(Errors.timedOut(123456));
+      await test(Errors.badValue('foo', 'bar'));
     });
 
     it('should reject an empty change', async () => {
@@ -312,7 +312,7 @@ describe('doc-server/BaseControl', () => {
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(101, []);
 
-      await assert.isRejected(control.appendChange(change), /bad_value/);
+      await assert.isRejected(control.appendChange(change), /badValue/);
     });
 
     it('should reject a change of the wrong type', async () => {
@@ -320,7 +320,7 @@ describe('doc-server/BaseControl', () => {
       const fileAccess = new FileAccess(Codec.theOne, file);
       const control    = new MockControl(fileAccess, 'boop');
 
-      await assert.isRejected(control.appendChange('not_a_change'), /bad_value/);
+      await assert.isRejected(control.appendChange('not_a_change'), /badValue/);
     });
 
     it('should reject an invalid timeout value', async () => {
@@ -330,7 +330,7 @@ describe('doc-server/BaseControl', () => {
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
       async function test(v) {
-        await assert.isRejected(control.appendChange(change, v), /bad_value/);
+        await assert.isRejected(control.appendChange(change, v), /badValue/);
       }
 
       await test(-1);  // Must be a non-negative value.
@@ -406,7 +406,7 @@ describe('doc-server/BaseControl', () => {
           };
         };
 
-        await assert.isRejected(control.currentRevNum(), /^bad_value/);
+        await assert.isRejected(control.currentRevNum(), /^badValue/);
       }
 
       await test(null);
@@ -458,7 +458,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        await assert.isRejected(control.getChange(value), /^bad_value/);
+        await assert.isRejected(control.getChange(value), /^badValue/);
       }
 
       await test(undefined);
@@ -498,7 +498,7 @@ describe('doc-server/BaseControl', () => {
         throw new Error('This should not have been called.');
       };
 
-      await assert.isRejected(control.getChangeAfter(11), /^bad_value/);
+      await assert.isRejected(control.getChangeAfter(11), /^badValue/);
     });
 
     it('should reject blatantly invalid `baseRevNum` values', async () => {
@@ -514,7 +514,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        await assert.isRejected(control.getChangeAfter(value), /^bad_value/);
+        await assert.isRejected(control.getChangeAfter(value), /^badValue/);
       }
 
       await test(null);
@@ -598,7 +598,7 @@ describe('doc-server/BaseControl', () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
 
       async function test(base, newer) {
-        await assert.isRejected(control.getDiff(base, newer), /^bad_value/);
+        await assert.isRejected(control.getDiff(base, newer), /^badValue/);
       }
 
       await test(undefined, 10);
@@ -710,7 +710,7 @@ describe('doc-server/BaseControl', () => {
         throw new Error('This should not have been called.');
       };
 
-      await assert.isRejected(control.getSnapshot(11), /^bad_value/);
+      await assert.isRejected(control.getSnapshot(11), /^badValue/);
     });
 
     it('should reject blatantly invalid `revNum` values', async () => {
@@ -723,7 +723,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        await assert.isRejected(control.getSnapshot(value), /^bad_value/);
+        await assert.isRejected(control.getSnapshot(value), /^badValue/);
       }
 
       await test(false);
@@ -764,7 +764,7 @@ describe('doc-server/BaseControl', () => {
       assert.deepEqual(result.contents.ops, [new MockOp('x', 37)]);
     });
 
-    it('should convert a `null` subclass response to a `revision_not_available` error', async () => {
+    it('should convert a `null` subclass response to a `revisionNotAvailable` error', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -773,7 +773,7 @@ describe('doc-server/BaseControl', () => {
         return null;
       };
 
-      await assert.isRejected(control.getSnapshot(1), /^revision_not_available/);
+      await assert.isRejected(control.getSnapshot(1), /^revisionNotAvailable/);
     });
 
     it('should reject a non-snapshot subclass response', async () => {
@@ -787,7 +787,7 @@ describe('doc-server/BaseControl', () => {
           return value;
         };
 
-        await assert.isRejected(control.getSnapshot(1), /^bad_value/);
+        await assert.isRejected(control.getSnapshot(1), /^badValue/);
       }
 
       await test(-1);
@@ -811,7 +811,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        await assert.isRejected(control.update(value), /^bad_value/);
+        await assert.isRejected(control.update(value), /^badValue/);
       }
 
       await test(null);
@@ -834,7 +834,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       async function test(value) {
-        await assert.isRejected(control.update(value), /^bad_value/);
+        await assert.isRejected(control.update(value), /^badValue/);
       }
 
       // `0` is not a valid `revNum` for this method.
@@ -859,7 +859,7 @@ describe('doc-server/BaseControl', () => {
       const change = new MockChange(11, [], Timestamp.MIN_VALUE);
 
       async function test(value) {
-        await assert.isRejected(control.update(change, value), /^bad_value/);
+        await assert.isRejected(control.update(change, value), /^badValue/);
       }
 
       await test(-1);  // Must be a non-negative value.
@@ -883,7 +883,7 @@ describe('doc-server/BaseControl', () => {
       };
 
       const change = new MockChange(12, [new MockOp('abc')], Timestamp.MIN_VALUE);
-      await assert.isRejected(control.update(change), /^bad_value/);
+      await assert.isRejected(control.update(change), /^badValue/);
     });
 
     it('should call through to `_attemptUpdate()` given an empty change', async () => {

--- a/local-modules/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/doc-server/tests/test_BaseDataManager.js
@@ -94,7 +94,7 @@ describe('doc-server/BaseDataManager', () => {
         return ['not actually a validation status'];
       };
 
-      await assert.isRejected(dm.validationStatus(), /bad_value/);
+      await assert.isRejected(dm.validationStatus(), /badValue/);
     });
   });
 });

--- a/local-modules/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/doc-server/tests/test_BaseDataManager.js
@@ -71,12 +71,12 @@ describe('doc-server/BaseDataManager', () => {
       let callCount = 0;
       dm._impl_validationStatus = async () => {
         callCount++;
-        return ValidationStatus.STATUS_OK;
+        return ValidationStatus.STATUS_ok;
       };
 
       const result = await dm.validationStatus();
       assert.strictEqual(callCount, 1);
-      assert.strictEqual(result, ValidationStatus.STATUS_OK);
+      assert.strictEqual(result, ValidationStatus.STATUS_ok);
     });
 
     it('should throw whatever error is thrown by the impl', async () => {

--- a/local-modules/env-client/ClientEnv.js
+++ b/local-modules/env-client/ClientEnv.js
@@ -27,7 +27,7 @@ export default class ClientEnv extends UtilityClass {
     TObject.check(window, Window);
 
     if (ClientEnv._window) {
-      throw Errors.bad_use('Already initialized.');
+      throw Errors.badUse('Already initialized.');
     }
 
     this._window = window;
@@ -39,7 +39,7 @@ export default class ClientEnv extends UtilityClass {
     const result = this._window;
 
     if (!result) {
-      throw Errors.bad_use('Not initialized.');
+      throw Errors.badUse('Not initialized.');
     }
 
     return result;

--- a/local-modules/env-server/Dirs.js
+++ b/local-modules/env-server/Dirs.js
@@ -90,7 +90,7 @@ export default class Dirs extends Singleton {
 
     for (;;) {
       if ((dir === '.') || (dir === '/')) {
-        throw Errors.bad_use(`Unable to determine base product directory, starting from: ${__dirname}`);
+        throw Errors.badUse(`Unable to determine base product directory, starting from: ${__dirname}`);
       }
 
       try {
@@ -119,7 +119,7 @@ export default class Dirs extends Singleton {
       if (stat.isDirectory()) {
         return;
       } else {
-        throw Errors.bad_use(`Expected a directory: ${dirPath}`);
+        throw Errors.badUse(`Expected a directory: ${dirPath}`);
       }
     } catch (e) {
       // Presumably not found. Ignore the exception, fall through, and attempt

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -214,7 +214,7 @@ export default class LocalFile extends BaseFile {
 
     await Promise.race([this._readStorageIfNecessary(), timeoutProm]);
     if (timeout) {
-      throw Errors.timed_out(timeoutMsec);
+      throw Errors.timedOut(timeoutMsec);
     }
 
     if (!this._fileShouldExist) {
@@ -301,7 +301,7 @@ export default class LocalFile extends BaseFile {
       this._changeCondition.value = false;
       await Promise.race([this._changeCondition.whenTrue(), timeoutProm]);
       if (timeout) {
-        throw Errors.timed_out(timeoutMsec);
+        throw Errors.timedOut(timeoutMsec);
       }
     }
 

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -218,7 +218,7 @@ export default class LocalFile extends BaseFile {
     }
 
     if (!this._fileShouldExist) {
-      throw FileStoreErrors.file_not_found(this.id);
+      throw FileStoreErrors.fileNotFound(this.id);
     }
 
     // Construct the "file friend" object. This exposes just enough private

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -387,7 +387,7 @@ export default class Transactor extends CommonBase {
     const { revNum } = props;
 
     if (this._fileFriend.revNum !== revNum) {
-      throw Errors.revision_not_available(revNum);
+      throw Errors.revisionNotAvailable(revNum);
     }
   }
 

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -145,7 +145,7 @@ export default class Transactor extends CommonBase {
     const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) !== null) {
-      throw FileStoreErrors.blob_not_absent(hash);
+      throw FileStoreErrors.blobNotAbsent(hash);
     }
   }
 
@@ -158,7 +158,7 @@ export default class Transactor extends CommonBase {
     const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) === null) {
-      throw FileStoreErrors.blob_not_found(hash);
+      throw FileStoreErrors.blobNotFound(hash);
     }
   }
 
@@ -171,7 +171,7 @@ export default class Transactor extends CommonBase {
     const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
-      throw FileStoreErrors.path_not_absent(storagePath);
+      throw FileStoreErrors.pathNotAbsent(storagePath);
     }
   }
 
@@ -185,9 +185,9 @@ export default class Transactor extends CommonBase {
     const data = this._fileFriend.readPathOrNull(storagePath);
 
     if (data === null) {
-      throw FileStoreErrors.path_not_found(storagePath);
+      throw FileStoreErrors.pathNotFound(storagePath);
     } else if (data.hash !== expectedHash) {
-      throw FileStoreErrors.path_hash_mismatch(storagePath, expectedHash);
+      throw FileStoreErrors.pathHashMismatch(storagePath, expectedHash);
     }
   }
 
@@ -201,7 +201,7 @@ export default class Transactor extends CommonBase {
     const data = this._fileFriend.readPathOrNull(storagePath);
 
     if ((data !== null) && (data.hash === unexpectedHash)) {
-      throw FileStoreErrors.path_hash_mismatch(storagePath, unexpectedHash);
+      throw FileStoreErrors.pathHashMismatch(storagePath, unexpectedHash);
     }
   }
 
@@ -214,7 +214,7 @@ export default class Transactor extends CommonBase {
     const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
-      throw FileStoreErrors.path_not_found(storagePath);
+      throw FileStoreErrors.pathNotFound(storagePath);
     }
   }
 

--- a/local-modules/file-store/BaseFile.js
+++ b/local-modules/file-store/BaseFile.js
@@ -210,24 +210,24 @@ export default class BaseFile extends CommonBase {
 
     if (spec.hasReadOps()) {
       if (result.data === null) {
-        throw Errors.bad_use('Improper subclass behavior: Expected non-`null` `data`.');
+        throw Errors.badUse('Improper subclass behavior: Expected non-`null` `data`.');
       }
       TMap.check(result.data, StorageId.check, FrozenBuffer.check);
     } else {
       if (result.data !== null) {
-        throw Errors.bad_use('Improper subclass behavior: Expected `null` `data`.');
+        throw Errors.badUse('Improper subclass behavior: Expected `null` `data`.');
       }
       delete result.data;
     }
 
     if (spec.hasPathOps()) {
       if (result.paths === null) {
-        throw Errors.bad_use('Improper subclass behavior: Expected non-`null` `paths`.');
+        throw Errors.badUse('Improper subclass behavior: Expected non-`null` `paths`.');
       }
       TSet.check(result.paths, StoragePath.check);
     } else {
       if (result.paths !== null) {
-        throw Errors.bad_use('Improper subclass behavior: Expected `null` `paths`.');
+        throw Errors.badUse('Improper subclass behavior: Expected `null` `paths`.');
       }
       delete result.paths;
     }

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -21,9 +21,9 @@ export default class Errors extends UtilityClass {
    * @param {string} hash Hash of the blob in question.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static blob_not_absent(hash) {
+  static blobNotAbsent(hash) {
     FrozenBuffer.checkHash(hash);
-    return new InfoError('blob_not_absent', hash);
+    return new InfoError('blobNotAbsent', hash);
   }
 
   /**
@@ -33,9 +33,9 @@ export default class Errors extends UtilityClass {
    * @param {string} hash Hash of the blob in question.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static blob_not_found(hash) {
+  static blobNotFound(hash) {
     FrozenBuffer.checkHash(hash);
-    return new InfoError('blob_not_found', hash);
+    return new InfoError('blobNotFound', hash);
   }
 
   /**
@@ -44,9 +44,9 @@ export default class Errors extends UtilityClass {
    * @param {string} id ID of the file.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static file_not_found(id) {
+  static fileNotFound(id) {
     TString.check(id);
-    return new InfoError('file_not_found', id);
+    return new InfoError('fileNotFound', id);
   }
 
   /**
@@ -57,10 +57,10 @@ export default class Errors extends UtilityClass {
    * @param {string} hash The expected hash.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static path_hash_mismatch(storagePath, hash) {
+  static pathHashMismatch(storagePath, hash) {
     StoragePath.check(storagePath);
     TString.nonEmpty(hash);
-    return new InfoError('path_hash_mismatch', storagePath, hash);
+    return new InfoError('pathHashMismatch', storagePath, hash);
   }
 
   /**
@@ -70,9 +70,9 @@ export default class Errors extends UtilityClass {
    * @param {string} storagePath Path in question.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static path_not_absent(storagePath) {
+  static pathNotAbsent(storagePath) {
     StoragePath.check(storagePath);
-    return new InfoError('path_not_absent', storagePath);
+    return new InfoError('pathNotAbsent', storagePath);
   }
 
   /**
@@ -82,38 +82,38 @@ export default class Errors extends UtilityClass {
    * @param {string} storagePath Path in question.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static path_not_found(storagePath) {
+  static pathNotFound(storagePath) {
     StoragePath.check(storagePath);
-    return new InfoError('path_not_found', storagePath);
+    return new InfoError('pathNotFound', storagePath);
   }
 
   /**
-   * Indicates whether or not the given error is a `path_hash_mismatch`.
+   * Indicates whether or not the given error is a `pathHashMismatch`.
    *
    * @param {Error} error Error in question.
-   * @returns {boolean} `true` iff it represents a `path_hash_mismatch`.
+   * @returns {boolean} `true` iff it represents a `pathHashMismatch`.
    */
   static is_pathHashMismatch(error) {
-    return InfoError.hasName(error, 'path_hash_mismatch');
+    return InfoError.hasName(error, 'pathHashMismatch');
   }
 
   /**
-   * Indicates whether or not the given error is a `path_not_absent`.
+   * Indicates whether or not the given error is a `pathNotAbsent`.
    *
    * @param {Error} error Error in question.
-   * @returns {boolean} `true` iff it represents a `path_not_absent`.
+   * @returns {boolean} `true` iff it represents a `pathNotAbsent`.
    */
   static is_pathNotAbsent(error) {
-    return InfoError.hasName(error, 'path_not_absent');
+    return InfoError.hasName(error, 'pathNotAbsent');
   }
 
   /**
-   * Indicates whether or not the given error is a `path_not_found`.
+   * Indicates whether or not the given error is a `pathNotFound`.
    *
    * @param {Error} error Error in question.
-   * @returns {boolean} `true` iff it represents a `path_not_found`.
+   * @returns {boolean} `true` iff it represents a `pathNotFound`.
    */
   static is_pathNotFound(error) {
-    return InfoError.hasName(error, 'path_not_found');
+    return InfoError.hasName(error, 'pathNotFound');
   }
 }

--- a/local-modules/file-store/Errors.js
+++ b/local-modules/file-store/Errors.js
@@ -93,7 +93,7 @@ export default class Errors extends UtilityClass {
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a `path_hash_mismatch`.
    */
-  static isPathHashMismatch(error) {
+  static is_pathHashMismatch(error) {
     return InfoError.hasName(error, 'path_hash_mismatch');
   }
 
@@ -103,7 +103,7 @@ export default class Errors extends UtilityClass {
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a `path_not_absent`.
    */
-  static isPathNotAbsent(error) {
+  static is_pathNotAbsent(error) {
     return InfoError.hasName(error, 'path_not_absent');
   }
 
@@ -113,7 +113,7 @@ export default class Errors extends UtilityClass {
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a `path_not_found`.
    */
-  static isPathNotFound(error) {
+  static is_pathNotFound(error) {
     return InfoError.hasName(error, 'path_not_found');
   }
 }

--- a/local-modules/file-store/FileCodec.js
+++ b/local-modules/file-store/FileCodec.js
@@ -90,7 +90,7 @@ export default class FileCodec extends CommonBase {
       const bufferAt = [];
       for (let i = 0; i < argInfo.length; i++) {
         const [name_unused, type] = argInfo[i];
-        if ((type === FileOp.TYPE_BUFFER) || (type === FileOp.TYPE_HASH)) {
+        if ((type === FileOp.TYPE_Buffer) || (type === FileOp.TYPE_Hash)) {
           bufferAt.push(i);
         }
       }

--- a/local-modules/file-store/FileId.js
+++ b/local-modules/file-store/FileId.js
@@ -31,7 +31,7 @@ export default class FileId extends UtilityClass {
     if (   (typeof value !== 'string')
         || (value.length === 0)
         || !Hooks.theOne.isFileId(value)) {
-      throw Errors.bad_value(value, FileId);
+      throw Errors.badValue(value, FileId);
     }
 
     return value;

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -444,6 +444,30 @@ export default class FileOp extends CommonBase {
   }
 
   /**
+   * Validates a category string. Throws an error given an invalid category.
+   *
+   * @param {*} category The (alleged) category string.
+   * @returns {string} `category` but only if valid.
+   */
+  static checkCategory(category) {
+    switch (category) {
+      case CAT_delete:
+      case CAT_environment:
+      case CAT_list:
+      case CAT_prerequisite:
+      case CAT_read:
+      case CAT_revision:
+      case CAT_wait:
+      case CAT_write: {
+        return category;
+      }
+      default: {
+        throw Errors.badValue(category, 'category string');
+      }
+    }
+  }
+
+  /**
    * Gets the properties associated with a given operation, by name. Properties
    * are as follows:
    *
@@ -497,30 +521,6 @@ export default class FileOp extends CommonBase {
     }
 
     return result;
-  }
-
-  /**
-   * Validates a category string. Throws an error given an invalid category.
-   *
-   * @param {*} category The (alleged) category string.
-   * @returns {string} `category` but only if valid.
-   */
-  static validateCategory(category) {
-    switch (category) {
-      case CAT_delete:
-      case CAT_environment:
-      case CAT_list:
-      case CAT_prerequisite:
-      case CAT_read:
-      case CAT_revision:
-      case CAT_wait:
-      case CAT_write: {
-        return category;
-      }
-      default: {
-        throw Errors.badValue(category, 'category string');
-      }
-    }
   }
 
   /**

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -10,19 +10,19 @@ import { CommonBase, DataUtil, Errors, FrozenBuffer } from 'util-common';
 import StoragePath from './StoragePath';
 
 // Operation category constants. See docs on the static properties for details.
-const CAT_DELETE       = 'delete';
-const CAT_ENVIRONMENT  = 'environment';
-const CAT_LIST         = 'list';
-const CAT_PREREQUISITE = 'prerequisite';
-const CAT_READ         = 'read';
-const CAT_REVISION     = 'revision';
-const CAT_WAIT         = 'wait';
-const CAT_WRITE        = 'write';
+const CAT_delete       = 'delete';
+const CAT_environment  = 'environment';
+const CAT_list         = 'list';
+const CAT_prerequisite = 'prerequisite';
+const CAT_read         = 'read';
+const CAT_revision     = 'revision';
+const CAT_wait         = 'wait';
+const CAT_write        = 'write';
 
 /** {array<string>} List of categories in defined execution order. */
 const CATEGORY_EXECUTION_ORDER = [
-  CAT_ENVIRONMENT, CAT_REVISION, CAT_PREREQUISITE, CAT_LIST, CAT_READ,
-  CAT_DELETE, CAT_WRITE, CAT_WAIT
+  CAT_environment, CAT_revision, CAT_prerequisite, CAT_list, CAT_read,
+  CAT_delete, CAT_write, CAT_wait
 ];
 
 // Schema argument type constants. See docs on the static properties for
@@ -47,7 +47,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The expected-to-be-absent hash.
    */
-  [CAT_PREREQUISITE, 'checkBlobAbsent', ['hash', TYPE_HASH]],
+  [CAT_prerequisite, 'checkBlobAbsent', ['hash', TYPE_HASH]],
 
   /*
    * A `checkBlobPresent` operation. This is a prerequisite operation that
@@ -55,7 +55,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The expected hash.
    */
-  [CAT_PREREQUISITE, 'checkBlobPresent', ['hash', TYPE_HASH]],
+  [CAT_prerequisite, 'checkBlobPresent', ['hash', TYPE_HASH]],
 
   /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
@@ -64,7 +64,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_PREREQUISITE, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
+  [CAT_prerequisite, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `checkPathIs` operation. This is a prerequisite operation that verifies
@@ -74,7 +74,7 @@ const OPERATIONS = [
    * @param {string} hash The expected hash.
    */
   [
-    CAT_PREREQUISITE, 'checkPathIs',
+    CAT_prerequisite, 'checkPathIs',
     ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
   ],
 
@@ -90,7 +90,7 @@ const OPERATIONS = [
    * @param {string} hash The non-expected hash.
    */
   [
-    CAT_PREREQUISITE, 'checkPathNot',
+    CAT_prerequisite, 'checkPathNot',
     ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
   ],
 
@@ -102,14 +102,14 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_PREREQUISITE, 'checkPathPresent', ['storagePath', TYPE_PATH]],
+  [CAT_prerequisite, 'checkPathPresent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `deleteAll` operation. This is a write operation that removes all stored
    * items in the file. If the file was already empty, then this operation does
    * nothing.
    */
-  [CAT_DELETE, 'deleteAll'],
+  [CAT_delete, 'deleteAll'],
 
   /*
    * A `deleteBlob` operation. This is a write operation that removes from the
@@ -118,7 +118,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The hash of the blob to delete.
    */
-  [CAT_DELETE, 'deleteBlob', ['hash', TYPE_HASH]],
+  [CAT_delete, 'deleteBlob', ['hash', TYPE_HASH]],
 
   /*
    * A `deletePath` operation. This is a write operation that deletes the
@@ -127,7 +127,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to delete.
    */
-  [CAT_DELETE, 'deletePath', ['storagePath', TYPE_PATH]],
+  [CAT_delete, 'deletePath', ['storagePath', TYPE_PATH]],
 
   /*
    * A `deletePathPrefix` operation. This is a write operation that deletes the
@@ -137,7 +137,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path prefix to delete.
    */
-  [CAT_DELETE, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
+  [CAT_delete, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
    * A `deletePathRange` operation. This is a write operation that deletes the
@@ -154,7 +154,7 @@ const OPERATIONS = [
    *   effect (as it would be an empty range).
    */
   [
-    CAT_DELETE, 'deletePathRange',
+    CAT_delete, 'deletePathRange',
     ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
   ],
 
@@ -168,7 +168,7 @@ const OPERATIONS = [
    * @param {string} storagePath The storage path prefix to list the contents
    *   of.
    */
-  [CAT_LIST, 'listPathPrefix', ['storagePath', TYPE_PATH]],
+  [CAT_list, 'listPathPrefix', ['storagePath', TYPE_PATH]],
 
   /*
    * A `listPathRange` operation. This is a read operation that retrieves a
@@ -184,7 +184,7 @@ const OPERATIONS = [
    *   result in an empty list (as it would be an empty range).
    */
   [
-    CAT_LIST, 'listPathRange',
+    CAT_list, 'listPathRange',
     ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
   ],
 
@@ -202,7 +202,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The content hash of the blob to read.
    */
-  [CAT_READ, 'readBlob', ['hash', TYPE_HASH]],
+  [CAT_read, 'readBlob', ['hash', TYPE_HASH]],
 
   /*
    * A `readPath` operation. This is a read operation that retrieves the value
@@ -217,7 +217,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to read from.
    */
-  [CAT_READ, 'readPath', ['storagePath', TYPE_PATH]],
+  [CAT_read, 'readPath', ['storagePath', TYPE_PATH]],
 
   /*
    * A `readPathRange` operation. This is a read operation that retrieves all
@@ -234,7 +234,7 @@ const OPERATIONS = [
    *   effect (as it would be an empty range).
    */
   [
-    CAT_READ, 'readPathRange',
+    CAT_read, 'readPathRange',
     ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
   ],
 
@@ -248,7 +248,7 @@ const OPERATIONS = [
    *
    * @param {Int} revNum Required revision number.
    */
-  [CAT_REVISION, 'revNum', ['revNum', TYPE_REV_NUM]],
+  [CAT_revision, 'revNum', ['revNum', TYPE_REV_NUM]],
 
   /*
    * A `timeout` operation. This is an environment operation which limits a
@@ -261,7 +261,7 @@ const OPERATIONS = [
    *
    * @param {Int} durMsec Duration of the timeout, in milliseconds.
    */
-  [CAT_ENVIRONMENT, 'timeout', ['durMsec', TYPE_DUR_MSEC]],
+  [CAT_environment, 'timeout', ['durMsec', TYPE_DUR_MSEC]],
 
   /*
    * A `whenPathAbsent` operation. This is a wait operation that blocks the
@@ -269,7 +269,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to observe.
    */
-  [CAT_WAIT, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
+  [CAT_wait, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `whenPathNot` operation. This is a wait operation that blocks the
@@ -281,7 +281,7 @@ const OPERATIONS = [
    * @param {string} hash Hash of the blob which must _not_ be at `storagePath`
    *   for the operation to complete.
    */
-  [CAT_WAIT, 'whenPathNot', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
+  [CAT_wait, 'whenPathNot', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
 
   /*
    * A `whenPathPresent` operation. This is a wait operation that blocks the
@@ -289,7 +289,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to observe.
    */
-  [CAT_WAIT, 'whenPathPresent', ['storagePath', TYPE_PATH]],
+  [CAT_wait, 'whenPathPresent', ['storagePath', TYPE_PATH]],
 
   /*
    * A `writeBlob` operation. This is a write operation that stores the
@@ -298,7 +298,7 @@ const OPERATIONS = [
    *
    * @param {FrozenBuffer} value The value to store.
    */
-  [CAT_WRITE, 'writeBlob', ['value', TYPE_BUFFER]],
+  [CAT_write, 'writeBlob', ['value', TYPE_BUFFER]],
 
   /*
    * A `writePath` operation. This is a write operation that stores the
@@ -308,7 +308,7 @@ const OPERATIONS = [
    * @param {string} storagePath The storage path to bind to.
    * @param {FrozenBuffer} value The value to store and bind to `storagePath`.
    */
-  [CAT_WRITE, 'writePath', ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]]
+  [CAT_write, 'writePath', ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]]
 ];
 
 /**
@@ -317,8 +317,8 @@ const OPERATIONS = [
  */
 const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
   const [category, name, ...args] = schema;
-  const isPull = (category === CAT_READ) || (category === CAT_LIST);
-  const isPush = (category === CAT_WRITE) || (category === CAT_DELETE);
+  const isPull = (category === CAT_read) || (category === CAT_list);
+  const isPush = (category === CAT_write) || (category === CAT_delete);
 
   const props = { category, name, args, isPull, isPush };
   return [name, DataUtil.deepFreeze(props)];
@@ -362,43 +362,43 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
  */
 export default class FileOp extends CommonBase {
   /** {string} Operation category for deletion ops. */
-  static get CAT_DELETE() {
-    return CAT_DELETE;
+  static get CAT_delete() {
+    return CAT_delete;
   }
 
   /** {string} Operation category for environment ops. */
-  static get CAT_ENVIRONMENT() {
-    return CAT_ENVIRONMENT;
+  static get CAT_environment() {
+    return CAT_environment;
   }
 
   /** {string} Operation category for path lists. */
-  static get CAT_LIST() {
-    return CAT_LIST;
+  static get CAT_list() {
+    return CAT_list;
   }
 
   /** {string} Operation category for prerequisites. */
-  static get CAT_PREREQUISITE() {
-    return CAT_PREREQUISITE;
+  static get CAT_prerequisite() {
+    return CAT_prerequisite;
   }
 
   /** {string} Operation category for data reads. */
-  static get CAT_READ() {
-    return CAT_READ;
+  static get CAT_read() {
+    return CAT_read;
   }
 
   /** {string} Operation category for revision restrictions. */
-  static get CAT_REVISION() {
-    return CAT_REVISION;
+  static get CAT_revision() {
+    return CAT_revision;
   }
 
   /** {string} Operation category for waits. */
-  static get CAT_WAIT() {
-    return CAT_WAIT;
+  static get CAT_wait() {
+    return CAT_wait;
   }
 
   /** {string} Operation category for data writes. */
-  static get CAT_WRITE() {
-    return CAT_WRITE;
+  static get CAT_write() {
+    return CAT_write;
   }
 
   /** {array<string>} List of all operation names. This is a frozen value. */
@@ -507,14 +507,14 @@ export default class FileOp extends CommonBase {
    */
   static validateCategory(category) {
     switch (category) {
-      case CAT_DELETE:
-      case CAT_ENVIRONMENT:
-      case CAT_LIST:
-      case CAT_PREREQUISITE:
-      case CAT_READ:
-      case CAT_REVISION:
-      case CAT_WAIT:
-      case CAT_WRITE: {
+      case CAT_delete:
+      case CAT_environment:
+      case CAT_list:
+      case CAT_prerequisite:
+      case CAT_read:
+      case CAT_revision:
+      case CAT_wait:
+      case CAT_write: {
         return category;
       }
       default: {

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -27,12 +27,12 @@ const CATEGORY_EXECUTION_ORDER = [
 
 // Schema argument type constants. See docs on the static properties for
 // details.
-const TYPE_BUFFER    = 'Buffer';
-const TYPE_DUR_MSEC  = 'DurMsec';
-const TYPE_HASH      = 'Hash';
-const TYPE_INDEX     = 'Index';
-const TYPE_PATH      = 'Path';
-const TYPE_REV_NUM   = 'RevNum';
+const TYPE_Buffer  = 'Buffer';
+const TYPE_DurMsec = 'DurMsec';
+const TYPE_Hash    = 'Hash';
+const TYPE_Index   = 'Index';
+const TYPE_Path    = 'Path';
+const TYPE_RevNum  = 'RevNum';
 
 // Operation schemata. See the doc for {@link FileOp#propsFromName} for
 // details.
@@ -47,7 +47,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The expected-to-be-absent hash.
    */
-  [CAT_prerequisite, 'checkBlobAbsent', ['hash', TYPE_HASH]],
+  [CAT_prerequisite, 'checkBlobAbsent', ['hash', TYPE_Hash]],
 
   /*
    * A `checkBlobPresent` operation. This is a prerequisite operation that
@@ -55,7 +55,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The expected hash.
    */
-  [CAT_prerequisite, 'checkBlobPresent', ['hash', TYPE_HASH]],
+  [CAT_prerequisite, 'checkBlobPresent', ['hash', TYPE_Hash]],
 
   /*
    * A `checkPathAbsent` operation. This is a prerequisite operation that
@@ -64,7 +64,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_prerequisite, 'checkPathAbsent', ['storagePath', TYPE_PATH]],
+  [CAT_prerequisite, 'checkPathAbsent', ['storagePath', TYPE_Path]],
 
   /*
    * A `checkPathIs` operation. This is a prerequisite operation that verifies
@@ -75,7 +75,7 @@ const OPERATIONS = [
    */
   [
     CAT_prerequisite, 'checkPathIs',
-    ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
+    ['storagePath', TYPE_Path], ['hash', TYPE_Hash]
   ],
 
   /*
@@ -91,7 +91,7 @@ const OPERATIONS = [
    */
   [
     CAT_prerequisite, 'checkPathNot',
-    ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]
+    ['storagePath', TYPE_Path], ['hash', TYPE_Hash]
   ],
 
   /*
@@ -102,7 +102,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to check.
    */
-  [CAT_prerequisite, 'checkPathPresent', ['storagePath', TYPE_PATH]],
+  [CAT_prerequisite, 'checkPathPresent', ['storagePath', TYPE_Path]],
 
   /*
    * A `deleteAll` operation. This is a write operation that removes all stored
@@ -118,7 +118,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The hash of the blob to delete.
    */
-  [CAT_delete, 'deleteBlob', ['hash', TYPE_HASH]],
+  [CAT_delete, 'deleteBlob', ['hash', TYPE_Hash]],
 
   /*
    * A `deletePath` operation. This is a write operation that deletes the
@@ -127,7 +127,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to delete.
    */
-  [CAT_delete, 'deletePath', ['storagePath', TYPE_PATH]],
+  [CAT_delete, 'deletePath', ['storagePath', TYPE_Path]],
 
   /*
    * A `deletePathPrefix` operation. This is a write operation that deletes the
@@ -137,7 +137,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path prefix to delete.
    */
-  [CAT_delete, 'deletePathPrefix', ['storagePath', TYPE_PATH]],
+  [CAT_delete, 'deletePathPrefix', ['storagePath', TYPE_Path]],
 
   /*
    * A `deletePathRange` operation. This is a write operation that deletes the
@@ -155,7 +155,7 @@ const OPERATIONS = [
    */
   [
     CAT_delete, 'deletePathRange',
-    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
+    ['storagePath', TYPE_Path], ['startInclusive', TYPE_Index], ['endExclusive', TYPE_Index]
   ],
 
   /*
@@ -168,7 +168,7 @@ const OPERATIONS = [
    * @param {string} storagePath The storage path prefix to list the contents
    *   of.
    */
-  [CAT_list, 'listPathPrefix', ['storagePath', TYPE_PATH]],
+  [CAT_list, 'listPathPrefix', ['storagePath', TYPE_Path]],
 
   /*
    * A `listPathRange` operation. This is a read operation that retrieves a
@@ -185,7 +185,7 @@ const OPERATIONS = [
    */
   [
     CAT_list, 'listPathRange',
-    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
+    ['storagePath', TYPE_Path], ['startInclusive', TYPE_Index], ['endExclusive', TYPE_Index]
   ],
 
   /*
@@ -202,7 +202,7 @@ const OPERATIONS = [
    *
    * @param {string} hash The content hash of the blob to read.
    */
-  [CAT_read, 'readBlob', ['hash', TYPE_HASH]],
+  [CAT_read, 'readBlob', ['hash', TYPE_Hash]],
 
   /*
    * A `readPath` operation. This is a read operation that retrieves the value
@@ -217,7 +217,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to read from.
    */
-  [CAT_read, 'readPath', ['storagePath', TYPE_PATH]],
+  [CAT_read, 'readPath', ['storagePath', TYPE_Path]],
 
   /*
    * A `readPathRange` operation. This is a read operation that retrieves all
@@ -235,7 +235,7 @@ const OPERATIONS = [
    */
   [
     CAT_read, 'readPathRange',
-    ['storagePath', TYPE_PATH], ['startInclusive', TYPE_INDEX], ['endExclusive', TYPE_INDEX]
+    ['storagePath', TYPE_Path], ['startInclusive', TYPE_Index], ['endExclusive', TYPE_Index]
   ],
 
   /*
@@ -248,7 +248,7 @@ const OPERATIONS = [
    *
    * @param {Int} revNum Required revision number.
    */
-  [CAT_revision, 'revNum', ['revNum', TYPE_REV_NUM]],
+  [CAT_revision, 'revNum', ['revNum', TYPE_RevNum]],
 
   /*
    * A `timeout` operation. This is an environment operation which limits a
@@ -261,7 +261,7 @@ const OPERATIONS = [
    *
    * @param {Int} durMsec Duration of the timeout, in milliseconds.
    */
-  [CAT_environment, 'timeout', ['durMsec', TYPE_DUR_MSEC]],
+  [CAT_environment, 'timeout', ['durMsec', TYPE_DurMsec]],
 
   /*
    * A `whenPathAbsent` operation. This is a wait operation that blocks the
@@ -269,7 +269,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to observe.
    */
-  [CAT_wait, 'whenPathAbsent', ['storagePath', TYPE_PATH]],
+  [CAT_wait, 'whenPathAbsent', ['storagePath', TYPE_Path]],
 
   /*
    * A `whenPathNot` operation. This is a wait operation that blocks the
@@ -281,7 +281,7 @@ const OPERATIONS = [
    * @param {string} hash Hash of the blob which must _not_ be at `storagePath`
    *   for the operation to complete.
    */
-  [CAT_wait, 'whenPathNot', ['storagePath', TYPE_PATH], ['hash', TYPE_HASH]],
+  [CAT_wait, 'whenPathNot', ['storagePath', TYPE_Path], ['hash', TYPE_Hash]],
 
   /*
    * A `whenPathPresent` operation. This is a wait operation that blocks the
@@ -289,7 +289,7 @@ const OPERATIONS = [
    *
    * @param {string} storagePath The storage path to observe.
    */
-  [CAT_wait, 'whenPathPresent', ['storagePath', TYPE_PATH]],
+  [CAT_wait, 'whenPathPresent', ['storagePath', TYPE_Path]],
 
   /*
    * A `writeBlob` operation. This is a write operation that stores the
@@ -298,7 +298,7 @@ const OPERATIONS = [
    *
    * @param {FrozenBuffer} value The value to store.
    */
-  [CAT_write, 'writeBlob', ['value', TYPE_BUFFER]],
+  [CAT_write, 'writeBlob', ['value', TYPE_Buffer]],
 
   /*
    * A `writePath` operation. This is a write operation that stores the
@@ -308,7 +308,7 @@ const OPERATIONS = [
    * @param {string} storagePath The storage path to bind to.
    * @param {FrozenBuffer} value The value to store and bind to `storagePath`.
    */
-  [CAT_write, 'writePath', ['storagePath', TYPE_PATH], ['value', TYPE_BUFFER]]
+  [CAT_write, 'writePath', ['storagePath', TYPE_Path], ['value', TYPE_Buffer]]
 ];
 
 /**
@@ -407,13 +407,13 @@ export default class FileOp extends CommonBase {
   }
 
   /** {string} Type name for a `FrozenBuffer`. */
-  static get TYPE_BUFFER() {
-    return TYPE_BUFFER;
+  static get TYPE_Buffer() {
+    return TYPE_Buffer;
   }
 
   /** {string} Type name for a millisecond-accuracy duration. */
-  static get TYPE_DUR_MSEC() {
-    return TYPE_DUR_MSEC;
+  static get TYPE_DurMsec() {
+    return TYPE_DurMsec;
   }
 
   /**
@@ -421,26 +421,26 @@ export default class FileOp extends CommonBase {
    * accept instances of `FrozenBuffer`. When given a buffer, the constructor
    * automatically converts it to its hash.
    */
-  static get TYPE_HASH() {
-    return TYPE_HASH;
+  static get TYPE_Hash() {
+    return TYPE_Hash;
   }
 
   /**
    * {string} Type name for index values, which is to say non-negative integers.
    * These are used to with the `*Range` operations.
    */
-  static get TYPE_INDEX() {
-    return TYPE_INDEX;
+  static get TYPE_Index() {
+    return TYPE_Index;
   }
 
   /** {string} Type name for storage paths. */
-  static get TYPE_PATH() {
-    return TYPE_PATH;
+  static get TYPE_Path() {
+    return TYPE_Path;
   }
 
   /** {string} Type name for revision numbers. */
-  static get TYPE_REV_NUM() {
-    return TYPE_REV_NUM;
+  static get TYPE_RevNum() {
+    return TYPE_RevNum;
   }
 
   /**
@@ -634,17 +634,17 @@ export default class FileOp extends CommonBase {
    */
   static _fixArg(value, type) {
     switch (type) {
-      case TYPE_BUFFER: {
+      case TYPE_Buffer: {
         FrozenBuffer.check(value);
         break;
       }
 
-      case TYPE_DUR_MSEC: {
+      case TYPE_DurMsec: {
         TInt.nonNegative(value);
         break;
       }
 
-      case TYPE_HASH: {
+      case TYPE_Hash: {
         if (value instanceof FrozenBuffer) {
           value = value.hash;
         } else {
@@ -653,17 +653,17 @@ export default class FileOp extends CommonBase {
         break;
       }
 
-      case TYPE_INDEX: {
+      case TYPE_Index: {
         TInt.nonNegative(value);
         break;
       }
 
-      case TYPE_PATH: {
+      case TYPE_Path: {
         StoragePath.check(value);
         break;
       }
 
-      case TYPE_REV_NUM: {
+      case TYPE_RevNum: {
         TInt.nonNegative(value);
         break;
       }

--- a/local-modules/file-store/FileOp.js
+++ b/local-modules/file-store/FileOp.js
@@ -466,7 +466,7 @@ export default class FileOp extends CommonBase {
     const schema = OPERATION_MAP.get(name);
 
     if (!schema) {
-      throw Errors.bad_value(name, 'FileOp operation name');
+      throw Errors.badValue(name, 'FileOp operation name');
     }
 
     return schema;
@@ -518,7 +518,7 @@ export default class FileOp extends CommonBase {
         return category;
       }
       default: {
-        throw Errors.bad_value(category, 'category string');
+        throw Errors.badValue(category, 'category string');
       }
     }
   }
@@ -688,7 +688,7 @@ export default class FileOp extends CommonBase {
     const { args: argInfo, name } = opProps;
 
     if (args.length !== argInfo.length) {
-      throw Errors.bad_use(`Wrong argument count for op \`${name}\`; expected ${argInfo.length}.`);
+      throw Errors.badUse(`Wrong argument count for op \`${name}\`; expected ${argInfo.length}.`);
     }
 
     for (let i = 0; i < argInfo.length; i++) {

--- a/local-modules/file-store/StorageId.js
+++ b/local-modules/file-store/StorageId.js
@@ -28,7 +28,7 @@ export default class StorageId extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, StorageId);
+    throw Errors.badValue(value, StorageId);
   }
 
   /**

--- a/local-modules/file-store/StoragePath.js
+++ b/local-modules/file-store/StoragePath.js
@@ -67,7 +67,7 @@ export default class StoragePath extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, StoragePath);
+    throw Errors.badValue(value, StoragePath);
   }
 
   /**
@@ -82,7 +82,7 @@ export default class StoragePath extends UtilityClass {
     TString.nonEmpty(value);
 
     if (!COMPONENT_REGEX.test(value)) {
-      throw Errors.bad_value(value, 'StoragePath component');
+      throw Errors.badValue(value, 'StoragePath component');
     }
 
     return value;
@@ -102,7 +102,7 @@ export default class StoragePath extends UtilityClass {
     const match = path.match(/[/](0|[1-9][0-9]*)$/);
 
     if (match === null) {
-      throw Errors.bad_value(path, StoragePath, 'with index');
+      throw Errors.badValue(path, StoragePath, 'with index');
     }
 
     return TInt.nonNegative(parseInt(match[1]));
@@ -180,7 +180,7 @@ export default class StoragePath extends UtilityClass {
       return StoragePath.check(value);
     } catch (e) {
       // More specific error.
-      throw Errors.bad_value(value, 'StoragePath|null');
+      throw Errors.badValue(value, 'StoragePath|null');
     }
   }
 

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -142,7 +142,7 @@ export default class TransactionSpec extends CommonBase {
    * @returns {array<FileOp>} Array of all such operations.
    */
   opsWithCategory(category) {
-    FileOp.validateCategory(category);
+    FileOp.checkCategory(category);
     return this._ops.filter(op => (op.category === category));
   }
 

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -27,15 +27,15 @@ export default class TransactionSpec extends CommonBase {
     // Validate the op combo restrictions.
 
     if (this.opsWithName('timeout').length > 1) {
-      throw Errors.bad_use('Too many `timeout` operations.');
+      throw Errors.badUse('Too many `timeout` operations.');
     }
 
     if (this.opsWithName('revNum').length > 1) {
-      throw Errors.bad_use('Too many `revNum` operations.');
+      throw Errors.badUse('Too many `revNum` operations.');
     }
 
     if (this.hasWaitOps() && (this.hasPullOps() || this.hasPushOps())) {
-      throw Errors.bad_use('Cannot mix wait operations with reads and modifications.');
+      throw Errors.badUse('Cannot mix wait operations with reads and modifications.');
     }
 
     Object.freeze(this);

--- a/local-modules/file-store/TransactionSpec.js
+++ b/local-modules/file-store/TransactionSpec.js
@@ -76,63 +76,63 @@ export default class TransactionSpec extends CommonBase {
 
   /**
    * Indicates whether or not this instance has any operations which return
-   * path results, that is, any operations with category `CAT_LIST` or
-   * `CAT_WAIT`.
+   * path results, that is, any operations with category `CAT_list` or
+   * `CAT_wait`.
    *
    * @returns {boolean} `true` iff there are any push operations in this
    *   instance.
    */
   hasPathOps() {
-    return (this.opsWithCategory(FileOp.CAT_LIST).length !== 0)
-      || (this.opsWithCategory(FileOp.CAT_WAIT).length !== 0);
+    return (this.opsWithCategory(FileOp.CAT_list).length !== 0)
+      || (this.opsWithCategory(FileOp.CAT_wait).length !== 0);
   }
 
   /**
    * Indicates whether or not this instance has any push operations (data
-   * storage of any sort), that is, any operations with category `CAT_DELETE` or
-   * `CAT_WRITE`.
+   * storage of any sort), that is, any operations with category `CAT_delete` or
+   * `CAT_write`.
    *
    * @returns {boolean} `true` iff there are any push operations in this
    *   instance.
    */
   hasPushOps() {
-    return (this.opsWithCategory(FileOp.CAT_DELETE).length !== 0)
-      || (this.opsWithCategory(FileOp.CAT_WRITE).length !== 0);
+    return (this.opsWithCategory(FileOp.CAT_delete).length !== 0)
+      || (this.opsWithCategory(FileOp.CAT_write).length !== 0);
   }
 
   /**
    * Indicates whether or not this instance has any pull operations (data
-   * retrieval of any sort), that is, any operations with category `CAT_LIST` or
-   * `CAT_READ`.
+   * retrieval of any sort), that is, any operations with category `CAT_list` or
+   * `CAT_read`.
    *
    * @returns {boolean} `true` iff there are any pull operations in this
    *   instance.
    */
   hasPullOps() {
-    return (this.opsWithCategory(FileOp.CAT_LIST).length !== 0)
-      || (this.opsWithCategory(FileOp.CAT_READ).length !== 0);
+    return (this.opsWithCategory(FileOp.CAT_list).length !== 0)
+      || (this.opsWithCategory(FileOp.CAT_read).length !== 0);
   }
 
   /**
    * Indicates whether or not this instance has any read operations, that is,
-   * any operations with category `CAT_READ`.
+   * any operations with category `CAT_read`.
    *
    * @returns {boolean} `true` iff there are any read operations in this
    *   instance.
    */
   hasReadOps() {
-    return this.opsWithCategory(FileOp.CAT_READ).length !== 0;
+    return this.opsWithCategory(FileOp.CAT_read).length !== 0;
   }
 
   /**
    * Indicates whether or not this instance has any wait operations, that is,
-   * any operations with category `CAT_WAIT`.
+   * any operations with category `CAT_wait`.
    *
    * @returns {boolean} `true` iff there are any wait operations in this
    *   instance.
    */
   hasWaitOps() {
-    return this.opsWithCategory(FileOp.CAT_WAIT).length !== 0;
+    return this.opsWithCategory(FileOp.CAT_wait).length !== 0;
   }
 
   /**

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -144,23 +144,23 @@ export default class FileOpMaker extends UtilityClass {
    */
   static _makeValue(type, n) {
     switch (type) {
-      case FileOp.TYPE_BUFFER: {
+      case FileOp.TYPE_Buffer: {
         return FrozenBuffer.coerce(`buffer_${n}`);
       }
-      case FileOp.TYPE_DUR_MSEC: {
+      case FileOp.TYPE_DurMsec: {
         return n * 1234;
       }
-      case FileOp.TYPE_HASH: {
+      case FileOp.TYPE_Hash: {
         const buf = FrozenBuffer.coerce(`buffer_hash_${n}`);
         return buf.hash;
       }
-      case FileOp.TYPE_INDEX: {
+      case FileOp.TYPE_Index: {
         return n + 100;
       }
-      case FileOp.TYPE_PATH: {
+      case FileOp.TYPE_Path: {
         return `/path/${n}`;
       }
-      case FileOp.TYPE_REV_NUM: {
+      case FileOp.TYPE_RevNum: {
         return n;
       }
       default: {

--- a/local-modules/file-store/tests/FileOpMaker.js
+++ b/local-modules/file-store/tests/FileOpMaker.js
@@ -62,7 +62,7 @@ export default class FileOpMaker extends UtilityClass {
 
     for (const name of FileOp.OPERATION_NAMES) {
       const schema = FileOp.propsFromName(name);
-      if (schema.category === FileOp.CAT_WAIT) {
+      if (schema.category === FileOp.CAT_wait) {
         continue;
       }
 
@@ -91,7 +91,7 @@ export default class FileOpMaker extends UtilityClass {
         continue;
       }
 
-      const n = (schema.category === FileOp.CAT_WAIT) ? count : 1;
+      const n = (schema.category === FileOp.CAT_wait) ? count : 1;
       for (let i = 0; i < n; i++) {
         ops.push(FileOpMaker.makeOp(name, i));
       }

--- a/local-modules/file-store/tests/test_StoragePath.js
+++ b/local-modules/file-store/tests/test_StoragePath.js
@@ -160,7 +160,7 @@ describe('file-store/StoragePath', () => {
 
     it('should reject non-index-bearing paths', () => {
       function test(value) {
-        assert.throws(() => StoragePath.getIndex(value), /bad_value/);
+        assert.throws(() => StoragePath.getIndex(value), /badValue/);
       }
 
       // Nothing even vaguely index-like.
@@ -183,7 +183,7 @@ describe('file-store/StoragePath', () => {
 
     it('should reject entirely invalid path arguments', () => {
       for (const value of [...INVALID_PATHS, ...NON_STRINGS]) {
-        assert.throws(() => StoragePath.getIndex(value), /bad_value/);
+        assert.throws(() => StoragePath.getIndex(value), /badValue/);
       }
     });
   });

--- a/local-modules/file-store/tests/test_TransactionSpec.js
+++ b/local-modules/file-store/tests/test_TransactionSpec.js
@@ -27,7 +27,7 @@ describe('file-store/TransactionSpec', () => {
           for (let i = 0; i < ops.length; i += 9) {
             const useOps = ops.slice();
             useOps[i] = badValues[badAt];
-            assert.throws(() => new TransactionSpec(...useOps), /bad_value/);
+            assert.throws(() => new TransactionSpec(...useOps), /badValue/);
             badAt = (badAt + 1) % badValues.length;
           }
         });

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -39,7 +39,7 @@ export default class Hooks extends Singleton {
       return `http://${host}`;
     }
 
-    throw Errors.bad_data('Missing `host` header on request.');
+    throw Errors.badData('Missing `host` header on request.');
   }
 
   /**

--- a/local-modules/mocha-client-shim/index.js
+++ b/local-modules/mocha-client-shim/index.js
@@ -29,7 +29,7 @@ const mocha = global.mocha;
 class MochaShim {
   constructor(opts) {
     if (MochaShim._constructed) {
-      throw Errors.bad_use('Can only instantiate the client `Mocha` shim once.');
+      throw Errors.badUse('Can only instantiate the client `Mocha` shim once.');
     }
 
     mocha.setup(opts);

--- a/local-modules/ot-common/AuthorId.js
+++ b/local-modules/ot-common/AuthorId.js
@@ -30,7 +30,7 @@ export default class AuthorId extends UtilityClass {
     if (   (typeof value !== 'string')
         || (value.length === 0)
         || !Hooks.theOne.isAuthorId(value)) {
-      throw Errors.bad_value(value, AuthorId);
+      throw Errors.badValue(value, AuthorId);
     }
 
     return value;
@@ -51,7 +51,7 @@ export default class AuthorId extends UtilityClass {
       return AuthorId.check(value);
     } catch (e) {
       // Higher-fidelity error.
-      throw Errors.bad_value(value, 'AuthorId|null');
+      throw Errors.badValue(value, 'AuthorId|null');
     }
   }
 }

--- a/local-modules/ot-common/BaseDelta.js
+++ b/local-modules/ot-common/BaseDelta.js
@@ -128,7 +128,7 @@ export default class BaseDelta extends CommonBase {
     TBoolean.check(wantDocument);
 
     if (wantDocument && !this.isDocument()) {
-      throw Errors.bad_use('`wantDocument === true` on non-document instance.');
+      throw Errors.badUse('`wantDocument === true` on non-document instance.');
     }
 
     const result = this._impl_compose(other, wantDocument);

--- a/local-modules/ot-common/BaseSnapshot.js
+++ b/local-modules/ot-common/BaseSnapshot.js
@@ -87,7 +87,7 @@ export default class BaseSnapshot extends CommonBase {
     // is probably a good idea to evaluate how expensive this is in practice,
     // and figure out a better tactic if need be.
     if (!this._contents.isDocument()) {
-      throw Errors.bad_value(contents, this.constructor.deltaClass, 'document');
+      throw Errors.badValue(contents, this.constructor.deltaClass, 'document');
     }
   }
 

--- a/local-modules/ot-common/RevisionNumber.js
+++ b/local-modules/ot-common/RevisionNumber.js
@@ -21,7 +21,7 @@ export default class RevisionNumber extends UtilityClass {
       return TInt.nonNegative(value);
     } catch (e) {
       // More appropriate error.
-      throw Errors.bad_value(value, RevisionNumber);
+      throw Errors.badValue(value, RevisionNumber);
     }
   }
 
@@ -38,7 +38,7 @@ export default class RevisionNumber extends UtilityClass {
       return TInt.range(value, 0, maxExc);
     } catch (e) {
       // More appropriate error.
-      throw Errors.bad_value(value, RevisionNumber, `value < ${maxExc}`);
+      throw Errors.badValue(value, RevisionNumber, `value < ${maxExc}`);
     }
   }
 
@@ -55,7 +55,7 @@ export default class RevisionNumber extends UtilityClass {
       return TInt.rangeInc(value, 0, maxInc);
     } catch (e) {
       // More appropriate error.
-      throw Errors.bad_value(value, RevisionNumber, `value <= ${maxInc}`);
+      throw Errors.badValue(value, RevisionNumber, `value <= ${maxInc}`);
     }
   }
 
@@ -72,7 +72,7 @@ export default class RevisionNumber extends UtilityClass {
       return TInt.min(value, minInc);
     } catch (e) {
       // More appropriate error.
-      throw Errors.bad_value(value, RevisionNumber, `value >= ${minInc}`);
+      throw Errors.badValue(value, RevisionNumber, `value >= ${minInc}`);
     }
   }
 }

--- a/local-modules/ot-common/Timestamp.js
+++ b/local-modules/ot-common/Timestamp.js
@@ -96,7 +96,7 @@ export default class Timestamp extends CommonBase {
       return Timestamp.check(value);
     } catch (e) {
       // Higher-fidelity error.
-      throw Errors.bad_value(value, 'TimeStamp|null');
+      throw Errors.badValue(value, 'TimeStamp|null');
     }
   }
 

--- a/local-modules/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/ot-common/tests/test_BaseDelta.js
@@ -133,7 +133,7 @@ describe('doc-common/BaseDelta', () => {
     it('should reject invalid `other` arguments', () => {
       function test(value) {
         const delta = MockDelta.EMPTY;
-        assert.throws(() => { delta.compose(value, false); }, /bad_value/);
+        assert.throws(() => { delta.compose(value, false); }, /badValue/);
       }
 
       test(undefined);
@@ -147,7 +147,7 @@ describe('doc-common/BaseDelta', () => {
     it('should reject non-boolean `wantDocument` arguments', () => {
       function test(value) {
         const delta = MockDelta.EMPTY;
-        assert.throws(() => { delta.compose(delta, value); }, /bad_value/);
+        assert.throws(() => { delta.compose(delta, value); }, /badValue/);
       }
 
       test(undefined);
@@ -159,7 +159,7 @@ describe('doc-common/BaseDelta', () => {
 
     it('should reject a non-document `this` when `wantDocument` is `true`', () => {
       const delta = new MockDelta([['not_document']]);
-      assert.throws(() => { delta.compose(MockDelta.EMPTY, true); }, /bad_use/);
+      assert.throws(() => { delta.compose(MockDelta.EMPTY, true); }, /badUse/);
     });
   });
 

--- a/local-modules/ot-common/tests/test_RevisionNumber.js
+++ b/local-modules/ot-common/tests/test_RevisionNumber.js
@@ -16,7 +16,7 @@ import { RevisionNumber } from 'ot-common';
  */
 function rejectBadNumbers(name, ...args) {
   function test(value) {
-    assert.throws(() => RevisionNumber[name](value, ...args), /^bad_value/);
+    assert.throws(() => RevisionNumber[name](value, ...args), /^badValue/);
   }
 
   test(-1);
@@ -35,7 +35,7 @@ function rejectBadNumbers(name, ...args) {
  */
 function rejectNonNumbers(name, ...args) {
   function test(value) {
-    assert.throws(() => RevisionNumber[name](value, ...args), /^bad_value/);
+    assert.throws(() => RevisionNumber[name](value, ...args), /^badValue/);
   }
 
   test(null);
@@ -89,7 +89,7 @@ describe('doc-common/RevisionNumber', () => {
 
     it('should reject non-negative integers beyond the specified limit', () => {
       function test(value, limit) {
-        assert.throws(() => RevisionNumber.maxExc(value, limit), /^bad_value/);
+        assert.throws(() => RevisionNumber.maxExc(value, limit), /^badValue/);
       }
 
       test(0,   0);
@@ -128,7 +128,7 @@ describe('doc-common/RevisionNumber', () => {
 
     it('should reject non-negative integers beyond the specified limit', () => {
       function test(value, limit) {
-        assert.throws(() => RevisionNumber.maxInc(value, limit), /^bad_value/);
+        assert.throws(() => RevisionNumber.maxInc(value, limit), /^badValue/);
       }
 
       test(1,   0);
@@ -164,7 +164,7 @@ describe('doc-common/RevisionNumber', () => {
 
     it('should reject non-negative integers below the specified limit', () => {
       function test(value, limit) {
-        assert.throws(() => RevisionNumber.min(value, limit), /^bad_value/);
+        assert.throws(() => RevisionNumber.min(value, limit), /^badValue/);
       }
 
       test(0,   1);

--- a/local-modules/promise-util/ChainedEvent.js
+++ b/local-modules/promise-util/ChainedEvent.js
@@ -263,11 +263,11 @@ export default class ChainedEvent extends CommonBase {
   _resolveNext(event) {
     ChainedEvent.check(event);
     if (this._source !== event._source) {
-      throw Errors.bad_use('Mismatched `event` source.');
+      throw Errors.badUse('Mismatched `event` source.');
     }
 
     if (this._nextNow !== null) {
-      throw Errors.bad_use('Can only call `_resolveNext()` once.');
+      throw Errors.badUse('Can only call `_resolveNext()` once.');
     }
 
     this._nextNow = event;

--- a/local-modules/promise-util/Mutex.js
+++ b/local-modules/promise-util/Mutex.js
@@ -79,7 +79,7 @@ export default class Mutex extends CommonBase {
     // The return value is the unlock function.
     return () => {
       if (this._lockedBy !== key) {
-        throw Errors.bad_use('Attempt to unlock by non-owner.');
+        throw Errors.badUse('Attempt to unlock by non-owner.');
       }
 
       this._lockedBy = null;

--- a/local-modules/proppy/Proppy.js
+++ b/local-modules/proppy/Proppy.js
@@ -90,7 +90,7 @@ export default class Proppy extends UtilityClass {
             const key = t.value;
             if (keys.has(key)) {
               // Already have this key.
-              throw Errors.bad_data(`Duplicate key: \`${key}\``);
+              throw Errors.badData(`Duplicate key: \`${key}\``);
             }
             keys.add(key);
             result[key] = value.value;
@@ -102,7 +102,7 @@ export default class Proppy extends UtilityClass {
 
         default: {
           const value = t.value ? ` \`${t.value}\`` : '';
-          throw Errors.bad_data(`Syntax error at \`${t.type}\` token${value}.`);
+          throw Errors.badData(`Syntax error at \`${t.type}\` token${value}.`);
         }
       }
     }
@@ -164,7 +164,7 @@ export default class Proppy extends UtilityClass {
       const context = (source.length > 10)
         ? `${source.slice(0, 10)}...`
         : source;
-      throw Errors.bad_data(`Invalid character at: \`${context}\``);
+      throw Errors.badData(`Invalid character at: \`${context}\``);
     }
 
     // We treat the string as always ending with a newline.
@@ -209,7 +209,7 @@ export default class Proppy extends UtilityClass {
           case '\'': { replacement = '\''; break; }
           case '"':  { replacement = '"';  break; }
           default: {
-            throw Errors.bad_data(`Invalid escape character in quoted string: \`${source[0]}\``);
+            throw Errors.badData(`Invalid escape character in quoted string: \`${source[0]}\``);
           }
         }
 
@@ -217,7 +217,7 @@ export default class Proppy extends UtilityClass {
         continue;
       }
 
-      throw Errors.bad_data(`Invalid character in quoted string: \`${source[0]}\``);
+      throw Errors.badData(`Invalid character in quoted string: \`${source[0]}\``);
     }
 
     return result.join('');

--- a/local-modules/quill-util/Macros.js
+++ b/local-modules/quill-util/Macros.js
@@ -5,6 +5,8 @@
 import { Clock, ImageEmbed } from 'ui-embeds';
 import { UtilityClass } from 'util-core';
 
+import QuillEvents from './QuillEvents';
+
 /**
  * This class handles the processing of text macros within sources
  * editor environment. Macros are pieces of text delimited by
@@ -38,10 +40,10 @@ export default class Macros extends UtilityClass {
       const index = keyRange.index - matchLength;
 
       // Delete the opening marker
-      quill.deleteText(index, 1, 'user');
+      quill.deleteText(index, 1, QuillEvents.SOURCE_user);
 
       // Delete the macro name
-      quill.deleteText(index, text.length, 'user');
+      quill.deleteText(index, text.length, QuillEvents.SOURCE_user);
 
       // Pick the right component
       const args = text.split(':');

--- a/local-modules/quill-util/NotReallyMarkdown.js
+++ b/local-modules/quill-util/NotReallyMarkdown.js
@@ -5,6 +5,8 @@
 import { Logger } from 'see-all';
 import { UtilityClass } from 'util-core';
 
+import QuillEvents from './QuillEvents';
+
 const log = new Logger('not-md');
 
 export default class NotReallyMarkdown extends UtilityClass {
@@ -54,14 +56,14 @@ export default class NotReallyMarkdown extends UtilityClass {
       const index = keyRange.index - matchLength;
 
       //  Delete the opening marker
-      this.quill.deleteText(index, 1, 'user');
+      this.quill.deleteText(index, 1, QuillEvents.SOURCE_user);
 
       //  Add the format to the text between the markers
-      this.quill.formatText(index, text.length, { [format]: true }, 'user');
+      this.quill.formatText(index, text.length, { [format]: true }, QuillEvents.SOURCE_user);
 
       //  Turn format formatting off at the cursor so that it doesn't get
       //  extended if the user keeps typing at that location.
-      this.quill.format(format, false, 'user');
+      this.quill.format(format, false, QuillEvents.SOURCE_user);
 
       //  Don't allow the trigger character into the document.
       return false;

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -27,7 +27,7 @@ export default class QuillEvents extends UtilityClass {
    */
   static get EMPTY_TEXT_CHANGE_PAYLOAD() {
     return new Functor(
-      QuillEvents.EVENT_textChange, BodyDelta.EMPTY, BodyDelta.EMPTY, QuillEvents.SOURCE_api);
+      QuillEvents.TYPE_textChange, BodyDelta.EMPTY, BodyDelta.EMPTY, QuillEvents.SOURCE_api);
   }
 
   /**
@@ -35,7 +35,7 @@ export default class QuillEvents extends UtilityClass {
    * value of this variable is dictated by Quill and so violates the default
    * local conventions.
    */
-  static get EVENT_editorChange() {
+  static get TYPE_editorChange() {
     return 'editor-change';
   }
 
@@ -44,7 +44,7 @@ export default class QuillEvents extends UtilityClass {
    * value of this variable is dictated by Quill and so violates the default
    * local conventions.
    */
-  static get EVENT_selectionChange() {
+  static get TYPE_selectionChange() {
     return 'selection-change';
   }
 
@@ -53,7 +53,7 @@ export default class QuillEvents extends UtilityClass {
    * of this variable is dictated by Quill and so violates the default local
    * conventions.
    */
-  static get EVENT_textChange() {
+  static get TYPE_textChange() {
     return 'text-change';
   }
 
@@ -87,7 +87,7 @@ export default class QuillEvents extends UtilityClass {
     const name = payload.name;
 
     switch (name) {
-      case QuillEvents.EVENT_textChange: {
+      case QuillEvents.TYPE_textChange: {
         const [delta, oldContents, source] = payload.args;
         return new Functor(name,
           BodyDelta.fromQuillForm(delta),
@@ -95,7 +95,7 @@ export default class QuillEvents extends UtilityClass {
           TString.check(source));
       }
 
-      case QuillEvents.EVENT_selectionChange: {
+      case QuillEvents.TYPE_selectionChange: {
         const [range, oldRange, source] = payload.args;
         return new Functor(name,
           QuillEvents._checkAndFreezeRange(range),
@@ -125,12 +125,12 @@ export default class QuillEvents extends UtilityClass {
     const name = payload.name;
 
     switch (name) {
-      case QuillEvents.EVENT_textChange: {
+      case QuillEvents.TYPE_textChange: {
         const [delta, oldContents, source] = payload.args;
         return { name, delta, oldContents, source };
       }
 
-      case QuillEvents.EVENT_selectionChange: {
+      case QuillEvents.TYPE_selectionChange: {
         const [range, oldRange, source] = payload.args;
         return { name, range, oldRange, source };
       }

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -12,13 +12,13 @@ import { Errors, Functor, ObjectUtil, UtilityClass } from 'util-common';
  */
 export default class QuillEvents extends UtilityClass {
   /** {String} Event source for the API. */
-  static get API() {
+  static get SOURCE_api() {
     return 'api';
   }
 
-  /** {String} Event name for editor change events. */
-  static get EDITOR_CHANGE() {
-    return 'editor-change';
+  /** {String} Event source for user (human) activity. */
+  static get SOURCE_user() {
+    return 'user';
   }
 
   /**
@@ -27,16 +27,33 @@ export default class QuillEvents extends UtilityClass {
    */
   static get EMPTY_TEXT_CHANGE_PAYLOAD() {
     return new Functor(
-      QuillEvents.TEXT_CHANGE, BodyDelta.EMPTY, BodyDelta.EMPTY, QuillEvents.API);
+      QuillEvents.EVENT_textChange, BodyDelta.EMPTY, BodyDelta.EMPTY, QuillEvents.SOURCE_api);
   }
 
-  /** {String} Event name for selection change events. */
-  static get SELECTION_CHANGE() {
+  /**
+   * {String} Event type/name for editor change events. **Note:** The string
+   * value of this variable is dictated by Quill and so violates the default
+   * local conventions.
+   */
+  static get EVENT_editorChange() {
+    return 'editor-change';
+  }
+
+  /**
+   * {String} Event type/name for selection change events. **Note:** The string
+   * value of this variable is dictated by Quill and so violates the default
+   * local conventions.
+   */
+  static get EVENT_selectionChange() {
     return 'selection-change';
   }
 
-  /** {String} Event name for text change events. */
-  static get TEXT_CHANGE() {
+  /**
+   * {String} Event type/name for text change events. **Note:** The string value
+   * of this variable is dictated by Quill and so violates the default local
+   * conventions.
+   */
+  static get EVENT_textChange() {
     return 'text-change';
   }
 
@@ -70,7 +87,7 @@ export default class QuillEvents extends UtilityClass {
     const name = payload.name;
 
     switch (name) {
-      case QuillEvents.TEXT_CHANGE: {
+      case QuillEvents.EVENT_textChange: {
         const [delta, oldContents, source] = payload.args;
         return new Functor(name,
           BodyDelta.fromQuillForm(delta),
@@ -78,7 +95,7 @@ export default class QuillEvents extends UtilityClass {
           TString.check(source));
       }
 
-      case QuillEvents.SELECTION_CHANGE: {
+      case QuillEvents.EVENT_selectionChange: {
         const [range, oldRange, source] = payload.args;
         return new Functor(name,
           QuillEvents._checkAndFreezeRange(range),
@@ -108,12 +125,12 @@ export default class QuillEvents extends UtilityClass {
     const name = payload.name;
 
     switch (name) {
-      case QuillEvents.TEXT_CHANGE: {
+      case QuillEvents.EVENT_textChange: {
         const [delta, oldContents, source] = payload.args;
         return { name, delta, oldContents, source };
       }
 
-      case QuillEvents.SELECTION_CHANGE: {
+      case QuillEvents.EVENT_selectionChange: {
         const [range, oldRange, source] = payload.args;
         return { name, range, oldRange, source };
       }

--- a/local-modules/quill-util/QuillEvents.js
+++ b/local-modules/quill-util/QuillEvents.js
@@ -87,7 +87,7 @@ export default class QuillEvents extends UtilityClass {
       }
 
       default: {
-        throw Errors.bad_value(payload, 'Quill event payload');
+        throw Errors.badValue(payload, 'Quill event payload');
       }
     }
   }
@@ -119,7 +119,7 @@ export default class QuillEvents extends UtilityClass {
       }
 
       default: {
-        throw Errors.bad_value(payload, 'Quill event payload');
+        throw Errors.badValue(payload, 'Quill event payload');
       }
     }
   }

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -69,7 +69,7 @@ export default class QuillProm extends Quill {
     // synchronously on stale information.
     const origEmit = origEmitter.emit;
     origEmitter.emit = (type, ...rest) => {
-      if (type === QuillEvents.EVENT_editorChange) {
+      if (type === QuillEvents.TYPE_editorChange) {
         // We attach to the `editor-change` event so that we see all changes in
         // their original order, even when changes were made with the "silent"
         // flag (because if we miss events, then the local and server state will

--- a/local-modules/quill-util/QuillProm.js
+++ b/local-modules/quill-util/QuillProm.js
@@ -69,7 +69,7 @@ export default class QuillProm extends Quill {
     // synchronously on stale information.
     const origEmit = origEmitter.emit;
     origEmitter.emit = (type, ...rest) => {
-      if (type === QuillEvents.EDITOR_CHANGE) {
+      if (type === QuillEvents.EVENT_editorChange) {
         // We attach to the `editor-change` event so that we see all changes in
         // their original order, even when changes were made with the "silent"
         // flag (because if we miss events, then the local and server state will

--- a/local-modules/quill-util/QuillUtil.js
+++ b/local-modules/quill-util/QuillUtil.js
@@ -12,7 +12,7 @@ const POSITION_NOT_FOUND = Object.freeze({
   blotOffset: 0,
   line: null,
   lineOffset: 0,
-  range: { index: -1, length: 0 }
+  range: Object.freeze({ index: -1, length: 0 })
 });
 
 /**
@@ -21,7 +21,7 @@ const POSITION_NOT_FOUND = Object.freeze({
  */
 export default class QuillUtil extends UtilityClass {
   /**
-   * Return value for `.quillContextForPixelPosition()` for cases where the
+   * Return value for {@link #quillContextForPixelPosition} for cases where the
    * pixel is not in the Quill context. All properties are nulled/zeroed except
    * for `range: [-1, 0]`.
    */

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -79,7 +79,7 @@ export default class AllSinks extends Singleton {
       // reasonably blatant that something needs to be fixed during application
       // bootstrap.
       const details = inspect(level, tag, ...message);
-      throw Errors.bad_use(`Overly early log call: ${details}`);
+      throw Errors.badUse(`Overly early log call: ${details}`);
     }
 
     const logRecord =

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -24,7 +24,7 @@ export default class BaseLogger extends CommonBase {
    *   contains an exception, this will log the stack trace.
    */
   log(level, ...message) {
-    LogRecord.validateLevel(level);
+    LogRecord.checkLevel(level);
     this._impl_log(level, message);
   }
 

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -26,6 +26,21 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
+   * Validates a logging severity level value. Throws an error if invalid.
+   *
+   * @param {string} level Severity level. Must be one of the severity level
+   *   constants defined by this class.
+   * @returns {string} `level`, if it is indeed valid.
+   */
+  static checkLevel(level) {
+    if (!LEVELS_SET.has(level)) {
+      throw Errors.badValue(level, 'logging severity level');
+    }
+
+    return level;
+  }
+
+  /**
    * Constructs an instance of this class for representing a timestamp. The
    * result is an `info` level record tagged with `time`, and with a three-array
    * `messages` argument consisting of `[<utc>, '/', <local>]`, where `<utc>`
@@ -112,21 +127,6 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
-   * Validates a logging severity level value. Throws an error if invalid.
-   *
-   * @param {string} level Severity level. Must be one of the severity level
-   *   constants defined by this class.
-   * @returns {string} `level`, if it is indeed valid.
-   */
-  static validateLevel(level) {
-    if (!LEVELS_SET.has(level)) {
-      throw Errors.badValue(level, 'logging severity level');
-    }
-
-    return level;
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {Int} timeMsec Timestamp of the message.
@@ -152,7 +152,7 @@ export default class LogRecord extends CommonBase {
     this._stack = TString.orNull(stack);
 
     /** {string} Severity level. */
-    this._level = LogRecord.validateLevel(level);
+    this._level = LogRecord.checkLevel(level);
 
     /**
      * {LogTag} Tag (component name and optional context) associated with the

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -120,7 +120,7 @@ export default class LogRecord extends CommonBase {
    */
   static validateLevel(level) {
     if (!LEVELS_SET.has(level)) {
-      throw Errors.bad_value(level, 'logging severity level');
+      throw Errors.badValue(level, 'logging severity level');
     }
 
     return level;

--- a/local-modules/see-all/LogStream.js
+++ b/local-modules/see-all/LogStream.js
@@ -28,7 +28,7 @@ export default class LogStream extends CommonBase {
     this._logger = BaseLogger.check(logger);
 
     /** {string} Severity level. */
-    this._level = LogRecord.validateLevel(level);
+    this._level = LogRecord.checkLevel(level);
   }
 
   /**

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -24,10 +24,10 @@ describe('see-all/LogRecord', () => {
     });
   });
 
-  describe('validateLevel()', () => {
+  describe('checkLevel()', () => {
     it('accepts valid levels', () => {
       function test(level) {
-        assert.strictEqual(LogRecord.validateLevel(level), level);
+        assert.strictEqual(LogRecord.checkLevel(level), level);
       }
 
       for (const level of LogRecord.LEVELS) {
@@ -37,7 +37,7 @@ describe('see-all/LogRecord', () => {
 
     it('rejects invalid levels', () => {
       function test(level) {
-        assert.throws(() => { LogRecord.validateLevel(level); });
+        assert.throws(() => { LogRecord.checkLevel(level); });
       }
 
       test('');

--- a/local-modules/state-machine/StateMachine.js
+++ b/local-modules/state-machine/StateMachine.js
@@ -141,11 +141,11 @@ export default class StateMachine {
         const validArgs = validator.apply(this, args) || args;
 
         if ((validArgs !== undefined) && !Array.isArray(validArgs)) {
-          throw Errors.bad_use(`Invalid validator result (non-array) for \`${name}\`.`);
+          throw Errors.badUse(`Invalid validator result (non-array) for \`${name}\`.`);
         }
 
         if (this._eventQueue === null) {
-          throw Errors.bad_use('Attempt to queue events on aborted instance.');
+          throw Errors.badUse('Attempt to queue events on aborted instance.');
         }
 
         const event = new Functor(name, ...args);
@@ -300,7 +300,7 @@ export default class StateMachine {
 
       if ((eventName !== 'any') && !this._eventValidators[eventName]) {
         // No associated validator.
-        throw Errors.bad_use(`Unknown event name ${eventName} in method ${desc.name}.`);
+        throw Errors.badUse(`Unknown event name ${eventName} in method ${desc.name}.`);
       }
 
       if (!result[stateName]) {
@@ -402,16 +402,16 @@ export default class StateMachine {
 
   /**
    * Default handler for any event in any state, which responds by throwing a
-   * `bad_use` error, because subclasses should cover all the event
+   * `badUse` error, because subclasses should cover all the event
    * possibilities. This may be overridden by subclasses if in fact having a
    * wildcard handler is the right tactic for their particular case.
    *
    * @param {string} name The event name.
    * @param {...*} args_unused Arguments to the event.
-   * @throws {Errors.bad_use} Always thrown.
+   * @throws {Errors.badUse} Always thrown.
    */
   _handle_any_any(name, ...args_unused) {
-    throw Errors.bad_use(`Cannot handle event \`${name}\` in state \`${this._stateName}\`.`);
+    throw Errors.badUse(`Cannot handle event \`${name}\` in state \`${this._stateName}\`.`);
   }
 
   /**

--- a/local-modules/testing-server/TestCollector.js
+++ b/local-modules/testing-server/TestCollector.js
@@ -80,7 +80,7 @@ export default class TestCollector extends CommonBase {
    */
   allDone() {
     if (this._done) {
-      throw Errors.bad_use('Already done!');
+      throw Errors.badUse('Already done!');
     }
 
     this._done = true;
@@ -108,7 +108,7 @@ export default class TestCollector extends CommonBase {
    */
   suiteEnd() {
     if (this._suites.length === 0) {
-      throw Errors.bad_use('No active suite.');
+      throw Errors.badUse('No active suite.');
     }
 
     this._suites.pop();

--- a/local-modules/typecheck/TArray.js
+++ b/local-modules/typecheck/TArray.js
@@ -19,7 +19,7 @@ export default class TArray extends UtilityClass {
    */
   static check(value, elementCheck = null) {
     if (!Array.isArray(value)) {
-      throw Errors.bad_value(value, Array);
+      throw Errors.badValue(value, Array);
     }
 
     if (elementCheck !== null) {

--- a/local-modules/typecheck/TBoolean.js
+++ b/local-modules/typecheck/TBoolean.js
@@ -16,7 +16,7 @@ export default class TBoolean extends UtilityClass {
    */
   static check(value) {
     if (typeof value !== 'boolean') {
-      throw Errors.bad_value(value, Boolean);
+      throw Errors.badValue(value, Boolean);
     }
 
     return value;

--- a/local-modules/typecheck/TBuffer.js
+++ b/local-modules/typecheck/TBuffer.js
@@ -19,7 +19,7 @@ export default class TBuffer extends UtilityClass {
    */
   static check(value) {
     if (!Buffer.isBuffer(value)) {
-      throw Errors.bad_value(value, Buffer);
+      throw Errors.badValue(value, Buffer);
     }
 
     return value;

--- a/local-modules/typecheck/TFunction.js
+++ b/local-modules/typecheck/TFunction.js
@@ -16,7 +16,7 @@ export default class TFunction extends UtilityClass {
    */
   static check(value) {
     if (typeof value !== 'function') {
-      throw Errors.bad_value(value, Function);
+      throw Errors.badValue(value, Function);
     }
 
     return value;
@@ -37,7 +37,7 @@ export default class TFunction extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, Function, 'callable');
+    throw Errors.badValue(value, Function, 'callable');
   }
 
   /**
@@ -52,7 +52,7 @@ export default class TFunction extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, 'Function|null', 'callable');
+    throw Errors.badValue(value, 'Function|null', 'callable');
   }
 
   /**
@@ -74,7 +74,7 @@ export default class TFunction extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, Function, 'class');
+    throw Errors.badValue(value, Function, 'class');
   }
 
   /**
@@ -127,7 +127,7 @@ export default class TFunction extends UtilityClass {
    */
   static isClass(value, ancestor = null) {
     if (ancestor && !TFunction.isClass(ancestor)) {
-      throw Errors.bad_value(value, Function, 'class');
+      throw Errors.badValue(value, Function, 'class');
     }
 
     if (   ((typeof value) !== 'function')
@@ -183,7 +183,7 @@ export default class TFunction extends UtilityClass {
    */
   static orNull(value) {
     if ((value !== null) && (typeof value !== 'function')) {
-      throw Errors.bad_value(value, 'Function|null');
+      throw Errors.badValue(value, 'Function|null');
     }
 
     return value;

--- a/local-modules/typecheck/TInt.js
+++ b/local-modules/typecheck/TInt.js
@@ -47,7 +47,7 @@ export default class TInt extends UtilityClass {
     TInt.check(maxInc);
 
     if (value > maxInc) {
-      throw Errors.bad_value(value, 'Int', `value <= ${maxInc}`);
+      throw Errors.badValue(value, 'Int', `value <= ${maxInc}`);
     }
 
     return value;
@@ -110,7 +110,7 @@ export default class TInt extends UtilityClass {
     TInt.check(maxInc);
 
     if ((value < minInc) || (value > maxInc)) {
-      throw Errors.bad_value(value, 'Int', `${minInc} <= value <= ${maxInc}`);
+      throw Errors.badValue(value, 'Int', `${minInc} <= value <= ${maxInc}`);
     }
 
     return value;

--- a/local-modules/typecheck/TIterable.js
+++ b/local-modules/typecheck/TIterable.js
@@ -29,7 +29,7 @@ export default class TIterable extends UtilityClass {
   static check(value, entryCheck = null) {
     if (   ((typeof value) !== 'object')
         || ((typeof value[Symbol.iterator]) !== 'function')) {
-      throw Errors.bad_value(value, 'Iterable');
+      throw Errors.badValue(value, 'Iterable');
     }
 
     if (entryCheck !== null) {

--- a/local-modules/typecheck/TMap.js
+++ b/local-modules/typecheck/TMap.js
@@ -23,7 +23,7 @@ export default class TMap extends UtilityClass {
    */
   static check(value, keyCheck = null, valueCheck = null) {
     if (!(value instanceof Map)) {
-      throw Errors.bad_value(value, Map);
+      throw Errors.badValue(value, Map);
     }
 
     if ((keyCheck !== null) || (valueCheck !== null)) {

--- a/local-modules/typecheck/TNumber.js
+++ b/local-modules/typecheck/TNumber.js
@@ -16,7 +16,7 @@ export default class TNumber extends UtilityClass {
    */
   static check(value) {
     if (typeof value !== 'number') {
-      throw Errors.bad_value(value, Number);
+      throw Errors.badValue(value, Number);
     }
 
     return value;
@@ -37,7 +37,7 @@ export default class TNumber extends UtilityClass {
     TNumber.check(maxExc);
 
     if ((value < minInc) || (value >= maxExc)) {
-      throw Errors.bad_value(value, Number, `${minInc} <= value < ${maxExc}`);
+      throw Errors.badValue(value, Number, `${minInc} <= value < ${maxExc}`);
     }
 
     return value;
@@ -58,7 +58,7 @@ export default class TNumber extends UtilityClass {
     TNumber.check(maxInc);
 
     if ((value < minInc) || (value > maxInc)) {
-      throw Errors.bad_value(value, Number, `${minInc} <= value <= ${maxInc}`);
+      throw Errors.badValue(value, Number, `${minInc} <= value <= ${maxInc}`);
     }
 
     return value;

--- a/local-modules/typecheck/TObject.js
+++ b/local-modules/typecheck/TObject.js
@@ -37,7 +37,7 @@ export default class TObject extends UtilityClass {
       return value;
     }
 
-    throw Errors.bad_value(value, 'plain object');
+    throw Errors.badValue(value, 'plain object');
   }
 
   /**
@@ -57,7 +57,7 @@ export default class TObject extends UtilityClass {
     const copy = Object.assign({}, value);
     for (const k of keys) {
       if (!ObjectUtil.hasOwnProperty(copy, k)) {
-        throw Errors.bad_value(value, Object, `with key \`${k}\``);
+        throw Errors.badValue(value, Object, `with key \`${k}\``);
       }
       delete copy[k];
     }
@@ -68,7 +68,7 @@ export default class TObject extends UtilityClass {
       for (const k of remainingKeys) {
         msg += ` \`${k}\``;
       }
-      throw Errors.bad_value(value, Object, msg);
+      throw Errors.badValue(value, Object, msg);
     }
 
     return value;

--- a/local-modules/typecheck/TSet.js
+++ b/local-modules/typecheck/TSet.js
@@ -19,7 +19,7 @@ export default class TSet extends UtilityClass {
    */
   static check(value, valueCheck = null) {
     if (!(value instanceof Set)) {
-      throw Errors.bad_value(value, Set);
+      throw Errors.badValue(value, Set);
     }
 
     if (valueCheck !== null) {

--- a/local-modules/typecheck/TString.js
+++ b/local-modules/typecheck/TString.js
@@ -40,13 +40,13 @@ export default class TString extends UtilityClass {
       TString.check(value, /^([0-9a-f]{2})*$/);
     } catch (e) {
       // More on-point error.
-      throw Errors.bad_value(value, String, 'even number of hex digits');
+      throw Errors.badValue(value, String, 'even number of hex digits');
     }
 
     if (value.length < (minBytes * 2)) {
-      throw Errors.bad_value(value, String, `byteCount >= ${minBytes}`);
+      throw Errors.badValue(value, String, `byteCount >= ${minBytes}`);
     } else if ((maxBytes !== null) && (value.length > (maxBytes * 2))) {
-      throw Errors.bad_value(value, String, `byteCount <= ${maxBytes}`);
+      throw Errors.badValue(value, String, `byteCount <= ${maxBytes}`);
     }
 
     return value;
@@ -91,7 +91,7 @@ export default class TString extends UtilityClass {
    */
   static maxLen(value, maxLen) {
     if ((typeof value !== 'string') || (value.length > maxLen)) {
-      throw Errors.bad_value(value, String, `value.length <= ${maxLen}`);
+      throw Errors.badValue(value, String, `value.length <= ${maxLen}`);
     }
 
     return value;
@@ -107,7 +107,7 @@ export default class TString extends UtilityClass {
    */
   static minLen(value, minLen) {
     if ((typeof value !== 'string') || (value.length < minLen)) {
-      throw Errors.bad_value(value, String, `value.length >= ${minLen}`);
+      throw Errors.badValue(value, String, `value.length >= ${minLen}`);
     }
 
     return value;
@@ -121,7 +121,7 @@ export default class TString extends UtilityClass {
    */
   static nonEmpty(value) {
     if ((typeof value !== 'string') || (value === '')) {
-      throw Errors.bad_value(value, String, 'value !== \'\'');
+      throw Errors.badValue(value, String, 'value !== \'\'');
     }
 
     return value;
@@ -154,7 +154,7 @@ export default class TString extends UtilityClass {
       url = new URL(TString.nonEmpty(value));
     } catch (e) {
       // Throw a higher-fidelity error.
-      throw Errors.bad_value(value, String, 'absolute URL syntax');
+      throw Errors.badValue(value, String, 'absolute URL syntax');
     }
 
     // Some versions of `URL` will parse a missing origin into the literal
@@ -167,11 +167,11 @@ export default class TString extends UtilityClass {
           && url.origin
           && (url.origin !== 'null')
           && (url.href === value))) {
-      throw Errors.bad_value(value, String, 'absolute URL syntax');
+      throw Errors.badValue(value, String, 'absolute URL syntax');
     }
 
     if (url.username || url.password) {
-      throw Errors.bad_value(value, String, 'absolute URL syntax, without auth');
+      throw Errors.badValue(value, String, 'absolute URL syntax, without auth');
     }
 
     return value;
@@ -190,7 +190,7 @@ export default class TString extends UtilityClass {
       url = new URL(TString.nonEmpty(value));
     } catch (e) {
       // Throw a higher-fidelity error.
-      throw Errors.bad_value(value, String, 'origin-only URL syntax');
+      throw Errors.badValue(value, String, 'origin-only URL syntax');
     }
 
     // **Note:** Though `new URL()` is lenient with respect to parsing, if it
@@ -198,7 +198,7 @@ export default class TString extends UtilityClass {
     // prefix, and the `!==` comparison here therefore transitively confirms
     // that the original `value` is also well-formed.
     if (value !== url.origin) {
-      throw Errors.bad_value(value, String, 'origin-only URL syntax');
+      throw Errors.badValue(value, String, 'origin-only URL syntax');
     }
 
     return value;

--- a/local-modules/typecheck/tests/test_TInt.js
+++ b/local-modules/typecheck/tests/test_TInt.js
@@ -48,7 +48,7 @@ describe('typecheck/TInt', () => {
 
     it('rejects out-of-range integers', () => {
       function test(value, maxExc) {
-        assert.throws(() => TInt.maxExc(value, maxExc), /^bad_value/);
+        assert.throws(() => TInt.maxExc(value, maxExc), /^badValue/);
       }
 
       test(-1,  -2);
@@ -86,7 +86,7 @@ describe('typecheck/TInt', () => {
 
     it('rejects out-of-range integers', () => {
       function test(value, minInc) {
-        assert.throws(() => TInt.min(value, minInc), /^bad_value/);
+        assert.throws(() => TInt.min(value, minInc), /^badValue/);
       }
 
       test(-1,  0);
@@ -116,7 +116,7 @@ describe('typecheck/TInt', () => {
 
     it('rejects out-of-range integers', () => {
       function test(value, minInc, maxExc) {
-        assert.throws(() => TInt.range(value, minInc, maxExc), /^bad_value/);
+        assert.throws(() => TInt.range(value, minInc, maxExc), /^badValue/);
       }
 
       test(-1,  0,   10);

--- a/local-modules/typecheck/tests/test_TString.js
+++ b/local-modules/typecheck/tests/test_TString.js
@@ -142,7 +142,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.identifier(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'identifier syntax']);
       }
 
@@ -171,7 +171,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.identifier(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'identifier syntax']);
       }
 
@@ -205,7 +205,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.label(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'label syntax']);
       }
 
@@ -234,7 +234,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.label(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'label syntax']);
       }
 
@@ -264,7 +264,7 @@ describe('typecheck/TString', () => {
       function test(value, len) {
         Assert.throwsInfo(
           () => { TString.maxLen(value, len); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', `value.length <= ${len}`]);
       }
 
@@ -280,7 +280,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.maxLen(value, 123); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'value.length <= 123']);
       }
 
@@ -310,7 +310,7 @@ describe('typecheck/TString', () => {
       function test(value, len) {
         Assert.throwsInfo(
           () => { TString.minLen(value, len); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', `value.length >= ${len}`]);
       }
 
@@ -329,7 +329,7 @@ describe('typecheck/TString', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { TString.minLen(value, 1); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'value.length >= 1']);
       }
 

--- a/local-modules/ui-embeds/ComponentBlotWrapper.js
+++ b/local-modules/ui-embeds/ComponentBlotWrapper.js
@@ -78,7 +78,7 @@ export default class BlockEmbedWrapper extends UtilityClass {
     try {
       TString.nonEmpty(blotName);
     } catch (e) {
-      throw Errors.bad_value(component, 'React.Component', 'with `blotName`');
+      throw Errors.badValue(component, 'React.Component', 'with `blotName`');
     }
 
     TString.nonEmpty(blotName);
@@ -203,7 +203,7 @@ export default class BlockEmbedWrapper extends UtilityClass {
 
           // If a required property is missing, it's an error.
           if (isRequired && ((prop in props) === false)) {
-            throw Errors.bad_data(`'${prop}' is required`);
+            throw Errors.badData(`'${prop}' is required`);
           }
 
           let value = props[prop];
@@ -212,7 +212,7 @@ export default class BlockEmbedWrapper extends UtilityClass {
             // A property is missing or has no value, check to see if it was
             // required
             if (isRequired) {
-              throw Errors.bad_data(`'${prop}' is required`);
+              throw Errors.badData(`'${prop}' is required`);
             } else {
               continue;
             }
@@ -273,7 +273,7 @@ export default class BlockEmbedWrapper extends UtilityClass {
           if (value === null) {
             if (isRequired) {
               // There wasn't a value and it was a required property.
-              throw Errors.bad_data(`'${prop}' is required`);
+              throw Errors.badData(`'${prop}' is required`);
             }
           } else {
             value = converter(value);

--- a/local-modules/ui-embeds/components/Clock.js
+++ b/local-modules/ui-embeds/components/Clock.js
@@ -8,7 +8,7 @@ import ComponentBlotWrapper from '../ComponentBlotWrapper';
 
 export default class Clock extends React.Component {
   static get blotName() {
-    return 'clock_embed';
+    return 'clockEmbed';
   }
   constructor(props) {
     super(props);

--- a/local-modules/ui-embeds/components/FigmaEmbed.js
+++ b/local-modules/ui-embeds/components/FigmaEmbed.js
@@ -14,7 +14,7 @@ export default class FigmaEmbed extends React.Component {
    * by `ComponentBlotWrapper`.
    */
   static get blotName() {
-    return 'figma_embed';
+    return 'figmaEmbed';
   }
 
   /**

--- a/local-modules/ui-embeds/components/FileEmbed.js
+++ b/local-modules/ui-embeds/components/FileEmbed.js
@@ -22,7 +22,7 @@ export default class FileEmbed extends React.Component {
    * by `ComponentBlotWrapper`.
    */
   static get blotName() {
-    return 'file_embed';
+    return 'fileEmbed';
   }
 
   constructor(props) {

--- a/local-modules/ui-embeds/components/ImageEmbed.js
+++ b/local-modules/ui-embeds/components/ImageEmbed.js
@@ -49,7 +49,7 @@ export default class ImageEmbed extends React.Component {
    * by `ComponentBlotWrapper`.
    */
   static get blotName() {
-    return 'image_embed';
+    return 'imageEmbed';
   }
 
   /**

--- a/local-modules/util-common/DeferredLoader.js
+++ b/local-modules/util-common/DeferredLoader.js
@@ -49,10 +49,10 @@ class DeferredLoaderHandler {
 
         const type = typeof target;
         if ((target === null) || ((type !== 'object') && (type !== 'function'))) {
-          target = Errors.bad_use(`Loader for ${this._label} object returned an invalid value.`);
+          target = Errors.badUse(`Loader for ${this._label} object returned an invalid value.`);
         }
       } catch (e) {
-        target = Errors.bad_use(e, `Error in loader for ${this._label} object.`);
+        target = Errors.badUse(e, `Error in loader for ${this._label} object.`);
       }
 
       this._target = target; // Either the valid value or the error to throw.
@@ -67,7 +67,7 @@ class DeferredLoaderHandler {
     const result = target[property];
 
     if (result === undefined) {
-      throw Errors.bad_use(`Missing property: ${this._label}.${property}`);
+      throw Errors.badUse(`Missing property: ${this._label}.${property}`);
     }
 
     return result;

--- a/local-modules/util-common/FrozenBuffer.js
+++ b/local-modules/util-common/FrozenBuffer.js
@@ -35,7 +35,7 @@ export default class FrozenBuffer extends CommonBase {
       return value;
     }
 
-    throw Errors.bad_value(value, 'FrozenBuffer hash');
+    throw Errors.badValue(value, 'FrozenBuffer hash');
   }
 
   /**
@@ -96,7 +96,7 @@ export default class FrozenBuffer extends CommonBase {
     const isBuffer = Buffer.isBuffer(value);
 
     if (!(isString || isBuffer)) {
-      throw Errors.bad_value(value, 'Buffer|string');
+      throw Errors.badValue(value, 'Buffer|string');
     }
 
     super();

--- a/local-modules/util-common/Singleton.js
+++ b/local-modules/util-common/Singleton.js
@@ -47,7 +47,7 @@ export default class Singleton extends CommonBase {
 
     // See the note in `theOne` above in re `hasOwnProperty`.
     if (ObjectUtil.hasOwnProperty(this.constructor, '_theOne')) {
-      throw Errors.bad_use('Attempt to re-instantiate singleton class.');
+      throw Errors.badUse('Attempt to re-instantiate singleton class.');
     }
 
     this.constructor._theOne = this;

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -61,7 +61,7 @@ export default class CommonBase {
       if (!(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
-        throw Errors.bad_use('Invalid `_impl_coerce()` implementation.');
+        throw Errors.badUse('Invalid `_impl_coerce()` implementation.');
       }
       return result;
     }
@@ -97,7 +97,7 @@ export default class CommonBase {
       if ((result !== null) && !(result instanceof this)) {
         // There is a bug in the subclass, as it should never return any other
         // kind of value.
-        throw Errors.bad_use('Invalid `_impl_coerceOrNull()` implementation.');
+        throw Errors.badUse('Invalid `_impl_coerceOrNull()` implementation.');
       }
       return result;
     }
@@ -347,6 +347,6 @@ export default class CommonBase {
    * @param {...*} args_unused Anything you want, to keep the linter happy.
    */
   static _mustOverride(...args_unused) {
-    throw Errors.bad_use('Subclass must override this method.');
+    throw Errors.badUse('Subclass must override this method.');
   }
 }

--- a/local-modules/util-core/CoreTypecheck.js
+++ b/local-modules/util-core/CoreTypecheck.js
@@ -23,7 +23,7 @@ export default class CoreTypecheck extends UtilityClass {
       return CoreTypecheck.checkString(value, /^[a-zA-Z_][a-zA-Z_0-9]*$/);
     } catch (e) {
       // More accurate error.
-      throw Errors.bad_value(value, String, 'identifier syntax');
+      throw Errors.badValue(value, String, 'identifier syntax');
     }
   }
 
@@ -66,7 +66,7 @@ export default class CoreTypecheck extends UtilityClass {
       msgArg = [];
     }
 
-    throw Errors.bad_value(value, 'Int', ...msgArg);
+    throw Errors.badValue(value, 'Int', ...msgArg);
   }
 
   /**
@@ -82,7 +82,7 @@ export default class CoreTypecheck extends UtilityClass {
       return CoreTypecheck.checkString(value, /^[-a-zA-Z_][-a-zA-Z_0-9]*$/);
     } catch (e) {
       // More accurate error.
-      throw Errors.bad_value(value, String, 'label syntax');
+      throw Errors.badValue(value, String, 'label syntax');
     }
   }
 
@@ -99,14 +99,14 @@ export default class CoreTypecheck extends UtilityClass {
   static checkObject(value, clazz = null) {
     if (clazz !== null) {
       if (!(value instanceof clazz)) {
-        throw Errors.bad_value(value, `class ${clazz.name}`);
+        throw Errors.badValue(value, `class ${clazz.name}`);
       }
     } else if (value === null) {
-      throw Errors.bad_value(value, Object);
+      throw Errors.badValue(value, Object);
     } else {
       const type = typeof value;
       if ((type !== 'object') && (type !== 'function')) {
-        throw Errors.bad_value(value, Object);
+        throw Errors.badValue(value, Object);
       }
     }
 
@@ -123,15 +123,15 @@ export default class CoreTypecheck extends UtilityClass {
    */
   static checkString(value, regex = null) {
     if ((regex !== null) && !(regex instanceof RegExp)) {
-      throw Errors.bad_value(regex, RegExp);
+      throw Errors.badValue(regex, RegExp);
     }
 
     if (typeof value !== 'string') {
-      throw Errors.bad_value(value, String, (regex ? regex.toString() : null));
+      throw Errors.badValue(value, String, (regex ? regex.toString() : null));
     }
 
     if ((regex !== null) && !regex.test(value)) {
-      throw Errors.bad_value(value, String, regex.toString());
+      throw Errors.badValue(value, String, regex.toString());
     }
 
     return value;
@@ -145,7 +145,7 @@ export default class CoreTypecheck extends UtilityClass {
    */
   static checkStringOrNull(value) {
     if ((value !== null) && (typeof value !== 'string')) {
-      throw Errors.bad_value(value, 'String|null');
+      throw Errors.badValue(value, 'String|null');
     }
 
     return value;

--- a/local-modules/util-core/DataUtil.js
+++ b/local-modules/util-core/DataUtil.js
@@ -71,7 +71,7 @@ export default class DataUtil extends UtilityClass {
               : new Functor(value.name, ...(DataUtil.deepFreeze(args)));
           }
           default: {
-            throw Errors.bad_value(value, 'data value');
+            throw Errors.badValue(value, 'data value');
           }
         }
 
@@ -97,7 +97,7 @@ export default class DataUtil extends UtilityClass {
               && !ObjectUtil.hasOwnProperty(prop, 'value')) {
             // **Note:** The `undefined` check just prevents us from having to
             // call `hasOwnProperty()` in the usual case.
-            throw Errors.bad_value(value, 'data value', 'without synthetic properties');
+            throw Errors.badValue(value, 'data value', 'without synthetic properties');
           }
           const newValue = DataUtil.deepFreeze(oldValue);
           if (oldValue !== newValue) {
@@ -110,7 +110,7 @@ export default class DataUtil extends UtilityClass {
       }
 
       default: {
-        throw Errors.bad_value(value, 'data value');
+        throw Errors.badValue(value, 'data value');
       }
     }
   }

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -52,8 +52,8 @@ export default class Errors extends UtilityClass {
    * @param {string} message Description of the problem.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static bad_data(cause, message) {
-    return Errors._make('bad_data', cause, message);
+  static badData(cause, message) {
+    return Errors._make('badData', cause, message);
   }
 
   /**
@@ -73,8 +73,8 @@ export default class Errors extends UtilityClass {
    * @param {string} message Description of the problem.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static bad_use(cause, message) {
-    return Errors._make('bad_use', cause, message);
+  static badUse(cause, message) {
+    return Errors._make('badUse', cause, message);
   }
 
   /**
@@ -94,7 +94,7 @@ export default class Errors extends UtilityClass {
    *   value.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static bad_value(value, expectedType, extra = null) {
+  static badValue(value, expectedType, extra = null) {
     if (typeof expectedType === 'string') {
       // All good. No extra checks.
     } else if (   (typeof expectedType === 'function')
@@ -118,7 +118,7 @@ export default class Errors extends UtilityClass {
     }
 
     return new InfoError(
-      'bad_value',
+      'badValue',
       inspectedValue,
       expectedType,
       ...((extra === null) ? [] : [extra]));
@@ -131,9 +131,9 @@ export default class Errors extends UtilityClass {
    * @param {Int} revNum Requested revision number.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static revision_not_available(revNum) {
+  static revisionNotAvailable(revNum) {
     CoreTypecheck.checkInt(revNum, 0);
-    return new InfoError('revision_not_available', revNum);
+    return new InfoError('revisionNotAvailable', revNum);
   }
 
   /**
@@ -142,9 +142,9 @@ export default class Errors extends UtilityClass {
    * @param {Int} timeoutMsec The original length of the timeout, in msec.
    * @returns {InfoError} An appropriately-constructed error.
    */
-  static timed_out(timeoutMsec) {
+  static timedOut(timeoutMsec) {
     CoreTypecheck.checkInt(timeoutMsec, 0);
-    return new InfoError('timed_out', timeoutMsec);
+    return new InfoError('timedOut', timeoutMsec);
   }
 
   /**
@@ -172,13 +172,13 @@ export default class Errors extends UtilityClass {
   }
 
   /**
-   * Indicates whether or not the given error is a `timed_out`.
+   * Indicates whether or not the given error is a `timedOut`.
    *
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a timeout.
    */
   static is_timedOut(error) {
-    return InfoError.hasName(error, 'timed_out');
+    return InfoError.hasName(error, 'timedOut');
   }
 
   /**

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -12,8 +12,10 @@ import UtilityClass from './UtilityClass';
  * Utility class for constructing commonly-used errors, which are applicable to
  * a wide variety of code.
  *
- * **Note:** The names of the methods match the error functor names, and because
- * the convention for those is `lowercase_underscore`, that is what's used.
+ * In addition, this class defines some convenient predicates for checking to
+ * see if a given value is a particular sort of error. In general, if an error
+ * is created with the method `someName()`, then the corresponding predicate
+ * will be `is_someName()`.
  */
 export default class Errors extends UtilityClass {
   /**
@@ -175,7 +177,7 @@ export default class Errors extends UtilityClass {
    * @param {Error} error Error in question.
    * @returns {boolean} `true` iff it represents a timeout.
    */
-  static isTimedOut(error) {
+  static is_timedOut(error) {
     return InfoError.hasName(error, 'timed_out');
   }
 

--- a/local-modules/util-core/Functor.js
+++ b/local-modules/util-core/Functor.js
@@ -170,7 +170,7 @@ export default class Functor {
       } else if (Object.isFrozen(a)) {
         newArg = a;
       } else {
-        throw Errors.bad_use('Non-frozen non-data argument.');
+        throw Errors.badUse('Non-frozen non-data argument.');
       }
 
       args.push(newArg);

--- a/local-modules/util-core/InfoError.js
+++ b/local-modules/util-core/InfoError.js
@@ -14,7 +14,7 @@ import Functor from './Functor';
  * indicate a different error that was the "cause" of this one.
  *
  * The point of this is to be able to instantiate errors along the lines of
- * `new InfoError('file_not_found', '/foo/bar/baz.txt')` where the error comes
+ * `new InfoError('fileNotFound', '/foo/bar/baz.txt')` where the error comes
  * with a name and associated info in a well-defined form such that other code
  * can succeed in doing something useful with it, should it be useful to do so.
  *

--- a/local-modules/util-core/ObjectUtil.js
+++ b/local-modules/util-core/ObjectUtil.js
@@ -30,7 +30,7 @@ export default class ObjectUtil extends UtilityClass {
 
       const v = result[k] = value[k];
       if ((v === undefined) && !ObjectUtil.hasOwnProperty(value, k)) {
-        throw Errors.bad_use(`Missing property: ${k}`);
+        throw Errors.badUse(`Missing property: ${k}`);
       }
     }
 

--- a/local-modules/util-core/UtilityClass.js
+++ b/local-modules/util-core/UtilityClass.js
@@ -17,9 +17,9 @@ export default class UtilityClass {
    * Always throws an error. That is, utility classes are not ever supposed to
    * be instantiated.
    *
-   * @throws {Errors.bad_use} Always thrown.
+   * @throws {Errors.badUse} Always thrown.
    */
   constructor() {
-    throw Errors.bad_use('Attempt to instantiate utility class.');
+    throw Errors.badUse('Attempt to instantiate utility class.');
   }
 }

--- a/local-modules/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/util-core/tests/test_CoreTypecheck.js
@@ -52,7 +52,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkIdentifier(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'identifier syntax']);
       }
 
@@ -81,7 +81,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkIdentifier(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'identifier syntax']);
       }
 
@@ -120,7 +120,7 @@ describe('util-core/CoreTypecheck', () => {
 
       it('rejects out-of-range integers', () => {
         function test(value, minInc) {
-          assert.throws(() => CoreTypecheck.checkInt(value, minInc), /^bad_value/);
+          assert.throws(() => CoreTypecheck.checkInt(value, minInc), /^badValue/);
         }
 
         test(-1,  0);
@@ -132,7 +132,7 @@ describe('util-core/CoreTypecheck', () => {
 
       it('rejects bad values for `minInc`', () => {
         function test(minInc) {
-          assert.throws(() => CoreTypecheck.checkInt(0, minInc), /^bad_value/);
+          assert.throws(() => CoreTypecheck.checkInt(0, minInc), /^badValue/);
         }
 
         test(false);
@@ -158,7 +158,7 @@ describe('util-core/CoreTypecheck', () => {
 
       it('rejects out-of-range integers', () => {
         function test(value, maxExc) {
-          assert.throws(() => CoreTypecheck.checkInt(value, null, maxExc), /^bad_value/);
+          assert.throws(() => CoreTypecheck.checkInt(value, null, maxExc), /^badValue/);
         }
 
         test(-1,  -2);
@@ -171,7 +171,7 @@ describe('util-core/CoreTypecheck', () => {
 
       it('rejects bad values for `maxExc`', () => {
         function test(maxExc) {
-          assert.throws(() => CoreTypecheck.checkInt(0, null, maxExc), /^bad_value/);
+          assert.throws(() => CoreTypecheck.checkInt(0, null, maxExc), /^badValue/);
         }
 
         test(false);
@@ -199,7 +199,7 @@ describe('util-core/CoreTypecheck', () => {
 
       it('rejects out-of-range integers', () => {
         function test(value, minInc, maxExc) {
-          assert.throws(() => CoreTypecheck.checkInt(value, minInc, maxExc), /^bad_value/);
+          assert.throws(() => CoreTypecheck.checkInt(value, minInc, maxExc), /^badValue/);
         }
 
         test(-1,  0,   10);
@@ -216,10 +216,10 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects numbers that are not safe integers', () => {
       function test(value) {
-        assert.throws(() => CoreTypecheck.checkInt(value), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, null, 100), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, 5, 50), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, null, 100), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 5, 50), /^badValue/);
       }
 
       test(-0.5);
@@ -233,10 +233,10 @@ describe('util-core/CoreTypecheck', () => {
 
     it('rejects non-number values', () => {
       function test(value) {
-        assert.throws(() => CoreTypecheck.checkInt(value), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, null, 2), /^bad_value/);
-        assert.throws(() => CoreTypecheck.checkInt(value, 1, 2), /^bad_value/);
+        assert.throws(() => CoreTypecheck.checkInt(value), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, null, 2), /^badValue/);
+        assert.throws(() => CoreTypecheck.checkInt(value, 1, 2), /^badValue/);
       }
 
       test(undefined);
@@ -269,7 +269,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkLabel(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'label syntax']);
       }
 
@@ -298,7 +298,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkLabel(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', 'label syntax']);
       }
 
@@ -327,7 +327,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'Object']);
       }
 
@@ -367,7 +367,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value, clazz) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value, clazz); },
-          'bad_value',
+          'badValue',
           [inspect(value), `class ${clazz.name}`]);
       }
 
@@ -380,7 +380,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value, clazz) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkObject(value, clazz); },
-          'bad_value',
+          'badValue',
           [inspect(value), `class ${clazz.name}`]);
       }
 
@@ -407,7 +407,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String']);
       }
 
@@ -431,7 +431,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value, regex) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value, regex); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', regex.toString()]);
       }
 
@@ -443,7 +443,7 @@ describe('util-core/CoreTypecheck', () => {
       function test(value) {
         Assert.throwsInfo(
           () => { CoreTypecheck.checkString(value, /./); },
-          'bad_value',
+          'badValue',
           [inspect(value), 'String', '/./']);
       }
 
@@ -457,7 +457,7 @@ describe('util-core/CoreTypecheck', () => {
 
       Assert.throwsInfo(
         () => { CoreTypecheck.checkString('x', notRegex); },
-        'bad_value',
+        'badValue',
         [inspect(notRegex), 'RegExp']);
     });
   });

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.34.0
+version = 0.34.1


### PR DESCRIPTION
[This is big, but it's mostly grep-driven…]

This PR clarifies the conventions about how string-enum-like-things are named in the code, along with standardizing a preference for string representation as used for durable storage and across API boundaries. TLDR: Prefer `lowerCamelCase`, and continue the local tradition of using a `<context>_<name>` form where applicable.

The original impetus for this was the inconsistency in naming errors especially vis-a-vis their associated predicates. This boiled down to a tension between method naming conventions (mostly `camelCase`) and error constant names (which were `lower_snake_case`). E.g., the predicate to test for an error called `timed_out` was `isTimedOut()`. This seemed bad/confusing. But it also seemed bad/confusing for it to become (something like) `is_timed_out`, because that doesn't look like a JavaScript method name. So, something had to give.

Now the error name is `timedOut`, it is constructed with a method `Errors.timedOut()`, and its predicate uses the abovementioned underscore convention to become `Errors.is_timedOut()`. 

Error churn was the biggest portion of this PR, but it also hit a couple other areas of the code. Most notably, it affected the names of OT opcodes, which are now consistently `camelCase`. Because of this — specifically, because these both land in files and are used in API transport — this PR comes with a version bump.