### PR TITLE
Code all the buffers!

### DIFF
--- a/local-modules/codec/Registry.js
+++ b/local-modules/codec/Registry.js
@@ -45,6 +45,7 @@ export default class Registry extends CommonBase {
 
     // Register all the special codecs.
     this.registerCodec(SpecialCodecs.ARRAY);
+    this.registerCodec(SpecialCodecs.FROZEN_BUFFER);
     this.registerCodec(SpecialCodecs.FUNCTOR);
     this.registerCodec(SpecialCodecs.PLAIN_OBJECT);
     this.registerCodec(SpecialCodecs.selfRepresentative('boolean'));

--- a/local-modules/codec/SpecialCodecs.js
+++ b/local-modules/codec/SpecialCodecs.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Functor, ObjectUtil, UtilityClass } from 'util-common';
+import { FrozenBuffer, Functor, ObjectUtil, UtilityClass } from 'util-common';
 
 import ItemCodec from './ItemCodec';
 
@@ -72,6 +72,46 @@ export default class SpecialCodecs extends UtilityClass {
     }
 
     return true;
+  }
+
+  /** {ItemCodec} Codec used for coding `FrozenBuffer`s. */
+  static get FROZEN_BUFFER() {
+    return new ItemCodec('buf', FrozenBuffer, null,
+      this._frozenBufferEncode, this._frozenBufferDecode);
+  }
+
+  /**
+   * Decodes a `FrozenBuffer`.
+   *
+   * @param {array<*>} payload Construction payload as previously produced by
+   *   `_frozenBufferEncode()`.
+   * @param {function} subDecode Function to call to decode component values
+   *   inside `payload`, as needed.
+   * @returns {FrozenBuffer} Decoded instance.
+   */
+  static _frozenBufferDecode(payload, subDecode) {
+    // Even though the expected case is that strings self-code, we call
+    // `subDecode()` anyway to protect against the unexpected (at insubstantial
+    // cost).
+    const [base64Enc] = payload;
+    const base64      = subDecode(base64Enc);
+
+    return new FrozenBuffer(base64, 'base64');
+  }
+
+  /**
+   * Encodes a `FrozenBuffer`.
+   *
+   * @param {FrozenBuffer} value Instance to encode.
+   * @param {function} subEncode Function to call to encode component values
+   *   inside `value`, as needed.
+   * @returns {array<*>} Encoded form.
+   */
+  static _frozenBufferEncode(value, subEncode) {
+    // Even though the expected case is that strings self-code, we call
+    // `subEncode()` anyway to protect against the unexpected (at insubstantial
+    // cost).
+    return [subEncode(value.base64)];
   }
 
   /** {ItemCodec} Codec used for coding functors. */

--- a/local-modules/codec/tests/test_Codec_decode.js
+++ b/local-modules/codec/tests/test_Codec_decode.js
@@ -56,21 +56,26 @@ describe('api-common/Codec.decode*()', () => {
     });
 
     it('should decode an encoded array back to the original array', () => {
-      const orig = [1, 2, 'buckle my shoe'];
+      const orig    = [1, 2, 'buckle my shoe'];
       const encoded = encodeData(orig);
       assert.deepEqual(decodeData(encoded), orig);
     });
 
-    it('should convert propertly formatted values to a decoded instance', () => {
+    it('should decode an encoded `FrozenBuffer`s back to an equal instance', () => {
+      const orig    = new FrozenBuffer('florp');
+      const encoded = encodeData(orig);
+      const decoded = decodeData(encoded);
+
+      assert.deepEqual(decoded.string,     orig.string);
+      assert.deepEqual(decoded.toBuffer(), orig.toBuffer());
+    });
+
+    it('should decode an encoded class instance as expected', () => {
       const apiObject = new MockCodable();
-      const encoding = encodeData(apiObject);
-      let decodedObject = null;
+      const encoding  = encodeData(apiObject);
+      const decoded   = decodeData(encoding);
 
-      assert.doesNotThrow(() => {
-        decodedObject = decodeData(encoding);
-      });
-
-      assert.instanceOf(decodedObject, apiObject.constructor);
+      assert.instanceOf(decoded, apiObject.constructor);
     });
   });
 

--- a/local-modules/codec/tests/test_Codec_encode.js
+++ b/local-modules/codec/tests/test_Codec_encode.js
@@ -94,6 +94,13 @@ describe('api-common/Codec.encode*()', () => {
       assert.deepEqual(encodeData(orig), expect);
     });
 
