### PR TITLE
Hook for "var" directory setup.

### DIFF
--- a/local-modules/dev-mode/DevMode.js
+++ b/local-modules/dev-mode/DevMode.js
@@ -38,19 +38,26 @@ export default class DevMode extends Singleton {
   constructor() {
     super();
 
-    /** Base product output directory. */
+    /** {string} Base product output directory. */
     this._outDir = Dirs.theOne.BASE_DIR;
-    log.info('Product directory:', this._outDir);
 
-    /** The mappings from source to target directories, for the client code. */
+    /**
+     * {object} The mappings from source to target directories, for the client
+     * code.
+     */
     this._clientMappings =
       DevMode._makeMappings(path.resolve(this._outDir, 'client'));
 
-    /** The mappings from source to target directories, for the server code. */
+    /**
+     * {object} The mappings from source to target directories, for the server
+     * code.
+     */
     this._serverMappings =
       DevMode._makeMappings(path.resolve(this._outDir, 'server'));
 
-    /** Are we in the middle of shutting down (due to a server change)? */
+    /**
+     * {boolean} Are we in the middle of shutting down (due to a server change)?
+     */
     this._shuttingDown = false;
   }
 

--- a/local-modules/env-server/Dirs.js
+++ b/local-modules/env-server/Dirs.js
@@ -20,10 +20,10 @@ export default class Dirs extends Singleton {
     super();
 
     /** {string} Base directory of the product. */
-    this._baseDir = Dirs._findBaseDir();
+    this._baseDirectory = Dirs._findBaseDirectory();
 
     /** {string} "Var" directory to use. */
-    this._varDir = Dirs._findAndEnsureVarDir(this._baseDir);
+    this._varDirectory = Dirs._findAndEnsureVarDirectory(this._baseDirectory);
 
     Object.freeze(this);
   }
@@ -33,7 +33,7 @@ export default class Dirs extends Singleton {
    * as working files when running in development mode.
    */
   get BASE_DIR() {
-    return this._baseDir;
+    return this._baseDirectory;
   }
 
   /**
@@ -75,7 +75,7 @@ export default class Dirs extends Singleton {
    * is, it will create the directory if necessary).
    */
   get VAR_DIR() {
-    return this._varDir;
+    return this._varDirectory;
   }
 
   /**
@@ -85,7 +85,7 @@ export default class Dirs extends Singleton {
    *
    * @returns {string} The base directory path.
    */
-  static _findBaseDir() {
+  static _findBaseDirectory() {
     let dir = __dirname;
 
     for (;;) {
@@ -114,7 +114,7 @@ export default class Dirs extends Singleton {
    * @param {string} baseDir The product base directory.
    * @returns {string} The "var" directory.
    */
-  static _findAndEnsureVarDir(baseDir) {
+  static _findAndEnsureVarDirectory(baseDir) {
     const result = Hooks.theOne.findVarDirectory(baseDir);
 
     Dirs._ensureDir(result);

--- a/local-modules/env-server/Dirs.js
+++ b/local-modules/env-server/Dirs.js
@@ -22,10 +22,12 @@ export default class Dirs extends Singleton {
     /** {string} Base directory of the product. */
     this._baseDirectory = Dirs._findBaseDirectory();
 
-    /** {string} "Var" directory to use. */
-    this._varDirectory = Dirs._findAndEnsureVarDirectory(this._baseDirectory);
+    /**
+     * {string|null} "Var" directory to use, or `null` if not yet initialized.
+     */
+    this._varDirectory = null;
 
-    Object.freeze(this);
+    Object.seal(this);
   }
 
   /**
@@ -75,7 +77,24 @@ export default class Dirs extends Singleton {
    * is, it will create the directory if necessary).
    */
   get VAR_DIR() {
+    if (this._varDirectory === null) {
+      this._varDirectory = this._findAndEnsureVarDirectory();
+    }
+
     return this._varDirectory;
+  }
+
+  /**
+   * Figures out where the "var" directory is, by deferring to the salient hook.
+   * In addition, creates the directory if it doesn't already exist.
+   *
+   * @returns {string} The "var" directory.
+   */
+  _findAndEnsureVarDirectory() {
+    const result = Hooks.theOne.findVarDirectory(this._baseDirectory);
+
+    Dirs._ensureDir(result);
+    return result;
   }
 
   /**
@@ -105,20 +124,6 @@ export default class Dirs extends Singleton {
 
       dir = path.dirname(dir);
     }
-  }
-
-  /**
-   * Figures out where the "var" directory is, by deferring to the salient hook.
-   * In addition, creates the directory if it doesn't already exist.
-   *
-   * @param {string} baseDir The product base directory.
-   * @returns {string} The "var" directory.
-   */
-  static _findAndEnsureVarDirectory(baseDir) {
-    const result = Hooks.theOne.findVarDirectory(baseDir);
-
-    Dirs._ensureDir(result);
-    return result;
   }
 
   /**

--- a/local-modules/env-server/package.json
+++ b/local-modules/env-server/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "is-running": "^2.1.0",
 
+    "hooks-server": "local",
     "proppy": "local",
     "see-all": "local",
     "util-common": "local"

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -101,8 +101,7 @@ export default class Hooks extends Singleton {
   /**
    * Called during regular system startup (e.g. and in particular _not_ when
    * just building a client bundle offline). This is called after logging has
-   * been initialized but before almost everything else. Notably, this is the
-   * first method called on this class when the system is starting up.
+   * been initialized but before almost everything else.
    */
   async run() {
     // This space intentionally left blank.

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -15,13 +15,35 @@ import BearerTokens from './BearerTokens';
  */
 export default class Hooks extends Singleton {
   /**
-   * Called during regular system startup (e.g. and in particular _not_ when
-   * just building a client bundle offline). This is called after the very
-   * basic initialization but before any document-handling code has been
-   * initialized or run.
+   * {BearerTokens} The object which validates and authorizes bearer tokens.
+   * See that (base / default) class for details.
    */
-  async run() {
-    // This space intentionally left blank.
+  get bearerTokens() {
+    return BearerTokens.theOne;
+  }
+
+  /**
+   * {BaseFileStore} The object which provides access to file storage (roughly
+   * speaking, the filesystem to store the "files" this system deals with). This
+   * is an instance of a subclass of `BaseFileStore`, as defined by the
+   * `file-store` module.
+   */
+  get fileStore() {
+    return LocalFileStore.theOne;
+  }
+
+  /**
+   * {Int} The local port to listen for connections on by default. This
+   * typically but does not _necessarily_ match the values returned by
+   * {@link #baseUrlFromRequest}. It won't match in cases where this server runs
+   * behind a reverse proxy, for example. It also won't match when the system
+   * is brought up in `test` mode, as that mode will pick an arbitrary port to
+   * listen on.
+   *
+   * This (default) implementation of the property always returns `8080`.
+   */
+  get listenPort() {
+    return 8080;
   }
 
   /**
@@ -43,24 +65,6 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {BearerTokens} The object which validates and authorizes bearer tokens.
-   * See that (base / default) class for details.
-   */
-  get bearerTokens() {
-    return BearerTokens.theOne;
-  }
-
-  /**
-   * {BaseFileStore} The object which provides access to file storage (roughly
-   * speaking, the filesystem to store the "files" this system deals with). This
-   * is an instance of a subclass of `BaseFileStore`, as defined by the
-   * `file-store` module.
-   */
-  get fileStore() {
-    return LocalFileStore.theOne;
-  }
-
-  /**
    * Checks whether the given value is syntactically valid as a file ID.
    * This method is only ever called with a non-empty string.
    *
@@ -75,16 +79,12 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {Int} The local port to listen for connections on by default. This
-   * typically but does not _necessarily_ match the values returned by
-   * {@link #baseUrlFromRequest}. It won't match in cases where this server runs
-   * behind a reverse proxy, for example. It also won't match when the system
-   * is brought up in `test` mode, as that mode will pick an arbitrary port to
-   * listen on.
-   *
-   * This (default) implementation of the property always returns `8080`.
+   * Called during regular system startup (e.g. and in particular _not_ when
+   * just building a client bundle offline). This is called after the very
+   * basic initialization but before any document-handling code has been
+   * initialized or run.
    */
-  get listenPort() {
-    return 8080;
+  async run() {
+    // This space intentionally left blank.
   }
 }

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -100,9 +100,9 @@ export default class Hooks extends Singleton {
 
   /**
    * Called during regular system startup (e.g. and in particular _not_ when
-   * just building a client bundle offline). This is called after the very
-   * basic initialization but before any document-handling code has been
-   * initialized or run.
+   * just building a client bundle offline). This is called after logging has
+   * been initialized but before almost everything else. Notably, this is the
+   * first method called on this class when the system is starting up.
    */
   async run() {
     // This space intentionally left blank.

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import path from 'path';
+
 import { LocalFileStore } from 'file-store-local';
 import { Hooks as hooksCommon_Hooks } from 'hooks-common';
 import { Errors, Singleton } from 'util-common';
@@ -62,6 +64,24 @@ export default class Hooks extends Singleton {
     }
 
     throw Errors.badData('Missing `host` header on request.');
+  }
+
+  /**
+   * Determines the location of the "var" (variable / mutable data) directory,
+   * returning an absolute path to it. (This is where, for example, log files
+   * are stored.) The directory need not exist; the system will take care of
+   * creating it as needed.
+   *
+   * The default implementation (here) returns the base product directory (the
+   * argument), with `/var` appended. It's expected that in a production
+   * environment, it will be common to return an unrelated filesystem path
+   * (because, e.g., the base product directory is recursively read-only).
+   *
+   * @param {string} baseDir The base product directory.
+   * @returns {string} Absolute filesystem path to the "var" directory to use.
+   */
+  findVarDirectory(baseDir) {
+    return path.join(baseDir, 'var');
   }
 
   /**

--- a/local-modules/see-all/AllSinks.js
+++ b/local-modules/see-all/AllSinks.js
@@ -78,7 +78,7 @@ export default class AllSinks extends Singleton {
       // while logging to `console`), we die with an error here so that it is
       // reasonably blatant that something needs to be fixed during application
       // bootstrap.
-      const details = inspect(level, tag, ...message);
+      const details = inspect([level, tag, ...message]);
       throw Errors.badUse(`Overly early log call: ${details}`);
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -141,6 +141,12 @@ async function run(mode) {
     log.info(k, '=', info[k]);
   }
 
+  // A little spew to indicate where in the filesystem we live.
+  log.info(
+    'Directories:\n' +
+    `  product: ${Dirs.theOne.BASE_DIR}\n` +
+    `  var:     ${Dirs.theOne.VAR_DIR}`);
+
   if (mode === 'dev') {
     // We're in dev mode. This starts the system that live-syncs the client
     // source.

--- a/server/index.js
+++ b/server/index.js
@@ -132,6 +132,9 @@ if (showHelp || argError) {
  * @returns {Int} The port being listened on, once listening has started.
  */
 async function run(mode) {
+  // Give the overlay a chance to do any required early initialization.
+  await Hooks.theOne.run();
+
   // Set up the server environment bits (including, e.g. the PID file).
   await ServerEnv.theOne.init();
 
@@ -152,8 +155,6 @@ async function run(mode) {
     // source.
     DevMode.theOne.start();
   }
-
-  await Hooks.theOne.run();
 
   /** The main app server. */
   const theApp = new Application(mode !== 'prod');


### PR DESCRIPTION
This PR adds a server hook to be used when determining the `var` directory for a deployment, along with a default implementation which maintains the status quo.

Beyond the main thrust of the PR, I ended up doing some cleanup around how the server-side hooks run and are set up. This is some of the older code in our system, and, for example, it wasn't totally up-to-date with respect to our coding conventions.