### PR TITLE
`--dev-if-appropriate`

### DIFF
--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -101,9 +101,9 @@ export default class Hooks extends Singleton {
   /**
    * Checks to see if this server is running in a "development" environment,
    * returning an indication of the fact. A development environment is notable
-   * in that it has `/debug` endpoints enabled and may be less secure in other
-   * ways as a trade-off for higher internal visibility, that is, higher
-   * debugability.
+   * in that it notices when source files change (and acts accordingly), has
+   * `/debug` endpoints enabled, and may be less secure in other ways as a
+   * tradeoff for higher internal visibility, that is, higher debugability.
    *
    * The default implementation of this method always returns `true`.
    *

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -99,6 +99,22 @@ export default class Hooks extends Singleton {
   }
 
   /**
+   * Checks to see if this server is running in a "development" environment,
+   * returning an indication of the fact. A development environment is notable
+   * in that it has `/debug` endpoints enabled and may be less secure in other
+   * ways as a trade-off for higher internal visibility, that is, higher
+   * debugability.
+   *
+   * The default implementation of this method always returns `true`.
+   *
+   * @returns {boolean} `true` if this server is running in a development
+   *   environment, or `false` if not.
+   */
+  isRunningInDevelopment() {
+    return true;
+  }
+
+  /**
    * Called during regular system startup (e.g. and in particular _not_ when
    * just building a client bundle offline). This is called after logging has
    * been initialized but before almost everything else.

--- a/server/index.js
+++ b/server/index.js
@@ -187,6 +187,8 @@ async function run(mode) {
   if (mode === 'dev-if-appropriate') {
     if (Hooks.theOne.isRunningInDevelopment()) {
       mode = 'dev';
+    } else {
+      mode = 'production';
     }
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -130,7 +130,8 @@ if (showHelp || argError) {
     '    Run in development mode, for interactive development without having',
     '    to restart when client code changes, and to automatically exit when',
     '    server code changes. (The `develop` script automatically rebuilds and',
-    '    restarts when the latter happens.)',
+    '    restarts when the latter happens.) This option also enables `/debug`',
+    '    application endpoints.',
     '  --dev-if-appropriate',
     '    Run in development mode (per above), but only if the execution environment',
     '    indicates that it is meant to be so run. (This is determined by a hook in',
@@ -184,7 +185,9 @@ async function run(mode) {
     `  var:     ${Dirs.theOne.VAR_DIR}`);
 
   if (mode === 'dev-if-appropriate') {
-    // **TODO:** Check the hook, once it exists.
+    if (Hooks.theOne.isRunningInDevelopment()) {
+      mode = 'dev';
+    }
   }
 
   log.info('Running in mode:', mode);


### PR DESCRIPTION
This PR adds a new server option `--dev-if-appropriate` which can be used in helper scripts which want to work equally well in both development and production environments. The server was already in a position to make the determination, and this option makes it explicit when we want to make it do so. (I didn't want to make it implicit, because I figure that when it goes wrong it can be really bad, so it's better to be clear up-front about the intent.)