### PR TITLE
More prep for OT `file-store`.

### DIFF
--- a/local-modules/file-store-local/LocalFile.js
+++ b/local-modules/file-store-local/LocalFile.js
@@ -60,9 +60,17 @@ export default class LocalFile extends BaseFile {
    *
    * @param {string} fileId The ID of the file this instance represents.
    * @param {string} filePath The filesystem path for file storage.
+   * @param {Codec} codec Codec instance to use when encoding and decoding
+   *   changes.
    */
-  constructor(fileId, filePath) {
+  constructor(fileId, filePath, codec) {
     super(fileId);
+
+    /**
+     * {Codec} Codec instance to use when encoding and decoding items for
+     * storage. **Note:** This isn't used yet, as of this writing.
+     */
+    this._codec = Codec.check(codec);
 
     /**
      * {string} Path to the directory containing stored values for this file.

--- a/local-modules/file-store-local/LocalFileStore.js
+++ b/local-modules/file-store-local/LocalFileStore.js
@@ -8,6 +8,7 @@ import path from 'path';
 import { Codec } from 'codec';
 import { Dirs } from 'env-server';
 import { BaseFileStore } from 'file-store';
+import { TheModule as fileStoreOt_TheModule } from 'file-store-ot';
 import { Logger } from 'see-all';
 
 import LocalFile from './LocalFile';
@@ -28,6 +29,7 @@ export default class LocalFileStore extends BaseFileStore {
 
     /** {Codec} Codec to use when reading and writing file OT objects. */
     this._codec = new Codec();
+    fileStoreOt_TheModule.registerCodecs(this._codec.registry);
 
     /** {Map<string, LocalFile>} Map from file IDs to file instances. */
     this._files = new Map();

--- a/local-modules/file-store-local/LocalFileStore.js
+++ b/local-modules/file-store-local/LocalFileStore.js
@@ -5,6 +5,7 @@
 import afs from 'async-file';
 import path from 'path';
 
+import { Codec } from 'codec';
 import { Dirs } from 'env-server';
 import { BaseFileStore } from 'file-store';
 import { Logger } from 'see-all';
@@ -24,6 +25,9 @@ export default class LocalFileStore extends BaseFileStore {
    */
   constructor() {
     super();
+
+    /** {Codec} Codec to use when reading and writing file OT objects. */
+    this._codec = new Codec();
 
     /** {Map<string, LocalFile>} Map from file IDs to file instances. */
     this._files = new Map();
@@ -55,7 +59,7 @@ export default class LocalFileStore extends BaseFileStore {
 
     await this._ensureFileStorageDirectory();
 
-    const result = new LocalFile(fileId, this._filePath(fileId));
+    const result = new LocalFile(fileId, this._filePath(fileId), this._codec);
     this._files.set(fileId, result);
     return result;
   }

--- a/local-modules/file-store-local/Transactor.js
+++ b/local-modules/file-store-local/Transactor.js
@@ -378,21 +378,6 @@ export default class Transactor extends CommonBase {
   }
 
   /**
-   * Handler for `revNum` operations. In this implementation, we only ever have
-   * a single revision available, and we reject the transaction should it not be
-   * the requested restriction.
-   *
-   * @param {object} props The operation properties.
-   */
-  _op_revNum(props) {
-    const { revNum } = props;
-
-    if (this._fileFriend.revNum !== revNum) {
-      throw Errors.revisionNotAvailable(revNum);
-    }
-  }
-
-  /**
    * Handler for `timeout` operations. In this case, there's nothing to do
    * because the code in `LocalFile` that calls into here already takes care
    * of timeouts.
@@ -401,23 +386,6 @@ export default class Transactor extends CommonBase {
    */
   _op_timeout(props_unused) {
     // This space intentionally left blank.
-  }
-
-  /**
-   * Handler for `whenPathAbsent` operations.
-   *
-   * @param {object} props The operation properties.
-   */
-  _op_whenPathAbsent(props) {
-    const { storagePath } = props;
-    const value           = this._fileFriend.readPathOrNull(storagePath);
-
-    if (value === null) {
-      this._paths.add(storagePath);
-      this._waitSatisfied = true;
-    }
-
-    this._logAboutWaiting(`whenPathAbsent: ${storagePath}`);
   }
 
   /**
@@ -435,23 +403,6 @@ export default class Transactor extends CommonBase {
     }
 
     this._logAboutWaiting(`whenPathNot: ${storagePath}`);
-  }
-
-  /**
-   * Handler for `whenPathPresent` operations.
-   *
-   * @param {object} props The operation properties.
-   */
-  _op_whenPathPresent(props) {
-    const { storagePath } = props;
-    const value           = this._fileFriend.readPathOrNull(storagePath);
-
-    if (value !== null) {
-      this._paths.add(storagePath);
-      this._waitSatisfied = true;
-    }
-
-    this._logAboutWaiting(`whenPathPresent: ${storagePath}`);
   }
 
   /**

--- a/local-modules/file-store-local/tests/TempFiles.js
+++ b/local-modules/file-store-local/tests/TempFiles.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { UtilityClass } from 'util-common';
@@ -27,7 +28,7 @@ export default class TempFiles extends UtilityClass {
   /** {string} The directory prefix to use for all paths. */
   static get _prefix() {
     if (!TempFiles._thePrefix) {
-      TempFiles._thePrefix = fs.mkdtempSync('bayou-test');
+      TempFiles._thePrefix = fs.mkdtempSync(path.join(os.tmpdir(), 'bayou-test-'));
     }
 
     return TempFiles._thePrefix;

--- a/local-modules/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/file-store-local/tests/test_LocalFile.js
@@ -8,13 +8,14 @@ import { after, describe, it } from 'mocha';
 
 import { Codec } from 'codec';
 import { LocalFile } from 'file-store-local';
-import { TransactionOp, TransactionSpec } from 'file-store-ot';
+import { TheModule as fileStoreOt_TheModule, TransactionOp, TransactionSpec } from 'file-store-ot';
 import { FrozenBuffer } from 'util-common';
 
 import TempFiles from './TempFiles';
 
 /** {Codec} Codec instance to use. */
 const codec = new Codec();
+fileStoreOt_TheModule.registerCodecs(codec.registry);
 
 /**
  * Makes a {@link LocalFile}.

--- a/local-modules/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/file-store-local/tests/test_LocalFile.js
@@ -6,11 +6,30 @@ import { assert } from 'chai';
 import fs from 'fs';
 import { after, describe, it } from 'mocha';
 
+import { Codec } from 'codec';
 import { LocalFile } from 'file-store-local';
 import { TransactionOp, TransactionSpec } from 'file-store-ot';
 import { FrozenBuffer } from 'util-common';
 
 import TempFiles from './TempFiles';
+
+/** {Codec} Codec instance to use. */
+const codec = new Codec();
+
+/**
+ * Makes a {@link LocalFile}.
+ *
+ * @param {string} [path = null] Path to use for the file, or `null` to have
+ *   this function pick one (a unique temporary directory).
+ * @returns {LocalFile} An appropriately-constructed instance.
+ */
+function makeLocalFile(path = null) {
+  if (path === null) {
+    path = TempFiles.uniquePath();
+  }
+
+  return new LocalFile('x0x', path, codec);
+}
 
 describe('file-store-local/LocalFile', () => {
   // The expectation was that this would run after all tests were finish and
@@ -30,13 +49,13 @@ describe('file-store-local/LocalFile', () => {
 
   describe('constructor()', () => {
     it('should not throw given valid arguments', () => {
-      assert.doesNotThrow(() => { new LocalFile('0', TempFiles.uniquePath()); });
+      assert.doesNotThrow(() => { makeLocalFile(); });
     });
   });
 
   describe('create()', () => {
     it('should cause a non-existent file to come into existence', async () => {
-      const file = new LocalFile('0', TempFiles.uniquePath());
+      const file = makeLocalFile();
 
       assert.isFalse(await file.exists()); // Baseline assumption.
       await file.create();
@@ -45,7 +64,7 @@ describe('file-store-local/LocalFile', () => {
     });
 
     it('should do nothing if called on a non-empty file', async () => {
-      const file = new LocalFile('0', TempFiles.uniquePath());
+      const file = makeLocalFile();
       const storagePath = '/abc';
       const value = FrozenBuffer.coerce('x');
 
@@ -80,7 +99,7 @@ describe('file-store-local/LocalFile', () => {
 
   describe('delete()', () => {
     it('should cause an existing file to stop existing', async () => {
-      const file = new LocalFile('0', TempFiles.uniquePath());
+      const file = makeLocalFile();
       await file.create();
       assert.isTrue(await file.exists()); // Baseline assumption.
 
@@ -91,13 +110,13 @@ describe('file-store-local/LocalFile', () => {
 
   describe('exists()', () => {
     it('should return `false` if the underlying storage does not exist', async () => {
-      const file = new LocalFile('0', TempFiles.uniquePath());
+      const file = makeLocalFile();
       assert.isFalse(await file.exists());
     });
 
     it('should return `true` if the underlying storage does exist', async () => {
       const dir = TempFiles.uniquePath();
-      const file = new LocalFile('0', dir);
+      const file = makeLocalFile(dir);
 
       fs.mkdirSync(dir);
       assert.isTrue(await file.exists());

--- a/local-modules/file-store-ot/TheModule.js
+++ b/local-modules/file-store-ot/TheModule.js
@@ -1,0 +1,30 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Registry } from 'codec';
+import { UtilityClass } from 'util-common';
+
+import FileChange from './FileChange';
+import FileDelta from './FileDelta';
+import FileOp from './FileOp';
+import FileSnapshot from './FileSnapshot';
+
+/**
+ * Utilities for this module.
+ */
+export default class TheModule extends UtilityClass {
+  /**
+   * Registers this module's encodable classes with a given codec registry.
+   *
+   * @param {Registry} registry Codec registry to register with.
+   */
+  static registerCodecs(registry) {
+    Registry.check(registry);
+
+    registry.registerClass(FileChange);
+    registry.registerClass(FileDelta);
+    registry.registerClass(FileOp);
+    registry.registerClass(FileSnapshot);
+  }
+}

--- a/local-modules/file-store-ot/TransactionOp.js
+++ b/local-modules/file-store-ot/TransactionOp.js
@@ -322,11 +322,8 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
  * * Waits &mdash; A wait operation blocks a transaction until some condition
  *   holds. When a wait operation completes having detected one or more
  *   conditions, the paths related to the conditions that were satisfied are
- *   yielded in the results from the transaction. **Note:** If a transaction
- *   includes any wait operations, it must not perform any lists, reads,
- *   deletes, or writes. If a transaction includes more than one wait operation,
- *   the transaction will complete when _any_ of the operations' conditions is
- *   satisfied.
+ *   yielded in the results from the transaction. A given transaction must only
+ *   have at most one wait operation.
  *
  * When executed, the operations of a transaction are effectively performed in
  * order by category; but within a category there is no effective ordering.

--- a/local-modules/file-store-ot/TransactionOp.js
+++ b/local-modules/file-store-ot/TransactionOp.js
@@ -15,13 +15,12 @@ const CAT_environment  = 'environment';
 const CAT_list         = 'list';
 const CAT_prerequisite = 'prerequisite';
 const CAT_read         = 'read';
-const CAT_revision     = 'revision';
 const CAT_wait         = 'wait';
 const CAT_write        = 'write';
 
 /** {array<string>} List of categories in defined execution order. */
 const CATEGORY_EXECUTION_ORDER = [
-  CAT_environment, CAT_revision, CAT_prerequisite, CAT_list, CAT_read,
+  CAT_environment, CAT_prerequisite, CAT_list, CAT_read,
   CAT_delete, CAT_write, CAT_wait
 ];
 
@@ -32,7 +31,6 @@ const TYPE_DurMsec = 'DurMsec';
 const TYPE_Hash    = 'Hash';
 const TYPE_Index   = 'Index';
 const TYPE_Path    = 'Path';
-const TYPE_RevNum  = 'RevNum';
 
 // Operation schemata. See the doc for {@link TransactionOp#propsFromName} for
 // details.
@@ -239,18 +237,6 @@ const OPERATIONS = [
   ],
 
   /*
-   * A `revNum` operation. This is a revision restriction that limits a
-   * transaction to only be performed with respect to the indicated revision
-   * number.
-   *
-   * **Note:** It is an error (and pointless) for a transaction to contain more
-   * than one `revNum` operation.
-   *
-   * @param {Int} revNum Required revision number.
-   */
-  [CAT_revision, 'revNum', ['revNum', TYPE_RevNum]],
-
-  /*
    * A `timeout` operation. This is an environment operation which limits a
    * transaction to take no more than the indicated amount of time before it is
    * aborted. Timeouts are performed on a "best effort" basis as well as
@@ -334,9 +320,6 @@ const OPERATION_MAP = new Map(OPERATIONS.map((schema) => {
  * * Environment ops &mdash; An environment operation performs some action or
  *   checks some aspect of the execution environment of the transaction.
  *
- * * Revision restrictions &mdash; A revision restriction limits a transaction
- *   to being based only on a certain revision of the file.
- *
  * * Prerequisite checks &mdash; A prerequisite check must pass in order for
  *   the remainder of a transaction to apply.
  *
@@ -401,11 +384,6 @@ export default class TransactionOp extends CommonBase {
     return CAT_read;
   }
 
-  /** {string} Operation category for revision restrictions. */
-  static get CAT_revision() {
-    return CAT_revision;
-  }
-
   /** {string} Operation category for waits. */
   static get CAT_wait() {
     return CAT_wait;
@@ -453,11 +431,6 @@ export default class TransactionOp extends CommonBase {
     return TYPE_Path;
   }
 
-  /** {string} Type name for revision numbers. */
-  static get TYPE_RevNum() {
-    return TYPE_RevNum;
-  }
-
   /**
    * Validates a category string. Throws an error given an invalid category.
    *
@@ -471,7 +444,6 @@ export default class TransactionOp extends CommonBase {
       case CAT_list:
       case CAT_prerequisite:
       case CAT_read:
-      case CAT_revision:
       case CAT_wait:
       case CAT_write: {
         return category;
@@ -676,11 +648,6 @@ export default class TransactionOp extends CommonBase {
 
       case TYPE_Path: {
         StoragePath.check(value);
-        break;
-      }
-
-      case TYPE_RevNum: {
-        TInt.nonNegative(value);
         break;
       }
 

--- a/local-modules/file-store-ot/TransactionOp.js
+++ b/local-modules/file-store-ot/TransactionOp.js
@@ -250,14 +250,6 @@ const OPERATIONS = [
   [CAT_environment, 'timeout', ['durMsec', TYPE_DurMsec]],
 
   /*
-   * A `whenPathAbsent` operation. This is a wait operation that blocks the
-   * transaction until a specific path _does not_ have any data stored.
-   *
-   * @param {string} storagePath The storage path to observe.
-   */
-  [CAT_wait, 'whenPathAbsent', ['storagePath', TYPE_Path]],
-
-  /*
    * A `whenPathNot` operation. This is a wait operation that blocks the
    * transaction until a specific path does not store data which hashes as
    * given. This includes both storing data with other hashes as well as the
@@ -268,14 +260,6 @@ const OPERATIONS = [
    *   for the operation to complete.
    */
   [CAT_wait, 'whenPathNot', ['storagePath', TYPE_Path], ['hash', TYPE_Hash]],
-
-  /*
-   * A `whenPathPresent` operation. This is a wait operation that blocks the
-   * transaction until a specific path has some data (any value) stored.
-   *
-   * @param {string} storagePath The storage path to observe.
-   */
-  [CAT_wait, 'whenPathPresent', ['storagePath', TYPE_Path]],
 
   /*
    * A `writeBlob` operation. This is a write operation that stores the

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -209,14 +209,14 @@ export default class TransactionSpec extends CommonBase {
 
   /**
    * Runs this instance as a "wait" transaction. This includes first testing
-   * prerequisites and then returning a boolean indicating whether the wait
-   * conditions (as encoded by the wait operations of this instance) are
-   * satisfied by the given snapshot. If a prerequisite fails, this method will
-   * throw an error.
+   * prerequisites and then returning a value which indicates whether the wait
+   * condition (as encoded by the wait operations of this instance) is satisfied
+   * by the given snapshot. If a prerequisite fails, this method will throw an
+   * error.
    *
    * @param {FileSnapshot} snapshot Snapshot to operate on.
-   * @returns {boolean} `true` if the wait conditions are satisfied by
-   *   `snapshot`, or `false` if not.
+   * @returns {string|null} The storage ID which caused the wait transaction to
+   *   be satisfied, or _null_ if the transaction is not in fact satisfied.
    */
   runWait(snapshot) {
     FileSnapshot.check(snapshot);

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -30,10 +30,6 @@ export default class TransactionSpec extends CommonBase {
       throw Errors.badUse('Too many `timeout` operations.');
     }
 
-    if (this.opsWithName('revNum').length > 1) {
-      throw Errors.badUse('Too many `revNum` operations.');
-    }
-
     if ((this.hasWaitOps() + this.hasPullOps() + this.hasPushOps()) > 1) {
       throw Errors.badUse('Must only have one of wait operations, pull operations, or push operations.');
     }

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -4,6 +4,7 @@
 
 import { CommonBase, Errors } from 'util-common';
 
+import FileSnapshot from './FileSnapshot';
 import TransactionOp from './TransactionOp';
 
 /**
@@ -153,5 +154,77 @@ export default class TransactionSpec extends CommonBase {
     TransactionOp.propsFromName(name);
 
     return this._ops.filter(op => (op.name === name));
+  }
+
+  /**
+   * Runs this instance's prerequisites, throwing an error if any are not
+   * satisfied.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to operate on.
+   */
+  runPrerequeisites(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    throw Errors.wtf('TODO');
+  }
+
+  /**
+   * Runs this instance as a "pull" transaction. This includes first testing
+   * prerequisites and then gathering the data as indicated by pull operations.
+   * If a prerequisite fails, this method will throw an error.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to operate on.
+   * @returns {object} Plain object which maps `data` and `paths` as defined
+   *   by {@link file-store.BaseFile#transact}.
+   */
+  runPull(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    this.runPrerequisites(snapshot);
+
+    // Arrangement to keep the linter happy, even though this always throws.
+    if (snapshot !== null) throw Errors.wtf('TODO');
+    else return null;
+  }
+
+  /**
+   * Runs this instance as a "push" transaction. This includes first testing
+   * prerequisites and then producing a change which can be composed with the
+   * given snapshot to achieve the effect of this instance's push operations.
+   * If a prerequisite fails, this method will throw an error.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to operate on.
+   * @returns {FileChange} Change which can be composed with `snapshot` that has
+   *   the effect of this instance's push operations.
+   */
+  runPush(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    this.runPrerequisites(snapshot);
+
+    // Arrangement to keep the linter happy, even though this always throws.
+    if (snapshot !== null) throw Errors.wtf('TODO');
+    else return null;
+  }
+
+  /**
+   * Runs this instance as a "wait" transaction. This includes first testing
+   * prerequisites and then returning a boolean indicating whether the wait
+   * conditions (as encoded by the wait operations of this instance) are
+   * satisfied by the given snapshot. If a prerequisite fails, this method will
+   * throw an error.
+   *
+   * @param {FileSnapshot} snapshot Snapshot to operate on.
+   * @returns {boolean} `true` if the wait conditions are satisfied by
+   *   `snapshot`, or `false` if not.
+   */
+  runWait(snapshot) {
+    FileSnapshot.check(snapshot);
+
+    this.runPrerequisites(snapshot);
+
+    // Arrangement to keep the linter happy, even though this always throws.
+    if (snapshot !== null) throw Errors.wtf('TODO');
+    else return null;
   }
 }

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -31,6 +31,10 @@ export default class TransactionSpec extends CommonBase {
       throw Errors.badUse('Too many `timeout` operations.');
     }
 
+    if (this.opsWithCategory(TransactionOp.CAT_wait).length > 1) {
+      throw Errors.badUse('Too many `wait` operations.');
+    }
+
     if ((this.hasWaitOps() + this.hasPullOps() + this.hasPushOps()) > 1) {
       throw Errors.badUse('Must only have one of wait operations, pull operations, or push operations.');
     }
@@ -162,7 +166,7 @@ export default class TransactionSpec extends CommonBase {
    *
    * @param {FileSnapshot} snapshot Snapshot to operate on.
    */
-  runPrerequeisites(snapshot) {
+  runPrerequisites(snapshot) {
     FileSnapshot.check(snapshot);
 
     throw Errors.wtf('TODO');

--- a/local-modules/file-store-ot/index.js
+++ b/local-modules/file-store-ot/index.js
@@ -10,10 +10,12 @@ import PredicateOp from './PredicateOp';
 import PredicateSpec from './PredicateSpec';
 import StorageId from './StorageId';
 import StoragePath from './StoragePath';
+import TheModule from './TheModule';
 import TransactionOp from './TransactionOp';
 import TransactionSpec from './TransactionSpec';
 
 export {
+  TheModule,
   FileChange,
   FileDelta,
   FileOp,

--- a/local-modules/file-store-ot/tests/TransactionOpMaker.js
+++ b/local-modules/file-store-ot/tests/TransactionOpMaker.js
@@ -12,7 +12,7 @@ import { Errors, FrozenBuffer, UtilityClass } from 'util-common';
  * Test helper utility class for constructing valid arrays of ops which cover
  * all op types.
  */
-export default class FileOpMaker extends UtilityClass {
+export default class TransactionOpMaker extends UtilityClass {
   /**
    * Makes a valid ops array of the given length. All ops in the result are of
    * the same type.
@@ -44,7 +44,7 @@ export default class FileOpMaker extends UtilityClass {
     const args   = [];
 
     for (const [name_unused, type] of schema.args) {
-      args.push(FileOpMaker._makeValue(type, n));
+      args.push(TransactionOpMaker._makeValue(type, n));
     }
 
     return TransactionOp[`op_${name}`](...args);
@@ -79,7 +79,7 @@ export default class FileOpMaker extends UtilityClass {
       else                       { n = 0;     }
 
       for (let i = 0; i < n; i++) {
-        ops.push(FileOpMaker.makeOp(name, i));
+        ops.push(TransactionOpMaker.makeOp(name, i));
       }
     }
 
@@ -106,20 +106,20 @@ export default class FileOpMaker extends UtilityClass {
     }
 
     test([]);
-    test(FileOpMaker.makeLength(1));
-    test(FileOpMaker.makeLength(2));
-    test(FileOpMaker.makeLength(10));
-    test(FileOpMaker.makeLength(50),  '(length 50)');
-    test(FileOpMaker.makeLength(123), '(length 123)');
-    test(FileOpMaker.makeWithCategory('push', 1));
-    test(FileOpMaker.makeWithCategory('push', 2), '(push 2)');
-    test(FileOpMaker.makeWithCategory('push', 5), '(push 5)');
-    test(FileOpMaker.makeWithCategory('pull', 1));
-    test(FileOpMaker.makeWithCategory('pull', 2), '(pull 2)');
-    test(FileOpMaker.makeWithCategory('pull', 5), '(pull 5)');
-    test(FileOpMaker.makeWithCategory('wait', 1));
-    test(FileOpMaker.makeWithCategory('wait', 2), '(wait 2)');
-    test(FileOpMaker.makeWithCategory('wait', 5), '(wait 5)');
+    test(TransactionOpMaker.makeLength(1));
+    test(TransactionOpMaker.makeLength(2));
+    test(TransactionOpMaker.makeLength(10));
+    test(TransactionOpMaker.makeLength(50),  '(length 50)');
+    test(TransactionOpMaker.makeLength(123), '(length 123)');
+    test(TransactionOpMaker.makeWithCategory('push', 1));
+    test(TransactionOpMaker.makeWithCategory('push', 2), '(push 2)');
+    test(TransactionOpMaker.makeWithCategory('push', 5), '(push 5)');
+    test(TransactionOpMaker.makeWithCategory('pull', 1));
+    test(TransactionOpMaker.makeWithCategory('pull', 2), '(pull 2)');
+    test(TransactionOpMaker.makeWithCategory('pull', 5), '(pull 5)');
+    test(TransactionOpMaker.makeWithCategory('wait', 1));
+    test(TransactionOpMaker.makeWithCategory('wait', 2), '(wait 2)');
+    test(TransactionOpMaker.makeWithCategory('wait', 5), '(wait 5)');
   }
 
   /**

--- a/local-modules/file-store-ot/tests/TransactionOpMaker.js
+++ b/local-modules/file-store-ot/tests/TransactionOpMaker.js
@@ -118,8 +118,6 @@ export default class TransactionOpMaker extends UtilityClass {
     test(TransactionOpMaker.makeWithCategory('pull', 2), '(pull 2)');
     test(TransactionOpMaker.makeWithCategory('pull', 5), '(pull 5)');
     test(TransactionOpMaker.makeWithCategory('wait', 1));
-    test(TransactionOpMaker.makeWithCategory('wait', 2), '(wait 2)');
-    test(TransactionOpMaker.makeWithCategory('wait', 5), '(wait 5)');
   }
 
   /**

--- a/local-modules/file-store-ot/tests/test_TransactionSpec.js
+++ b/local-modules/file-store-ot/tests/test_TransactionSpec.js
@@ -61,7 +61,7 @@ describe('file-store-ot/TransactionSpec', () => {
 
     it('should reject arguments with both a wait and a pull', () => {
       const ops = [
-        TransactionOp.op_whenPathPresent('/blort'),
+        TransactionOp.op_whenPathNot('/blort', new FrozenBuffer('florp')),
         TransactionOp.op_readPath('/x/y')
       ];
 
@@ -70,7 +70,7 @@ describe('file-store-ot/TransactionSpec', () => {
 
     it('should reject arguments with both a wait and a push', () => {
       const ops = [
-        TransactionOp.op_whenPathPresent('/blort'),
+        TransactionOp.op_whenPathNot('/blort', new FrozenBuffer('florp')),
         TransactionOp.op_writeBlob(new FrozenBuffer('florp'))
       ];
 

--- a/local-modules/file-store-ot/tests/test_TransactionSpec.js
+++ b/local-modules/file-store-ot/tests/test_TransactionSpec.js
@@ -76,6 +76,15 @@ describe('file-store-ot/TransactionSpec', () => {
 
       assert.throws(() => { new TransactionSpec(...ops); }, /badUse/);
     });
+
+    it('should reject arguments with two (or more) wait operations', () => {
+      const ops = [
+        TransactionOp.op_whenPathNot('/blort', new FrozenBuffer('florp')),
+        TransactionOp.op_whenPathNot('/florp', new FrozenBuffer('blort'))
+      ];
+
+      assert.throws(() => { new TransactionSpec(...ops); }, /badUse/);
+    });
   });
 
   describe('concat()', () => {

--- a/local-modules/file-store-ot/tests/test_TransactionSpec.js
+++ b/local-modules/file-store-ot/tests/test_TransactionSpec.js
@@ -8,12 +8,12 @@ import { describe, it } from 'mocha';
 import { TransactionOp, TransactionSpec } from 'file-store-ot';
 import { FrozenBuffer } from 'util-common';
 
-import FileOpMaker from './FileOpMaker';
+import TransactionOpMaker from './TransactionOpMaker';
 
 describe('file-store-ot/TransactionSpec', () => {
-  // The call to `FileOpMaker.testCases()` provides outer `describe()`s for each
-  // value to test with.
-  FileOpMaker.testCases((ops) => {
+  // The call to `TransactionOpMaker.testCases()` provides outer `describe()`s
+  // for each value to test with.
+  TransactionOpMaker.testCases((ops) => {
     describe('constructor()', () => {
       it('should accept any number of valid arguments', () => {
         assert.doesNotThrow(() => new TransactionSpec(...ops));

--- a/local-modules/file-store-ot/tests/test_TransactionSpec.js
+++ b/local-modules/file-store-ot/tests/test_TransactionSpec.js
@@ -100,14 +100,22 @@ describe('file-store-ot/TransactionSpec', () => {
         assert.sameMembers(resOps2, expectOps);
       }
 
-      test([], []);
-      test([TransactionOp.op_revNum(10)], []);
-      test([TransactionOp.op_revNum(10), TransactionOp.op_timeout(123)], []);
-      test([TransactionOp.op_revNum(20)], [TransactionOp.op_checkPathPresent('/foo')]);
-      test(
-        [TransactionOp.op_timeout(123456), TransactionOp.op_checkPathAbsent('/bar')],
-        [TransactionOp.op_checkPathPresent('/blort'), TransactionOp.op_checkPathAbsent('/florp')]
-      );
+      const op1 = TransactionOp.op_timeout(123);
+      const op2 = TransactionOp.op_checkPathPresent('/foo');
+      const op3 = TransactionOp.op_checkPathPresent('/bar');
+      const op4 = TransactionOp.op_checkPathAbsent('/florp');
+
+      test([],              []);
+      test([op1],           []);
+      test([op1, op2],      []);
+      test([op1, op2, op3], []);
+      test([],              [op4]);
+      test([op1],           [op4]);
+      test([op1, op2],      [op4]);
+      test([op1, op2, op3], [op4]);
+      test([],              [op3, op4]);
+      test([op1],           [op3, op4]);
+      test([op1, op2],      [op3, op4]);
     });
 
     it('should reject a bad argument', () => {


### PR DESCRIPTION
This PR is a bit of a "work-in-progress" type deal. It consists of changes that pave the way for reworking `file-store-local` into an OT-friendly form, which then paves the way for setting up a similar structure for a production-quality `file-store` implementation.