### PR TITLE
Fix handling of ephemeral parts.

### DIFF
--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -838,7 +838,7 @@ export default class BaseControl extends BaseDataManager {
 
     // For ephemeral parts, _if_ a change is present before the snapshot's
     // revision, it must be valid.
-    for (let i = 0; i < requiredChangesAt; i++) {
+    for (let i = 0; i < requiredChangesAt; i += MAX) {
       const lastI = Math.min(i + MAX - 1, requiredChangesAt - 1);
       try {
         // `true` === Allow missing changes.

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -268,7 +268,10 @@ export default class BaseControl extends BaseDataManager {
 
   /**
    * Gets a particular change to the part of the document that this instance
-   * controls.
+   * controls. It is an error to request a revision that does not yet exist. For
+   * subclasses that don't keep full history, it is also an error to
+   * request a revision that is _no longer_ available; in this case, the error
+   * name is always `revisionNotAvailable`.
    *
    * @param {Int} revNum The revision number of the change. The result is the
    *   change which produced that revision. E.g., `0` is a request for the first
@@ -277,9 +280,14 @@ export default class BaseControl extends BaseDataManager {
    */
   async getChange(revNum) {
     RevisionNumber.check(revNum); // So we know we can `+1` without weirdness.
-    const changes = await this._getChangeRange(revNum, revNum + 1, false);
+    const changes = await this._getChangeRange(revNum, revNum + 1, true);
+    const result = changes[0];
 
-    return changes[0];
+    if (result === null) {
+      throw Errors.revisionNotAvailable(revNum);
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/doc-server/BaseControl.js
+++ b/local-modules/doc-server/BaseControl.js
@@ -1003,7 +1003,7 @@ export default class BaseControl extends BaseDataManager {
         clazz.changeClass.check(change);
         result.push(change);
       } else if (!allowMissing) {
-        throw new Error.badUse(`Missing change in requested range: r${i}`);
+        throw Errors.badUse(`Missing change in requested range: r${i}`);
       }
     }
 

--- a/local-modules/doc-server/SnapshotManager.js
+++ b/local-modules/doc-server/SnapshotManager.js
@@ -75,8 +75,7 @@ export default class SnapshotManager extends CommonBase {
         // snapshot cache. Depending on its revision number and the one being
         // requested, it _might_ (but won't _necessarily_) end up being the base
         // used to satisfy this call. At the same time (well, right after), also
-        // set up an entry for revision `0`, which allows for the rest of this
-        // class to be a little simpler.
+        // set up an entry for revision 0 if in fact change 0 exists.
         this._storedSnapshotRetrieved = (async () => {
           const storedPromise = this._control.readStoredSnapshotOrNull();
           const stored = await storedPromise;
@@ -85,14 +84,12 @@ export default class SnapshotManager extends CommonBase {
             this._snapshots.set(stored.revNum, storedPromise);
           }
 
-          if ((stored === null) || (stored.revNum !== 0)) {
-            // Derive a snapshot for revision `0` in the standard way, that is,
-            // by composing change 0 on top of an empty delta, requesting a
-            // document result (`wantDocument = true` for the last argument).
-            const rev0Contents = this._control.getComposedChanges(this._deltaClass.EMPTY, 0, 1, true);
-            const rev0Snapshot = new this._snapshotClass(0, await rev0Contents);
-            this._snapshots.set(0, rev0Snapshot);
-          }
+          // Set up the revision 0 snapshot, if appropriate. The `await` here is
+          // done so that any errors coming from the call get propagated back up
+          // the chain instead of getting dropped on the floor (and turning more
+          // directly into process aborts due to an unhandled promise
+          // rejection).
+          await this._makeSnapshot0();
 
           this._storedSnapshotRetrieved = null;
           return true;
@@ -104,9 +101,9 @@ export default class SnapshotManager extends CommonBase {
     }
 
     // Search backward through the full revisions for a base for forward
-    // composition. **Note:** The initialization step above should have
-    // guaranteed that we always find a suitable base revision, either the
-    // stored snapshot or the constructed revision 0.
+    // composition. **Note:** The initialization step above will guarantee that
+    // we always find a suitable base revision if the managed part isn't
+    // ephemeral.
 
     let basePromise = null;
     let baseRevNum  = -1;
@@ -127,8 +124,8 @@ export default class SnapshotManager extends CommonBase {
     }
 
     if (basePromise === null) {
-      // Shouldn't happen, per above description (and code).
-      throw Errors.wtf('Did not find a snapshot!');
+      // Ephemeral part, and the revision is no longer available.
+      return null;
     }
 
     // We didn't actully find a snapshot of the requested revision. Make it,
@@ -164,5 +161,42 @@ export default class SnapshotManager extends CommonBase {
     }
 
     return result;
+  }
+
+  /**
+   * Makes the snapshot for revision 0, if change 0 is in fact available and
+   * snapshot 0 wasn't already cached. (It might have gotten cached because it
+   * was in fact the revision which was stored in the underlying file). If
+   * change 0 is not not available, this method does nothing and reports no
+   * error.
+   *
+   * This special-case setup is done to make the logic in the rest of the clas
+   * a bit simpler.
+   */
+  async _makeSnapshot0() {
+    if (this._snapshots.has(0)) {
+      // Already cached.
+      return;
+    }
+
+    // Look for change 0 using the public `getChange()` call which has a
+    // well-defined error for when the revision isn't available.
+    try {
+      await this._control.getChange(0);
+    } catch (e) {
+      if (Errors.is_revisionNotAvailable(e)) {
+        // No big deal, and nothing more to do (per above docs).
+        return;
+      }
+      throw e; // Anything else is unexpected and is throw-worthy.
+    }
+
+    // Derive a snapshot for revision `0` in the standard way, that is,
+    // by composing change 0 on top of an empty delta, requesting a
+    // document result (`wantDocument = true` for the last argument).
+
+    const rev0Contents = this._control.getComposedChanges(this._deltaClass.EMPTY, 0, 1, true);
+    const rev0Snapshot = new this._snapshotClass(0, await rev0Contents);
+    this._snapshots.set(0, rev0Snapshot);
   }
 }

--- a/local-modules/doc-server/SnapshotManager.js
+++ b/local-modules/doc-server/SnapshotManager.js
@@ -170,7 +170,7 @@ export default class SnapshotManager extends CommonBase {
    * change 0 is not not available, this method does nothing and reports no
    * error.
    *
-   * This special-case setup is done to make the logic in the rest of the clas
+   * This special-case setup is done to make the logic in the rest of the class
    * a bit simpler.
    */
   async _makeSnapshot0() {

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -424,16 +424,17 @@ describe('doc-server/BaseControl', () => {
 
   describe('getChange()', () => {
     describe('when given a valid-typed argument', () => {
-      const control = new MockControl(FILE_ACCESS, 'boop');
-      let gotStart  = null;
-      let gotEnd    = null;
-      let gotAllow  = null;
+      const control    = new MockControl(FILE_ACCESS, 'boop');
+      let gotStart     = null;
+      let gotEnd       = null;
+      let gotAllow     = null;
+      let changeResult = 'filled in in tests';
 
       control._getChangeRange = async (start, end, allowMissing) => {
         gotStart = start;
         gotEnd   = end;
         gotAllow = allowMissing;
-        return ['foomp'];
+        return changeResult;
       };
 
       it('should pass appropriate arguments to `_getChangeRange()`', async () => {
@@ -441,7 +442,7 @@ describe('doc-server/BaseControl', () => {
           await control.getChange(n);
           assert.strictEqual(gotStart, n);
           assert.strictEqual(gotEnd,   n + 1);
-          assert.isFalse(gotAllow);
+          assert.isTrue(gotAllow);
         }
 
         await test(0);
@@ -450,8 +451,14 @@ describe('doc-server/BaseControl', () => {
       });
 
       it('should return the first element of the return value from `_getChangeRange()`', async () => {
+        changeResult = ['foomp'];
         const result = await control.getChange(123);
         assert.strictEqual(result, 'foomp');
+      });
+
+      it('should convert a `null` result from `_getChangeRange()` a `revisionNotAvailable` error', async () => {
+        changeResult = [null];
+        await assert.isRejected(control.getChange(1), /^revisionNotAvailable/);
       });
     });
 

--- a/local-modules/doc-server/tests/test_BaseControl.js
+++ b/local-modules/doc-server/tests/test_BaseControl.js
@@ -456,8 +456,8 @@ describe('doc-server/BaseControl', () => {
         assert.strictEqual(result, 'foomp');
       });
 
-      it('should convert a `null` result from `_getChangeRange()` a `revisionNotAvailable` error', async () => {
-        changeResult = [null];
+      it('should convert an empty result from `_getChangeRange()` a `revisionNotAvailable` error', async () => {
+        changeResult = [];
         await assert.isRejected(control.getChange(1), /^revisionNotAvailable/);
       });
     });

--- a/local-modules/util-core/Errors.js
+++ b/local-modules/util-core/Errors.js
@@ -172,6 +172,16 @@ export default class Errors extends UtilityClass {
   }
 
   /**
+   * Indicates whether or not the given error is a `revisionNotAvailable`.
+   *
+   * @param {Error} error Error in question.
+   * @returns {boolean} `true` iff it represents a timeout.
+   */
+  static is_revisionNotAvailable(error) {
+    return InfoError.hasName(error, 'revisionNotAvailable');
+  }
+
+  /**
    * Indicates whether or not the given error is a `timedOut`.
    *
    * @param {Error} error Error in question.


### PR DESCRIPTION
This PR fixes a handful of edge-case-ish bugs that cropped up with ephemeral document parts. (As a reminder, the caret info is such a thing.)
