### PR TITLE
A bit of logging prep.

### DIFF
--- a/local-modules/see-all-client/ClientSink.js
+++ b/local-modules/see-all-client/ClientSink.js
@@ -72,8 +72,8 @@ export default class ClientSink extends BaseSink {
    * @param {LogRecord} logRecord Log record, which must be for a time.
    */
   _logTime(logRecord) {
-    const { message, tag: { main } } = logRecord;
-    console.log(`%c[${main}] %c${message[0]} %c${message[1]} %c${message[2]}`,
+    const [utc, local] = logRecord.timeStrings;
+    console.log(`%c[time] %c${utc} %c/ %c${local}`,
       'color: #999; font-weight: bold',
       'color: #66a; font-weight: bold',
       'color: #999; font-weight: bold',

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -119,7 +119,7 @@ export default class RecentSink extends BaseSink {
     let   body;
 
     if (logRecord.isTime()) {
-      const [utc, slash_unused, local] = logRecord.message;
+      const [utc, local] = logRecord.timeStrings;
       const utcString = chalk.blue.bold(utc);
       const localString = chalk.blue.dim.bold(local);
       body = `${utcString} ${chalk.dim.bold('/')} ${localString}`;

--- a/local-modules/see-all-server/ServerSink.js
+++ b/local-modules/see-all-server/ServerSink.js
@@ -227,8 +227,8 @@ export default class ServerSink extends BaseSink {
    * @returns {string} Corresponding colorized message.
    */
   static _timeString(logRecord) {
-    const [utc, separator, local] = logRecord.message;
+    const [utc, local] = logRecord.timeStrings;
 
-    return `${chalk.blue.bold(utc)} ${separator} ${chalk.blue.dim.bold(local)}`;
+    return `${chalk.blue.bold(utc)} / ${chalk.blue.dim.bold(local)}`;
   }
 }

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -92,7 +92,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
+        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', LOG_TAG, 'info', 'florp', i));
       }
 
       const contents = sink.htmlContents;

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -16,12 +16,12 @@ describe('see-all-server/RecentSink', () => {
     it('should log a regular item as given', () => {
       const sink = new RecentSink(1);
 
-      sink.sinkLog(new LogRecord(90909, 'yay-stack', 'error', LOG_TAG, 'bar', 'baz'));
+      sink.sinkLog(LogRecord.forMessage(90909, 'yay-stack', 'error', LOG_TAG, 'bar', 'baz'));
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
       assert.deepEqual(contents[0],
-        new LogRecord(90909, 'yay-stack', 'error', LOG_TAG, 'bar baz'));
+        LogRecord.forMessage(90909, 'yay-stack', 'error', LOG_TAG, 'bar baz'));
     });
 
     it('should log a time record as given', () => {
@@ -42,7 +42,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
+        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
       }
 
       const contents = sink.contents;
@@ -69,7 +69,7 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(MAX_AGE);
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(timeForLine(i), 'yay-stack', 'info', LOG_TAG, 'florp'));
+        sink.sinkLog(LogRecord.forMessage(timeForLine(i), 'yay-stack', 'info', LOG_TAG, 'florp'));
       }
 
       sink.sinkLog(LogRecord.forTime(FINAL_TIME));
@@ -92,7 +92,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(new LogRecord(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
+        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
       }
 
       const contents = sink.htmlContents;

--- a/local-modules/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/see-all-server/tests/test_RecentSink.js
@@ -16,12 +16,12 @@ describe('see-all-server/RecentSink', () => {
     it('should log a regular item as given', () => {
       const sink = new RecentSink(1);
 
-      sink.sinkLog(LogRecord.forMessage(90909, 'yay-stack', 'error', LOG_TAG, 'bar', 'baz'));
+      sink.sinkLog(LogRecord.forMessage(90909, 'yay-stack', LOG_TAG, 'error', 'bar', 'baz'));
 
       const contents = sink.contents;
       assert.lengthOf(contents, 1);
       assert.deepEqual(contents[0],
-        LogRecord.forMessage(90909, 'yay-stack', 'error', LOG_TAG, 'bar baz'));
+        LogRecord.forMessage(90909, 'yay-stack', LOG_TAG, 'error', 'bar baz'));
     });
 
     it('should log a time record as given', () => {
@@ -42,7 +42,7 @@ describe('see-all-server/RecentSink', () => {
       const NUM_LINES = 10;
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', 'info', LOG_TAG, 'florp', i));
+        sink.sinkLog(LogRecord.forMessage(12345 + i, 'yay-stack', LOG_TAG, 'info', 'florp', i));
       }
 
       const contents = sink.contents;
@@ -69,7 +69,7 @@ describe('see-all-server/RecentSink', () => {
       const sink = new RecentSink(MAX_AGE);
 
       for (let i = 0; i < NUM_LINES; i++) {
-        sink.sinkLog(LogRecord.forMessage(timeForLine(i), 'yay-stack', 'info', LOG_TAG, 'florp'));
+        sink.sinkLog(LogRecord.forMessage(timeForLine(i), 'yay-stack', LOG_TAG, 'info', 'florp'));
       }
 
       sink.sinkLog(LogRecord.forTime(FINAL_TIME));

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -83,7 +83,7 @@ export default class AllSinks extends Singleton {
     }
 
     const logRecord =
-      LogRecord.forMessage(this._nowMsec(), LogRecord.makeStack(), level, tag, ...message);
+      LogRecord.forMessage(this._nowMsec(), LogRecord.makeStack(), tag, level, ...message);
 
     for (const s of this._sinks) {
       s.sinkLog(logRecord);

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -83,7 +83,7 @@ export default class AllSinks extends Singleton {
     }
 
     const logRecord =
-      new LogRecord(this._nowMsec(), LogRecord.makeStack(), level, tag, ...message);
+      LogRecord.forMessage(this._nowMsec(), LogRecord.makeStack(), level, tag, ...message);
 
     for (const s of this._sinks) {
       s.sinkLog(logRecord);

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -48,14 +48,14 @@ export default class LogRecord extends CommonBase {
    * @param {string|null} stack Stack trace representing the call site which
    *   caused this instance to be created. or `null` if that information is not
    *   available.
-   * @param {string} level Severity level.
    * @param {LogTag} tag Tag (component name and optional context) associated
    *   with the message.
+   * @param {string} level Severity level.
    * @param {...*} message Message to log.
    * @returns {LogRecord} Appropriately-constructed instance of this class.
    */
-  static forMessage(timeMsec, stack, level, tag, ...message) {
-    return new LogRecord(timeMsec, stack, level, tag, ...message);
+  static forMessage(timeMsec, stack, tag, level, ...message) {
+    return new LogRecord(timeMsec, stack, tag, level, ...message);
   }
 
   /**
@@ -78,7 +78,7 @@ export default class LogRecord extends CommonBase {
     const utcString   = LogRecord._utcTimeString(date);
     const localString = LogRecord._localTimeString(date);
 
-    return LogRecord.forMessage(timeMsec, null, 'info', LogTag.TIME,
+    return LogRecord.forMessage(timeMsec, null, LogTag.TIME, 'info',
       utcString, '/', localString);
   }
 
@@ -151,12 +151,12 @@ export default class LogRecord extends CommonBase {
    * @param {string|null} stack Stack trace representing the call site which
    *   caused this instance to be created. or `null` if that information is not
    *   available.
-   * @param {string} level Severity level.
    * @param {LogTag} tag Tag (component name and optional context) associated
    *   with the message.
+   * @param {string} level Severity level.
    * @param {...*} message Message to log.
    */
-  constructor(timeMsec, stack, level, tag, ...message) {
+  constructor(timeMsec, stack, tag, level, ...message) {
     super();
 
     /** {Int} Timestamp of the message. */
@@ -350,7 +350,7 @@ export default class LogRecord extends CommonBase {
       throw Errors.badUse('Requires a message instance.');
     }
 
-    return LogRecord.forMessage(timeMsec, stack, level, tag, ...message);
+    return LogRecord.forMessage(timeMsec, stack, tag, level, ...message);
   }
 
   /**

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -276,6 +276,22 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
+   * {array<string>} Two-element array of the time strings embedded in timestamp
+   * instances, namely the UTC time string and the local-timezone time string.
+   * It is only valid to access this property on timestamp instances; it is an
+   * error to use it with any other instance.
+   */
+  get timeStrings() {
+    if (!this.isTime()) {
+      throw Errors.badUse('Requires a timestamp instance.');
+    }
+
+    const [utc, slash_unused, local] = this.message;
+
+    return [utc, local];
+  }
+
+  /**
    * Indicates whether any of the `message` arguments of this instance is an
    * `Error`.
    *

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -145,7 +145,9 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
-   * Constructs an instance.
+   * Constructs an instance. **Note:** This constructor is meant to _only_ be
+   * used within this class; external callers should construct instances via
+   * one of the static constructor methods, e.g. {@link #forMessage}.
    *
    * @param {Int} timeMsec Timestamp of the message.
    * @param {string|null} stack Stack trace representing the call site which

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -52,7 +52,7 @@ describe('see-all/LogRecord', () => {
       const LOG_TAG = new LogTag('whee');
 
       function test(expected, ...message) {
-        const lr = LogRecord.forMessage(0, 'some-stack-trace', 'info', LOG_TAG, ...message);
+        const lr = LogRecord.forMessage(0, 'some-stack-trace', LOG_TAG, 'info', ...message);
         const got = lr.messageString;
         assert.strictEqual(got, expected);
       }

--- a/local-modules/see-all/tests/test_LogRecord.js
+++ b/local-modules/see-all/tests/test_LogRecord.js
@@ -52,7 +52,7 @@ describe('see-all/LogRecord', () => {
       const LOG_TAG = new LogTag('whee');
 
       function test(expected, ...message) {
-        const lr = new LogRecord(0, 'some-stack-trace', 'info', LOG_TAG, ...message);
+        const lr = LogRecord.forMessage(0, 'some-stack-trace', 'info', LOG_TAG, ...message);
         const got = lr.messageString;
         assert.strictEqual(got, expected);
       }


### PR DESCRIPTION
In addition to the usual "human-oriented" logs, we currently have a couple of log files that have more structured information (HTTP logs and API logs), but both are set up in a fairly ad-hoc fashion. In addition, it's a good idea to make it easy to add even more structured logging. This PR lays a bit of groundwork so that the existing logging system can be more easily adapted to accept such structured logs.

Future PRs will add the actual "structured event" logging facility and retarget the pre-existing structured logs to use it.