### PR TITLE
`/health`

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -15,6 +15,7 @@ import { ClientBundle } from 'client-bundle';
 import { Dirs } from 'env-server';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
+import { CommonBase } from 'util-common';
 
 import DebugTools from './DebugTools';
 import RequestLogger from './RequestLogger';
@@ -24,10 +25,10 @@ import RootAccess from './RootAccess';
 const log = new Logger('app');
 
 /**
- * Web server for the application. This serves all HTTP(S) requests, including
- * websocket requests.
+ * Web server for the application. This serves all application HTTP(S) requests,
+ * including websocket requests.
  */
-export default class Application {
+export default class Application extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -35,6 +36,8 @@ export default class Application {
    *   activates `/debug/*` endpoints.
    */
   constructor(devMode) {
+    super();
+
     const codec = appCommon_TheModule.fullCodec;
 
     /**
@@ -89,6 +92,17 @@ export default class Application {
     if (devMode) {
       this._addDevModeRoutes();
     }
+  }
+
+  /**
+   * Indicates whether or not this instance currently considers itself
+   * "healthy."
+   *
+   * @returns {boolean} `true` if this is a healthy instance, or `false` if not.
+   */
+  async isHealthy() {
+    // **TODO:** Something useful.
+    return true;
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -121,7 +121,7 @@ export default class Application extends CommonBase {
 
     const resultPort = server.address().port;
 
-    log.info(`Listening on port: ${resultPort}.`);
+    log.info(`Application server port: ${resultPort}`);
 
     if ((port !== 0) && (port !== resultPort)) {
       log.warn(`Originally requested port: ${port}`);

--- a/local-modules/app-setup/Monitor.js
+++ b/local-modules/app-setup/Monitor.js
@@ -72,7 +72,11 @@ export default class Monitor extends CommonBase {
   _addRequestLogging() {
     const app = this._app;
 
-    app.use((req, res_unused, next) => {
+    app.use((req, res, next) => {
+      res.on('finish', () => {
+        log.event.httpResponse(req.originalUrl, res.statusCode);
+      });
+
       log.event.httpRequest(req.originalUrl);
       next();
     });
@@ -92,6 +96,7 @@ export default class Monitor extends CommonBase {
       res
         .status(status)
         .type('text/plain; charset=utf-8')
+        .set('Cache-Control', 'no-cache, no-store, no-transform')
         .send(text);
     });
   }

--- a/local-modules/app-setup/Monitor.js
+++ b/local-modules/app-setup/Monitor.js
@@ -1,0 +1,101 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import express from 'express';
+import http from 'http';
+import { promisify } from 'util';
+
+import { Hooks } from 'hooks-server';
+import { Logger } from 'see-all';
+import { CommonBase } from 'util-common';
+
+import Application from './Application';
+
+/** Logger. */
+const log = new Logger('app-monitor');
+
+/**
+ * Web server for the monitoring endpoints.
+ */
+export default class Monitor extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Application} mainApplication The main application instance.
+   */
+  constructor(mainApplication) {
+    super();
+
+    /** {Application} The main application instance. */
+    this._mainApplication = Application.check(mainApplication);
+
+    /**
+     * {function} The top-level "Express application" run by this instance. It
+     * is a request handler function which is suitable for use with Node's
+     * `http` library.
+     */
+    this._app = express();
+
+    /** {http.Server} The server that directly answers HTTP requests. */
+    this._server = http.createServer(this._app);
+
+    this._addRequestLogging();
+    this._addRoutes();
+  }
+
+  /**
+   * Starts up the server.
+   *
+   * @param {boolean} [pickPort = false] If `true`, causes the app to pick an
+   *   arbitrary available port to listen on instead of the configured port.
+   *   This is only meant to be passed as `true` in testing scenarios.
+   * @returns {Int} The port being listened on, once listening has started.
+   */
+  async start(pickPort = false) {
+    const port   = pickPort ? 0 : Hooks.theOne.monitorPort;
+    const server = this._server;
+
+    await promisify(cb => server.listen(port, value => cb(null, value)))();
+
+    const resultPort = server.address().port;
+
+    log.info(`Listening on port: ${resultPort}.`);
+
+    if ((port !== 0) && (port !== resultPort)) {
+      log.warn(`Originally requested port: ${port}`);
+    }
+
+    return resultPort;
+  }
+
+  /**
+   * Sets up logging for webserver requests.
+   */
+  _addRequestLogging() {
+    const app = this._app;
+
+    app.use((req, res_unused, next) => {
+      log.event.httpRequest(req.originalUrl);
+      next();
+    });
+  }
+
+  /**
+   * Sets up the webserver routes.
+   */
+  _addRoutes() {
+    const app = this._app;
+
+    app.get('/health', async (req_unused, res) => {
+      const [status, text] = await this._app.isHealthy()
+        ? [200, '🍑 Everything\'s peachy! 🍑\n']
+        : [503, '😿 Sorry to say we can\'t help you right now. 😿\n'];
+
+      res
+        .status(status)
+        .type('text/plain; charset=utf-8')
+        .send(text);
+    });
+  }
+}

--- a/local-modules/app-setup/index.js
+++ b/local-modules/app-setup/index.js
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Application from './Application';
+import Monitor from './Monitor';
 
-export { Application };
+export { Application, Monitor };

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -49,6 +49,16 @@ export default class Hooks extends Singleton {
   }
 
   /**
+   * {Int} The local port to use for internal monitoring. Internal monitoring is
+   * activated by the `--monitor` server option.
+   *
+   * This (default) implementation of the property always returns `9999`.
+   */
+  get monitorPort() {
+    return 9999;
+  }
+
+  /**
    * Given an HTTP request, returns the "public" base URL of that request.
    * By default this is just the `host` as indicated in the headers, prefixed
    * by `http://`. However, when deployed behind a reverse proxy, the

--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -49,10 +49,8 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {Int} The local port to use for internal monitoring. Internal monitoring is
-   * activated by the `--monitor` server option.
-   *
-   * This (default) implementation of the property always returns `9999`.
+   * {Int|null} The local port to use for internal monitoring, or `null` to
+   * not expose monitoring endpoints.
    */
   get monitorPort() {
     return 9999;

--- a/server/index.js
+++ b/server/index.js
@@ -117,7 +117,7 @@ if (showHelp || argError) {
     'Usage:',
     '',
     `${progName} [--dev | --dev-if-appropriate | --client-bundle | --client-test | `,
-    '  --monitor | --server-test ] [--prog-name=<name>] [--test-out=<path>]',
+    '  --server-test ] [--prog-name=<name>] [--test-out=<path>]',
     '',
     '  Run the project.',
     '',

--- a/server/index.js
+++ b/server/index.js
@@ -16,7 +16,7 @@ import 'babel-polyfill';
 import path from 'path';
 import minimist from 'minimist';
 
-import { Application } from 'app-setup';
+import { Application, Monitor } from 'app-setup';
 import { ClientBundle } from 'client-bundle';
 import { DevMode } from 'dev-mode';
 import { Dirs, ProductInfo, ServerEnv } from 'env-server';
@@ -117,7 +117,7 @@ if (showHelp || argError) {
     'Usage:',
     '',
     `${progName} [--dev | --dev-if-appropriate | --client-bundle | --client-test | `,
-    '  --server-test ] [--prog-name=<name>] [--test-out=<path>]',
+    '  --monitor | --server-test ] [--prog-name=<name>] [--test-out=<path>]',
     '',
     '  Run the project.',
     '',
@@ -163,9 +163,11 @@ if (showHelp || argError) {
  * * `test` &mdash; Configured for live testing.
  *
  * @param {string} mode The mode as described above.
+ * @param {boolean} [doMonitor = false] Whether or not to enable the monitoring
+ *   endpoints.
  * @returns {Int} The port being listened on, once listening has started.
  */
-async function run(mode) {
+async function run(mode, doMonitor = false) {
   // Give the overlay a chance to do any required early initialization.
   await Hooks.theOne.run();
 
@@ -203,8 +205,18 @@ async function run(mode) {
   /** The main app server. */
   const theApp = new Application(mode !== 'production');
 
-  // Start the app!
-  return theApp.start(mode === 'test');
+  // Start the app! The result is the port that it ends up listening on.
+  const result = theApp.start(mode === 'test');
+
+  if (doMonitor) {
+    const monitorPort = Hooks.theOne.monitorPort;
+    if (monitorPort !== null) {
+      const monitor = new Monitor(theApp, monitorPort);
+      await monitor.start();
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -312,7 +324,7 @@ switch (executionMode) {
   default: {
     ServerSink.init(true);
     new FileSink(path.resolve(Dirs.theOne.LOG_DIR, 'general.log'));
-    run(executionMode);
+    run(executionMode, true);
     break;
   }
 }


### PR DESCRIPTION
This PR adds a new monitoring server, listening on a separate port, to the app. It listens on port 9999 (I wanted to do five-nines but y'know 16 bits). Right now there's just one endpoint, `/health`, which just reports a single-bit of info, healthy (status 200) or not (status 503). And, well, for now, it's pegged at "healthy." In our glorious future, this will be expanded to actually report something less trivial than, "Is the monitoring server up?" .