### PR TITLE
Make `compiler` and `linter` be local modules.

### DIFF
--- a/compiler/bayou-compile
+++ b/compiler/bayou-compile
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
-// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
-// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
-
-require('./index.js');

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -1,20 +1,8 @@
 {
-  "name": "bayou-compiler",
+  "name": "@bayou/top-package-client",
   "version": "1.0.0",
-  "description": "Compiler (transpiler) code for Bayou",
-  "license": "Apache-2.0",
-  "author": "Dan Bornstein <danfuzz@milk.com>",
-  "contributors": [
-    "SEE AUTHORS.md"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/danfuzz/bayou.git"
-  },
 
   "dependencies": {
-    "@bayou/deps-ansi-color": "local",
-    "@bayou/deps-compiler": "local",
-    "@bayou/deps-util-server": "local"
+    "@bayou/main-compiler": "local"
   }
 }

--- a/linter/package.json
+++ b/linter/package.json
@@ -1,19 +1,8 @@
 {
-  "name": "bayou-linter",
+  "name": "@bayou/top-package-client",
   "version": "1.0.0",
-  "description": "Linter for Bayou",
-  "license": "Apache-2.0",
-  "author": "Dan Bornstein <danfuzz@milk.com>",
-  "contributors": [
-    "SEE AUTHORS.md"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/danfuzz/bayou.git"
-  },
 
   "dependencies": {
-    "eslint": "^4.7.1",
-    "eslint-plugin-react": "^7.4.0"
+    "@bayou/main-linter": "local"
   }
 }

--- a/local-modules/@bayou/main-client/README.md
+++ b/local-modules/@bayou/main-client/README.md
@@ -1,5 +1,5 @@
-main-client
-===========
+@bayou/main-client
+==================
 
 This module contains the top level code for the client, including a
 `package.json` which is specific to the client side. That is, the modules

--- a/local-modules/@bayou/main-compiler/README.md
+++ b/local-modules/@bayou/main-compiler/README.md
@@ -1,0 +1,13 @@
+@bayou/main-compiler
+====================
+
+This module contains code to drive invocation of the Babel compiler, including
+smarts to avoid recompiling unchanged files.
+
+- - - - - - - - - -
+
+```
+Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+```

--- a/local-modules/@bayou/main-compiler/index.js
+++ b/local-modules/@bayou/main-compiler/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>

--- a/local-modules/@bayou/main-compiler/package.json
+++ b/local-modules/@bayou/main-compiler/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bayou/main-compiler",
+  "version": "1.0.0",
+
+  "bin": {
+    "bayou-compile": "./index.js"
+  },
+
+  "dependencies": {
+    "@bayou/deps-ansi-color": "local",
+    "@bayou/deps-compiler": "local",
+    "@bayou/deps-util-server": "local"
+  }
+}

--- a/local-modules/@bayou/main-linter/README.md
+++ b/local-modules/@bayou/main-linter/README.md
@@ -1,5 +1,5 @@
-linter
-======
+@bayou/main-linter
+==================
 
 This subproject just serves as a place to hold the `eslint` dependency; there
 is no other code here. This gets used when using `scripts/lint`.

--- a/local-modules/@bayou/main-linter/package.json
+++ b/local-modules/@bayou/main-linter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bayou/main-linter",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "eslint": "^4.7.1",
+    "eslint-plugin-react": "^7.4.0"
+  }
+}

