### PR TITLE
Switch the monitoring port.

### DIFF
--- a/local-modules/hooks-server/Hooks.js
+++ b/local-modules/hooks-server/Hooks.js
@@ -51,9 +51,11 @@ export default class Hooks extends Singleton {
   /**
    * {Int|null} The local port to use for internal monitoring, or `null` to
    * not expose monitoring endpoints.
+   *
+   * This (default) implementation of the property always returns `8888`.
    */
   get monitorPort() {
-    return 9999;
+    return 8888;
   }
 
   /**


### PR DESCRIPTION
...in the wake of having come to a newly-revised consensus.