### PR TITLE
Structured event logging: almost there!

### DIFF
--- a/local-modules/api-client/TargetHandler.js
+++ b/local-modules/api-client/TargetHandler.js
@@ -4,19 +4,7 @@
 
 import { TargetId } from 'api-common';
 import { TFunction } from 'typecheck';
-import { CommonBase, Errors, Functor } from 'util-common';
-
-/** {Set<string>} Set of methods which never get proxied. */
-const VERBOTEN_METHODS = new Set([
-  // Standard constructor method name.
-  'constructor',
-
-  // Promise interface. If proxied, this confuses the promise system, as it
-  // just looks for these methods to figure out if it's working with a
-  // "promise."
-  'then',
-  'catch'
-]);
+import { Functor, MethodCacheProxyHandler } from 'util-common';
 
 /**
  * `Proxy` handler which redirects method calls to an indicated client. It does
@@ -25,7 +13,7 @@ const VERBOTEN_METHODS = new Set([
  * the properties it returns are always functions which perform calls to
  * `ApiClient._send()`.
  */
-export default class TargetHandler extends CommonBase {
+export default class TargetHandler extends MethodCacheProxyHandler {
   /**
    * Makes a proxy that is handled by an instance of this class.
    *
@@ -54,184 +42,7 @@ export default class TargetHandler extends CommonBase {
     /** {string} The ID of the target. */
     this._targetId = TargetId.check(targetId);
 
-    /**
-     * {Map<string, function>} Cached method call handlers, as a map from name
-     * to handler.
-     */
-    this._methods = new Map();
-
     Object.freeze(this);
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {object} thisArg_unused The `this` argument passed to the call.
-   * @param {array} args_unused List of arguments passed to the call.
-   */
-  apply(target_unused, thisArg_unused, args_unused) {
-    throw Errors.badUse('Unsupported proxy operation.');
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {array} args_unused List of arguments passed to the constructor.
-   * @param {object} newTarget_unused The constructor that was originally
-   *   called, which is to say, the proxy object.
-   */
-  construct(target_unused, args_unused, newTarget_unused) {
-    throw Errors.badUse('Unsupported proxy operation.');
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
-   * @param {object} descriptor_unused The property descriptor.
-   * @returns {boolean} `false`, always.
-   */
-  defineProperty(target_unused, property_unused, descriptor_unused) {
-    return false;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
-   * @returns {boolean} `false`, always.
-   */
-  deleteProperty(target_unused, property_unused) {
-    return false;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property The property name.
-   * @param {object} receiver_unused The original receiver of the request.
-   * @returns {*} The property, or `undefined` if there is no such property
-   *   defined.
-   */
-  get(target_unused, property, receiver_unused) {
-    const method = this._methods.get(property);
-
-    if (method) {
-      return method;
-    } else if (VERBOTEN_METHODS.has(property)) {
-      // This property is on the blacklist of ones to never proxy.
-      return undefined;
-    } else {
-      // The property is allowed to be proxied. Set up and cache a handler for
-      // it.
-      const result = this._makeMethodHandler(property);
-      this._methods.set(property, result);
-      return result;
-    }
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
-   */
-  getOwnPropertyDescriptor(target_unused, property_unused) {
-    throw Errors.badUse('Unsupported proxy operation.');
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target The proxy target.
-   * @returns {*} `target`'s prototype.
-   */
-  getPrototypeOf(target) {
-    // **Note:** In the original version of this class, this method was
-    // implemented as simply `return null`. However, the Babel polyfill code for
-    // `Proxy` complained thusly:
-    //
-    //   Proxy's 'getPrototypeOf' trap for a non-extensible target should return
-    //   the same value as the target's prototype
-    //
-    // The Mozilla docs for `Proxy` agree with this assessment, stating:
-    //
-    //   If `target` is not extensible, `Object.getPrototypeOf(proxy)` method
-    //   must return the same value as `Object.getPrototypeOf(target).`
-    //
-    // Hence this revised version.
-
-    return Object.getPrototypeOf(target);
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
-   * @returns {boolean} `false`, always.
-   */
-  has(target_unused, property_unused) {
-    return false;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @returns {boolean} `false`, always.
-   */
-  isExtensible(target_unused) {
-    return false;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @returns {array} `[]`, always.
-   */
-  ownKeys(target_unused) {
-    return [];
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @returns {boolean} `true`, always.
-   */
-  preventExtensions(target_unused) {
-    return true;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
-   * @param {*} value_unused The new property value.
-   * @param {object} receiver_unused The original receiver of the request.
-   * @returns {boolean} `false`, always.
-   */
-  set(target_unused, property_unused, value_unused, receiver_unused) {
-    return false;
-  }
-
-  /**
-   * Standard `Proxy` handler method.
-   *
-   * @param {object} target_unused The proxy target.
-   * @param {object|null} prototype_unused The new prototype.
-   * @returns {boolean} `false`, always.
-   */
-  setPrototypeOf(target_unused, prototype_unused) {
-    return false;
   }
 
   /**
@@ -240,7 +51,7 @@ export default class TargetHandler extends CommonBase {
    * @param {string} name The method name.
    * @returns {function} An appropriately-constructed handler.
    */
-  _makeMethodHandler(name) {
+  _impl_methodFor(name) {
     const sendMessage = this._sendMessage;  // Avoid re-(re-)lookup on every call.
     const targetId    = this._targetId;     // Likewise.
 

--- a/local-modules/api-client/tests/test_TargetHandler.js
+++ b/local-modules/api-client/tests/test_TargetHandler.js
@@ -76,40 +76,6 @@ describe('api-common/TargetHandler', () => {
     });
   });
 
-  describe('apply()', () => {
-    it('should always throw', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      const proxy = new Proxy(func, th);
-      assert.throws(() => th.apply(func, proxy, [1, 2, 3]), /badUse/);
-    });
-  });
-
-  describe('construct()', () => {
-    it('should always throw', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      const proxy = new Proxy(func, th);
-      assert.throws(() => th.construct(func, [1, 2, 3], proxy), /badUse/);
-    });
-  });
-
-  describe('defineProperty()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.isFalse(th.defineProperty({}, 'blort', { value: 123 }));
-    });
-  });
-
-  describe('deleteProperty()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.isFalse(th.deleteProperty({ blort: 10 }, 'blort'));
-    });
-  });
-
   describe('get()', () => {
     it('should return `undefined` for verboten property names', () => {
       const func = () => { throw new Error('should not have been called'); };
@@ -176,74 +142,6 @@ describe('api-common/TargetHandler', () => {
       test('foo', foo);
       test('bar', bar);
       test('zor', zor);
-    });
-  });
-
-  describe('getOwnPropertyDescriptor()', () => {
-    it('should always throw', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.throws(() => th.getOwnPropertyDescriptor({ blort: 123 }, 'blort'));
-    });
-  });
-
-  describe('getPrototypeOf()', () => {
-    it('should return the target\'s prototype', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      const obj = new Map();
-      assert.strictEqual(th.getPrototypeOf(obj), Object.getPrototypeOf(obj));
-    });
-  });
-
-  describe('has()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.isFalse(th.has({ blort: 10 }, 'blort'));
-    });
-  });
-
-  describe('isExtensible()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.isFalse(th.isExtensible({}));
-    });
-  });
-
-  describe('ownKeys()', () => {
-    it('should always return `[]`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.deepEqual(th.ownKeys({ a: 10, b: 20 }), []);
-    });
-  });
-
-  describe('preventExstensions()', () => {
-    it('should always return `true`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      assert.isFalse(th.isExtensible({}));
-    });
-  });
-
-  describe('set()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-      const proxy = new Proxy(func, th);
-      assert.isFalse(th.set({}, 'blort', 123, proxy));
-    });
-  });
-
-  describe('setPrototypeOf()', () => {
-    it('should always return `false`', () => {
-      const func = () => { throw new Error('should not have been called'); };
-      const th = new TargetHandler(func, 'some-target-id');
-
-      assert.isFalse(th.setPrototypeOf({}, null));
-      assert.isFalse(th.setPrototypeOf({}, {}));
     });
   });
 });

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -4,6 +4,7 @@
 
 import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
 
