### PR TITLE
One log to bring them all and in the darkness bind them.

### DIFF
--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -83,7 +83,8 @@ export default class Application extends CommonBase {
     // Make the webserver able to handle websockets.
     express_ws(this._app, this._server);
 
-    this._addRequestLogging();
+    RequestLogger.addLoggers(this._app, log);
+
     this._addRoutes();
 
     if (devMode) {
@@ -122,13 +123,6 @@ export default class Application extends CommonBase {
     }
 
     return resultPort;
-  }
-
-  /**
-   * Sets up logging for webserver requests.
-   */
-  _addRequestLogging() {
-    RequestLogger.addLoggers(this._app, log);
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -5,7 +5,6 @@
 import express from 'express';
 import express_ws from 'express-ws';
 import http from 'http';
-import fs from 'fs';
 import path from 'path';
 
 import { BearerToken, Context, PostConnection, WsConnection } from 'api-server';
@@ -129,12 +128,7 @@ export default class Application extends CommonBase {
    * Sets up logging for webserver requests.
    */
   _addRequestLogging() {
-    // Stream to write to, when logging to a file.
-    const accessStream = fs.createWriteStream(
-      path.resolve(Dirs.theOne.LOG_DIR, 'access.log'),
-      { flags: 'a' });
-
-    RequestLogger.addLoggers(this._app, log.streamFor('info'), accessStream);
+    RequestLogger.addLoggers(this._app, log);
   }
 
   /**

--- a/local-modules/app-setup/Application.js
+++ b/local-modules/app-setup/Application.js
@@ -10,7 +10,7 @@ import path from 'path';
 import { BearerToken, Context, PostConnection, WsConnection } from 'api-server';
 import { TheModule as appCommon_TheModule } from 'app-common';
 import { ClientBundle } from 'client-bundle';
-import { Dirs } from 'env-server';
+import { Dirs, ProductInfo } from 'env-server';
 import { Hooks } from 'hooks-server';
 import { Logger } from 'see-all';
 import { CommonBase } from 'util-common';
@@ -80,6 +80,12 @@ export default class Application extends CommonBase {
     /** {http.Server} The server that directly answers HTTP requests. */
     this._server = http.createServer(this._app);
 
+    /**
+     * {string} Public ID of this server as reported through HTTP response
+     * headers.
+     */
+    this._serverId = Application._makeIdString();
+
     // Make the webserver able to handle websockets.
     express_ws(this._app, this._server);
 
@@ -126,10 +132,26 @@ export default class Application extends CommonBase {
   }
 
   /**
+   * Adds the dev mode routes.
+   */
+  _addDevModeRoutes() {
+    const app = this._app;
+    const debugTools = new DebugTools(this._rootAccess);
+    app.use('/debug', debugTools.requestHandler);
+  }
+
+  /**
    * Sets up the webserver routes.
    */
   _addRoutes() {
     const app = this._app;
+
+    // Thwack the `X-Powered-By` header that Express provides by default,
+    // replacing it with something that identifies this product.
+    app.use((req_unused, res, next) => {
+      res.setHeader('X-Powered-By', this._serverId);
+      next();
+    });
 
     // Map Quill files into `/static/quill`. This is used for CSS files but not
     // for the JS code; the JS code is included in the overall JS bundle file.
@@ -167,15 +189,6 @@ export default class Application extends CommonBase {
   }
 
   /**
-   * Adds the dev mode routes.
-   */
-  _addDevModeRoutes() {
-    const app = this._app;
-    const debugTools = new DebugTools(this._rootAccess);
-    app.use('/debug', debugTools.requestHandler);
-  }
-
-  /**
    * Maintains up-to-date bindings for the `rootAccess` object, based on the
    * root token(s) reported via `hooks-server.bearerTokens`. This includes
    * a promise-chain-based ongoing update mechanism.
@@ -199,5 +212,20 @@ export default class Application extends CommonBase {
       }
       this._rootTokens = rootTokens;
     }
+  }
+
+  /**
+   * Makes the server ID string to report in HTTP responses.
+   *
+   * @returns {string} The server ID string.
+   */
+  static _makeIdString() {
+    const { name, version, commit_id } = ProductInfo.theOne.INFO;
+
+    const id = ((typeof commit_id === 'string') && commit_id !== '')
+      ? `-${commit_id.slice(0, 8)}`
+      : '';
+
+    return `${name}-${version}${id}`;
   }
 }

--- a/local-modules/app-setup/Monitor.js
+++ b/local-modules/app-setup/Monitor.js
@@ -10,6 +10,7 @@ import { TInt } from 'typecheck';
 import { CommonBase } from 'util-common';
 
 import Application from './Application';
+import RequestLogger from './RequestLogger';
 import ServerUtil from './ServerUtil';
 
 /** {Logger} Logger. */
@@ -44,7 +45,8 @@ export default class Monitor extends CommonBase {
     /** {http.Server} The server that directly answers HTTP requests. */
     this._server = http.createServer(this._app);
 
-    this._addRequestLogging();
+    RequestLogger.addLoggers(this._app, log);
+
     this._addRoutes();
   }
 
@@ -61,22 +63,6 @@ export default class Monitor extends CommonBase {
     if ((port !== 0) && (port !== resultPort)) {
       log.warn(`Originally requested port: ${port}`);
     }
-  }
-
-  /**
-   * Sets up logging for webserver requests.
-   */
-  _addRequestLogging() {
-    const app = this._app;
-
-    app.use((req, res, next) => {
-      res.on('finish', () => {
-        log.event.httpResponse(req.originalUrl, res.statusCode);
-      });
-
-      log.event.httpRequest(req.originalUrl);
-      next();
-    });
   }
 
   /**

--- a/local-modules/app-setup/Monitor.js
+++ b/local-modules/app-setup/Monitor.js
@@ -5,6 +5,7 @@
 import express from 'express';
 import http from 'http';
 
+import { ProductInfo } from 'env-server';
 import { Logger } from 'see-all';
 import { TInt } from 'typecheck';
 import { CommonBase } from 'util-common';
@@ -79,6 +80,16 @@ export default class Monitor extends CommonBase {
       res
         .status(status)
         .type('text/plain; charset=utf-8')
+        .set('Cache-Control', 'no-cache, no-store, no-transform')
+        .send(text);
+    });
+
+    app.get('/info', async (req_unused, res) => {
+      const text = JSON.stringify(ProductInfo.theOne.INFO, null, 2);
+
+      res
+        .status(200)
+        .type('application/json; charset=utf-8')
         .set('Cache-Control', 'no-cache, no-store, no-transform')
         .send(text);
     });

--- a/local-modules/app-setup/RequestLogger.js
+++ b/local-modules/app-setup/RequestLogger.js
@@ -35,7 +35,7 @@ export default class RequestLogger extends CommonBase {
     /** {Logger} Logger to use. */
     this._log = Logger.check(log);
 
-    Object.seal(this);
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/app-setup/RequestLogger.js
+++ b/local-modules/app-setup/RequestLogger.js
@@ -2,10 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import chalk from 'chalk';
-import morgan from 'morgan';
-
-import { UtilityClass } from 'util-common';
+import { Logger } from 'see-all';
+import { CommonBase, Random } from 'util-common';
 
 /**
  * HTTP request logging functions. This includes logging to an HTTP `access.log`
@@ -14,81 +12,51 @@ import { UtilityClass } from 'util-common';
  * built-in `dev` style, intended to produce concise logs for display on a
  * developer's console.
  */
-export default class RequestLogger extends UtilityClass {
+export default class RequestLogger extends CommonBase {
   /**
    * Add all the loggers for the given application.
    *
    * @param {object} app The `express` application.
-   * @param {object} consoleStream The stream to write console logs to.
-   * @param {object} accessStream The stream to write HTTP access logs to.
+   * @param {Logger} log The logger instance to use.
    */
-  static addLoggers(app, consoleStream, accessStream) {
-    // These log regular (non-websocket) requests, at the time of completion.
-
-    app.use(morgan(
-      RequestLogger._makeConsoleLogEnd,
-      {
-        stream: consoleStream
-      }
-    ));
-
-    app.use(morgan(
-      'common',
-      {
-        stream: accessStream
-      }
-    ));
-
-    // These log websocket requests, at the time of request start (not at the
-    // time of completion because these are long-lived requests).
-
-    app.use(morgan(
-      RequestLogger._makeConsoleLogStart,
-      {
-        stream:    consoleStream,
-        immediate: true
-      }
-    ));
-
-    app.use(morgan(
-      'common',
-      {
-        stream:    accessStream,
-        immediate: true
-      }
-    ));
-  }
-
-  static _makeConsoleLogStart(tokens_unused, req, res_unused) {
-    return RequestLogger._makeConsoleLog(req, null);
-  }
-
-  static _makeConsoleLogEnd(tokens_unused, req, res) {
-    return RequestLogger._makeConsoleLog(req, res);
+  static addLoggers(app, log) {
+    const instance = new RequestLogger(log);
+    app.use(instance.expressMiddleware);
   }
 
   /**
-   * Helper for the console logger methods, which does most of the work. If
-   * `res` is passed as `null`, this indicates that the logging is being done at
-   * the start of the request, so (e.g.) things like content length won't be
-   * available.
+   * Constructs an instance.
    *
-   * @param {object} req Request object.
-   * @param {object|null} res Response object.
-   * @returns {string} String to log.
+   * @param {Logger} log Logger to use.
    */
-  static _makeConsoleLog(req, res) {
+  constructor(log) {
+    super();
+
+    /** {Logger} Logger to use. */
+    this._log = Logger.check(log);
+
+    Object.seal(this);
+  }
+
+  /**
+   * {function} Express "middleware" function which performs request (and
+   * response) logging.
+   */
+  get expressMiddleware() {
+    return this._logRequest.bind(this);
+  }
+
+  /**
+   * Standard Express middleware implementation, underlying the property
+   * {@link #expressMiddleware}.
+   *
+   * @param {object} req The HTTP request.
+   * @param {object} res The HTTP response.
+   * @param {function} next Function to call in order to continue request
+   *   dispatch.
+   */
+  _logRequest(req, res, next) {
     const isWs = RequestLogger._isWsRequest(req);
-
-    if ((res === null) && !isWs) {
-      // We skip start-of-request logging for everything but websockets.
-      return null;
-    }
-
-    const status    = (res === null) ? 0 : (res.statusCode || 0);
-    const statusStr = `${status || '-'}  `.slice(0, 3);
-    const colorFn   = RequestLogger._colorForStatus(status);
-    const method    = `${isWs ? 'WS' : req.method}   `.slice(0,4);
 
     // `express-ws` appends a pseudo-path `/.websocket` to the end of
     // websocket requests. We chop that off here.
@@ -96,37 +64,32 @@ export default class RequestLogger extends UtilityClass {
       ? req.originalUrl.replace(/[/]\.websocket$/, '')
       : req.originalUrl;
 
-    let contentLength = (res === null) ? undefined : res.get('content-length');
-    if (contentLength === undefined) {
-      contentLength = '-';
-    } else if (contentLength > (1024 * 1024)) {
-      contentLength = `${Math.round(contentLength / 1024 / 1024 * 10) / 10}M`;
-    } else if (contentLength > 1024) {
-      contentLength = `${Math.round(contentLength / 1024 * 10) / 10}K`;
+    // **Note:** `url` is put in the top-level event and not the details
+    // because it is so handy and deserves prominent placement.
+    const requestDetails = {
+      hostname: req.hostname,
+      ip:       req.ip,
+      method:   req.method,
+      params:   req.params,
+      query:    req.query
+    };
+
+    if (isWs) {
+      this._log.event.wsRequest(url, requestDetails, req.headers);
     } else {
-      contentLength = `${contentLength}B`;
+      const id = Random.shortLabel('req');
+
+      this._log.event.httpRequest(id, url, requestDetails, req.headers);
+
+      res.on('finish', () => {
+        // Make the headers a plain object, so it gets logged in a clean
+        // fashion.
+        const responseHeaders = Object.assign({}, res.getHeaders());
+        this._log.event.httpResponse(id, res.statusCode, responseHeaders);
+      });
     }
 
-    if (contentLength.length < 7) {
-      contentLength += ' '.repeat(7 - contentLength.length);
-    }
-
-    return `${colorFn(statusStr)} ${contentLength} ${method} ${url}`;
-  }
-
-  /**
-   * Given an HTTP status, returns the corresponding `chalk` coloring function,
-   * or a no-op function if the status doesn't demand colorization.
-   *
-   * @param {number} status The HTTP status code.
-   * @returns {function} The corresponding coloring function.
-   */
-  static _colorForStatus(status) {
-    if      (status >= 500) { return chalk.red;    }
-    else if (status >= 400) { return chalk.yellow; }
-    else if (status >= 300) { return chalk.cyan;   }
-    else if (status >= 200) { return chalk.green;  }
-    else                    { return (x => x);     } // No-op by default.
+    next();
   }
 
   /**

--- a/local-modules/app-setup/package.json
+++ b/local-modules/app-setup/package.json
@@ -6,7 +6,6 @@
     "camel-case": "^3.0.0",
     "express": "^4.16.0",
     "express-ws": "^3.0.0",
-    "morgan": "^1.7.0",
 
     "api-common": "local",
     "api-server": "local",

--- a/local-modules/env-server/tests/test_ProductInfo.js
+++ b/local-modules/env-server/tests/test_ProductInfo.js
@@ -17,7 +17,7 @@ describe('env-server/ProductInfo', () => {
       // and those from a privately-used overlay. Ugh. Not good. This should
       // probably be broken out into two separate tests so that each
       // environment's expected contributions can be tested independently.
-      const productKeys = ['name', 'version', 'commit_id', 'commit_date'];
+      const productKeys = ['name', 'version', 'commit_id', 'commit_date', 'build_date'];
 
       assert.doesNotThrow(() => TObject.withExactKeys(info, productKeys));
     });

--- a/local-modules/see-all-server/FileSink.js
+++ b/local-modules/see-all-server/FileSink.js
@@ -45,7 +45,12 @@ export default class FileSink extends BaseSink {
     const tag     = [main, ...context];
     const details = { timeMsec, stack, tag, message: logRecord.messageString };
 
-    if (logRecord.isMessage()) {
+    if (logRecord.isTime()) {
+      // No need to log timestamp records. Those are only really useful for
+      // human-oriented logging, because every log record builds in a timestamp
+      // which gets included in its JSON-encoded form.
+      return;
+    } else if (logRecord.isMessage()) {
       details.level = logRecord.payload.name;
     }
 

--- a/local-modules/see-all-server/RecentSink.js
+++ b/local-modules/see-all-server/RecentSink.js
@@ -101,8 +101,8 @@ export default class RecentSink extends BaseSink {
 
     if (logRecord.isTime()) {
       const [utc, local] = logRecord.timeStrings;
-      const utcString = ck.blue.bold(utc);
-      const localString = ck.blue.dim.bold(local);
+      const utcString    = ck.blue.bold(utc);
+      const localString  = ck.blue.dim.bold(local);
       body = `${utcString} ${ck.dim.bold('/')} ${localString}`;
     } else {
       // Distill the message (or event) down to a single string, and trim
@@ -110,7 +110,7 @@ export default class RecentSink extends BaseSink {
       body = logRecord.messageString.replace(/(^\n+)|(\n+$)/g, '');
 
       if (logRecord.isEvent()) {
-        body = ck.green.dim.bold(body);
+        body = ck.dim.bold(body);
       }
     }
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.35.1
+version = 0.35.2

--- a/scripts/build
+++ b/scripts/build
@@ -471,7 +471,8 @@ function build-product-info {
         )
     )"
 
-    # The current date/time.
+    # The current date/time. This is the same format as is produced by the
+    # `git log` command, above.
     local buildDate="build_date = '$(date '+%Y-%m-%d %H:%M:%S %z')'"
 
     mkdir -p "$(dirname "${outFile}")"

--- a/scripts/build
+++ b/scripts/build
@@ -471,13 +471,17 @@ function build-product-info {
         )
     )"
 
+    # The current date/time.
+    local buildDate="build_date = '$(date '+%Y-%m-%d %H:%M:%S %z')'"
+
     mkdir -p "$(dirname "${outFile}")"
 
-    # Combine the static info file from the source with the git info to produce
-    # the final output.
+    # Combine the static info file from the source with the additional info
+    # derived here, to produce the final output.
     (
         cat "${inFile}"
         echo "${commitInfo}"
+        echo "${buildDate}"
     ) > "${outFile}"
 }
 


### PR DESCRIPTION
This PR changes the system to no longer write a separate HTTP log file, instead using the same structured event logging that we are increasingly using for the rest of the system.

**Bonus:** We no longer advertise that we are `X-Powered-By: Express` in HTTP responses. Instead, we use that to report the product version and commit ID[*], which might turn out to be handy some day!

**Bonus 2:** New `/info` monitor endpoint which reports all of the product info.

[*] The commit ID is included only if available. It's notably not available if the product was built outside of a git-managed checkout that includes the usual `.git` directory.