### PR TITLE
Two more dependency fixes, and another random fix.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -191,6 +191,10 @@ export default class Application extends CommonBase {
       } catch (e) {
         log.error('Trouble with API websocket connection:', e);
       }
+
+    });
+    wsServer.on('headers', (headers, req) => {
+      this._requestLogger.logWebsocketRequest(req, headers);
     });
   }
 

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -86,7 +86,8 @@ export default class Application extends CommonBase {
      */
     this._serverId = Application._makeIdString();
 
-    RequestLogger.addLoggers(this._app, log);
+    /** {RequestLogger} HTTP request / response logger. */
+    this._requestLogger = new RequestLogger(log);
 
     this._addRoutes();
 
@@ -142,6 +143,9 @@ export default class Application extends CommonBase {
    */
   _addRoutes() {
     const app = this._app;
+
+    // Logging.
+    app.use(this._requestLogger.expressMiddleware);
 
     // Thwack the `X-Powered-By` header that Express provides by default,
     // replacing it with something that identifies this product.

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -46,7 +46,8 @@ export default class Monitor extends CommonBase {
     /** {http.Server} The server that directly answers HTTP requests. */
     this._server = http.createServer(this._app);
 
-    RequestLogger.addLoggers(this._app, log);
+    /** {RequestLogger} HTTP request / response logger. */
+    this._requestLogger = new RequestLogger(log);
 
     this._addRoutes();
   }
@@ -71,6 +72,9 @@ export default class Monitor extends CommonBase {
    */
   _addRoutes() {
     const app = this._app;
+
+    // Logging.
+    app.use(this._requestLogger.expressMiddleware);
 
     app.get('/health', async (req_unused, res) => {
       const [status, text] = await this._mainApplication.isHealthy()

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -54,7 +54,7 @@ export default class RequestLogger extends CommonBase {
     const url     = new URL(req.url, 'http://x.x');
 
     const details = {
-      ip:     'TBD', // **TODO**
+      ip:     req.socket.remoteAddress,
       method: req.method,
       query:  fromPairs([...url.searchParams])
     };

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -14,17 +14,6 @@ import { CommonBase, Random } from '@bayou/util-common';
  */
 export default class RequestLogger extends CommonBase {
   /**
-   * Add all the loggers for the given application.
-   *
-   * @param {object} app The `express` application.
-   * @param {Logger} log The logger instance to use.
-   */
-  static addLoggers(app, log) {
-    const instance = new RequestLogger(log);
-    app.use(instance.expressMiddleware);
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {Logger} log Logger to use.

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -2,6 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { fromPairs } from 'lodash';
+import { URL } from 'url';
+
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Random } from '@bayou/util-common';
 
@@ -32,7 +35,46 @@ export default class RequestLogger extends CommonBase {
    * response) logging.
    */
   get expressMiddleware() {
-    return this._logRequest.bind(this);
+    return this._logExpressRequest.bind(this);
+  }
+
+  /**
+   * Logs a websocket request.
+   *
+   * @param {object} req The HTTP request, which is assumed to be a
+   *   successfully-upgraded websocket.
+   * @param {array<string>} responseHeaderLines Response header, including
+   *   status code and key-value pairs.
+   */
+  logWebsocketRequest(req, responseHeaderLines) {
+    const id = Random.shortLabel('req');
+
+    // Second arg (base URL) is needed because `req.url` doesn't come with a
+    // protocol or host.
+    const url     = new URL(req.url, 'http://x.x');
+
+    const details = {
+      ip:     'TBD', // **TODO**
+      method: req.method,
+      query:  fromPairs([...url.searchParams])
+    };
+
+    this._log.event.websocketRequest(id, url.pathname, details, req.headers);
+
+    // Turn the response array into a status code and an object that matches the
+    // form of the usual `headers` on an HTTP response object.
+
+    const statusString    = responseHeaderLines[0].match(/^HTTP[^ ]* ([0-9]+)/)[1];
+    const statusInt       = parseInt(statusString);
+    const status          = isNaN(statusInt) ? statusString : statusInt;
+    const responseHeaders = {};
+
+    for (let i = 1; i < responseHeaderLines.length; i++) {
+      const match = responseHeaderLines[i].match(/([^:]+): *(.*[^ ]) *$/);
+      responseHeaders[match[1].toLowerCase()] = match[2];
+    }
+
+    this._log.event.websocketResponse(id, status, responseHeaders);
   }
 
   /**
@@ -44,52 +86,27 @@ export default class RequestLogger extends CommonBase {
    * @param {function} next Function to call in order to continue request
    *   dispatch.
    */
-  _logRequest(req, res, next) {
-    const isWs = RequestLogger._isWsRequest(req);
+  _logExpressRequest(req, res, next) {
+    const id = Random.shortLabel('req');
 
-    // `express-ws` appends a pseudo-path `/.websocket` to the end of
-    // websocket requests. We chop that off here.
-    const url = isWs
-      ? req.originalUrl.replace(/[/]\.websocket$/, '')
-      : req.originalUrl;
-
-    // **Note:** `url` is put in the top-level event and not the details
-    // because it is so handy and deserves prominent placement.
-    const requestDetails = {
-      hostname: req.hostname,
+    // **Note:** This doesn't include `url` or `headers`, as those end up in the
+    // top level of the logged event because they are so handy and deserve
+    // prominent placement.
+    const details = {
       ip:       req.ip,
       method:   req.method,
-      params:   req.params,
       query:    req.query
     };
 
-    if (isWs) {
-      this._log.event.wsRequest(url, requestDetails, req.headers);
-    } else {
-      const id = Random.shortLabel('req');
+    this._log.event.httpRequest(id, req.originalUrl, details, req.headers);
 
-      this._log.event.httpRequest(id, url, requestDetails, req.headers);
-
-      res.on('finish', () => {
-        // Make the headers a plain object, so it gets logged in a clean
-        // fashion.
-        const responseHeaders = Object.assign({}, res.getHeaders());
-        this._log.event.httpResponse(id, res.statusCode, responseHeaders);
-      });
-    }
+    res.on('finish', () => {
+      // Make the headers a plain object, so it gets logged in a clean
+      // fashion.
+      const responseHeaders = Object.assign({}, res.getHeaders());
+      this._log.event.httpResponse(id, res.statusCode, responseHeaders);
+    });
 
     next();
-  }
-
-  /**
-   * Returns whether or not the given request is a websocket request.
-   *
-   * @param {object} req Request object.
-   * @returns {boolean} `true` iff the given request is a websocket request.
-   */
-  static _isWsRequest(req) {
-    // Case doesn't matter, hence the regex test instead of just `===`.
-    const upgrade = req.get('upgrade');
-    return (upgrade !== undefined) && upgrade.match(/^websocket$/i);
   }
 }

--- a/local-modules/@bayou/deps-compiler/package.json
+++ b/local-modules/@bayou/deps-compiler/package.json
@@ -10,7 +10,7 @@
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",
     "html-loader": "^0.5.5",
-    "less": "^2.7.2",
+    "less": "^3.0.4",
     "less-loader": "^4.1.0",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.21.0",

--- a/local-modules/@bayou/deps-express/package.json
+++ b/local-modules/@bayou/deps-express/package.json
@@ -4,6 +4,6 @@
 
   "dependencies": {
     "express": "^4.16.0",
-    "express-ws": "^3.0.0"
+    "ws": "^5.2.0"
   }
 }

--- a/local-modules/@bayou/see-all-server/HumanSink.js
+++ b/local-modules/@bayou/see-all-server/HumanSink.js
@@ -330,9 +330,7 @@ export default class HumanSink extends BaseSink {
     const skipEnd  = this._skipEndTime;
 
     if (!HumanSink._isSkippable(logRecord)) {
-      if (timeMsec >= skipEnd) {
-        emitSkipLogIfNecessary();
-      }
+      emitSkipLogIfNecessary();
       return false;
     } else if (timeMsec >= skipEnd) {
       emitSkipLogIfNecessary();

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.36.0
+version = 0.36.1


### PR DESCRIPTION
This PR updates the two remaining module dependencies that were sources of known security issues:

* `less` — Updated from v2 to v3 with no muss no fuss (that is, no code changes required).
* `express-ws` — Removed this dependency, as it is a de facto unmaintained project. Instead, our code now uses the `ws` module directly… which is the same well-maintained module that `express-ws` uses, except that `express-ws` depends on an outdated and insecure version. In the end the code changes to do this were pretty modest, but it did take a fair amount of head scratching, poking, prodding, and tweaking to land at a working solution.

Bumped the product version, to commemorate the fact that we no longer have any known security issues.

**Bonus:** Fixed the "human-oriented" console logger with regard to how it (intentionally) skips logging messages when faced with a rapid torrent of logging events.