### PR TITLE
More server code rearrangement.

### DIFF
--- a/local-modules/@bayou/main-server/index.js
+++ b/local-modules/@bayou/main-server/index.js
@@ -4,31 +4,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { injectAll } from '@bayou/config-common-default';
-import { Action, Options, TopErrorHandler } from '@bayou/server-top';
+import { Server } from '@bayou/server-top';
 
-TopErrorHandler.init();
-
-/** {Options} Parsed command-line arguments / options. */
-const options = new Options(process.argv);
-
-if (options.errorMessage !== null) {
-  // eslint-disable-next-line no-console
-  console.log(`${options.errorMessage}\n`);
-  options.usage();
-  process.exit(1);
-}
-
-// Inject all the system configs. **TODO:** This module needs to be split
-// apart such that a _different_ "main" module can choose to perform different
-// configuration and still reuse most of the code defined in _this_ module.
-injectAll();
-
-// Dispatch the selected top-level action.
-(async () => {
-  const resultPromise = new Action(options).run();
-  const exitCode      = await resultPromise;
-
-  if (exitCode !== null) {
-    process.exit(exitCode);
-  }
-})();
+Server.runAndExit(process.argv, injectAll);

--- a/local-modules/@bayou/server-top/Server.js
+++ b/local-modules/@bayou/server-top/Server.js
@@ -1,0 +1,67 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TArray, TFunction, TString } from '@bayou/typecheck';
+import { UtilityClass } from '@bayou/util-common';
+
+import Action from './Action';
+import Options from './Options';
+import TopErrorHandler from './TopErrorHandler';
+
+/**
+ * Top-level logic for starting a server or running server actions (such as unit
+ * tests).
+ */
+export default class Server extends UtilityClass {
+  /**
+   * Starts the server or runs a server action (such as a unit test), based on
+   * the given command-line arguments.
+   *
+   * @param {array<string>} args Command-line arguments to parse and act upon.
+   * @param {function} configFunction Function to call in order to perform
+   *   system configuration. This is called very early, but _after_ some
+   *   fundamental system setup is performed.
+   * @returns {Int|null} Process exit code as returned by the action
+   *   implementation (see {@link Action#run}), or `null` to indicate that the
+   *   process should not exit once the immediate action is complete.
+   */
+  static async run(args, configFunction) {
+    TArray.check(args, TString.check);
+    TFunction.checkCallable(configFunction);
+
+    TopErrorHandler.init();
+
+    /** {Options} Parsed command-line arguments / options. */
+    const options = new Options(args);
+
+    if (options.errorMessage !== null) {
+      // eslint-disable-next-line no-console
+      console.log(`${options.errorMessage}\n`);
+      options.usage();
+      return 1;
+    }
+
+    // Perform system configuration, as driven / defined by the caller of this
+    // function.
+    configFunction();
+
+    // Dispatch the selected top-level action.
+    return new Action(options).run();
+  }
+
+  /**
+   * Calls {@link #run}, and responds to a non-`null` return value by exiting
+   * the process.
+   *
+   * @param {array<string>} args Same as for {@link #run}.
+   * @param {function} configFunction Same as for {@link #run}.
+   */
+  static async runAndExit(args, configFunction) {
+    const exitCode = await Server.run(args, configFunction);
+
+    if (exitCode !== null) {
+      process.exit(exitCode);
+    }
+  }
+}

--- a/local-modules/@bayou/server-top/index.js
+++ b/local-modules/@bayou/server-top/index.js
@@ -14,6 +14,7 @@ import 'babel-polyfill';
 
 import Action from './Action';
 import Options from './Options';
+import Server from './Server';
 import TopErrorHandler from './TopErrorHandler';
 
-export { Action, Options, TopErrorHandler };
+export { Action, Options, Server, TopErrorHandler };

