### PR TITLE
New `Predicate*` classes.

### DIFF
--- a/local-modules/doc-common/Caret.js
+++ b/local-modules/doc-common/Caret.js
@@ -15,9 +15,13 @@ import CaretOp from './CaretOp';
  *
  * **Note:** `sessionId` is not included, because that's separate from the
  * caret's "fields" per se.
+ *
+ * **Note:** We use the `bind(...)` form for method binding instead of an
+ * anonymous function because the latter &mdash; while more standard &mdash;
+ * confuses the linter.
  */
 const CARET_FIELDS = new Map([
-  ['lastActive', Timestamp.check],
+  ['lastActive', Timestamp.check.bind(Timestamp)],
   ['revNum',     RevisionNumber.check],
   ['index',      TInt.nonNegative],
   ['length',     TInt.nonNegative],

--- a/local-modules/doc-server/FileBootstrap.js
+++ b/local-modules/doc-server/FileBootstrap.js
@@ -247,7 +247,7 @@ export default class FileBootstrap extends BaseDataManager {
     await this.afterInit();
 
     // **TODO:** Ideally, this would be rolled into the transaction as defined
-    // by `fullSpec` above.
+    // by `initSpec` above.
     await this._bodyControl.update(change);
 
     return true;

--- a/local-modules/file-store-ot/FileOp.js
+++ b/local-modules/file-store-ot/FileOp.js
@@ -5,6 +5,7 @@
 import { BaseOp } from 'ot-common';
 import { Errors, FrozenBuffer } from 'util-common';
 
+import StorageId from './StorageId';
 import StoragePath from './StoragePath';
 
 /**
@@ -53,11 +54,7 @@ export default class FileOp extends BaseOp {
    * @returns {FileOp} An appropriately-constructed operation.
    */
   static op_deleteBlob(hash) {
-    if (hash instanceof FrozenBuffer) {
-      hash = hash.hash;
-    } else {
-      FrozenBuffer.checkHash(hash);
-    }
+    hash = StorageId.checkOrGetHash(hash);
 
     return new FileOp(FileOp.CODE_deleteBlob, hash);
   }

--- a/local-modules/file-store-ot/PredicateOp.js
+++ b/local-modules/file-store-ot/PredicateOp.js
@@ -1,0 +1,282 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseOp, RevisionNumber } from 'ot-common';
+import { Errors } from 'util-common';
+
+import FileSnapshot from './FileSnapshot';
+import StorageId from './StorageId';
+import StoragePath from './StoragePath';
+
+/**
+ * Operation which defines a predicate on a {@link FileSnapshot}.
+ */
+export default class PredicateOp extends BaseOp {
+  /** {string} Opcode constant for "blob absent" operations. */
+  static get CODE_blobAbsent() {
+    return 'blobAbsent';
+  }
+
+  /** {string} Opcode constant for "blob present" operations. */
+  static get CODE_blobPresent() {
+    return 'blobPresent';
+  }
+
+  /** {string} Opcode constant for "path absent" operations. */
+  static get CODE_pathAbsent() {
+    return 'pathAbsent';
+  }
+
+  /** {string} Opcode constant for "path is" operations. */
+  static get CODE_pathIs() {
+    return 'pathIs';
+  }
+
+  /** {string} Opcode constant for "path is not" operations. */
+  static get CODE_pathIsNot() {
+    return 'pathIsNot';
+  }
+
+  /** {string} Opcode constant for "path present" operations. */
+  static get CODE_pathPresent() {
+    return 'pathPresent';
+  }
+
+  /** {string} Opcode constant for "revision number is" operations. */
+  static get CODE_revNumIs() {
+    return 'revNumIs';
+  }
+
+  /**
+   * Constructs a new "blob absent" operation.
+   *
+   * @param {string|FrozenBuffer} hash Hash of the blob to check for the absence
+   *   of, or a buffer whose hash is to be used as the blob identifier.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_blobAbsent(hash) {
+    hash = StorageId.checkOrGetHash(hash);
+    return new PredicateOp(PredicateOp.CODE_blobAbsent, hash);
+  }
+
+  /**
+   * Constructs a new "blob present" operation.
+   *
+   * @param {string|FrozenBuffer} hash Hash of the blob to check for the
+   *   presence of, or a buffer whose hash is to be used as the blob identifier.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_blobPresent(hash) {
+    hash = StorageId.checkOrGetHash(hash);
+    return new PredicateOp(PredicateOp.CODE_blobPresent, hash);
+  }
+
+  /**
+   * Constructs a new "path absent" operation.
+   *
+   * @param {string} path Storage path to check for the absence of.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_pathAbsent(path) {
+    StoragePath.check(path);
+
+    return new PredicateOp(PredicateOp.CODE_pathAbsent, path);
+  }
+
+  /**
+   * Constructs a new "path is" operation.
+   *
+   * @param {string} path Storage path to check.
+   * @param {string|FrozenBuffer} hash Hash of the blob to compare to what is
+   *   stored at `path`, or a buffer whose hash is to be used as the blob
+   *   identifier.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_pathIs(path, hash) {
+    StoragePath.check(path);
+
+    return new PredicateOp(PredicateOp.CODE_pathIs, path, hash);
+  }
+
+  /**
+   * Constructs a new "path is not" operation.
+   *
+   * @param {string} path Storage path to check.
+   * @param {string|FrozenBuffer} hash Hash of the blob to compare to what is
+   *   stored at `path`, or a buffer whose hash is to be used as the blob
+   *   identifier.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_pathIsNot(path, hash) {
+    StoragePath.check(path);
+
+    return new PredicateOp(PredicateOp.CODE_pathIsNot, path, hash);
+  }
+
+  /**
+   * Constructs a new "path present" operation.
+   *
+   * @param {string} path Storage path to check for the presence of.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_pathPresent(path) {
+    StoragePath.check(path);
+
+    return new PredicateOp(PredicateOp.CODE_pathPresent, path);
+  }
+
+  /**
+   * Constructs a new "revision number is" operation.
+   *
+   * @param {int} revNum Revision number to check for.
+   * @returns {PredicateOp} An appropriately-constructed operation.
+   */
+  static op_revNumIs(revNum) {
+    RevisionNumber.check(revNum);
+
+    return new PredicateOp(PredicateOp.CODE_revNumIs, revNum);
+  }
+
+  /**
+   * {object} The properties of this operation, as a conveniently-accessed
+   * plain object. `opName` is always bound to the operation name. Other
+   * bindings depend on the operation name. Guaranteed to be an immutable
+   * object.
+   */
+  get props() {
+    const payload = this._payload;
+    const opName  = payload.name;
+
+    switch (opName) {
+      case PredicateOp.CODE_blobAbsent:
+      case PredicateOp.CODE_blobPresent: {
+        const [hash] = payload.args;
+        return Object.freeze({ opName, hash });
+      }
+
+      case PredicateOp.CODE_pathAbsent:
+      case PredicateOp.CODE_pathPresent: {
+        const [path] = payload.args;
+        return Object.freeze({ opName, path });
+      }
+
+      case PredicateOp.CODE_pathIs:
+      case PredicateOp.CODE_pathIsNot: {
+        const [path, hash] = payload.args;
+        return Object.freeze({ opName, path, hash });
+      }
+
+      case PredicateOp.CODE_revNumIs: {
+        const [revNum] = payload.args;
+        return Object.freeze({ opName, revNum });
+      }
+
+      default: {
+        throw Errors.wtf(`Weird operation name: ${opName}`);
+      }
+    }
+  }
+
+  /**
+   * Runs this instance on a given snapshot.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @returns {boolean} `true` if `snapshot` passes the test defined by this
+   *   instance, or `false` if not.
+   */
+  run(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    // Dispatch to the private static method `_op_<opName>`.
+    const clazz   = this.constructor;
+    const props   = this.props;
+    const handler = clazz[`_op_${props.opName}`];
+    if (!handler) {
+      throw Errors.wtf(`Missing handler for op: ${props.opName}`);
+    }
+
+    return handler.call(clazz, snapshot, props);
+  }
+
+  /**
+   * Runs the test for `blobAbsent` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_blobAbsent(snapshot, props) {
+    return snapshot.getOrNull(props.hash) === null;
+  }
+
+  /**
+   * Runs the test for `blobPresent` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_blobPresent(snapshot, props) {
+    return snapshot.getOrNull(props.hash) !== null;
+  }
+
+  /**
+   * Runs the test for `pathAbsent` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_pathAbsent(snapshot, props) {
+    return snapshot.getOrNull(props.path) === null;
+  }
+
+  /**
+   * Runs the test for `pathIs` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_pathIs(snapshot, props) {
+    const got = snapshot.getOrNull(props.path);
+
+    return (got !== null) && (got.hash === props.hash);
+  }
+
+  /**
+   * Runs the test for `pathIsNot` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_pathIsNot(snapshot, props) {
+    const got = snapshot.getOrNull(props.path);
+
+    return (got === null) || (got.hash !== props.hash);
+  }
+
+  /**
+   * Runs the test for `pathPresent` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_pathPresent(snapshot, props) {
+    return snapshot.getOrNull(props.path) !== null;
+  }
+
+  /**
+   * Runs the test for `revNumIs` operations.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @param {object} props Operation properties as a plain object.
+   * @returns {boolean} Test result.
+   */
+  static _op_revNumIs(snapshot, props) {
+    return snapshot.revNum === props.revNum;
+  }
+}

--- a/local-modules/file-store-ot/PredicateSpec.js
+++ b/local-modules/file-store-ot/PredicateSpec.js
@@ -1,0 +1,61 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray } from 'typecheck';
+import { CommonBase } from 'util-common';
+
+import FileSnapshot from './FileSnapshot';
+import PredicateOp from './PredicateOp';
+
+/**
+ * File predicate specification. This is a set of operations (each an instance
+ * of {@link PredicateOp}) which is to be executed with respect to a {@link
+ * FileSnapshot}. The result of running these is a boolean which indicates that
+ * the snapshot does (`true`) or does not (`false`) satisfy all of the
+ * predicate operations.
+ */
+export default class PredicateSpec extends CommonBase {
+  /**
+   * Constructs an instance consisting of all of the indicated operations.
+   *
+   * @param {...PredicateOp} ops The operations to perform.
+   */
+  constructor(...ops) {
+    TArray.check(ops, v => PredicateOp.check(v));
+
+    super();
+
+    /** {array<PredicateOp>} Array of operations. */
+    this._ops = Object.freeze(ops);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {array<PredicateOp>} The predicate operations. This value is always frozen
+   * (immutable).
+   */
+  get ops() {
+    return this._ops;
+  }
+
+  /**
+   * Runs this instance on a given snapshot.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to test.
+   * @returns {boolean} `true` if this instance's predicate operations all pass
+   *   on `snapshot`, or `false` if not.
+   */
+  run(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    for (const op of this._ops) {
+      if (!op.run(snapshot)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/local-modules/file-store-ot/StorageId.js
+++ b/local-modules/file-store-ot/StorageId.js
@@ -31,6 +31,23 @@ export default class StorageId extends UtilityClass {
   }
 
   /**
+   * Checks or converts a hash value. If given a valid hash value, returns it.
+   * Otherwise, the given value must be a `FrozenBuffer`, and its hash is
+   * returned. Throws an error in all other cases.
+   *
+   * @param {string|FrozenBuffer} hashOrBuffer The value in question.
+   * @returns {string} The given value if it is in fact a valid hash string, or
+   *   the hash of the given `FrozenBuffer` value if not.
+   */
+  static checkOrGetHash(hashOrBuffer) {
+    if (hashOrBuffer instanceof FrozenBuffer) {
+      return hashOrBuffer.hash;
+    }
+
+    return FrozenBuffer.checkHash(hashOrBuffer);
+  }
+
+  /**
    * Indicates whether the given value is a valid storage ID string.
    *
    * @param {*} value Value in question.

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -42,9 +42,9 @@ export default class TransactionSpec extends CommonBase {
   }
 
   /**
-   * {array<TransactionOp>} An iterator for the operations to perform. The
-   * operations are in category-sorted order, as documented by `TransactionOp`.
-   * This value is always frozen (immutable).
+   * {array<TransactionOp>} The operations to perform. These are in
+   * category-sorted order, as documented by `TransactionOp`. This value is
+   * always frozen (immutable).
    */
   get ops() {
     return this._ops;

--- a/local-modules/file-store-ot/index.js
+++ b/local-modules/file-store-ot/index.js
@@ -6,6 +6,8 @@ import FileChange from './FileChange';
 import FileDelta from './FileDelta';
 import FileOp from './FileOp';
 import FileSnapshot from './FileSnapshot';
+import PredicateOp from './PredicateOp';
+import PredicateSpec from './PredicateSpec';
 import StorageId from './StorageId';
 import StoragePath from './StoragePath';
 import TransactionOp from './TransactionOp';
@@ -16,6 +18,8 @@ export {
   FileDelta,
   FileOp,
   FileSnapshot,
+  PredicateOp,
+  PredicateSpec,
   StorageId,
   StoragePath,
   TransactionOp,

--- a/local-modules/file-store-ot/tests/test_PredicateSpec.js
+++ b/local-modules/file-store-ot/tests/test_PredicateSpec.js
@@ -1,0 +1,87 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { PredicateOp, PredicateSpec } from 'file-store-ot';
+import { FrozenBuffer } from 'util-common';
+
+describe('file-store-ot/PredicateSpec', () => {
+  describe('constructor()', () => {
+    it('should accept any number of `PredicateOp`s', () => {
+      function test(...ops) {
+        assert.doesNotThrow(() => new PredicateSpec(...ops));
+      }
+
+      test();
+      test(PredicateOp.op_revNumIs(1));
+      test(
+        PredicateOp.op_blobAbsent(new FrozenBuffer('x')),
+        PredicateOp.op_blobPresent(new FrozenBuffer('y')));
+      test(
+        PredicateOp.op_pathAbsent('/foo'),
+        PredicateOp.op_pathIs('/x', new FrozenBuffer('x')),
+        PredicateOp.op_pathIsNot('/y', new FrozenBuffer('not-y')),
+        PredicateOp.op_pathPresent('/foo/bar'));
+    });
+
+    it('should reject non-`PredicateOp`s', () => {
+      const goodOps1 = [
+        PredicateOp.op_revNumIs(1),
+        PredicateOp.op_blobAbsent(new FrozenBuffer('x')),
+        PredicateOp.op_blobPresent(new FrozenBuffer('y'))
+      ];
+      const goodOps2 = [
+        PredicateOp.op_blobAbsent(new FrozenBuffer('a')),
+        PredicateOp.op_blobPresent(new FrozenBuffer('b'))
+      ];
+
+      function test(value) {
+        assert.throws(() => new PredicateSpec(value), /badValue/);
+        assert.throws(() => new PredicateSpec(...goodOps1, value, ...goodOps2), /badValue/);
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test(123);
+      test('blort');
+      test(['boop']);
+      test({ x: 'florp' });
+      test([PredicateOp.op_revNumIs(123)]);
+      test(['x', PredicateOp.op_revNumIs(123)]);
+      test([PredicateOp.op_revNumIs(123), 'x']);
+    });
+  });
+
+  describe('.ops', () => {
+    it('should be a frozen array', () => {
+      const spec = new PredicateSpec(PredicateOp.op_revNumIs(123));
+      const ops  = spec.ops;
+
+      assert.isArray(ops);
+      assert.isFrozen(ops);
+    });
+
+    it('should contain the values passed in the constructor, in the same order', () => {
+      function test(...ops) {
+        const spec = new PredicateSpec(...ops);
+
+        assert.deepEqual(spec.ops, ops);
+      }
+
+      test();
+      test(PredicateOp.op_revNumIs(1));
+      test(
+        PredicateOp.op_blobAbsent(new FrozenBuffer('x')),
+        PredicateOp.op_blobPresent(new FrozenBuffer('y')));
+      test(
+        PredicateOp.op_pathAbsent('/foo'),
+        PredicateOp.op_pathIs('/x', new FrozenBuffer('x')),
+        PredicateOp.op_pathIsNot('/y', new FrozenBuffer('not-y')),
+        PredicateOp.op_pathPresent('/foo/bar'));
+    });
+  });
+});

--- a/local-modules/file-store-ot/tests/test_StorageId.js
+++ b/local-modules/file-store-ot/tests/test_StorageId.js
@@ -44,6 +44,53 @@ describe('file-store-ot/StorageId', () => {
     });
   });
 
+  describe('checkOrGetHash()', () => {
+    it('should accept valid hash strings', () => {
+      function test(value) {
+        assert.strictEqual(StorageId.checkOrGetHash(value), value);
+      }
+
+      test(FrozenBuffer.coerce('blort').hash);
+      test(FrozenBuffer.coerce('zorch').hash);
+    });
+
+    it('should accept `FrozenBuffer` instances, converting to their respective hashes', () => {
+      function test(value) {
+        const buf = new FrozenBuffer(value);
+        assert.strictEqual(StorageId.checkOrGetHash(buf), buf.hash);
+      }
+
+      test('');
+      test('florp');
+      test('splatch');
+    });
+
+    it('should reject invalid strings', () => {
+      function test(value) {
+        assert.throws(() => { StorageId.checkOrGetHash(value); });
+      }
+
+      test('');
+      test('x');
+      test('/x/y');
+      test('/foo!!');
+      test(FrozenBuffer.coerce('blort').hash + '123123');
+    });
+
+    it('should reject non-`FrozenBuffer` non-strings', () => {
+      function test(value) {
+        assert.throws(() => { StorageId.checkOrGetHash(value); });
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test(true);
+      test(123);
+      test(['/foo']);
+    });
+  });
+
   describe('isInstance()', () => {
     it('should return `true` for valid id strings', () => {
       function test(value) {

--- a/local-modules/file-store/BaseFile.js
+++ b/local-modules/file-store/BaseFile.js
@@ -211,7 +211,7 @@ export default class BaseFile extends CommonBase {
       if (result.data === null) {
         throw Errors.badUse('Improper subclass behavior: Expected non-`null` `data`.');
       }
-      TMap.check(result.data, StorageId.check, FrozenBuffer.check);
+      TMap.check(result.data, StorageId.check, x => FrozenBuffer.check(x));
     } else {
       if (result.data !== null) {
         throw Errors.badUse('Improper subclass behavior: Expected `null` `data`.');


### PR DESCRIPTION
In the transition away from `Transaction{Op,Spec}`, we will need new classes to cover the use cases that used to be covered by precondition and wait ops. The new classes `Predicate{Op,Spec}` are meant to be a suitable vessel for such operations.

**Bonus:** Fixed a couple random problems I ran across as I was working on the main stuff.