### PR TITLE
Avoid the "plain object" hack except when dealing specifically with JSON encoding.

### DIFF
--- a/local-modules/codec/ConstructorCall.js
+++ b/local-modules/codec/ConstructorCall.js
@@ -1,0 +1,34 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase, Functor } from 'util-common';
+
+/**
+ * Representation of a "constructor call" encoded data form. Instances of this
+ * class are used as the representation of class instances in the structured
+ * values produced by {@link Codec#encode} and accepted by {@link Codec#decode}.
+ * Instances of this class are always frozen (immutable).
+ */
+export default class ConstructorCall extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Functor} payload Construction payload. It is a functor whose name
+   *   indicates which class (or class-like-thing) to construct and whose
+   *   arguments are to be passed to the salient constructor function.
+   */
+  constructor(payload) {
+    super();
+
+    /** {Functor} Construction payload. */
+    this._payload = Functor.check(payload);
+
+    Object.freeze(this);
+  }
+
+  /** {Functor} Construction payload. */
+  get payload() {
+    return this._payload;
+  }
+}

--- a/local-modules/codec/ConstructorCall.js
+++ b/local-modules/codec/ConstructorCall.js
@@ -45,6 +45,21 @@ export default class ConstructorCall extends CommonBase {
   }
 
   /**
+   * Constructs an instance from individual name and arguments elements, instead
+   * of from a full {@link Functor}. This is just convenient wrapper which calls
+   * `new ConstructorCall(new Functor(...args))`.
+   *
+   * @param {...*} args Arguments to pass to the {@link Functor} constructor
+   *  (which expects a string name followed by zero or more arbitrary
+   *  additional arguments).
+   * @returns {ConstructorCall} An appropriately-constructed instance of this
+   *   class.
+   */
+  static from(...args) {
+    return new ConstructorCall(new Functor(...args));
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {Functor} payload Construction payload. It is a functor whose name

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -13,7 +13,7 @@ import SpecialCodecs from './SpecialCodecs';
  */
 export default class Registry extends CommonBase {
   /**
-   * Constructs the instance.
+   * Constructs an instance.
    */
   constructor() {
     super();

--- a/local-modules/codec/index.js
+++ b/local-modules/codec/index.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Codec from './Codec';
+import ConstructorCall from './ConstructorCall';
 import ItemCodec from './ItemCodec';
 
-export { Codec, ItemCodec };
+export { Codec, ConstructorCall, ItemCodec };

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codec } from 'codec';
+import { Codec, ConstructorCall } from 'codec';
 import { MockCodable } from 'codec/mocks';
 import { FrozenBuffer } from 'util-common';
 
@@ -72,7 +72,7 @@ describe('api-common/Codec.encode*()', () => {
 
     it('should accept plain objects and encode as a tagged entries array', () => {
       function test(value) {
-        const expect = { object: Object.entries(value) };
+        const expect = ConstructorCall.from('object', ...Object.entries(value));
         assert.deepEqual(encodeData(value), expect);
       }
 
@@ -84,10 +84,10 @@ describe('api-common/Codec.encode*()', () => {
 
     it('should sort plain object keys in encoded form', () => {
       const orig   = { d: [1, 2, 3], a: { c: 'cx', b: 'bx' } };
-      const expect = { object: [
-        ['a', { object: [['b', 'bx'], ['c', 'cx']] }],
-        ['d', [1, 2, 3]]]
-      };
+      const expect = ConstructorCall.from('object',
+        ['a', ConstructorCall.from('object', ['b', 'bx'], ['c', 'cx'])],
+        ['d', [1, 2, 3]]
+      );
 
       assert.deepEqual(encodeData(orig), expect);
     });

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { ItemCodec } from 'codec';
+import { ConstructorCall, ItemCodec } from 'codec';
 
 // The class being tested here isn't exported from the module, so we import it
 // by path.
@@ -69,19 +69,24 @@ describe('api-common/Registry', () => {
   describe('codecForPayload()', () => {
     it('should throw an error if an unregistered tag is requested', () => {
       const reg = new Registry();
+
+      // Throws because `Boop` isn't a registered class.
+      assert.throws(() => reg.codecForPayload(new ConstructorCall('Boop', 1, 2, 3)));
+
+      // Throws because `object` (plain object) wasn't a registered type.
       assert.throws(() => reg.codecForPayload({ florp: [1, 2, 3] }));
 
-      // Throws because `Symbol` wasn't a registered type.
+      // Throws because `symbol` wasn't a registered type.
       assert.throws(() => reg.codecForPayload(Symbol('foo')));
     });
 
     it('should return the named codec if it is registered', () => {
       const reg       = new Registry();
-      const itemCodec = new ItemCodec('florp', Boolean, null, () => 0, () => 0);
+      const itemCodec = new ItemCodec('Boop', Boolean, null, () => 0, () => 0);
 
       reg.registerCodec(itemCodec);
 
-      const testCodec = reg.codecForPayload({ florp: [1, 2, 3] });
+      const testCodec = reg.codecForPayload(ConstructorCall.from('Boop', 1, 2, 3));
       assert.strictEqual(testCodec, itemCodec);
     });
 


### PR DESCRIPTION
This PR is a bit of a follow-on from yesterday's codec work. It doesn't change the encoded format at all, rather it reworks the code which produces and parses encoded values. More specifically:

Our encoding defines a "reconstruction arguments" form for representing class instances. This form has a particular manifestation when represented as JSON, which is dictated in part by restrictions of the JSON spec. In our Glorious Future™, we will have a binary encoding for values in general, which will be free from JSON-specific restrictions. To prepare for that would-be future, I split apart how instances are represented as "encodable object graphs" vs. how they are represented as "JSON-encodable values." The former reifies reconstruction arguments as instances of a new class, `ConstructorCall`, while the latter reifies them in the single-key plain object form introduced with the earlier codec changes (to reiterate, a form which is tailored to the restrictions of JSON).

The upshot is that there's some added complexity around JSON encoding and decoding, balanced by the underlying object encoding layer getting slightly simplified.