+    it('should accept `FrozenBuffer`s and encode as a single base-64 string argument', () => {
+      const orig   = new FrozenBuffer('florp');
+      const expect = ConstructorCall.from('buf', 'ZmxvcnA=');
+
+      assert.deepEqual(encodeData(orig), expect);
+    });
+
     it('should reject objects with no `deconstruct()` method', () => {
       class NoDeconstruct {
         get CODEC_TAG() {

--- a/local-modules/util-core/FrozenBuffer.js
+++ b/local-modules/util-core/FrozenBuffer.js
@@ -126,6 +126,13 @@ export default class FrozenBuffer {
     Object.seal(this);
   }
 
+  /** {string} Value of this instance, encoded as a base-64 string. */
+  get base64() {
+    const buf = this._ensureBuffer();
+
+    return buf.toString('base64');
+  }
+
   /** {Int} Length of hash used by this instance, in bits. */
   get hashLength() {
     return HASH_BIT_LENGTH;

--- a/local-modules/util-core/FrozenBuffer.js
+++ b/local-modules/util-core/FrozenBuffer.js
@@ -96,7 +96,10 @@ export default class FrozenBuffer {
   /**
    * Constructs an instance.
    *
-   * @param {Buffer|string} value Contents of the buffer.
+   * @param {Buffer|string} value Contents of the buffer. If given a `Buffer`,
+   *   it is copied so that the data stored within this instance is _not_ shared
+   *   with the original. (Not doing so would mean that the instance wouldn't
+   *   actually be frozen!)
    * @param {string} [encoding = 'utf8'] Encoding to use to convert a `string`
    *   argument to bytes. Valid options are _just_ `utf8` and `base64`. This
    *   argument is ignored (not even typechecked) if `value` is a `Buffer`.
@@ -107,11 +110,8 @@ export default class FrozenBuffer {
     let bufferValue = null;
 
     if (Buffer.isBuffer(value)) {
-      // Clone the buffer to guarantee safe use.
-      // TODO: Actually clone this. This deficiency is temporarily-intentional,
-      // in order to duplicate the buggy pre-existing behavior. It will be fixed
-      // when corresponding test cases are added.
-      bufferValue = value;
+      // Clone the buffer to guarantee safe and independent use.
+      bufferValue = Buffer.from(value);
     } else if (typeof value === 'string') {
       if (encoding === 'utf8') {
         // No need to set `bufferValue`; that gets constructed as needed via

--- a/local-modules/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/util-core/tests/test_FrozenBuffer.js
@@ -187,13 +187,26 @@ describe('util-core/FrozenBuffer', () => {
       it('should convert bytes to strings using UTF-8 encoding', () => {
         function test(string) {
           const nodeBuf = Buffer.from(string, 'utf8');
-          const buf = new FrozenBuffer(nodeBuf);
+          const buf     = new FrozenBuffer(nodeBuf);
           assert.strictEqual(buf.string, string);
         }
 
         for (const s of STRING_CASES) {
           test(s);
         }
+      });
+
+      it('should not share the original buffer data; should be a copy', () => {
+        const nodeBuf1 = Buffer.from('blortch', 'utf8');
+        const nodeBuf2 = Buffer.from(nodeBuf1);
+        const buf      = new FrozenBuffer(nodeBuf1);
+
+        nodeBuf1[0] = 0;
+        nodeBuf1[1] = 0;
+        nodeBuf1[2] = 0;
+
+        assert.strictEqual(buf.string, 'blortch');
+        assert.deepEqual(buf.toBuffer(), nodeBuf2);
       });
     });
   });

--- a/local-modules/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/util-core/tests/test_FrozenBuffer.js
@@ -156,6 +156,18 @@ describe('util-core/FrozenBuffer', () => {
     });
   });
 
+  describe('.base64', () => {
+    it('should be as expected when originally constructed from a `Buffer`', () => {
+      const buf = new FrozenBuffer(Buffer.from('florp splat', 'utf8'));
+      assert.strictEqual(buf.base64, 'ZmxvcnAgc3BsYXQ=');
+    });
+
+    it('should be as expected when originally constructed from a string', () => {
+      const buf = new FrozenBuffer('blort splat florp');
+      assert.strictEqual(buf.base64, 'YmxvcnQgc3BsYXQgZmxvcnA=');
+    });
+  });
+
   describe('.hashLength', () => {
     it('should be `256`', () => {
       assert.strictEqual(new FrozenBuffer('x').hashLength, 256);

--- a/local-modules/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/util-core/tests/test_FrozenBuffer.js
@@ -373,5 +373,20 @@ describe('util-core/FrozenBuffer', () => {
         test(s);
       }
     });
+
+    it('should be independent of the internally-stored buffer and to other results from this method', () => {
+      const nodeBuf = Buffer.from('abc', 'utf8');
+      const origBuf = new FrozenBuffer(nodeBuf);
+      const toBuf1  = origBuf.toBuffer();
+
+      toBuf1[0] = 0;
+      toBuf1[1] = 0;
+      toBuf1[2] = 0;
+
+      const toBuf2  = origBuf.toBuffer();
+
+      assert.notStrictEqual(toBuf2, toBuf1);
+      assert.deepEqual(toBuf2, nodeBuf);
+    });
   });
 });


### PR DESCRIPTION
This PR adds codec support for `FrozenBuffer`. Why? Because those are what the `file-store-ot` OT classes use to represent file contents, and those file contents will eventually get coded via the `codec` module.

As it stands, the encoded form for these includes a base-64-encoded string, which is of course always a real crowd pleaser. Alas, this is about the sanest option available, given that the low-layer encoding form is currently JSON. To be clear, JSON has been used because it was an easy form to work with as the project was ramping up, _not_ because we expected to use it forever. **We _will_ jettison JSON at some point, and when we do that, we can do something much better when it comes to encoding byte buffers.**