### PR TITLE
Fill in the last transaction translation holes.

### DIFF
--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -213,12 +213,58 @@ export default class TransactionSpec extends CommonBase {
     for (const op of [...listOps, ...readOps]) {
       const props = op.props;
       switch (props.opName) {
-        case 'listPathPrefix':
-        case 'listPathRange':
-        case 'readBlob':
-        case 'readPath':
+        case 'listPathPrefix': {
+          const got = snapshot.getPathPrefix(props.storagePath);
+
+          for (const path of got.keys()) {
+            result.paths.add(path);
+          }
+
+          break;
+        }
+
+        case 'listPathRange': {
+          const { storagePath, startInclusive, endExclusive } = props;
+          const got = snapshot.getPathRange(storagePath, startInclusive, endExclusive);
+
+          for (const path of got.keys()) {
+            result.paths.add(path);
+          }
+
+          break;
+        }
+
+        case 'readBlob': {
+          const { hash } = props;
+          const got = snapshot.getOrNull(hash);
+
+          if (got !== null) {
+            result.data.set(hash, got);
+          }
+
+          break;
+        }
+
+        case 'readPath': {
+          const { storagePath } = props;
+          const got = snapshot.getOrNull(storagePath);
+
+          if (got !== null) {
+            result.data.set(storagePath, got);
+          }
+
+          break;
+        }
+
         case 'readPathRange': {
-          throw Errors.wtf('TODO');
+          const { storagePath, startInclusive, endExclusive } = props;
+          const got = snapshot.getPathRange(storagePath, startInclusive, endExclusive);
+
+          for (const [path, blob] of got) {
+            result.data.set(path, blob);
+          }
+
+          break;
         }
 
         default: {

--- a/local-modules/file-store-ot/TransactionSpec.js
+++ b/local-modules/file-store-ot/TransactionSpec.js
@@ -205,16 +205,28 @@ export default class TransactionSpec extends CommonBase {
 
     this.runPrerequisites(snapshot);
 
-    const result = { data: null, paths: null };
+    const result = {
+      data:  (readOps.length === 0) ? null : new Map(),
+      paths: (listOps.length === 0) ? null : new Set()
+    };
 
-    if (listOps.length !== 0) {
-      result.data = new Set();
-      throw Errors.wtf('TODO');
-    }
+    for (const op of [...listOps, ...readOps]) {
+      const props = op.props;
+      switch (props.opName) {
+        case 'listPathPrefix':
+        case 'listPathRange':
+        case 'readBlob':
+        case 'readPath':
+        case 'readPathRange': {
+          throw Errors.wtf('TODO');
+        }
 
-    if (readOps.length !== 0) {
-      result.paths = new Map;
-      throw Errors.wtf('TODO');
+        default: {
+          // Shouldn't happen, because the cases above should have covered all
+          // read and list ops.
+          throw Errors.wtf(`Weird pull op: ${props.opName}`);
+        }
+      }
     }
 
     return result;


### PR DESCRIPTION
This PR fills in the last bits in `file-store-ot` (more specifically in `TransactionSpec` and `FileSnapshot` that were missing, in terms of making it reasonably straightforward to run `file-store` transactions in terms of OT class instances. Actual usage of the code coming soon to a repo near you!
