### PR TITLE
Cleaner event logging of non-data payloads.

### DIFF
--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -41,10 +41,15 @@ export default class FileSink extends BaseSink {
    * @param {LogRecord} logRecord The record to write.
    */
   _impl_sinkLog(logRecord) {
-    const { level, tag: { main, context }, stack, timeMsec } = logRecord;
-    const tag = [main, ...context];
+    const { tag: { main, context }, stack, timeMsec } = logRecord;
+    const tag     = [main, ...context];
+    const details = { timeMsec, stack, tag, message: logRecord.messageString };
 
-    this._writeJson({ timeMsec, stack, level, tag, message: logRecord.messageString });
+    if (logRecord.isMessage()) {
+      details.level = logRecord.payload.name;
+    }
+
+    this._writeJson(details);
   }
 
   /**

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { CommonBase, DataUtil, Errors, Functor } from 'util-common';
 
 import EventProxyHandler from './EventProxyHandler';
@@ -44,12 +46,11 @@ export default class BaseLogger extends CommonBase {
    * @param {string} name Event name. Must _not_ correspond to the event name
    *   used for any of the ad-hoc message severity levels or for timestamp logs.
    * @param {...*} args Event payload arguments. **Note:** Non-data arguments
-   *   will get converted (with loss of fidelity) by {@link DataUtil#deepFreeze}
-   *   which in turn uses `util.inspect()`.
+   *   will get converted (with loss of fidelity) by `util.inspect()`.
    */
   logEvent(name, ...args) {
     LogRecord.checkEventName(name);
-    args = DataUtil.deepFreeze(args, true);
+    args = DataUtil.deepFreeze(args, inspect);
     this._impl_logEvent(new Functor(name, ...args));
   }
 

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -202,20 +202,18 @@ export default class BaseLogger extends CommonBase {
    * @returns {*} Converted form of the object.
    */
   static _convertNonDataForEventLog(obj) {
+    const rawName = obj.constructor ? obj.constructor.name : null;
+    const name    = rawName ? `new_${rawName}` : `new_Anonymous`;
+
     if (typeof obj.deconstruct === 'function') {
       // It (presumably) follows the project's `deconstruct()` protocol. Use it
-      // to produce a replacement plain object that looks more or less like how
-      // we represent the constructor form in the JSON representation in the
-      // `codec` module.
-      const name = `new_${obj.constructor.name}`;
+      // to produce a replacement that looks kind of like a constructor call.
       const args = obj.deconstruct();
-      return { [name]: args };
+      return new Functor(name, ...args);
     } else {
       // Use `util.inspect()` as a last resort. The result won't necessarily be
       // pretty (probably won't), but at least we'll have _something_ to show.
-      const rawName = obj.constructor ? obj.constructor.name : null;
-      const name    = rawName ? `new_${rawName}` : `anonymous`;
-      return { [name]: inspect(obj) };
+      return new Functor(name, inspect(obj));
     }
   }
 }

--- a/local-modules/see-all/BaseLogger.js
+++ b/local-modules/see-all/BaseLogger.js
@@ -214,7 +214,7 @@ export default class BaseLogger extends CommonBase {
       // Use `util.inspect()` as a last resort. The result won't necessarily be
       // pretty (probably won't), but at least we'll have _something_ to show.
       const rawName = obj.constructor ? obj.constructor.name : null;
-      const name    = rawName ? `new_${name}` : `anonymous`;
+      const name    = rawName ? `new_${rawName}` : `anonymous`;
       return { [name]: inspect(obj) };
     }
   }

--- a/local-modules/see-all/LogRecord.js
+++ b/local-modules/see-all/LogRecord.js
@@ -217,7 +217,7 @@ export default class LogRecord extends CommonBase {
     } else if (value instanceof Error) {
       raw = ErrorUtil.fullTrace(value);
     } else {
-      raw = inspect(value);
+      raw = LogRecord._justInspect(value);
     }
 
     // Trim off initial and trailing newlines.
