### PR TITLE
Better logging UX and CX (computer experience).

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -44,6 +44,15 @@ directory:
 $ ./out/final/bin/run
 ```
 
+There are a couple of options you might want to pass to `run` when developing
+interactively.
+
+* `--dev` &mdash; This tells the system to run in "development mode."
+
+* `--human-console` &mdash; Write human-oriented logs to the console, instead
+  of the default JSON form. (The JSON form is intended for consumption by a
+  log-processing pipeline.)
+
 ### Testing
 
 The script `run-tests` will run all of the existing tests, sending output to the

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -5,7 +5,7 @@
 import fs from 'fs';
 
 import { BaseSink, SeeAll } from 'see-all';
-import { TString } from 'typecheck';
+import { TBoolean, TString } from 'typecheck';
 
 /**
  * Implementation of the `see-all` logging sink protocol which stores logged
@@ -17,12 +17,20 @@ export default class FileSink extends BaseSink {
    * the main `see-all` module.
    *
    * @param {string} path Path of the file to log to.
+   * @param {boolean} useConsole If `true`, also write logs to the console.
+   *   (Technically, write to `process.stdout`.)
    */
-  constructor(path) {
+  constructor(path, useConsole) {
     super();
 
     /** {string} Path of the file to log to. */
     this._path = TString.nonEmpty(path);
+
+    /**
+     * {boolean} Whether or not to write logs to the console (`process.stdout`,
+     * really).
+     */
+    this._useConsole = TBoolean.check(useConsole);
 
     SeeAll.theOne.add(this);
   }
@@ -47,6 +55,11 @@ export default class FileSink extends BaseSink {
    */
   _writeJson(value) {
     const string = `${JSON.stringify(value)}\n`;
+
+    if (this._useConsole) {
+      process.stdout.write(string);
+    }
+
     fs.appendFileSync(this._path, string);
   }
 }

--- a/local-modules/see-all-server/index.js
+++ b/local-modules/see-all-server/index.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import FileSink from './FileSink';
+import HumanSink from './HumanSink';
 import RecentSink from './RecentSink';
-import ServerSink from './ServerSink';
 
-export { FileSink, RecentSink, ServerSink };
+export { FileSink, HumanSink, RecentSink };

--- a/scripts/develop
+++ b/scripts/develop
@@ -130,7 +130,7 @@ while true; do
 
     echo ''
 
-    "${outDir}/final/bin/run" --dev
+    "${outDir}/final/bin/run" --dev --human-console
     status="$?"
 
     if (( ${status} >= 128 && ${status} <= 191 )); then

--- a/server/index.js
+++ b/server/index.js
@@ -23,7 +23,7 @@ import { Dirs, ProductInfo, ServerEnv } from 'env-server';
 import { Hooks } from 'hooks-server';
 import { Delay } from 'promise-util';
 import { Logger } from 'see-all';
-import { FileSink, ServerSink } from 'see-all-server';
+import { HumanSink, FileSink } from 'see-all-server';
 import { ClientTests, ServerTests } from 'testing-server';
 
 
@@ -44,6 +44,7 @@ const opts = minimist(process.argv.slice(2), {
     'dev',
     'dev-if-appropriate',
     'help',
+    'human-console',
     'server-test'
   ],
   string: [
@@ -73,6 +74,9 @@ const devMode = opts['dev'];
 
 /** {boolean} Dev-if-appropriate mode? */
 const devIfAppropriateMode = opts['dev-if-appropriate'];
+
+/** {boolean} Write human-oriented console logs? */
+const humanConsole = opts['human-console'];
 
 /** {boolean} Server test mode? */
 const serverTestMode = opts['server-test'];
@@ -117,7 +121,7 @@ if (showHelp || argError) {
     'Usage:',
     '',
     `${progName} [--dev | --dev-if-appropriate | --client-bundle | --client-test | `,
-    '  --server-test ] [--prog-name=<name>] [--test-out=<path>]',
+    '  --server-test ] [--human-console] [--prog-name=<name>] [--test-out=<path>]',
     '',
     '  Run the project.',
     '',
@@ -136,6 +140,9 @@ if (showHelp || argError) {
     '    Run in development mode (per above), but only if the execution environment',
     '    indicates that it is meant to be so run. (This is determined by a hook in',
     '    the `hooks-server` module, see which.)',
+    '  --human-console',
+    '    Provide human-oriented logging output on `stdout`. The default is to write',
+    '    JSON-encoded event records.',
     '  --prog-name=<name>',
     '    Name of this program, for use when reporting errors and diagnostics.',
     '  --server-test',
@@ -309,26 +316,32 @@ process.on('uncaughtException', (error) => {
 
 switch (executionMode) {
   case 'client-bundle': {
-    ServerSink.init(false);
+    new HumanSink(null, true);
     clientBundle();
     break;
   }
 
   case 'client-test': {
-    ServerSink.init(false);
+    new HumanSink(null, true);
     clientTest();
     break;
   }
 
   case 'server-test': {
-    ServerSink.init(false);
+    new HumanSink(null, true);
     serverTest();
     break;
   }
 
   default: {
-    ServerSink.init(true);
-    new FileSink(path.resolve(Dirs.theOne.LOG_DIR, 'general.log'));
+    const humanLogFile = path.resolve(Dirs.theOne.LOG_DIR, 'general.txt');
+    const jsonLogFile = path.resolve(Dirs.theOne.LOG_DIR, 'general.json');
+
+    new FileSink(jsonLogFile);
+    new HumanSink(humanLogFile, humanConsole);
+
+    HumanSink.patchConsole();
+
     run(executionMode, true);
     break;
   }

--- a/server/index.js
+++ b/server/index.js
@@ -337,7 +337,7 @@ switch (executionMode) {
     const humanLogFile = path.resolve(Dirs.theOne.LOG_DIR, 'general.txt');
     const jsonLogFile = path.resolve(Dirs.theOne.LOG_DIR, 'general.json');
 
-    new FileSink(jsonLogFile);
+    new FileSink(jsonLogFile, !humanConsole);
     new HumanSink(humanLogFile, humanConsole);
 
     HumanSink.patchConsole();


### PR DESCRIPTION
This PR achieves two things, both of which are meant to make for a better log experience, in different contexts:

* The system will now always write the "human-oriented" version of the logs to a file, both when running locally and in a deployment environment. It is _much_ easier to read these than the direct console output. **Note:** This file is "marked up" with ANSI control sequences, so the recommended command to view the file is `less -R general.txt`.

* When running in a deployment environment, the logs written to the console are now in the JSON-encoded form. This is intended to make it easier to use the console output as the input to a real log-ingestion pipeline. The JSON form is _also_ available as a file, `general.json`.