--- a/scripts/build
+++ b/scripts/build
@@ -320,6 +320,7 @@ function do-install {
     local npmDir="${toDir}/from-npm"
     local packageJson="${toDir}/package.json"
     local npmPackageJson="${toDir}/package-npm.json"
+    local npmBinDir="${npmDir}/node_modules/.bin"
 
     # Integrates local module dependencies into this package. It copies the
     # required local modules and also rewrites the top-level `package.json` so
@@ -371,12 +372,23 @@ function do-install {
 
     local d
     for d in $(cd "${npmDir}/node_modules"; /bin/ls -A); do
+        if [[ ${d} == '.bin' ]]; then
+            # `.bin` is handled specially. See below.
+            continue
+        fi
+
         (
             fromDir="${npmDir}/node_modules/${d}"
             toDir="${toDir}/node_modules/${d}"
             rm -rf "${toDir}" && mv "${fromDir}" "${toDir}"
         ) || return 1
     done
+
+    if [[ -d "${npmBinDir}" ]]; then
+        # Merge `.bin` directory contents into the pre-existing one (if any).
+        mkdir -p "${toDir}/node_modules/.bin"
+        rsync-archive "${npmBinDir}/" "${toDir}/node_modules/.bin"
+    fi
 
     rm -rf "${npmDir}" || return 1
 

--- a/scripts/build
+++ b/scripts/build
@@ -406,7 +406,8 @@ function build-server {
     local fromDir="${outDir}/server"
     local toDir="${finalDir}/server"
 
-    # Find the `babel` script (provided by the `compiler` submodule).
+    # Find the script to invoke the Babel compiler (provided by the `compiler`
+    # subproject).
     local compile="$(find "${outDir}/compiler" -name 'bayou-compile')"
     if [[ ${compile} == '' ]]; then
         echo 'Could not find compiler script.' 1>&2

--- a/scripts/lib/copy-local-dependencies
+++ b/scripts/lib/copy-local-dependencies
@@ -151,6 +151,7 @@ function link-module-bin {
         (
             rm -f "${targetPath}" \
             && mkdir -p "${nodeModulesBinDir}" \
+            && rm -f "${binPath}" \
             && ln -s "${targetPath}" "${binPath}"
         ) || return 1
     done
@@ -314,7 +315,7 @@ for d in "${localDeps[@]}"; do
     toDir="${nodeModules}/${name}"
 
     mkdir -p "${toDir}" || exit 1
-    rsync-archive --delete "${d}/" "${toDir}"
+    rsync-archive --delete "${d}/" "${toDir}" || exit 1
 
     # Remove the `dependencies` from the `package.json`, because otherwise `npm`
     # tries to process them (and they aren't valid as far as it's concerned).
@@ -322,10 +323,11 @@ for d in "${localDeps[@]}"; do
     jq '
           del(.dependencies)
         | .localModule = true' \
-        "${d}/package.json" > "${toDir}/package.json"
+        "${d}/package.json" > "${toDir}/package.json" \
+    || exit 1
 
     # Link up the `bin` entries, if any. **Note:** This can only be done once
     # the rest of the module is copied and definitely needs to happen after the
     # module's `package.json` is set up.
-    link-module-bin "${nodeModules}" "${name}"
+    link-module-bin "${nodeModules}" "${name}" || exit 1
 done

--- a/scripts/lib/copy-local-dependencies
+++ b/scripts/lib/copy-local-dependencies
@@ -126,6 +126,35 @@ function path-to-module-name {
     echo "${BASH_REMATCH[1]}"
 }
 
+# Given a `node_modules` directory and a module name, links any `bin` entries in
+# the `package.json` of the module into the `node_modules/.bin` directory.
+function link-module-bin {
+    local nodeModulesDir="$1"
+    local moduleName="$2"
+    local packageJson="${nodeModulesDir}/${moduleName}/package.json"
+    local nodeModulesBinDir="${nodeModulesDir}/.bin"
+    local binPath
+    local targetPath
+
+    jq -r '(.bin // {}) | to_entries | .[] | "\(.key) \(.value)"' "${packageJson}" | \
+    while read -r binPath targetPath; do
+        binPath="${nodeModulesBinDir}/${binPath}"
+
+        if [[ ! (${targetPath} =~ ^/) ]]; then
+            # It's a relative path.
+            targetPath="../${moduleName}/${targetPath}"
+        fi
+
+        # Clean up superfluous `.` path elements.
+        targetPath="$(echo "${targetPath}" | sed -e 's#\(/\.\)*/#/#g')"
+
+        (
+            rm -f "${targetPath}" \
+            && mkdir -p "${nodeModulesBinDir}" \
+            && ln -s "${targetPath}" "${binPath}"
+        ) || return 1
+    done
+}
 
 #
 # Main script
@@ -294,4 +323,9 @@ for d in "${localDeps[@]}"; do
           del(.dependencies)
         | .localModule = true' \
         "${d}/package.json" > "${toDir}/package.json"
+
+    # Link up the `bin` entries, if any. **Note:** This can only be done once
+    # the rest of the module is copied and definitely needs to happen after the
+    # module's `package.json` is set up.
+    link-module-bin "${nodeModules}" "${name}"
 done


### PR DESCRIPTION
This PR continues the conversion of top-level "sub-projects" into local modules. `client` was done earlier, and this one tackles `compiler` and `linter`. The top-level directories for the sub-projects remain but are simple boilerplate stubs; the hope is that these can get removed once all the sub-projects get converted. (Just one more to go after this.)
