### PR TITLE
Actually handle errors resulting from `server.listen()`.

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -7,7 +7,6 @@ import express_ws from 'express-ws';
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
-import { promisify } from 'util';
 
 import { ApiLog, BearerToken, Context, PostConnection, WsConnection } from 'api-server';
 import { TheModule as appCommon_TheModule } from 'app-common';
@@ -20,8 +19,9 @@ import { CommonBase } from 'util-common';
 import DebugTools from './DebugTools';
 import RequestLogger from './RequestLogger';
 import RootAccess from './RootAccess';
+import ServerUtil from './ServerUtil';
 
-/** Logger. */
+/** {Logger} Logger. */
 const log = new Logger('app');
 
 /**
@@ -114,12 +114,9 @@ export default class Application extends CommonBase {
    * @returns {Int} The port being listened on, once listening has started.
    */
   async start(pickPort = false) {
-    const port   = pickPort ? 0 : Hooks.theOne.listenPort;
-    const server = this._server;
-
-    await promisify(cb => server.listen(port, value => cb(null, value)))();
-
-    const resultPort = server.address().port;
+    const server     = this._server;
+    const port       = pickPort ? 0 : Hooks.theOne.listenPort;
+    const resultPort = await ServerUtil.listen(server, port);
 
     log.info(`Application server port: ${resultPort}`);
 

--- a/local-modules/app-setup/Monitor.js
+++ b/local-modules/app-setup/Monitor.js
@@ -4,15 +4,15 @@
 
 import express from 'express';
 import http from 'http';
-import { promisify } from 'util';
 
 import { Logger } from 'see-all';
 import { TInt } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import Application from './Application';
+import ServerUtil from './ServerUtil';
 
-/** Logger. */
+/** {Logger} Logger. */
 const log = new Logger('app-monitor');
 
 /**
@@ -52,12 +52,9 @@ export default class Monitor extends CommonBase {
    * Starts up the server.
    */
   async start() {
-    const port   = this._port;
-    const server = this._server;
-
-    await promisify(cb => server.listen(port, value => cb(null, value)))();
-
-    const resultPort = server.address().port;
+    const server     = this._server;
+    const port       = this._port;
+    const resultPort = await ServerUtil.listen(server, port);
 
     log.info(`Monitor server port: ${resultPort}`);
 

--- a/local-modules/app-setup/ServerUtil.js
+++ b/local-modules/app-setup/ServerUtil.js
@@ -1,0 +1,57 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from 'util-common';
+
+
+/**
+ * Utility functions for dealing with `Server`s (e.g., HTTP server objects and
+ * the like).
+ */
+export default class ServerUtil extends UtilityClass {
+  /**
+   * Issues a `listen()` to a `Server` instance, converting the subsequent
+   * events to a promise.
+   *
+   * **Note:** This method exists because the standard `Server.listen()` as
+   * defined and implemented by the Node library doesn't actually use its
+   * callback argument in the Node-standard way. Specifically, it won't report
+   * errors through that callback.
+   *
+   * @param {Server} server Server to tell to `listen()`.
+   * @param {Int} port Port to listen on, or `0` to have the system pick an
+   *   available port.
+   * @returns {Int} The port actually being listened on.
+   * @throws {Error} Whatever shows up in an `error` event caused by the
+   *   attempt, if that event gets emitted.
+   */
+  static async listen(server, port) {
+    await new Promise((resolve, reject) => {
+      function done(err) {
+        server.removeListener('listening', handleListening);
+        server.removeListener('error',     handleError);
+
+        if (err !== null) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      }
+
+      function handleListening() {
+        done(null);
+      }
+
+      function handleError(err) {
+        done(err);
+      }
+
+      server.on('listening', handleListening);
+      server.on('error',     handleError);
+      server.listen(port);
+    });
+
+    return server.address().port;
+  }
+}


### PR DESCRIPTION
A close read of the Node spec indicates that, unlike most other callbacks
defined by Node, the one from `server.listen()` only gets called on success,
not on failure. In order to detect failure, one has to attach a listener for
the `error` event on the server instance. Whee!