@@ -344,7 +344,7 @@ export default class LogRecord extends CommonBase {
       const [utc, local] = this.timeStrings;
       return `${utc} / ${local}`;
     } else if (this.isEvent()) {
-      return inspect(this.payload);
+      return LogRecord._justInspect(this.payload);
     }
 
     // The rest of this is for the ad-hoc message case (which is considerably
@@ -515,6 +515,16 @@ export default class LogRecord extends CommonBase {
     const newPayload = new Functor(payload.name, ...message);
 
     return new LogRecord(timeMsec, stack, tag, newPayload);
+  }
+
+  /**
+   * Calls `util.inspect()` on the given value, with standardized options.
+   *
+   * @param {*} value Value to inspect.
+   * @returns {string} The inspected form.
+   */
+  static _justInspect(value) {
+    return inspect(value, { depth: 20, maxArrayLength: 200, breakLength: 120 });
   }
 
   /**

--- a/local-modules/util-core/DataUtil.js
+++ b/local-modules/util-core/DataUtil.js
@@ -40,7 +40,8 @@ export default class DataUtil extends UtilityClass {
    *   throws an error when non-data is encountered. If non-`null`, must be a
    *   function of one argument. It gets passed a non-data value and is expected
    *   to return a replacement which is a deep-freezable (if not already
-   *   deep-frozen) data value.
+   *   deep-frozen) data value, using the same `nonDataConverter` for any
+   *   recursively-encountered non-data values.
    * @returns {*} The deep-frozen version of `value`.
    */
   static deepFreeze(value, nonDataConverter = null) {
@@ -84,7 +85,7 @@ export default class DataUtil extends UtilityClass {
           }
           default: {
             if (nonDataConverter !== null) {
-              return DataUtil.deepFreeze(nonDataConverter(value));
+              return DataUtil.deepFreeze(nonDataConverter(value), nonDataConverter);
             } else {
               throw Errors.badValue(value, 'data value');
             }
@@ -112,7 +113,7 @@ export default class DataUtil extends UtilityClass {
             if (nonDataConverter !== null) {
               // Use the converter on the original object (instead of, say,
               // trying to "edit" its contents).
-              return DataUtil.deepFreeze(nonDataConverter(value));
+              return DataUtil.deepFreeze(nonDataConverter(value), nonDataConverter);
             } else {
               throw Errors.badValue(value, 'data value', 'without synthetic properties');
             }
@@ -130,7 +131,7 @@ export default class DataUtil extends UtilityClass {
 
       default: {
         if (nonDataConverter !== null) {
-          return DataUtil.deepFreeze(nonDataConverter(value));
+          return DataUtil.deepFreeze(nonDataConverter(value), nonDataConverter);
         } else {
           throw Errors.badValue(value, 'data value');
         }

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -10,12 +10,12 @@ import { DataUtil, FrozenBuffer, Functor } from 'util-core';
 
 describe('util-core/DataUtil', () => {
   describe('deepFreeze()', () => {
-    // Tests that should work the same for both possible values of
-    // `convertNonData`.
-    function commonTests(convertNonData) {
+    // Tests that should work the same for both `null` and non-`null` values for
+    // `nonDataConverter`.
+    function commonTests(nonDataConverter) {
       it('should return the given value if it is a primitive', () => {
         function test(value) {
-          const popsicle = DataUtil.deepFreeze(value, convertNonData);
+          const popsicle = DataUtil.deepFreeze(value, nonDataConverter);
           assert.strictEqual(popsicle, value);
         }
 
@@ -30,8 +30,8 @@ describe('util-core/DataUtil', () => {
 
       it('should return the provided value if it is already deep-frozen', () => {
         function test(value) {
-          const popsicle     = DataUtil.deepFreeze(value, convertNonData);
-          const deepPopsicle = DataUtil.deepFreeze(popsicle, convertNonData);
+          const popsicle     = DataUtil.deepFreeze(value, nonDataConverter);
+          const deepPopsicle = DataUtil.deepFreeze(popsicle, nonDataConverter);
           assert.isTrue(DataUtil.isDeepFrozen(popsicle));
           assert.strictEqual(deepPopsicle, popsicle, 'Frozen strict-equals re-frozen.');
           assert.deepEqual(deepPopsicle, value, 'Re-frozen deep-equals original.');
@@ -47,8 +47,8 @@ describe('util-core/DataUtil', () => {
 
       it('should return a deep-frozen object if passed one that isn\'t already deep-frozen', () => {
         function test(value) {
-          const popsicle = DataUtil.deepFreeze(value, convertNonData);
-          assert.isTrue(DataUtil.isDeepFrozen(popsicle, convertNonData));
+          const popsicle = DataUtil.deepFreeze(value, nonDataConverter);
+          assert.isTrue(DataUtil.isDeepFrozen(popsicle, nonDataConverter));
           assert.deepEqual(popsicle, value);
         }
 
@@ -62,7 +62,7 @@ describe('util-core/DataUtil', () => {
 
       it('should not freeze the originally passed value', () => {
         const orig = [1, 2, 3];
-        const popsicle = DataUtil.deepFreeze(orig, convertNonData);
+        const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 
         assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.isNotFrozen(orig);
@@ -73,7 +73,7 @@ describe('util-core/DataUtil', () => {
         orig[37]   = ['florp'];
         orig[914]  = [[['like']]];
 
-        const popsicle = DataUtil.deepFreeze(orig, convertNonData);
+        const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 
         assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.deepEqual(popsicle, orig);
@@ -84,7 +84,7 @@ describe('util-core/DataUtil', () => {
         orig.florp = ['florp'];
         orig.like  = [[['like']]];
 
-        const popsicle = DataUtil.deepFreeze(orig, convertNonData);
+        const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 
         assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.deepEqual(popsicle, orig);
@@ -95,7 +95,7 @@ describe('util-core/DataUtil', () => {
         orig[Symbol('florp')] = ['florp'];
         orig[Symbol('like')] = [[['like']]];
 
-        const popsicle = DataUtil.deepFreeze(orig, convertNonData);
+        const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 
         assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.deepEqual(popsicle, orig);
@@ -104,7 +104,7 @@ describe('util-core/DataUtil', () => {
       it('should work on objects with symbol-named properties', () => {
         const orig = { a: 10, [Symbol('b')]: 20 };
 
-        const popsicle = DataUtil.deepFreeze(orig, convertNonData);
+        const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 
         assert.isTrue(DataUtil.isDeepFrozen(popsicle));
         assert.deepEqual(popsicle, orig);
@@ -112,7 +112,7 @@ describe('util-core/DataUtil', () => {
 
       it('should return a given `FrozenBuffer`', () => {
         function test(value) {
-          assert.strictEqual(DataUtil.deepFreeze(value, convertNonData), value);
+          assert.strictEqual(DataUtil.deepFreeze(value, nonDataConverter), value);
         }
 
         test(FrozenBuffer.coerce(''));
@@ -122,7 +122,7 @@ describe('util-core/DataUtil', () => {
       it('should work on functors with freezable arguments', () => {
         function test(...args) {
           const ftor = new Functor(...args);
-          const popsicle = DataUtil.deepFreeze(ftor, convertNonData);
+          const popsicle = DataUtil.deepFreeze(ftor, nonDataConverter);
           assert.deepEqual(ftor, popsicle);
           assert.notStrictEqual(ftor, popsicle);
         }
@@ -138,7 +138,7 @@ describe('util-core/DataUtil', () => {
       it('should work on already-deep-frozen functors', () => {
         function test(...args) {
           const ftor = new Functor(...args);
-          const popsicle = DataUtil.deepFreeze(ftor, convertNonData);
+          const popsicle = DataUtil.deepFreeze(ftor, nonDataConverter);
           assert.strictEqual(ftor, popsicle);
         }
 
@@ -149,8 +149,8 @@ describe('util-core/DataUtil', () => {
       });
     }
 
-    describe('with `convertNonData = false`', () => {
-      commonTests(false);
+    describe('with `nonDataConverter === null`', () => {
+      commonTests(null);
 
       it('should fail if given a function or a composite that contains same', () => {
         function test(value) {
@@ -185,46 +185,57 @@ describe('util-core/DataUtil', () => {
       });
     });
 
-    describe('with `convertNonData = true`', () => {
-      commonTests(true);
+    describe('with `nonDataConverter !== null`', () => {
+      commonTests(inspect);
 
-      it('should convert a non-plain object via `util.inspect`', () => {
+      it('should convert a non-plain object via the converter function', () => {
         class Florp {
           inspect() {
             return '{florp}';
           }
         }
 
-        const result = DataUtil.deepFreeze(new Florp(), true);
+        const result = DataUtil.deepFreeze(new Florp(), inspect);
 
         assert.strictEqual(result, '{florp}');
       });
 
-      it('should convert a function via `util.inspect`', () => {
+      it('should convert a function via the converter function', () => {
         function someFunc() { return 10; }
-        const result = DataUtil.deepFreeze(someFunc, true);
+        const result = DataUtil.deepFreeze(someFunc, inspect);
 
         assert.strictEqual(result, '[Function: someFunc]');
       });
 
-      it('should strip synthetic properties from plain objects', () => {
+      it('should convert a plain object with synthetic properties via the converter function', () => {
         const obj = {
           a: 10,
           b: 20,
 
-          get x() { return 1; },
-          get y() { return 1; },
-          set y(value_unused) { /*empty*/ },
-
           c: {
-            d: 'ddd',
+            a: 'a',
+            b: 'b',
             get z() { return 1; }
+          },
+
+          d: {
+            a: 1,
+            b: 2,
+            set y(value_unused) { /*empty*/ }
           }
         };
 
-        const result = DataUtil.deepFreeze(obj, true);
+        function converter(x) {
+          return `${x.a} ${x.b}`;
+        }
 
-        assert.deepEqual(result, { a: 10, b: 20, c: { d: 'ddd' } });
+        const result1 = DataUtil.deepFreeze(obj.c, converter);
+        const result2 = DataUtil.deepFreeze(obj.d, converter);
+        const result3 = DataUtil.deepFreeze(obj, converter);
+
+        assert.strictEqual(result1, 'a b');
+        assert.strictEqual(result2, '1 2');
+        assert.deepEqual(result3, { a: 10, b: 20, c: 'a b', d: '1 2' });
       });
     });
   });

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -238,6 +238,30 @@ describe('util-core/DataUtil', () => {
         assert.deepEqual(result3, { a: 10, b: 20, c: 'a b', d: '1 2' });
       });
     });
+
+    it('should use the converter function recursively', () => {
+      const obj = {
+        get x() { return null; },
+        a: 10,
+        b: 20,
+        c: {
+          a: 'a',
+          b: 'b',
+          c: 'c',
+
+          get y() { return null; }
+        }
+      };
+
+      function converter(x) {
+        return [`${x.a} ${x.b}`, c];
+      }
+
+      const result = DataUtil.deepFreeze(obj, converter);
+
+      assert.deepEqual(result, ['10 20', ['a b', 'c']]);
+    });
+  });
   });
 
   describe('equalData()', () => {

--- a/local-modules/util-core/tests/test_DataUtil.js
+++ b/local-modules/util-core/tests/test_DataUtil.js
@@ -254,14 +254,13 @@ describe('util-core/DataUtil', () => {
       };
 
       function converter(x) {
-        return [`${x.a} ${x.b}`, c];
+        return [`${x.a} ${x.b}`, x.c];
       }
 
       const result = DataUtil.deepFreeze(obj, converter);
 
       assert.deepEqual(result, ['10 20', ['a b', 'c']]);
     });
-  });
   });
 
   describe('equalData()', () => {


### PR DESCRIPTION
Having started to see structured events getting logged as both text and JSON now, a handful of shortcomings have become apparent. This PR fixes a couple of them.

* When converting structured values for human output, increase the maximum depth being `inspect()`ed.
* Don't just `inspect()` non-data payload values in structured events. Instead, attempt to convert them into structured data. Specifically, for objects that implement the project's `deconstruct()` API, use that, and make the result look at least somewhat like a constructor call.