--- a/scripts/build
+++ b/scripts/build
@@ -40,7 +40,7 @@ buildProjects=(compiler server client bin product-info)
 overlayDir=''
 
 # Name of the `main` module for the server, if specified.
-serverMain=''
+mainServer=''
 
 # Options to pass to `out-dir-setup`.
 outOpts=()
@@ -63,8 +63,8 @@ while true; do
         --overlay=?*)
             overlayDir="${1#*=}"
             ;;
-        --server-main=?*)
-            serverMain="${1#*=}"
+        --main-server=?*)
+            mainServer="${1#*=}"
             ;;
         --) # End of all options
             shift
@@ -96,7 +96,7 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Place output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
-    echo '  --server-main=<name>'
+    echo '  --main-server=<name>'
     echo '    Name of the main module for the server.'
     echo ''
     echo "${progName} [--help | -h]"
@@ -434,7 +434,7 @@ function build-server {
     fi
 
     # Do the initial npm(ish) installation.
-    do-install server "${serverMain}" || return 1
+    do-install server "${mainServer}" || return 1
 
     # Run Babel on all of the local source files, storing them next to the
     # imported and patched modules.

--- a/scripts/build
+++ b/scripts/build
@@ -39,6 +39,9 @@ buildProjects=(compiler server client bin product-info)
 # Overlay source directory, if any.
 overlayDir=''
 
+# Name of the `main` module for the server, if specified.
+serverMain=''
+
 # Options to pass to `out-dir-setup`.
 outOpts=()
 
@@ -59,6 +62,9 @@ while true; do
             ;;
         --overlay=?*)
             overlayDir="${1#*=}"
+            ;;
+        --server-main=?*)
+            serverMain="${1#*=}"
             ;;
         --) # End of all options
             shift
@@ -90,6 +96,8 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Place output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
+    echo '  --server-main=<name>'
+    echo '    Name of the main module for the server.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -291,17 +299,26 @@ function copy-sources {
     echo 'Copying sources... done.'
 }
 
