### PR TITLE
De-singletonize `Codec`.

### DIFF
--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SplitKey } from 'api-common';
-import { TheModule as AppCommon_TheModule } from 'app-common';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { EditorComplex } from 'doc-client';
 import { Logger } from 'see-all';
 import { TFunction, TObject } from 'typecheck';
@@ -142,7 +142,7 @@ export default class TopControl {
    * @returns {SplitKey} The parsed and fixed key.
    */
   _parseAndFixKey(keyJson) {
-    const key = SplitKey.check(AppCommon_TheModule.fullCodec.decodeJson(keyJson));
+    const key = SplitKey.check(appCommon_TheModule.fullCodec.decodeJson(keyJson));
 
     if (key.url === '*') {
       const url = new URL(this._window.document.URL);

--- a/client/js/TopControl.js
+++ b/client/js/TopControl.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SplitKey } from 'api-common';
-import { Codec } from 'codec';
+import { TheModule as AppCommon_TheModule } from 'app-common';
 import { EditorComplex } from 'doc-client';
 import { Logger } from 'see-all';
 import { TFunction, TObject } from 'typecheck';
@@ -142,7 +142,7 @@ export default class TopControl {
    * @returns {SplitKey} The parsed and fixed key.
    */
   _parseAndFixKey(keyJson) {
-    const key = SplitKey.check(Codec.theOne.decodeJson(keyJson));
+    const key = SplitKey.check(AppCommon_TheModule.fullCodec.decodeJson(keyJson));
 
     if (key.url === '*') {
       const url = new URL(this._window.document.URL);

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
 
   "dependencies": {
     "api-common": "local",
+    "app-common": "local",
     "doc-client": "local",
     "env-client": "local",
     "see-all-client": "local",

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -101,6 +101,18 @@ taking into account recent additions to the language.
   import SpecialBlort from './SpecialBlort';
   ```
 
+* `import ... as` &mdash; If you have a name conflict that needs to be resolved,
+  always construct the replacement name as `<ModuleName>_<OriginalName>`, where
+  the module name is the `module-name` converted to `camelCase`. Among other
+  things, this preserves the ability to search for `<OriginalName>.whatever`
+  (and similar searches) which might otherwise be broken (and lead to incomplete
+  search-replace and therefore lead to bugs).
+
+  ```javascript
+  import { Foo as excellentModule_Foo } from 'excellent-module';
+  import { Foo as supremeModule_Foo } from 'supreme-module';
+  ```
+
 #### Class definitions
 
 * Private fields and methods &mdash; This project is coded as if JavaScript

--- a/local-modules/README.md
+++ b/local-modules/README.md
@@ -53,6 +53,17 @@ Internal to a module, the convention is a little more nuanced:
 * If a file defines a collection of data, then it is exported (as with the main
   module) as a set of explicit names and _no_ default.
 
+As a slightly special case, if a module wants to export a set of utility
+functionality, it should do so by defining a utility class named `TheModule`
+per se, and exported as that name.
+
+#### Standard `index` form
+
+The standard form of a module's main `index.js` file is to import all the
+local files to be exported, followed by a single `export { ... }` statement.
+Modules should be listed in sort order, except that `TheModule` is always
+listed first, when present.
+
 ### Exceptions to the conventions
 
 Because nobody and no scheme is perfect, there are no doubt exceptions to the

--- a/local-modules/api-common/ApiCommon.js
+++ b/local-modules/api-common/ApiCommon.js
@@ -1,0 +1,30 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Registry } from 'codec';
+import { UtilityClass } from 'util-common';
+
+import CodableError from './CodableError';
+import Message from './Message';
+import Response from './Response';
+import SplitKey from './SplitKey';
+
+/**
+ * Utilities for this module.
+ */
+export default class ApiCommon extends UtilityClass {
+  /**
+   * Registers this module's encodable classes with a given codec registry.
+   *
+   * @param {Registry} registry Codec registry to register with.
+   */
+  static registerCodecs(registry) {
+    Registry.check(registry);
+
+    registry.registerClass(CodableError);
+    registry.registerClass(Message);
+    registry.registerClass(Response);
+    registry.registerClass(SplitKey);
+  }
+}

--- a/local-modules/api-common/TheModule.js
+++ b/local-modules/api-common/TheModule.js
@@ -13,7 +13,7 @@ import SplitKey from './SplitKey';
 /**
  * Utilities for this module.
  */
-export default class ApiCommon extends UtilityClass {
+export default class TheModule extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *

--- a/local-modules/api-common/index.js
+++ b/local-modules/api-common/index.js
@@ -4,6 +4,7 @@
 
 import { Codec } from 'codec';
 
+import ApiCommon from './ApiCommon';
 import BaseKey from './BaseKey';
 import CodableError from './CodableError';
 import ConnectionError from './ConnectionError';
@@ -12,10 +13,7 @@ import Response from './Response';
 import SplitKey from './SplitKey';
 import TargetId from './TargetId';
 
-// Register classes for encoding / decoding.
-Codec.theOne.registerClass(CodableError);
-Codec.theOne.registerClass(Message);
-Codec.theOne.registerClass(Response);
-Codec.theOne.registerClass(SplitKey);
+// Register with the (senescent) singleton Codec. **TODO:** Remove this.
+ApiCommon.registerCodecs(Codec.theOne.registry);
 
-export { BaseKey, CodableError, ConnectionError, Message, Response, SplitKey, TargetId };
+export { ApiCommon, BaseKey, CodableError, ConnectionError, Message, Response, SplitKey, TargetId };

--- a/local-modules/api-common/index.js
+++ b/local-modules/api-common/index.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codec } from 'codec';
-
 import TheModule from './TheModule';
 import BaseKey from './BaseKey';
 import CodableError from './CodableError';
@@ -12,9 +10,6 @@ import Message from './Message';
 import Response from './Response';
 import SplitKey from './SplitKey';
 import TargetId from './TargetId';
-
-// Register with the (senescent) singleton Codec. **TODO:** Remove this.
-TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
   TheModule,

--- a/local-modules/api-common/index.js
+++ b/local-modules/api-common/index.js
@@ -4,7 +4,7 @@
 
 import { Codec } from 'codec';
 
-import ApiCommon from './ApiCommon';
+import TheModule from './TheModule';
 import BaseKey from './BaseKey';
 import CodableError from './CodableError';
 import ConnectionError from './ConnectionError';
@@ -14,6 +14,15 @@ import SplitKey from './SplitKey';
 import TargetId from './TargetId';
 
 // Register with the (senescent) singleton Codec. **TODO:** Remove this.
-ApiCommon.registerCodecs(Codec.theOne.registry);
+TheModule.registerCodecs(Codec.theOne.registry);
 
-export { ApiCommon, BaseKey, CodableError, ConnectionError, Message, Response, SplitKey, TargetId };
+export {
+  TheModule,
+  BaseKey,
+  CodableError,
+  ConnectionError,
+  Message,
+  Response,
+  SplitKey,
+  TargetId
+};

--- a/local-modules/app-common/TheModule.js
+++ b/local-modules/app-common/TheModule.js
@@ -19,6 +19,7 @@ export default class TheModule extends UtilityClass {
   static get fullCodec() {
     if (!this._fullCodec) {
       this._fullCodec = this.makeFullCodec();
+      this._fullCodec.registry.freeze();
     }
 
     return this._fullCodec;
@@ -31,6 +32,7 @@ export default class TheModule extends UtilityClass {
   static get modelCodec() {
     if (!this._modelCodec) {
       this._modelCodec = this.makeModelCodec();
+      this._modelCodec.registry.freeze();
     }
 
     return this._modelCodec;

--- a/local-modules/app-common/TheModule.js
+++ b/local-modules/app-common/TheModule.js
@@ -13,6 +13,30 @@ import { UtilityClass } from 'util-common';
  */
 export default class TheModule extends UtilityClass {
   /**
+   * {Codec} Standard {@link Codec} instance, constructed by
+   * {@link #makeFullCodec}.
+   */
+  static get fullCodec() {
+    if (!this._fullCodec) {
+      this._fullCodec = this.makeFullCodec();
+    }
+
+    return this._fullCodec;
+  }
+
+  /**
+   * {Codec} Standard {@link Codec} instance, constructed by
+   * {@link #makeModelCodec}.
+   */
+  static get modelCodec() {
+    if (!this._modelCodec) {
+      this._modelCodec = this.makeModelCodec();
+    }
+
+    return this._ModelCodec;
+  }
+
+  /**
    * Constructs a {@link Codec} which is configured for representation of all
    * application model values as well as API transport objects.
    *

--- a/local-modules/app-common/TheModule.js
+++ b/local-modules/app-common/TheModule.js
@@ -1,0 +1,45 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TheModule as ApiCommon_TheModule } from 'api-common';
+import { Codec, Registry } from 'codec';
+import { TheModule as DocCommon_TheModule } from 'doc-common';
+import { TheModule as OtCommon_TheModule } from 'ot-common';
+import { UtilityClass } from 'util-common';
+
+/**
+ * Utilities for this module.
+ */
+export default class TheModule extends UtilityClass {
+  /**
+   * Constructs a {@link Codec} which is configured for representation of all
+   * application model values as well as API transport objects.
+   *
+   * @returns {Codec} An appropriately-configured {@link Codec} instance.
+   */
+  static makeFullCodec() {
+    const registry = new Registry();
+
+    ApiCommon_TheModule.registerCodecs(registry);
+    DocCommon_TheModule.registerCodecs(registry);
+    OtCommon_TheModule.registerCodecs(registry);
+
+    return new Codec(registry);
+  }
+
+  /**
+   * Constructs a {@link Codec} which is configured for representation of all
+   * application model values (and nothing else).
+   *
+   * @returns {Codec} An appropriately-configured {@link Codec} instance.
+   */
+  static makeModelCodec() {
+    const registry = new Registry();
+
+    DocCommon_TheModule.registerCodecs(registry);
+    OtCommon_TheModule.registerCodecs(registry);
+
+    return new Codec(registry);
+  }
+}

--- a/local-modules/app-common/TheModule.js
+++ b/local-modules/app-common/TheModule.js
@@ -2,10 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule as ApiCommon_TheModule } from 'api-common';
+import { TheModule as apiCommon_TheModule } from 'api-common';
 import { Codec, Registry } from 'codec';
-import { TheModule as DocCommon_TheModule } from 'doc-common';
-import { TheModule as OtCommon_TheModule } from 'ot-common';
+import { TheModule as docCommon_TheModule } from 'doc-common';
+import { TheModule as otCommon_TheModule } from 'ot-common';
 import { UtilityClass } from 'util-common';
 
 /**
@@ -45,9 +45,9 @@ export default class TheModule extends UtilityClass {
   static makeFullCodec() {
     const registry = new Registry();
 
-    ApiCommon_TheModule.registerCodecs(registry);
-    DocCommon_TheModule.registerCodecs(registry);
-    OtCommon_TheModule.registerCodecs(registry);
+    apiCommon_TheModule.registerCodecs(registry);
+    docCommon_TheModule.registerCodecs(registry);
+    otCommon_TheModule.registerCodecs(registry);
 
     return new Codec(registry);
   }
@@ -61,8 +61,8 @@ export default class TheModule extends UtilityClass {
   static makeModelCodec() {
     const registry = new Registry();
 
-    DocCommon_TheModule.registerCodecs(registry);
-    OtCommon_TheModule.registerCodecs(registry);
+    docCommon_TheModule.registerCodecs(registry);
+    otCommon_TheModule.registerCodecs(registry);
 
     return new Codec(registry);
   }

--- a/local-modules/app-common/TheModule.js
+++ b/local-modules/app-common/TheModule.js
@@ -33,7 +33,7 @@ export default class TheModule extends UtilityClass {
       this._modelCodec = this.makeModelCodec();
     }
 
-    return this._ModelCodec;
+    return this._modelCodec;
   }
 
   /**

--- a/local-modules/app-common/index.js
+++ b/local-modules/app-common/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import TheModule from './TheModule';
+
+export { TheModule };

--- a/local-modules/app-common/package.json
+++ b/local-modules/app-common/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app-common",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "api-common": "local",
+    "codec": "local",
+    "doc-common": "local",
+    "ot-common": "local",
+    "util-common": "local"
+  }
+}

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -10,7 +10,7 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { ApiLog, BearerToken, Context, PostConnection, WsConnection } from 'api-server';
-import { TheModule as AppCommon_TheModule } from 'app-common';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { ClientBundle } from 'client-bundle';
 import { Dirs } from 'env-server';
 import { Hooks } from 'hooks-server';
@@ -35,7 +35,7 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
-    const codec = AppCommon_TheModule.fullCodec;
+    const codec = appCommon_TheModule.fullCodec;
 
     /**
      * {Context} All of the objects we provide access to via the API, along with

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -10,8 +10,8 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { ApiLog, BearerToken, Context, PostConnection, WsConnection } from 'api-server';
+import { TheModule as AppCommon_TheModule } from 'app-common';
 import { ClientBundle } from 'client-bundle';
-import { Codec } from 'codec';
 import { Dirs } from 'env-server';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
@@ -35,7 +35,7 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
-    const codec = Codec.theOne;
+    const codec = AppCommon_TheModule.fullCodec;
 
     /**
      * {Context} All of the objects we provide access to via the API, along with

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -6,7 +6,7 @@ import camelCase from 'camel-case';
 import express from 'express';
 import { inspect } from 'util';
 
-import { Codec } from 'codec';
+import { TheModule as AppCommon_TheModule } from 'app-common';
 import { DocumentId } from 'doc-common';
 import { DocServer } from 'doc-server';
 import { AuthorId } from 'ot-common';
@@ -180,7 +180,7 @@ export default class DebugTools {
     const revNum = req.params.revNum;
     const body = this._getExistingBody(req);
     const change = (await body).getChange(revNum);
-    const result = Codec.theOne.encodeJson(await change, true);
+    const result = AppCommon_TheModule.modelCodec.encodeJson(await change, true);
 
     this._textResponse(res, result);
   }
@@ -289,7 +289,7 @@ export default class DebugTools {
     const body = this._getExistingBody(req);
     const args = (revNum === undefined) ? [] : [revNum];
     const snapshot = (await body).getSnapshot(...args);
-    const result = Codec.theOne.encodeJson(await snapshot, true);
+    const result = AppCommon_TheModule.modelCodec.encodeJson(await snapshot, true);
 
     this._textResponse(res, result);
   }
@@ -372,7 +372,7 @@ export default class DebugTools {
    */
   async _makeEncodedKey(documentId, authorId) {
     const key = await this._rootAccess.makeAccessKey(authorId, documentId);
-    return Codec.theOne.encodeJson(key);
+    return AppCommon_TheModule.fullCodec.encodeJson(key);
   }
 
   /**

--- a/local-modules/app-setup/DebugTools.js
+++ b/local-modules/app-setup/DebugTools.js
@@ -6,7 +6,7 @@ import camelCase from 'camel-case';
 import express from 'express';
 import { inspect } from 'util';
 
-import { TheModule as AppCommon_TheModule } from 'app-common';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { DocumentId } from 'doc-common';
 import { DocServer } from 'doc-server';
 import { AuthorId } from 'ot-common';
@@ -180,7 +180,7 @@ export default class DebugTools {
     const revNum = req.params.revNum;
     const body = this._getExistingBody(req);
     const change = (await body).getChange(revNum);
-    const result = AppCommon_TheModule.modelCodec.encodeJson(await change, true);
+    const result = appCommon_TheModule.modelCodec.encodeJson(await change, true);
 
     this._textResponse(res, result);
   }
@@ -289,7 +289,7 @@ export default class DebugTools {
     const body = this._getExistingBody(req);
     const args = (revNum === undefined) ? [] : [revNum];
     const snapshot = (await body).getSnapshot(...args);
-    const result = AppCommon_TheModule.modelCodec.encodeJson(await snapshot, true);
+    const result = appCommon_TheModule.modelCodec.encodeJson(await snapshot, true);
 
     this._textResponse(res, result);
   }
@@ -372,7 +372,7 @@ export default class DebugTools {
    */
   async _makeEncodedKey(documentId, authorId) {
     const key = await this._rootAccess.makeAccessKey(authorId, documentId);
-    return AppCommon_TheModule.fullCodec.encodeJson(key);
+    return appCommon_TheModule.fullCodec.encodeJson(key);
   }
 
   /**

--- a/local-modules/app-setup/package.json
+++ b/local-modules/app-setup/package.json
@@ -10,6 +10,7 @@
 
     "api-common": "local",
     "api-server": "local",
+    "app-common": "local",
     "client-bundle": "local",
     "codec": "local",
     "deps-ansi-color": "local",

--- a/local-modules/codec/Codec.js
+++ b/local-modules/codec/Codec.js
@@ -7,32 +7,11 @@ import { CommonBase, FrozenBuffer } from 'util-common';
 import ConstructorCall from './ConstructorCall';
 import Registry from './Registry';
 
-
-/**
- * {Codec|null} "Singleton" instance of this class. This is just temporary
- * scaffolding while the class gets de-singletonized. **TODO:** Remove this.
- */
-let theOne = null;
-
 /**
  * Encoder and decoder of values for transport over an API or for storage on
  * disk or in databases, with binding to a name-to-class registry.
- *
- * **TODO:** This class should probably _not_ be a singleton, in that there are
- * legitimately multiple different coding contexts which ultimately might want
- * to have different sets of classes (or different name bindings even if the
- * classes overlap).
  */
 export default class Codec extends CommonBase {
-  /** {Codec} "Singleton" instance. */
-  static get theOne() {
-    if (theOne === null) {
-      theOne = new Codec();
-    }
-
-    return theOne;
-  }
-
   /**
    * Constructs an instance.
    *
@@ -43,7 +22,9 @@ export default class Codec extends CommonBase {
     super();
 
     /** {Registry} The registry to use. */
-    this._reg = (registry === null) ? new Registry() : Registry.check(registry);
+    this._registry = (registry === null)
+      ? new Registry()
+      : Registry.check(registry);
 
     /** {function} Handy pre-bound version of `decodeData()`. */
     this._decodeData = this.decodeData.bind(this);
@@ -54,7 +35,7 @@ export default class Codec extends CommonBase {
 
   /** {Registry} The codec registry used by this instance. */
   get registry() {
-    return this._reg;
+    return this._registry;
   }
 
   /**
@@ -80,7 +61,7 @@ export default class Codec extends CommonBase {
    * @returns {*} The decoded value.
    */
   decodeData(payload) {
-    const itemCodec = this._reg.codecForPayload(payload);
+    const itemCodec = this._registry.codecForPayload(payload);
     return itemCodec.decode(payload, this._decodeData);
   }
 
@@ -148,7 +129,7 @@ export default class Codec extends CommonBase {
    * @returns {*} The encoded value payload.
    */
   encodeData(value) {
-    const itemCodec = this._reg.codecForValue(value);
+    const itemCodec = this._registry.codecForValue(value);
     return itemCodec.encode(value, this._encodeData);
   }
 
@@ -158,8 +139,8 @@ export default class Codec extends CommonBase {
    *
    * * Instances of {@link ConstructorCall} are encoded as a single-binding
    *   plain object, mapping the class tag string to the constructor arguments.
-   *   For example, the encoding of `new ConstructorCall(new Functor('x', 1,
-   *   2))` is `{ "x": [1, 2] }`.
+   *   For example, the encoding of `ConstructorCall.from('x', 1, 2))` is
+   *   `{ "x": [1, 2] }`.
    *
    * @param {*} value Value to convert.
    * @param {boolean} [pretty = false] Whether to "pretty-print" (indent and
@@ -179,25 +160,5 @@ export default class Codec extends CommonBase {
    */
   encodeJsonBuffer(value) {
     return FrozenBuffer.coerce(this.encodeJson(value));
-  }
-
-  /**
-   * Registers a class to be accepted for codec use. This is a pass-through to
-   * the method of the same name on the instance's `Registry`.
-   *
-   * @param {class} clazz The class to register.
-   */
-  registerClass(clazz) {
-    this._reg.registerClass(clazz);
-  }
-
-  /**
-   * Registers an item codec to be accepted for codec use. This is a
-   * pass-through to the method of the same name on the instance's `Registry`.
-   *
-   * @param {ItemCodec} codec The codec to register.
-   */
-  registerCodec(codec) {
-    this._reg.registerCodec(codec);
   }
 }

--- a/local-modules/codec/Codec.js
+++ b/local-modules/codec/Codec.js
@@ -2,10 +2,17 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { FrozenBuffer, Singleton } from 'util-common';
+import { CommonBase, FrozenBuffer } from 'util-common';
 
 import ConstructorCall from './ConstructorCall';
 import Registry from './Registry';
+
+
+/**
+ * {Codec|null} "Singleton" instance of this class. This is just temporary
+ * scaffolding while the class gets de-singletonized. **TODO:** Remove this.
+ */
+let theOne = null;
 
 /**
  * Encoder and decoder of values for transport over an API or for storage on
@@ -16,24 +23,38 @@ import Registry from './Registry';
  * to have different sets of classes (or different name bindings even if the
  * classes overlap).
  */
-export default class Codec extends Singleton {
+export default class Codec extends CommonBase {
+  /** {Codec} "Singleton" instance. */
+  static get theOne() {
+    if (theOne === null) {
+      theOne = new Codec();
+    }
+
+    return theOne;
+  }
+
   /**
    * Constructs an instance.
+   *
+   * @param {Registry} [registry = null] Registry to use. If `null`, the
+   *   instance will use a newly-constructed {@link Registry} instance.
    */
-  constructor() {
+  constructor(registry = null) {
     super();
 
-    /**
-     * {Registry} The registry instance to use. **Note:** If and when this class
-     * stops being a singleton, this will get set from a constructor argument.
-     */
-    this._reg = new Registry();
+    /** {Registry} The registry to use. */
+    this._reg = (registry === null) ? new Registry() : Registry.check(registry);
 
     /** {function} Handy pre-bound version of `decodeData()`. */
     this._decodeData = this.decodeData.bind(this);
 
     /** {function} Handy pre-bound version of `encodeData()`. */
     this._encodeData = this.encodeData.bind(this);
+  }
+
+  /** {Registry} The codec registry used by this instance. */
+  get registry() {
+    return this._reg;
   }
 
   /**

--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -18,6 +18,9 @@ export default class Registry extends CommonBase {
   constructor() {
     super();
 
+    /** {boolean} Whether or not the registry is frozen. */
+    this._frozen = false;
+
     /**
      * {Map<string, ItemCodec>} Map of registered item tags to their respective
      * item codecs.
@@ -48,6 +51,15 @@ export default class Registry extends CommonBase {
     this.registerCodec(SpecialCodecs.selfRepresentative('null'));
     this.registerCodec(SpecialCodecs.selfRepresentative('number'));
     this.registerCodec(SpecialCodecs.selfRepresentative('string'));
+
+    Object.seal(this);
+  }
+
+  /**
+   * Prevents further changes to this instance.
+   */
+  freeze() {
+    this._frozen = true;
   }
 
   /**
@@ -68,6 +80,10 @@ export default class Registry extends CommonBase {
    * @param {ItemCodec} codec The codec to register.
    */
   registerCodec(codec) {
+    if (this._frozen) {
+      throw Errors.bad_use('Frozen.');
+    }
+
     ItemCodec.check(codec);
 
     const tag   = codec.tag;

--- a/local-modules/codec/index.js
+++ b/local-modules/codec/index.js
@@ -5,5 +5,6 @@
 import Codec from './Codec';
 import ConstructorCall from './ConstructorCall';
 import ItemCodec from './ItemCodec';
+import Registry from './Registry';
 
-export { Codec, ConstructorCall, ItemCodec };
+export { Codec, ConstructorCall, ItemCodec, Registry };

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -3,30 +3,22 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { assert } from 'chai';
-import { before, describe, it } from 'mocha';
+import { describe, it } from 'mocha';
 
 import { Codec } from 'codec';
 import { MockCodable } from 'codec/mocks';
 import { FrozenBuffer } from 'util-common';
 
-
 describe('api-common/Codec.decode*()', () => {
   // Convenient bindings for `decode*()` and `encodeData()` to avoid a lot of
   // boilerplate.
-  const codec            = Codec.theOne;
+  const codec            = new Codec();
   const decodeData       = (value) => { return codec.decodeData(value);       };
   const decodeJson       = (value) => { return codec.decodeJson(value);       };
   const decodeJsonBuffer = (value) => { return codec.decodeJsonBuffer(value); };
   const encodeData       = (value) => { return codec.encodeData(value);       };
 
-  before(() => {
-    try {
-      Codec.theOne.registerClass(MockCodable);
-    } catch (e) {
-      // nothing to do here, the try/catch is just in case some other test
-      // file has already registered the mock class.
-    }
-  });
+  codec.registry.registerClass(MockCodable);
 
   describe('decodeData()', () => {
     it('should pass non-object values through as-is', () => {

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -11,10 +11,12 @@ import { FrozenBuffer } from 'util-common';
 
 describe('api-common/Codec.encode*()', () => {
   // Convenient bindings for `encode*()` to avoid a lot of boilerplate.
-  const codec            = Codec.theOne;
+  const codec            = new Codec();
   const encodeData       = (value) => { return codec.encodeData(value);       };
   const encodeJson       = (value) => { return codec.encodeJson(value);       };
   const encodeJsonBuffer = (value) => { return codec.encodeJsonBuffer(value); };
+
+  codec.registry.registerClass(MockCodable);
 
   describe('encodeData()', () => {
     it('should reject function values', () => {

--- a/local-modules/codec/tests/test_Registry.js
+++ b/local-modules/codec/tests/test_Registry.js
@@ -5,11 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { ConstructorCall, ItemCodec } from 'codec';
-
-// The class being tested here isn't exported from the module, so we import it
-// by path.
-import Registry from 'codec/Registry';
+import { ConstructorCall, ItemCodec, Registry } from 'codec';
 
 class RegistryTestClass {
   constructor() {

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -4,7 +4,7 @@
 
 import { ApiClient } from 'api-client';
 import { BaseKey } from 'api-common';
-import { Codec } from 'codec';
+import { TheModule as AppCommon_TheModule } from 'app-common';
 import { Logger } from 'see-all';
 import { CommonBase } from 'util-common';
 
@@ -82,7 +82,7 @@ export default class DocSession extends CommonBase {
   get apiClient() {
     if (this._apiClient === null) {
       log.detail('Opening API client...');
-      this._apiClient = new ApiClient(this._key.url, Codec.theOne);
+      this._apiClient = new ApiClient(this._key.url, AppCommon_TheModule.fullCodec);
 
       (async () => {
         await this._apiClient.open();

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -4,6 +4,7 @@
 
 import { ApiClient } from 'api-client';
 import { BaseKey } from 'api-common';
+import { Codec } from 'codec';
 import { Logger } from 'see-all';
 import { CommonBase } from 'util-common';
 
@@ -81,7 +82,7 @@ export default class DocSession extends CommonBase {
   get apiClient() {
     if (this._apiClient === null) {
       log.detail('Opening API client...');
-      this._apiClient = new ApiClient(this._key.url);
+      this._apiClient = new ApiClient(this._key.url, Codec.theOne);
 
       (async () => {
         await this._apiClient.open();

--- a/local-modules/doc-client/DocSession.js
+++ b/local-modules/doc-client/DocSession.js
@@ -4,7 +4,7 @@
 
 import { ApiClient } from 'api-client';
 import { BaseKey } from 'api-common';
-import { TheModule as AppCommon_TheModule } from 'app-common';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { Logger } from 'see-all';
 import { CommonBase } from 'util-common';
 
@@ -82,7 +82,7 @@ export default class DocSession extends CommonBase {
   get apiClient() {
     if (this._apiClient === null) {
       log.detail('Opening API client...');
-      this._apiClient = new ApiClient(this._key.url, AppCommon_TheModule.fullCodec);
+      this._apiClient = new ApiClient(this._key.url, appCommon_TheModule.fullCodec);
 
       (async () => {
         await this._apiClient.open();

--- a/local-modules/doc-client/package.json
+++ b/local-modules/doc-client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "api-client": "local",
     "api-common": "local",
+    "app-common": "local",
     "data-model-client": "local",
     "deps-react": "local",
     "doc-client": "local",

--- a/local-modules/doc-common/DocCommon.js
+++ b/local-modules/doc-common/DocCommon.js
@@ -23,7 +23,7 @@ import PropertySnapshot from './PropertySnapshot';
 /**
  * Utilities for this module.
  */
-export default class ApiCommon extends UtilityClass {
+export default class DocCommon extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *

--- a/local-modules/doc-common/DocCommon.js
+++ b/local-modules/doc-common/DocCommon.js
@@ -1,0 +1,50 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Registry } from 'codec';
+import { UtilityClass } from 'util-common';
+
+import BodyChange from './BodyChange';
+import BodyDelta from './BodyDelta';
+import BodyOp from './BodyOp';
+import BodySnapshot from './BodySnapshot';
+import Caret from './Caret';
+import CaretChange from './CaretChange';
+import CaretDelta from './CaretDelta';
+import CaretOp from './CaretOp';
+import CaretSnapshot from './CaretSnapshot';
+import Property from './Property';
+import PropertyChange from './PropertyChange';
+import PropertyDelta from './PropertyDelta';
+import PropertyOp from './PropertyOp';
+import PropertySnapshot from './PropertySnapshot';
+
+/**
+ * Utilities for this module.
+ */
+export default class ApiCommon extends UtilityClass {
+  /**
+   * Registers this module's encodable classes with a given codec registry.
+   *
+   * @param {Registry} registry Codec registry to register with.
+   */
+  static registerCodecs(registry) {
+    Registry.check(registry);
+
+    registry.registerClass(BodyChange);
+    registry.registerClass(BodyDelta);
+    registry.registerClass(BodyOp);
+    registry.registerClass(BodySnapshot);
+    registry.registerClass(Caret);
+    registry.registerClass(CaretChange);
+    registry.registerClass(CaretDelta);
+    registry.registerClass(CaretOp);
+    registry.registerClass(CaretSnapshot);
+    registry.registerClass(Property);
+    registry.registerClass(PropertyChange);
+    registry.registerClass(PropertyDelta);
+    registry.registerClass(PropertyOp);
+    registry.registerClass(PropertySnapshot);
+  }
+}

--- a/local-modules/doc-common/TheModule.js
+++ b/local-modules/doc-common/TheModule.js
@@ -23,7 +23,7 @@ import PropertySnapshot from './PropertySnapshot';
 /**
  * Utilities for this module.
  */
-export default class DocCommon extends UtilityClass {
+export default class TheModule extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *

--- a/local-modules/doc-common/index.js
+++ b/local-modules/doc-common/index.js
@@ -4,6 +4,7 @@
 
 import { Codec } from 'codec';
 
+import TheModule from './TheModule';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
 import BodyOp from './BodyOp';
@@ -13,7 +14,6 @@ import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
-import DocCommon from './DocCommon';
 import DocumentId from './DocumentId';
 import Property from './Property';
 import PropertyChange from './PropertyChange';
@@ -23,9 +23,10 @@ import PropertySnapshot from './PropertySnapshot';
 import Timeouts from './Timeouts';
 
 // Register with the (senescent) singleton Codec. **TODO:** Remove this.
-DocCommon.registerCodecs(Codec.theOne.registry);
+TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
+  TheModule,
   BodyChange,
   BodyDelta,
   BodyOp,
@@ -35,7 +36,6 @@ export {
   CaretDelta,
   CaretOp,
   CaretSnapshot,
-  DocCommon,
   DocumentId,
   Property,
   PropertyChange,

--- a/local-modules/doc-common/index.js
+++ b/local-modules/doc-common/index.js
@@ -13,6 +13,7 @@ import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
+import DocCommon from './DocCommon';
 import DocumentId from './DocumentId';
 import Property from './Property';
 import PropertyChange from './PropertyChange';
@@ -21,21 +22,8 @@ import PropertyOp from './PropertyOp';
 import PropertySnapshot from './PropertySnapshot';
 import Timeouts from './Timeouts';
 
-// Register classes for encoding / decoding.
-Codec.theOne.registerClass(BodyChange);
-Codec.theOne.registerClass(BodyDelta);
-Codec.theOne.registerClass(BodyOp);
-Codec.theOne.registerClass(BodySnapshot);
-Codec.theOne.registerClass(Caret);
-Codec.theOne.registerClass(CaretChange);
-Codec.theOne.registerClass(CaretDelta);
-Codec.theOne.registerClass(CaretOp);
-Codec.theOne.registerClass(CaretSnapshot);
-Codec.theOne.registerClass(Property);
-Codec.theOne.registerClass(PropertyChange);
-Codec.theOne.registerClass(PropertyDelta);
-Codec.theOne.registerClass(PropertyOp);
-Codec.theOne.registerClass(PropertySnapshot);
+// Register with the (senescent) singleton Codec. **TODO:** Remove this.
+DocCommon.registerCodecs(Codec.theOne.registry);
 
 export {
   BodyChange,
@@ -47,6 +35,7 @@ export {
   CaretDelta,
   CaretOp,
   CaretSnapshot,
+  DocCommon,
   DocumentId,
   Property,
   PropertyChange,

--- a/local-modules/doc-common/index.js
+++ b/local-modules/doc-common/index.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codec } from 'codec';
-
 import TheModule from './TheModule';
 import BodyChange from './BodyChange';
 import BodyDelta from './BodyDelta';
@@ -21,9 +19,6 @@ import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 import PropertySnapshot from './PropertySnapshot';
 import Timeouts from './Timeouts';
-
-// Register with the (senescent) singleton Codec. **TODO:** Remove this.
-TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
   TheModule,

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Timeouts } from 'doc-common';
-import { Errors as FileStoreErrors, StoragePath, TransactionSpec } from 'file-store';
+import { Errors as fileStore_Errors, StoragePath, TransactionSpec } from 'file-store';
 import { BaseSnapshot, RevisionNumber } from 'ot-common';
 import { Delay } from 'promise-util';
 import { TBoolean, TFunction } from 'typecheck';
@@ -220,7 +220,7 @@ export default class BaseControl extends BaseDataManager {
     try {
       await fc.transact(spec);
     } catch (e) {
-      if (FileStoreErrors.is_pathNotAbsent(e) || FileStoreErrors.is_pathHashMismatch(e)) {
+      if (fileStore_Errors.is_pathNotAbsent(e) || fileStore_Errors.is_pathHashMismatch(e)) {
         // One of these will get thrown if and when we lose an append race. This
         // regularly occurs when there are simultaneous editors.
         this.log.info('Lost append race for revision:', revNum);

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -4,7 +4,7 @@
 
 import weak from 'weak';
 
-import { TheModule as AppCommon_TheModule } from 'app-common';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
 import { TFunction, TString } from 'typecheck';
@@ -33,7 +33,7 @@ export default class DocServer extends Singleton {
     super();
 
     /** {Codec} Codec instance to use. */
-    this._codec = AppCommon_TheModule.fullCodec;
+    this._codec = appCommon_TheModule.fullCodec;
 
     /**
      * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document

--- a/local-modules/doc-server/DocServer.js
+++ b/local-modules/doc-server/DocServer.js
@@ -4,7 +4,7 @@
 
 import weak from 'weak';
 
-import { Codec } from 'codec';
+import { TheModule as AppCommon_TheModule } from 'app-common';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
 import { TFunction, TString } from 'typecheck';
@@ -32,11 +32,8 @@ export default class DocServer extends Singleton {
   constructor() {
     super();
 
-    /**
-     * {Codec} Codec instance to use. **Note:** As of this writing, `Codec` is a
-     * singleton, but the intention is for it to stop being so.
-     */
-    this._codec = Codec.theOne;
+    /** {Codec} Codec instance to use. */
+    this._codec = AppCommon_TheModule.fullCodec;
 
     /**
      * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document

--- a/local-modules/doc-server/package.json
+++ b/local-modules/doc-server/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "weak": "^1.0.1",
 
+    "app-common": "local",
     "codec": "local",
     "doc-common": "local",
     "env-server": "local",

--- a/local-modules/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/doc-server/tests/test_BaseComplexMember.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { BaseComplexMember } from 'doc-server';
 
-import { Codec } from 'codec';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { FileAccess } from 'doc-server';
 import { MockFile } from 'file-store/mocks';
 import { MockLogger } from 'see-all/mocks';
@@ -15,7 +15,7 @@ import { MockLogger } from 'see-all/mocks';
 describe('doc-server/BaseComplexMember', () => {
   describe('constructor()', () => {
     it('should accept a `FileAccess` and reflect it in the getters', () => {
-      const codec  = Codec.theOne;
+      const codec  = appCommon_TheModule.modelCodec;
       const file   = new MockFile('blort');
       const fa     = new FileAccess(codec, file);
       const result = new BaseComplexMember(fa, 'boop');
@@ -35,8 +35,9 @@ describe('doc-server/BaseComplexMember', () => {
     });
 
     it('should use the `logLabel` to create an appropriate `log`', () => {
+      const codec  = appCommon_TheModule.modelCodec;
       const log    = new MockLogger();
-      const fa     = new FileAccess(Codec.theOne, new MockFile('file-id'), log);
+      const fa     = new FileAccess(codec, new MockFile('file-id'), log);
       const result = new BaseComplexMember(fa, 'boop');
 
       result.log.info('florp', 'like');

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -10,7 +10,7 @@ import { Timeouts } from 'doc-common';
 import { MockChange, MockDelta, MockOp, MockSnapshot } from 'ot-common/mocks';
 import { DurableControl, FileAccess } from 'doc-server';
 import { MockControl } from 'doc-server/mocks';
-import { Errors as FileErrors, TransactionSpec } from 'file-store';
+import { Errors as fileStore_Errors, TransactionSpec } from 'file-store';
 import { MockFile } from 'file-store/mocks';
 import { Timestamp } from 'ot-common';
 import { Errors, FrozenBuffer } from 'util-common';
@@ -279,8 +279,8 @@ describe('doc-server/BaseControl', () => {
         await assert.eventually.strictEqual(control.appendChange(change), false);
       }
 
-      await test(FileErrors.pathHashMismatch('/whatever', FrozenBuffer.coerce('x').hash));
-      await test(FileErrors.pathNotAbsent('/mock_control/change/99'));
+      await test(fileStore_Errors.pathHashMismatch('/whatever', FrozenBuffer.coerce('x').hash));
+      await test(fileStore_Errors.pathNotAbsent('/mock_control/change/99'));
     });
 
     it('should rethrow any transaction error other than a precondition failure', async () => {
@@ -301,7 +301,7 @@ describe('doc-server/BaseControl', () => {
         await assert.isRejected(control.appendChange(change), error);
       }
 
-      await test(FileErrors.fileNotFound('x'));
+      await test(fileStore_Errors.fileNotFound('x'));
       await test(Errors.timedOut(123456));
       await test(Errors.badValue('foo', 'bar'));
     });

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codec } from 'codec';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { Timeouts } from 'doc-common';
 import { MockChange, MockDelta, MockOp, MockSnapshot } from 'ot-common/mocks';
 import { DurableControl, FileAccess } from 'doc-server';
@@ -13,14 +13,19 @@ import { MockControl } from 'doc-server/mocks';
 import { Errors as fileStore_Errors, TransactionSpec } from 'file-store';
 import { MockFile } from 'file-store/mocks';
 import { Timestamp } from 'ot-common';
+import { TheModule as mocks_TheModule } from 'ot-common/mocks';
 import { Errors, FrozenBuffer } from 'util-common';
 
 // **Note:** Even though these tests are written in terms of `DurableControl`
 // and a subclass thereof, they are limited to testing behavior which is common
 // to all control classes. This is why it is labeled as being for `BaseControl`.
 describe('doc-server/BaseControl', () => {
+  /** {Codec} Convenient instance of `Codec`. */
+  const CODEC = appCommon_TheModule.makeModelCodec();
+  mocks_TheModule.registerCodecs(CODEC.registry);
+
   /** {FileAccess} Convenient instance of `FileAccess`. */
-  const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+  const FILE_ACCESS = new FileAccess(CODEC, new MockFile('blort'));
 
   describe('.changeClass', () => {
     it('should reflect the subclass\'s implementation', () => {
@@ -171,7 +176,7 @@ describe('doc-server/BaseControl', () => {
   describe('appendChange()', () => {
     it('should perform an appropriate transaction given a valid change', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -207,7 +212,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should provide a default for `null` and clamp an out-of-range (but otherwise valid) timeout', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -244,7 +249,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should call the snapshot maybe-writer and return `true` if the transaction succeeds', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -263,7 +268,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should return `false` if the transaction fails due to a precondition failure', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -285,7 +290,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should rethrow any transaction error other than a precondition failure', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -308,7 +313,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject an empty change', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(101, []);
 
@@ -317,7 +322,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject a change of the wrong type', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
 
       await assert.isRejected(control.appendChange('not_a_change'), /badValue/);
@@ -325,7 +330,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should reject an invalid timeout value', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
 
@@ -345,7 +350,7 @@ describe('doc-server/BaseControl', () => {
   describe('currentRevNum()', () => {
     it('should perform an appropriate transaction, and use the result', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
 
       let gotSpec = null;
@@ -371,7 +376,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should use the result of the transaction it performed', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
 
       file._impl_transact = (spec_unused) => {
@@ -380,7 +385,7 @@ describe('doc-server/BaseControl', () => {
           newRevNum: null,
           paths:     null,
           data: new Map(Object.entries({
-            '/mock_control/revision_number': Codec.theOne.encodeJsonBuffer(1234)
+            '/mock_control/revision_number': CODEC.encodeJsonBuffer(1234)
           }))
         };
       };
@@ -391,8 +396,7 @@ describe('doc-server/BaseControl', () => {
     it('should reject improper transaction results', async () => {
       async function test(value) {
         const file       = new MockFile('blort');
-        const codec      = Codec.theOne;
-        const fileAccess = new FileAccess(codec, file);
+        const fileAccess = new FileAccess(CODEC, file);
         const control    = new MockControl(fileAccess, 'boop');
 
         file._impl_transact = (spec_unused) => {
@@ -401,7 +405,7 @@ describe('doc-server/BaseControl', () => {
             newRevNum: null,
             paths:     null,
             data: new Map(Object.entries({
-              '/mock_control/revision_number': codec.encodeJsonBuffer(value)
+              '/mock_control/revision_number': CODEC.encodeJsonBuffer(value)
             }))
           };
         };
@@ -973,7 +977,7 @@ describe('doc-server/BaseControl', () => {
   describe('whenRevNum()', () => {
     it('should return promptly if the revision is already available', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
 
       file._impl_transact = (spec_unused) => {
@@ -991,7 +995,7 @@ describe('doc-server/BaseControl', () => {
 
     it('should issue transactions until the revision is written', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(Codec.theOne, file);
+      const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
 
       let revNum = 11;

--- a/local-modules/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/doc-server/tests/test_BaseDataManager.js
@@ -5,13 +5,13 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codec } from 'codec';
+import { TheModule as appCommon_TheModule } from 'app-common';
 import { BaseDataManager, FileAccess, ValidationStatus } from 'doc-server';
 import { TransactionSpec } from 'file-store';
 import { MockFile } from 'file-store/mocks';
 
 /** {FileAccess} Convenient instance of `FileAccess`. */
-const FILE_ACCESS = new FileAccess(Codec.theOne, new MockFile('blort'));
+const FILE_ACCESS = new FileAccess(appCommon_TheModule.modelCodec, new MockFile('blort'));
 
 describe('doc-server/BaseDataManager', () => {
   describe('.initSpec', () => {

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -44,6 +44,12 @@ const REVISION_NUMBER_ID =
 const MAX_PARALLEL_FS_CALLS = 20;
 
 /**
+ * {Codec} Codec to use specifically _just_ to encode and decode the file
+ * revision number. (Coding for file content is handled by the superclass.)
+ */
+const revNumCodec = new Codec();
+
+/**
  * File implementation that stores everything in the locally-accessible
  * filesystem.
  */
@@ -116,12 +122,6 @@ export default class LocalFile extends BaseFile {
      * comes along, it gets set to `false`.
      */
     this._changeCondition = new Condition(true);
-
-    /**
-     * {Codec} Codec to use specifically _just_ to encode and decode the file
-     * revision number. (Coding for file content is handled by the superclass.)
-     */
-    this._revNumCodec = Codec.theOne;
 
     /** {Logger} Logger specific to this file's ID. */
     this._log = log.withAddedContext(fileId);
@@ -429,7 +429,7 @@ export default class LocalFile extends BaseFile {
     // things reasonably gracefully if it's missing or corrupt.
     try {
       const revNumBuffer = storage.get(REVISION_NUMBER_ID);
-      revNum = this._revNumCodec.decodeJsonBuffer(revNumBuffer);
+      revNum = revNumCodec.decodeJsonBuffer(revNumBuffer);
       this._log.info('Starting revision number:', revNum);
     } catch (e) {
       // In case of failure, use the size of the storage map as a good enough
@@ -550,8 +550,7 @@ export default class LocalFile extends BaseFile {
 
     // Put the file revision number in the `dirtyValues` map. This way, it gets
     // written out without further special casing.
-    dirtyValues.set(REVISION_NUMBER_ID,
-      this._revNumCodec.encodeJsonBuffer(revNum));
+    dirtyValues.set(REVISION_NUMBER_ID, revNumCodec.encodeJsonBuffer(revNum));
 
     this._log.info(`About to write ${dirtyValues.size} value(s).`);
 

--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -6,7 +6,7 @@ import afs from 'async-file';
 import path from 'path';
 
 import { Codec } from 'codec';
-import { BaseFile, Errors as FileStoreErrors, StoragePath } from 'file-store';
+import { BaseFile, Errors as fileStore_Errors, StoragePath } from 'file-store';
 import { Condition, Delay, Mutex } from 'promise-util';
 import { Logger } from 'see-all';
 import { FrozenBuffer, Errors } from 'util-common';
@@ -218,7 +218,7 @@ export default class LocalFile extends BaseFile {
     }
 
     if (!this._fileShouldExist) {
-      throw FileStoreErrors.fileNotFound(this.id);
+      throw fileStore_Errors.fileNotFound(this.id);
     }
 
     // Construct the "file friend" object. This exposes just enough private

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Errors as FileStoreErrors, StoragePath } from 'file-store';
+import { Errors as fileStore_Errors, StoragePath } from 'file-store';
 import { CommonBase, Errors } from 'util-common';
 
 /**
@@ -145,7 +145,7 @@ export default class Transactor extends CommonBase {
     const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) !== null) {
-      throw FileStoreErrors.blobNotAbsent(hash);
+      throw fileStore_Errors.blobNotAbsent(hash);
     }
   }
 
@@ -158,7 +158,7 @@ export default class Transactor extends CommonBase {
     const { hash } = props;
 
     if (this._fileFriend.readBlobOrNull(hash) === null) {
-      throw FileStoreErrors.blobNotFound(hash);
+      throw fileStore_Errors.blobNotFound(hash);
     }
   }
 
@@ -171,7 +171,7 @@ export default class Transactor extends CommonBase {
     const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) !== null) {
-      throw FileStoreErrors.pathNotAbsent(storagePath);
+      throw fileStore_Errors.pathNotAbsent(storagePath);
     }
   }
 
@@ -185,9 +185,9 @@ export default class Transactor extends CommonBase {
     const data = this._fileFriend.readPathOrNull(storagePath);
 
     if (data === null) {
-      throw FileStoreErrors.pathNotFound(storagePath);
+      throw fileStore_Errors.pathNotFound(storagePath);
     } else if (data.hash !== expectedHash) {
-      throw FileStoreErrors.pathHashMismatch(storagePath, expectedHash);
+      throw fileStore_Errors.pathHashMismatch(storagePath, expectedHash);
     }
   }
 
@@ -201,7 +201,7 @@ export default class Transactor extends CommonBase {
     const data = this._fileFriend.readPathOrNull(storagePath);
 
     if ((data !== null) && (data.hash === unexpectedHash)) {
-      throw FileStoreErrors.pathHashMismatch(storagePath, unexpectedHash);
+      throw fileStore_Errors.pathHashMismatch(storagePath, unexpectedHash);
     }
   }
 
@@ -214,7 +214,7 @@ export default class Transactor extends CommonBase {
     const { storagePath } = props;
 
     if (this._fileFriend.readPathOrNull(storagePath) === null) {
-      throw FileStoreErrors.pathNotFound(storagePath);
+      throw fileStore_Errors.pathNotFound(storagePath);
     }
   }
 

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { LocalFileStore } from 'file-store-local';
-import { Hooks as HooksCommon } from 'hooks-common';
+import { Hooks as hooksCommon_Hooks } from 'hooks-common';
 import { Errors, Singleton } from 'util-common';
 
 import BearerTokens from './BearerTokens';
@@ -71,7 +71,7 @@ export default class Hooks extends Singleton {
    * @returns {boolen} `true` iff `id` is syntactically valid.
    */
   isFileId(id) {
-    return HooksCommon.theOne.isDocumentId(id);
+    return hooksCommon_Hooks.theOne.isDocumentId(id);
   }
 
   /**

--- a/local-modules/ot-common/TheModule.js
+++ b/local-modules/ot-common/TheModule.js
@@ -1,0 +1,24 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Registry } from 'codec';
+import { UtilityClass } from 'util-common';
+
+import Timestamp from './Timestamp';
+
+/**
+ * Utilities for this module.
+ */
+export default class TheModule extends UtilityClass {
+  /**
+   * Registers this module's encodable classes with a given codec registry.
+   *
+   * @param {Registry} registry Codec registry to register with.
+   */
+  static registerCodecs(registry) {
+    Registry.check(registry);
+
+    registry.registerClass(Timestamp);
+  }
+}

--- a/local-modules/ot-common/index.js
+++ b/local-modules/ot-common/index.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codec } from 'codec';
-
 import TheModule from './TheModule';
 import AuthorId from './AuthorId';
 import BaseChange from './BaseChange';
@@ -12,9 +10,6 @@ import BaseOp from './BaseOp';
 import BaseSnapshot from './BaseSnapshot';
 import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
-
-// Register with the (senescent) singleton Codec. **TODO:** Remove this.
-TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
   TheModule,

--- a/local-modules/ot-common/index.js
+++ b/local-modules/ot-common/index.js
@@ -4,6 +4,7 @@
 
 import { Codec } from 'codec';
 
+import TheModule from './TheModule';
 import AuthorId from './AuthorId';
 import BaseChange from './BaseChange';
 import BaseDelta from './BaseDelta';
@@ -12,10 +13,11 @@ import BaseSnapshot from './BaseSnapshot';
 import Timestamp from './Timestamp';
 import RevisionNumber from './RevisionNumber';
 
-// Register classes for encoding / decoding.
-Codec.theOne.registerClass(Timestamp);
+// Register with the (senescent) singleton Codec. **TODO:** Remove this.
+TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
+  TheModule,
   AuthorId,
   BaseChange,
   BaseDelta,

--- a/local-modules/ot-common/mocks/TheModule.js
+++ b/local-modules/ot-common/mocks/TheModule.js
@@ -1,0 +1,30 @@
+// Copyright 2016-2017 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Registry } from 'codec';
+import { UtilityClass } from 'util-common';
+
+import MockChange from './MockChange';
+import MockDelta from './MockDelta';
+import MockOp from './MockOp';
+import MockSnapshot from './MockSnapshot';
+
+/**
+ * Utilities for this module.
+ */
+export default class TheModule extends UtilityClass {
+  /**
+   * Registers this module's encodable classes with a given codec registry.
+   *
+   * @param {Registry} registry Codec registry to register with.
+   */
+  static registerCodecs(registry) {
+    Registry.check(registry);
+
+    registry.registerClass(MockChange);
+    registry.registerClass(MockDelta);
+    registry.registerClass(MockOp);
+    registry.registerClass(MockSnapshot);
+  }
+}

--- a/local-modules/ot-common/mocks/index.js
+++ b/local-modules/ot-common/mocks/index.js
@@ -2,16 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codec } from 'codec';
-
 import TheModule from './TheModule';
 import MockChange from './MockChange';
 import MockDelta from './MockDelta';
 import MockOp from './MockOp';
 import MockSnapshot from './MockSnapshot';
-
-// Register with the (senescent) singleton Codec. **TODO:** Remove this.
-TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
   TheModule,

--- a/local-modules/ot-common/mocks/index.js
+++ b/local-modules/ot-common/mocks/index.js
@@ -10,11 +10,8 @@ import MockDelta from './MockDelta';
 import MockOp from './MockOp';
 import MockSnapshot from './MockSnapshot';
 
-// Register classes for encoding / decoding.
-Codec.theOne.registerClass(MockChange);
-Codec.theOne.registerClass(MockDelta);
-Codec.theOne.registerClass(MockOp);
-Codec.theOne.registerClass(MockSnapshot);
+// Register with the (senescent) singleton Codec. **TODO:** Remove this.
+TheModule.registerCodecs(Codec.theOne.registry);
 
 export {
   TheModule,

--- a/local-modules/ot-common/mocks/index.js
+++ b/local-modules/ot-common/mocks/index.js
@@ -4,6 +4,7 @@
 
 import { Codec } from 'codec';
 
+import TheModule from './TheModule';
 import MockChange from './MockChange';
 import MockDelta from './MockDelta';
 import MockOp from './MockOp';
@@ -16,6 +17,7 @@ Codec.theOne.registerClass(MockOp);
 Codec.theOne.registerClass(MockSnapshot);
 
 export {
+  TheModule,
   MockChange,
   MockDelta,
   MockOp,


### PR DESCRIPTION
This PR converts `Codec` from a singleton class to a regular old multiply-instantiable class. The main reason for making this change was that we actually need multiple different instances of the class, and before this PR we just sorta "piled onto" the singleton instance with every possible thing we might need to encode. As it happens we currently have three different encoding situations, but of course we could easily end up with more.

And that doesn't even count testing, where it helps to have no limit at all on instantiating the class. Before this PR, testing of the `Codec` code per se as well as clients of the `codec` module were both fragile. Now, things are much more durable and reasonable.

**Bonus:** Settled on some additional coding conventions regarding `import`s and `export`s.
