### PR TITLE
Tighten up what's allowed in a file transaction.

### DIFF
--- a/local-modules/doc-client/EditorComplex.js
+++ b/local-modules/doc-client/EditorComplex.js
@@ -32,7 +32,7 @@ const DEFAULT_BODY_MODULE_CONFIG = {
   keyboard: BayouKeyHandlers.defaultKeyHandlers,
   toolbar: [
     [{ header: 1 }, { header: 2 }, { header: 3 }],
-    ['bold', 'italic', 'underline', 'strike', 'code'],
+    ['bold', 'italic', 'underline', 'strike', 'link', 'code'],
     [{ list: 'bullet' }, { list: 'ordered' }, { list: 'unchecked' }],
     ['blockquote', 'code-block']
   ]
@@ -42,7 +42,7 @@ const DEFAULT_BODY_MODULE_CONFIG = {
 const DEFAULT_TITLE_MODULE_CONFIG = {
   keyboard: BayouKeyHandlers.defaultSingleLineKeyHandlers,
   toolbar: [
-    ['italic', 'underline', 'strike', 'code'], // Toggled buttons.
+    ['italic', 'underline', 'strike', 'link', 'code'], // Toggled buttons.
   ]
 };
 

--- a/local-modules/file-store-ot/TransactionOp.js
+++ b/local-modules/file-store-ot/TransactionOp.js
@@ -333,16 +333,25 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
  *
  * * Environment ops &mdash; An environment operation performs some action or
  *   checks some aspect of the execution environment of the transaction.
+ *
  * * Revision restrictions &mdash; A revision restriction limits a transaction
  *   to being based only on a certain revision of the file.
+ *
  * * Prerequisite checks &mdash; A prerequisite check must pass in order for
  *   the remainder of a transaction to apply.
- * * Path lists &mdash; A path list finds or identifies some number of storage
- *   paths, yielding the paths themselves (and not the data so referenced).
- * * Data reads &mdash; A data read gets the value of a blob within a file.
- * * Data deletions &mdash; A data deletion erases previously-existing data
- *   within a file.
- * * Data writes &mdash; A data write stores new data into a file.
+ *
+ * * Pull operations &mdash; A pull operation reads data of some sort from a
+ *   file. Subcategories:
+ *   * Path lists &mdash; A path list finds or identifies some number of storage
+ *     paths, yielding the paths themselves (and not the data so referenced).
+ *   * Data reads &mdash; A data read gets the value of a blob within a file.
+ *
+ * * Push operations &mdash; A push operation makes a change of some sort to a
+ *   file. Subcategories:
+ *   * Data deletions &mdash; A data deletion erases previously-existing data
+ *     within a file.
+ *   * Data writes &mdash; A data write stores new data into a file.
+ *
  * * Waits &mdash; A wait operation blocks a transaction until some condition
  *   holds. When a wait operation completes having detected one or more
  *   conditions, the paths related to the conditions that were satisfied are
@@ -355,6 +364,12 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
  * When executed, the operations of a transaction are effectively performed in
  * order by category; but within a category there is no effective ordering.
  * Specifically, the category ordering is as listed above.
+ *
+ * Any given transaction can include pulls, pushes, or waits as a category; but
+ * it is invalid to have a transacation with two or more of these categories.
+ * For example, it is okay to have a transaction with a path list and two data
+ * reads, but it is not valid to have a transaction that has a data read and a
+ * data deletion.
  *
  * There are static methods on this class to construct each named operation,
  * named `op_<name>`. See documentation on those methods for details about the

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -34,8 +34,8 @@ export default class TransactionSpec extends CommonBase {
       throw Errors.badUse('Too many `revNum` operations.');
     }
 
-    if (this.hasWaitOps() && (this.hasPullOps() || this.hasPushOps())) {
-      throw Errors.badUse('Cannot mix wait operations with reads and modifications.');
+    if ((this.hasWaitOps() + this.hasPullOps() + this.hasPushOps()) > 1) {
+      throw Errors.badUse('Must only have one of wait operations, pull operations, or push operations.');
     }
 
     Object.freeze(this);

--- a/local-modules/file-store-ot/tests/FileOpMaker.js
+++ b/local-modules/file-store-ot/tests/FileOpMaker.js
@@ -62,7 +62,7 @@ export default class FileOpMaker extends UtilityClass {
   static makeWithCategory(category, count) {
     const ops = [];
 
-    function schemaCat(schema) {
+    function schemaCategory(schema) {
       if      (schema.isPush)                              { return 'push';  }
       else if (schema.isPull)                              { return 'pull';  }
       else if (schema.category === TransactionOp.CAT_wait) { return 'wait';  }
@@ -71,7 +71,7 @@ export default class FileOpMaker extends UtilityClass {
 
     for (const name of TransactionOp.OPERATION_NAMES) {
       const schema = TransactionOp.propsFromName(name);
-      const cat    = schemaCat(schema);
+      const cat    = schemaCategory(schema);
 
       let n;
       if      (cat === category) { n = count; }

--- a/local-modules/file-store-ot/tests/test_TransactionSpec.js
+++ b/local-modules/file-store-ot/tests/test_TransactionSpec.js
@@ -20,7 +20,7 @@ describe('file-store-ot/TransactionSpec', () => {
       });
 
       // This test doesn't make sense for length 0.
-      if (ops.length === 0) {
+      if (ops.length !== 0) {
         it('should reject an invalid argument in any position', () => {
           const badValues = [undefined, null, false, 'hello', ['blort'], { x: 914 }, new Map()];
           let   badAt     = 0;

--- a/local-modules/ui-header/components/Avatars.js
+++ b/local-modules/ui-header/components/Avatars.js
@@ -9,6 +9,10 @@ import { connect } from 'react-redux';
 import styles from './avatar.module.less';
 import { CaretState } from 'doc-client';
 
+// The hash is for '' which can't match anyone's email address so is safe to
+// use as a placeholder.
+const AVATAR_PLACEHOLDER_URL = 'https://gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=36&d=mm';
+
 class Avatars extends React.Component {
   render() {
     return (
@@ -17,8 +21,9 @@ class Avatars extends React.Component {
           [...this.props.sessions.entries()].map(([sessionId, caret]) => {
             return (
               <div key={ sessionId } className={ styles['document-header__avatar'] }>
-                <img src='' />
-                <div className={ styles['avatar-presence'] }
+                <img src={ AVATAR_PLACEHOLDER_URL } />
+                <div
+                  className={ styles['avatar-presence'] }
                   style={{ backgroundColor: caret.color }} />
               </div>
             );

--- a/local-modules/ui-header/components/avatar.module.less
+++ b/local-modules/ui-header/components/avatar.module.less
@@ -13,16 +13,17 @@
 	position: relative;
 	border: 1px solid @sk_white;
 	border-radius: 5px;
+	box-sizing: border-box;
+
+	img {
+		height: 100%;
+		width: 100%;
+		border-radius: 5px;
+	}
 }
 
 .document-header__avatar:last-child {
 	margin-right: 0;
-}
-
-.document-header__avatar img {
-	height: 36px;
-	width: 36px;
-	border-radius: 5px;
 }
 
 .avatar-presence {


### PR DESCRIPTION
This PR adds a new restriction on `TransactionSpec`, such that "push" and "pull" ops are no longer allowed to be in the same transaction. It wasn't the case that we ever ran such transactions, but I wanted to make the restriction explicit to be extra-double sure. The point of this is to make it just a bit easier when it comes to translating `TransactionSpec`s into OT-based operations.