-# Does an `npm install` of the indicated "main" module, in a directory with a
-# name that matches. (E.g., given `server`, it will install `@bayou/main-server`
-# into the directory `server`.) After installation, applies local patches to
-# installed external modules.
+# Does an `npm install` of the named top-level subproject, for a single given
+# module dependency. For example, given `florp @zorch/blort`, this will install
+# the module `@zorch/blort` into the directory `florp` under the `out`
+# directory. If the second argument is omitted, this uses the usual "main"
+# module name for the subproject, e.g. for `florp` it will install
+# `@bayou/main-florp` by default.
+#
+# After installation, this applies local patches to installed external modules.
 function do-install {
-    local moduleName="$1"
-    local toDir="${outDir}/${moduleName}"
+    local subprojectName="$1"
+    local moduleName="$2"
+    local toDir="${outDir}/${subprojectName}"
     local npmDir="${toDir}/from-npm"
     local packageJson="${toDir}/package.json"
     local npmPackageJson="${toDir}/package-npm.json"
     local npmBinDir="${npmDir}/node_modules/.bin"
+
+    if [[ ${moduleName} == '' ]]; then
+        moduleName="@bayou/main-${subprojectName}"
+    fi
 
     mkdir -p "${toDir}"
 
@@ -311,8 +328,8 @@ function do-install {
     # would change from time to time. **TODO:** Fix this janky bit of cruft.
     (
         echo '{'
-        echo "    \"name\": \"@bayou/top-package-for-${moduleName}\","
-        echo "    \"dependencies\": { \"@bayou/main-${moduleName}\": \"local\" },"
+        echo "    \"name\": \"@bayou/top-package-for-${subprojectName}\","
+        echo "    \"dependencies\": { \"${moduleName}\": \"local\" },"
 
         # These are irrelevant and are included just to prevent
         # `npm install` from complaining.
@@ -327,7 +344,7 @@ function do-install {
     # Integrates local module dependencies into this package. It copies the
     # required local modules and also rewrites the top-level `package.json` so
     # that it lists the transitive closure of external module dependencies.
-    echo "${moduleName}:" 'Copying local-module dependencies...'
+    echo "${subprojectName}:" 'Copying local-module dependencies...'
     "${progDir}/lib/copy-local-dependencies" \
         --local-modules="${outDir}/local-modules" "${toDir}" \
     || return 1
@@ -336,12 +353,12 @@ function do-install {
            && cmp --quiet "${npmPackageJson}" "${packageJson}"; then
         # The `package.json` hasn't changed since we `npm install`ed, so we can
         # skip the rest of this function.
-        echo "${moduleName}:" \
+        echo "${subprojectName}:" \
             'No change to external dependencies. Skipping `npm install`.'
         return
     fi
 
-    echo "${moduleName}:" 'Installing external dependencies...'
+    echo "${subprojectName}:" 'Installing external dependencies...'
 
     # This runs `npm install` in a new empty directory, because as of npm v5,
     # npm _really really_ wants to manage all modules under `node_modules`, and
@@ -370,7 +387,7 @@ function do-install {
     # **Note:** We don't just `mv` (or `rsync --delete`) the whole
     # `node_modules` directory, because we want to keep our local modules.
 
-    echo "${moduleName}:" 'Moving external dependencies into place...'
+    echo "${subprojectName}:" 'Moving external dependencies into place...'
 
     local d
     for d in $(cd "${npmDir}/node_modules"; /bin/ls -A); do
@@ -398,7 +415,7 @@ function do-install {
     # subsequent builds.
     rsync-archive "${packageJson}" "${npmPackageJson}" || return 1
 
-    echo "${moduleName}:" 'External dependencies... done.'
+    echo "${subprojectName}:" 'External dependencies... done.'
 }
 
 # Builds the server code. This builds from `server` into `final/server`. The
@@ -417,7 +434,7 @@ function build-server {
     fi
 
     # Do the initial npm(ish) installation.
-    do-install server || return 1
+    do-install server "${serverMain}" || return 1
 
     # Run Babel on all of the local source files, storing them next to the
     # imported and patched modules.

--- a/scripts/develop
+++ b/scripts/develop
@@ -66,6 +66,9 @@ while true; do
         --overlay=?*)
             buildOpts+=("$1");
             ;;
+        --server-main=?*)
+            buildOpts+=("$1");
+            ;;
         --) # End of all options
             shift
             break
@@ -85,7 +88,7 @@ done
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--clean] [--out=<dir>] [--overlay=<dir>]"
+    echo "${progName} [<opt> ...]"
     echo '  Build and run the project, in a live development manner.'
     echo ''
     echo '  --clean'
@@ -94,6 +97,8 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Find (and place) build output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
+    echo '  --server-main=<name>'
+    echo '    Name of the main module for the server.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'

--- a/scripts/develop
+++ b/scripts/develop
@@ -66,7 +66,7 @@ while true; do
         --overlay=?*)
             buildOpts+=("$1");
             ;;
-        --server-main=?*)
+        --main-server=?*)
             buildOpts+=("$1");
             ;;
         --) # End of all options
@@ -97,7 +97,7 @@ if (( ${showHelp} || ${argError} )); then
     echo '    Find (and place) build output in directory <dir>.'
     echo '  --overlay=<dir>'
     echo '    Find overlay source in directory <dir>.'
-    echo '  --server-main=<name>'
+    echo '  --main-server=<name>'
     echo '    Name of the main module for the server.'
     echo ''
     echo "${progName} [--help | -h]"


### PR DESCRIPTION
This PR finishes up what I started in the last one with regard to server-side configuration. Specifically:

* Move the remaining non-trivial server startup logic from `main-server` into `server-top`/
* Add build options so that `@bayou/main-server` is merely the _default_ main server module, which can be overridden by scripts that call `build` or `develop`.
