### PR TITLE
Let `local-modules` contain namespace-scoped modules.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -254,10 +254,10 @@ function set-up-dir-mapping {
     add-directory-mapping 'server'
     add-directory-mapping 'client'
 
-    # The `local-modules` get pulled into `client`, `server`, and `compiler` (as
-    # required by dependencies). We make a mapping per subdirectory because it
-    # is the subdirectories  that get pulled in (not the entirety of the
-    # `local-modules` directory).
+    # Individual packages under `local-modules` get pulled into `client`,
+    # `server`, and `compiler` (as required by dependencies). We make a mapping
+    # per package (and not just one for all of `local-modules`) exactly because
+    # packages get pulled in (and overlaid) individually.
     add-package-directory-mappings 'local-modules'
 }
 

--- a/scripts/build
+++ b/scripts/build
@@ -324,6 +324,7 @@ function do-install {
     # Integrates local module dependencies into this package. It copies the
     # required local modules and also rewrites the top-level `package.json` so
     # that it lists the transitive closure of external module dependencies.
+    echo "${dir}:" 'Copying local-module dependencies...'
     "${progDir}/lib/copy-local-dependencies" \
         --local-modules="${outDir}/local-modules" "${toDir}" \
     || return 1

--- a/scripts/build
+++ b/scripts/build
@@ -191,8 +191,8 @@ function local-module-names {
         | sort -u
 }
 
-# Adds a new directory mapping to the build info file. This includes handling
-# an overlay if it exists.
+# Adds a new directory mapping under the output directory pointing back to the
+# original source location(s). This includes handling an overlay if it exists.
 function add-directory-mapping {
     local dirName="$1"
     local dirInfoFile="${outDir}/${dirName}/${sourceMapName}"
@@ -214,18 +214,29 @@ function add-directory-mapping {
     mappingFiles+=("${dirInfoFile}")
 }
 
-# Adds new directory mappings to the build info file for each subdirectory of
-# a source directory. This includes handling of overlays if they exist.
-function add-subdirectory-mapping {
+# Helper for `add-package-directory-mapping` which finds package (node module)
+# directories under the given directory. It prints the partial path to each such
+# found directory.
+function find-package-directories {
+    local dir="$1"
+
+    # Parens to preserve original CWD. `awk` command to strip the leading `./`
+    # and trailing `/package.json` from the results of the `find` command.
+    (cd "${dir}"; find . -type f -name package.json) \
+        | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }'
+}
+
+# Adds new directory mappings for each subdirectory of a source directory which
+# appears to be a package (node module), as inferred by the existence of a
+# `package.json` file. This includes handling of overlays if they exist.
+function add-package-directory-mappings {
     local fromDir="$1"
 
     local names=($(
         (
-            cd "${baseDir}/${fromDir}"
-            find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-
+            find-package-directories "${baseDir}/${fromDir}"
             if [[ (${overlayDir} != '') && -e "${overlayDir}/${fromDir}" ]]; then
-                cd "${overlayDir}/${fromDir}"
-                find . -mindepth 1 -maxdepth 1 -type d | cut -c 3-
+                find-package-directories "${overlayDir}/${fromDir}"
             fi
         ) | sort -u
     ))
@@ -247,7 +258,7 @@ function set-up-dir-mapping {
     # required by dependencies). We make a mapping per subdirectory because it
     # is the subdirectories  that get pulled in (not the entirety of the
     # `local-modules` directory).
-    add-subdirectory-mapping 'local-modules'
+    add-package-directory-mappings 'local-modules'
 }
 
 # Copies the server and client source directories into `out`, including the

--- a/scripts/lib/copy-local-dependencies
+++ b/scripts/lib/copy-local-dependencies
@@ -116,6 +116,14 @@ function rsync-archive {
     rsync --archive --ignore-times "$@"
 }
 
+# Given a full path to a directory under `${localModules}`, prints out just the
+# relative portion under that directory. That is, it goes from a full path to
+# a simple but possibly scoped module name.
+function path-to-module-name {
+    [[ ${d} =~ ${localModules}/+(.*)$ ]] || return 1
+    echo "${BASH_REMATCH[1]}"
+}
+
 
 #
 # Main script
@@ -244,7 +252,7 @@ rsync-archive "${origFile}" "${unfixedFile}" || exit 1
     # purpose.
     echo '| .bayouLocalDependencies = []'
     for d in $(printf '%s\n' "${localDeps[@]}" | sort); do
-        name="$(basename "${d}")"
+        name="$(path-to-module-name "${d}")"
         nameq='"'"${name}"'"'
         echo "| .bayouLocalDependencies += [${nameq}]"
     done
@@ -271,14 +279,17 @@ nodeModules="${projectDir}/node_modules"
 mkdir -p "${nodeModules}" || exit 1
 
 for d in "${localDeps[@]}"; do
-    rsync-archive --delete "${d}" "${nodeModules}"
+    name="$(path-to-module-name "${d}")"
+    toDir="${nodeModules}/${name}"
+
+    mkdir -p "${toDir}" || exit 1
+    rsync-archive --delete "${d}/" "${toDir}"
 
     # Remove the `dependencies` from the `package.json`, because otherwise `npm`
     # tries to process them (and they aren't valid as far as it's concerned).
     # Also, add a binding to make it unambiguous that this is a local module.
-    name="$(basename "${d}")"
     jq '
           del(.dependencies)
         | .localModule = true' \
-        "${d}/package.json" > "${nodeModules}/${name}/package.json"
+        "${d}/package.json" > "${toDir}/package.json"
 done

--- a/scripts/lib/copy-local-dependencies
+++ b/scripts/lib/copy-local-dependencies
@@ -120,7 +120,9 @@ function rsync-archive {
 # relative portion under that directory. That is, it goes from a full path to
 # a simple but possibly scoped module name.
 function path-to-module-name {
-    [[ ${d} =~ ${localModules}/+(.*)$ ]] || return 1
+    local path="$1"
+
+    [[ ${path} =~ ${localModules}/+(.*)$ ]] || return 1
     echo "${BASH_REMATCH[1]}"
 }
 


### PR DESCRIPTION
This PR is the main prerequisite for a series of follow-on changes, wherein the local modules of this project get moved from the global scope into a namespace. This PR just implements the required new mechanism, but does not actually change any modules.