### PR TITLE
`FrozenBuffer` is frozen.

### DIFF
--- a/local-modules/util-common/index.js
+++ b/local-modules/util-common/index.js
@@ -6,7 +6,6 @@ import ColorSelector from './ColorSelector';
 import ColorUtil from './ColorUtil';
 import DeferredLoader from './DeferredLoader';
 import ErrorUtil from './ErrorUtil';
-import FrozenBuffer from './FrozenBuffer';
 import IterableUtil from './IterableUtil';
 import JsonUtil from './JsonUtil';
 import PropertyIterable from './PropertyIterable';
@@ -21,7 +20,6 @@ export {
   ColorUtil,
   DeferredLoader,
   ErrorUtil,
-  FrozenBuffer,
   IterableUtil,
   JsonUtil,
   PropertyIterable,

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -116,11 +116,14 @@ export default class CommonBase {
     // that was called upon.
 
     function mixOne(target, source) {
-      const descriptors = Object.getOwnPropertyDescriptors(source);
+      const keys = [
+        ...Object.getOwnPropertyNames(source),
+        ...Object.getOwnPropertySymbols(source)
+      ];
 
-      for (const [name, desc] of Object.entries(descriptors)) {
-        if (!ObjectUtil.hasOwnProperty(target, name)) {
-          Object.defineProperty(target, name, desc);
+      for (const key of keys) {
+        if (!ObjectUtil.hasOwnProperty(target, key)) {
+          Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
         }
       }
     }

--- a/local-modules/util-core/CommonBase.js
+++ b/local-modules/util-core/CommonBase.js
@@ -154,9 +154,11 @@ export default class CommonBase {
   /**
    * Custom inspector function, as called by `util.inspect()`. This
    * implementation returns a string that uses the instance's class name and
-   * public synthetic properties (which is an arrangement by and large suitable
-   * for classes as typically defined in this project), with the latter enclosed
-   * in `{...}` and displayed in a map-like way.
+   * either a constructor-like or map-like form for the payload. If the class
+   * defines `deconstruct()`, then the result of that is used for a
+   * constructor-like form. Otherwise, the public synthetic properties are used
+   * to form the map-like form (which is an arrangement by and large suitable
+   * for classes as typically defined in this project).
    *
    * Subclasses may choose to override this method if they can produce something
    * more appropriate and/or higher fidelity.

--- a/local-modules/util-core/FrozenBuffer.js
+++ b/local-modules/util-core/FrozenBuffer.js
@@ -6,7 +6,6 @@
 // module, which is why this is possible to import regardless of environment.
 import crypto from 'crypto';
 
-import CommonBase from './CommonBase';
 import CoreTypecheck from './CoreTypecheck';
 import Errors from './Errors';
 
@@ -21,8 +20,14 @@ const HASH_BIT_LENGTH = 256;
 
 /**
  * Immutable buffer of data.
+ *
+ * **Note:** This class mixes in `CommonBase`, so that it gets the static
+ * `check()` method and friends. However, because `CommonBase` uses this class,
+ * we can't just mix it in here (as this class is the one that gets initialized
+ * first). Instead, this happens during module initialization.
+ *
  */
-export default class FrozenBuffer extends CommonBase {
+export default class FrozenBuffer {
   /**
    * Validates that the given value is a valid hash string, such as might be
    * returned by the instance property `.hash` on this class. Throws an error if
@@ -99,8 +104,6 @@ export default class FrozenBuffer extends CommonBase {
     if (!(isString || isBuffer)) {
       throw Errors.badValue(value, 'Buffer|string');
     }
-
-    super();
 
     /** {string|null} String value, if constructed from a string. */
     this._string = isString ? value : null;

--- a/local-modules/util-core/FrozenBuffer.js
+++ b/local-modules/util-core/FrozenBuffer.js
@@ -6,8 +6,9 @@
 // module, which is why this is possible to import regardless of environment.
 import crypto from 'crypto';
 
-import { TBuffer, TInt } from 'typecheck';
-import { CommonBase, Errors } from 'util-core';
+import CommonBase from './CommonBase';
+import CoreTypecheck from './CoreTypecheck';
+import Errors from './Errors';
 
 /** {string} Node's name for the hashing algorithm to use. */
 const NODE_HASH_NAME = 'sha256';
@@ -195,10 +196,10 @@ export default class FrozenBuffer extends CommonBase {
    *   and the actual number of bytes copied is returned.
    */
   copy(target, targetStart = 0, sourceStart = 0, sourceEnd = this.length) {
-    TBuffer.check(target);
-    TInt.check(targetStart);
-    TInt.check(sourceStart);
-    TInt.check(sourceEnd);
+    CoreTypecheck.checkObject(target, Buffer);
+    CoreTypecheck.checkInt(targetStart, 0);
+    CoreTypecheck.checkInt(sourceStart, 0);
+    CoreTypecheck.checkInt(sourceEnd, sourceStart, this.length + 1);
 
     const buf = this._ensureBuffer();
     return buf.copy(target, targetStart, sourceStart, sourceEnd);

--- a/local-modules/util-core/FrozenBuffer.js
+++ b/local-modules/util-core/FrozenBuffer.js
@@ -6,6 +6,8 @@
 // module, which is why this is possible to import regardless of environment.
 import crypto from 'crypto';
 
+import { inspect } from 'util';
+
 import CoreTypecheck from './CoreTypecheck';
 import Errors from './Errors';
 
@@ -220,6 +222,29 @@ export default class FrozenBuffer {
     const thisBuf = this._ensureBuffer();
     const otherBuf = other._ensureBuffer();
     return thisBuf.equals(otherBuf);
+  }
+
+  /**
+   * Custom inspector function, as called by `util.inspect()`.
+   *
+   * @param {Int} depth Current inspection depth.
+   * @param {object} opts_unused Inspection options.
+   * @returns {string} The inspection string form of this instance.
+   */
+  [inspect.custom](depth, opts_unused) {
+    const name = this.constructor.name;
+    const buf  = this._ensureBuffer();
+
+    if (depth < 0) {
+      // Minimal expansion if we're at the depth limit.
+      return `${name}[${this.length === 0 ? '' : '...'}]`;
+    }
+
+    if (buf.length < 50) {
+      return `${name}[${buf.toString('hex')}]`;
+    }
+
+    return `${name}[${buf.slice(0, 50).toString('hex')}...]`;
   }
 
   /**

--- a/local-modules/util-core/index.js
+++ b/local-modules/util-core/index.js
@@ -6,6 +6,7 @@ import CommonBase from './CommonBase';
 import CoreTypecheck from './CoreTypecheck';
 import DataUtil from './DataUtil';
 import Errors from './Errors';
+import FrozenBuffer from './FrozenBuffer';
 import Functor from './Functor';
 import InfoError from './InfoError';
 import ObjectUtil from './ObjectUtil';
@@ -24,6 +25,7 @@ export {
   CoreTypecheck,
   DataUtil,
   Errors,
+  FrozenBuffer,
   Functor,
   InfoError,
   ObjectUtil,

--- a/local-modules/util-core/index.js
+++ b/local-modules/util-core/index.js
@@ -13,10 +13,9 @@ import ObjectUtil from './ObjectUtil';
 import URL from './URL';
 import UtilityClass from './UtilityClass';
 
-// Mix this class into `Functor` and `InfoError`. We do these here to avoid
-// circular dependencies: `CommonBase` uses `Errors` which uses `InfoError`
-// which uses `Functor`. `Functor` and `InfoError` both want to get the
-// `CommonBase` methods.
+// Mix this class into a few classes which would otherwise end up participating
+// in circular `import` dependencies.
+CommonBase.mixInto(FrozenBuffer);
 CommonBase.mixInto(Functor);
 CommonBase.mixInto(InfoError);
 

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import { inspect } from 'util';
 
-import { DataUtil, Functor } from 'util-core';
+import { DataUtil, FrozenBuffer, Functor } from 'util-core';
 
 describe('util-core/DataUtil', () => {
   describe('deepFreeze()', () => {
@@ -105,6 +105,15 @@ describe('util-core/DataUtil', () => {
 
       assert.isTrue(DataUtil.isDeepFrozen(popsicle));
       assert.deepEqual(popsicle, orig);
+    });
+
+    it('should return a given `FrozenBuffer`', () => {
+      function test(value) {
+        assert.strictEqual(DataUtil.deepFreeze(value), value);
+      }
+
+      test(FrozenBuffer.coerce(''));
+      test(FrozenBuffer.coerce('florp'));
     });
 
     it('should work on functors with freezable arguments', () => {
@@ -211,6 +220,17 @@ describe('util-core/DataUtil', () => {
       test({}, {});
       test({ a: 1 }, { a: 1 });
       test({ a: 1, b: { b: 2 } }, { a: 1, b: { b: 2 } });
+    });
+
+    it('should return `true` for equal-content `FrozenBuffer`s', () => {
+      function test(content) {
+        const buf1 = FrozenBuffer.coerce(content);
+        const buf2 = FrozenBuffer.coerce(content);
+        assert.isTrue(DataUtil.equalData(buf1, buf2), buf1);
+      }
+
+      test('');
+      test('Florps are now likes again.');
     });
 
     it('should return `true` for equal-content functors', () => {
@@ -326,6 +346,7 @@ describe('util-core/DataUtil', () => {
       test([]);
       test([1, 2, 3]);
       test([[1, 2, 3]]);
+      test([FrozenBuffer.coerce('zorch')]);
 
       test({});
       test({ a: 10, b: 20 });
@@ -335,6 +356,8 @@ describe('util-core/DataUtil', () => {
       test(new Functor('x', 1));
       test(new Functor('x', [1, 2, 3]));
       test(new Functor('x', new Functor('y', 914, 37)));
+
+      test(FrozenBuffer.coerce('florp'));
     });
 
     it('should return `false` for non-plain objects or composites with same', () => {
@@ -409,6 +432,15 @@ describe('util-core/DataUtil', () => {
       test(new Functor('x', 1));
       test(new Functor('x', Object.freeze([1, 2, 3])));
       test(new Functor('x', new Functor('y', 914, 37)));
+    });
+
+    it('should return `true` for `FrozenBuffer`s', () => {
+      function test(value) {
+        assert.isTrue(DataUtil.isDeepFrozen(value));
+      }
+
+      test(FrozenBuffer.coerce(''));
+      test(FrozenBuffer.coerce('blort'));
     });
 
     it('should return `false` for composites that are not frozen even if all elements are', () => {

--- a/local-modules/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/util-core/tests/test_FrozenBuffer.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { FrozenBuffer } from 'util-common';
+import { FrozenBuffer } from 'util-core';
 
 /**
  * {array<string>} List of string test cases meant to cover a good swath of test
@@ -71,7 +71,7 @@ const NON_STRINGS = [
   { '/x': '/y' }
 ];
 
-describe('util-common/FrozenBuffer', () => {
+describe('util-core/FrozenBuffer', () => {
   describe('checkHash()', () => {
     it('should accept valid hash strings', () => {
       for (const value of VALID_HASHES) {


### PR DESCRIPTION
This PR makes `FrozenBuffer` instances be considered to be "frozen data values" as defined by `util-core.DataUtil`. This is being done in preparation for using these as values in OT classes (which all require their data to be frozen).

This involved moving `FrozenBuffer` into `util-core`, because `DataUtil` needed to `import` it (and the move avoids creating a circular `import` dependency). And because nothing is easy, the move of the class meant that I had to do some additional rejiggering to avoid _module-internal_ circular `import` dependencies. Whee.