+import EventProxyHandler from './EventProxyHandler';
 import LogRecord from './LogRecord';
 import LogStream from './LogStream';
 import LogTag from './LogTag';
@@ -14,6 +15,29 @@ import LogTag from './LogTag';
  * `_impl_logMessage()`.
  */
 export default class BaseLogger extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {Proxy} Proxy which uses an instance of {@link EventProxyHandler}, so
+     * as to enable `this.event.whatever(...)`.
+     */
+    this._event = EventProxyHandler.makeProxy(this);
+  }
+
+  /**
+   * {Proxy} Event logger. This is a proxy object which synthesizes event
+   * logging functions. For any name `someName`, `event.someName` is a function
+   * that, when called with arguments `(some, args)`, will log a structured
+   * event `someName(some, args)`.
+   */
+  get event() {
+    return this._event;
+  }
+
   /**
    * Logs a structured event.
    *

--- a/local-modules/see-all/EventProxyHandler.js
+++ b/local-modules/see-all/EventProxyHandler.js
@@ -1,0 +1,53 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { MethodCacheProxyHandler } from 'util-common';
+
+import BaseLogger from './BaseLogger';
+
+/**
+ * Proxy handler which provides the illusion of an object with infinitely many
+ * properties, each of which is a method that can be used to emit a
+ * structured-event log with the same name as the property.
+ *
+ * For example, `proxy.blort(1, 2, 3)` will cause a `blort` event to
+ * be logged with arguments `[1, 2, 3]`.
+ */
+export default class EventProxyHandler extends MethodCacheProxyHandler {
+  /**
+   * Makes a proxy that is handled by an instance of this class.
+   *
+   * @param {BaseLogger} log Logger to call through to.
+   * @returns {Proxy} An appropriately-constructed proxy object.
+   */
+  static makeProxy(log) {
+    return new Proxy(Object.freeze({}), new EventProxyHandler(log));
+  }
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseLogger} log Logger to call through to.
+   */
+  constructor(log) {
+    super();
+
+    /** {BaseLogger} Logger to call through to. */
+    this._log = BaseLogger.check(log);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Makes a method handler for the given method name.
+   *
+   * @param {string} name The method name.
+   * @returns {function} An appropriately-constructed handler.
+   */
+  _impl_methodFor(name) {
+    return (...args) => {
+      this._log.logEvent(name, ...args);
+    };
+  }
+}

--- a/local-modules/util-common/MethodCacheProxyHandler.js
+++ b/local-modules/util-common/MethodCacheProxyHandler.js
@@ -1,0 +1,234 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TFunction } from 'typecheck';
+import { CommonBase, Errors } from 'util-core';
+
+/** {Set<string>} Set of methods which never get proxied. */
+const VERBOTEN_METHODS = new Set([
+  // Standard constructor method name.
+  'constructor',
+
+  // Promise interface. If proxied, this confuses the promise system, as it
+  // just looks for these methods to figure out if it's working with a
+  // "promise."
+  'then',
+  'catch'
+]);
+
+/**
+ * Base class for a proxy handler for the common pattern of keeping a cache of
+ * computed methods, along with a subclass hole to be filled in for how to
+ * compute those methods in the first place.
+ *
+ * As a special case, this class refuses to proxy properties named
+ * `constructor`, `then`, or `catch`. The former if proxied can confuse the
+ * system into thinking what's being proxied is a class. The latter two can
+ * confuse the system into thinking that what's being proxied is a promise.
+ * (Duck typing FTL!) Though in the larger sense it is okay to proxy these
+ * things, the usual case &mdash; and the one supported by this class &mdash; is
+ * that what's proxied is just a plain-old-instance filled with normal methods.
+ *
+ * Use this class by making a subclass, filling in the `_impl`, and constructing
+ * a `Proxy` with an instance of it as the handler. The "target" of the proxy is
+ * ignored and can just be an empty object.
+ */
+export default class MethodCacheProxyHandler extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {Map<string, function>} Cached method call handlers, as a map from name
+     * to handler.
+     */
+    this._methods = new Map();
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {object} thisArg_unused The `this` argument passed to the call.
+   * @param {array} args_unused List of arguments passed to the call.
+   */
+  apply(target_unused, thisArg_unused, args_unused) {
+    throw Errors.badUse('Unsupported proxy operation.');
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {array} args_unused List of arguments passed to the constructor.
+   * @param {object} newTarget_unused The constructor that was originally
+   *   called, which is to say, the proxy object.
+   */
+  construct(target_unused, args_unused, newTarget_unused) {
+    throw Errors.badUse('Unsupported proxy operation.');
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property_unused The property name.
+   * @param {object} descriptor_unused The property descriptor.
+   * @returns {boolean} `false`, always.
+   */
+  defineProperty(target_unused, property_unused, descriptor_unused) {
+    return false;
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property_unused The property name.
+   * @returns {boolean} `false`, always.
+   */
+  deleteProperty(target_unused, property_unused) {
+    return false;
+  }
+
+  /**
+   * Standard `Proxy` handler method. This defers to {@link #_impl_methodFor}
+   * to generate method handlers that aren't yet cached.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property The property name.
+   * @param {object} receiver_unused The original receiver of the request.
+   * @returns {*} The property, or `undefined` if there is no such property
+   *   defined.
+   */
+  get(target_unused, property, receiver_unused) {
+    const method = this._methods.get(property);
+
+    if (method) {
+      return method;
+    } else if (VERBOTEN_METHODS.has(property)) {
+      // This property is on the blacklist of ones to never proxy.
+      return undefined;
+    } else {
+      // The property is allowed to be proxied. Set up and cache a handler for
+      // it.
+      const result = TFunction.checkCallable(this._impl_methodFor(property));
+      this._methods.set(property, result);
+      return result;
+    }
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property_unused The property name.
+   */
+  getOwnPropertyDescriptor(target_unused, property_unused) {
+    throw Errors.badUse('Unsupported proxy operation.');
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target The proxy target.
+   * @returns {*} `target`'s prototype.
+   */
+  getPrototypeOf(target) {
+    // **Note:** In the original version of this class, this method was
+    // implemented as simply `return null`. However, the Babel polyfill code for
+    // `Proxy` complained thusly:
+    //
+    //   Proxy's 'getPrototypeOf' trap for a non-extensible target should return
+    //   the same value as the target's prototype
+    //
+    // The Mozilla docs for `Proxy` agree with this assessment, stating:
+    //
+    //   If `target` is not extensible, `Object.getPrototypeOf(proxy)` method
+    //   must return the same value as `Object.getPrototypeOf(target).`
+    //
+    // Hence this revised version.
+
+    return Object.getPrototypeOf(target);
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property_unused The property name.
+   * @returns {boolean} `false`, always.
+   */
+  has(target_unused, property_unused) {
+    return false;
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @returns {boolean} `false`, always.
+   */
+  isExtensible(target_unused) {
+    return false;
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @returns {array} `[]`, always.
+   */
+  ownKeys(target_unused) {
+    return [];
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @returns {boolean} `true`, always.
+   */
+  preventExtensions(target_unused) {
+    return true;
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {string} property_unused The property name.
+   * @param {*} value_unused The new property value.
+   * @param {object} receiver_unused The original receiver of the request.
+   * @returns {boolean} `false`, always.
+   */
+  set(target_unused, property_unused, value_unused, receiver_unused) {
+    return false;
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {object|null} prototype_unused The new prototype.
+   * @returns {boolean} `false`, always.
+   */
+  setPrototypeOf(target_unused, prototype_unused) {
+    return false;
+  }
+
+  /**
+   * Makes a method handler for the given method name. The handler will
+   * ultimately get called by client code as a method on a proxy instance.
+   *
+   * @abstract
+   * @param {string} name The method name.
+   * @returns {function} An appropriately-constructed handler.
+   */
+  _impl_methodFor(name) {
+    return this._mustOverride(name);
+  }
+}

--- a/local-modules/util-common/index.js
+++ b/local-modules/util-common/index.js
@@ -8,6 +8,7 @@ import DeferredLoader from './DeferredLoader';
 import ErrorUtil from './ErrorUtil';
 import IterableUtil from './IterableUtil';
 import JsonUtil from './JsonUtil';
+import MethodCacheProxyHandler from './MethodCacheProxyHandler';
 import PropertyIterable from './PropertyIterable';
 import Random from './Random';
 import Singleton from './Singleton';
@@ -22,6 +23,7 @@ export {
   ErrorUtil,
   IterableUtil,
   JsonUtil,
+  MethodCacheProxyHandler,
   PropertyIterable,
   Random,
   Singleton,

--- a/local-modules/util-common/tests/test_MethodCacheProxyHandler.js
+++ b/local-modules/util-common/tests/test_MethodCacheProxyHandler.js
@@ -1,0 +1,166 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { MethodCacheProxyHandler } from 'util-common';
+
+/**
+ * Subclass of the class to test which always throws when asked to create a
+ * method handler.
+ */
+class ThrowingHandler extends MethodCacheProxyHandler {
+  _impl_forMethod(name_unused) {
+    throw new Error('Should not have been called.');
+  }
+}
+
+describe('util-common/MethodCacheProxyHandler', () => {
+  describe('constructor', () => {
+    it('should construct an instance', () => {
+      assert.doesNotThrow(() => new MethodCacheProxyHandler());
+    });
+  });
+
+  describe('apply()', () => {
+    it('should always throw', () => {
+      const func = () => { throw new Error('should not have been called'); };
+      const th = new ThrowingHandler();
+      const proxy = new Proxy(func, th);
+      assert.throws(() => th.apply(func, proxy, [1, 2, 3]), /badUse/);
+    });
+  });
+
+  describe('construct()', () => {
+    it('should always throw', () => {
+      const func = () => { throw new Error('should not have been called'); };
+      const th = new ThrowingHandler();
+      const proxy = new Proxy(func, th);
+      assert.throws(() => th.construct(func, [1, 2, 3], proxy), /badUse/);
+    });
+  });
+
+  describe('defineProperty()', () => {
+    it('should always return `false`', () => {
+      const th = new ThrowingHandler();
+      assert.isFalse(th.defineProperty({}, 'blort', { value: 123 }));
+    });
+  });
+
+  describe('deleteProperty()', () => {
+    it('should always return `false`', () => {
+      const th = new ThrowingHandler();
+      assert.isFalse(th.deleteProperty({ blort: 10 }, 'blort'));
+    });
+  });
+
+  describe('get()', () => {
+    it('should return `undefined` for verboten property names', () => {
+      const th = new ThrowingHandler();
+
+      assert.isUndefined(th.get(Map, 'constructor'));
+
+      const prom = new Promise(() => { /*empty*/ });
+      assert.isUndefined(th.get(prom, 'then'));
+      assert.isUndefined(th.get(prom, 'catch'));
+    });
+
+    it('should return a function gotten from a call to the `_impl`', () => {
+      const handler = new MethodCacheProxyHandler();
+      const proxy   = new Proxy({}, handler);
+
+      handler._impl_methodFor = (name) => {
+        const result = () => { return; };
+        result.blorp = `blorp-${name}`;
+        return result;
+      };
+
+      const result = handler.get({}, 'bloop', proxy);
+      assert.strictEqual(result.blorp, 'blorp-bloop');
+    });
+
+    it('should return the same function upon a second-or-more call with the same name', () => {
+      const handler = new MethodCacheProxyHandler();
+      const proxy   = new Proxy({}, handler);
+
+      handler._impl_methodFor = (name) => {
+        const result = () => { return; };
+        result.blorp = `blorp-${name}`;
+        return result;
+      };
+
+      const result1a = handler.get({}, 'zip', proxy);
+      const result2a = handler.get({}, 'zot', proxy);
+      const result1b = handler.get({}, 'zip', proxy);
+      const result2b = handler.get({}, 'zot', proxy);
+
+      assert.strictEqual(result1a.blorp, 'blorp-zip');
+      assert.strictEqual(result2a.blorp, 'blorp-zot');
+      assert.strictEqual(result1a, result1b);
+      assert.strictEqual(result2a, result2b);
+    });
+  });
+
+  describe('getOwnPropertyDescriptor()', () => {
+    it('should always throw', () => {
+      const th = new ThrowingHandler();
+      assert.throws(() => th.getOwnPropertyDescriptor({ blort: 123 }, 'blort'));
+    });
+  });
+
+  describe('getPrototypeOf()', () => {
+    it('should return the target\'s prototype', () => {
+      const th = new ThrowingHandler();
+      const obj = new Map();
+      assert.strictEqual(th.getPrototypeOf(obj), Object.getPrototypeOf(obj));
+    });
+  });
+
+  describe('has()', () => {
+    it('should always return `false`', () => {
+      const th = new ThrowingHandler();
+      assert.isFalse(th.has({ blort: 10 }, 'blort'));
+    });
+  });
+
+  describe('isExtensible()', () => {
+    it('should always return `false`', () => {
+      const th = new ThrowingHandler();
+      assert.isFalse(th.isExtensible({}));
+    });
+  });
+
+  describe('ownKeys()', () => {
+    it('should always return `[]`', () => {
+      const th = new ThrowingHandler();
+      assert.deepEqual(th.ownKeys({ a: 10, b: 20 }), []);
+    });
+  });
+
+  describe('preventExstensions()', () => {
+    it('should always return `true`', () => {
+      const th = new ThrowingHandler();
+      assert.isTrue(th.preventExtensions({}));
+    });
+  });
+
+  describe('set()', () => {
+    it('should always return `false`', () => {
+      const func = () => { throw new Error('should not have been called'); };
+      const th = new ThrowingHandler();
+      const proxy = new Proxy(func, th);
+      assert.isFalse(th.set({}, 'blort', 123, proxy));
+    });
+  });
+
+  describe('setPrototypeOf()', () => {
+    it('should always return `false`', () => {
+      const th = new ThrowingHandler();
+
+      assert.isFalse(th.setPrototypeOf({}, null));
+      assert.isFalse(th.setPrototypeOf({}, {}));
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the property `.event` to all logger instances, which can be used to emit structured event log records in a pretty spiffy way. If you have a logger, `l`, you can now say `l.event.theName(some, [random], arguments)`, and the logger will dutifully emit the event `theName(some, [random], arguments)`. In case you're thinking, "I like key-value pairs in my events. What about me?!" then worry not, you can use the usual JS idiom for keyword arguments `l.event.theName({ some: 'random', arguments: ['or', 'whatever'] })`.

Still left to do:

* Displaying and storing events properly. Right now there's some loss of fidelity.
* Using event logs in place of other logs, as appropriate.