### PR TITLE
Introduce `config-server` and friends.

### DIFF
--- a/local-modules/@bayou/api-server/BearerToken.js
+++ b/local-modules/@bayou/api-server/BearerToken.js
@@ -3,16 +3,15 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseKey } from '@bayou/api-common';
-import { Hooks } from '@bayou/hooks-server';
+import { Network } from '@bayou/config-server';
 import { TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 /**
  * Bearer token, which is a kind of key which conflates ID and secret.
  * Conflation notwithstanding, some part of a bearer token is always considered
- * to be its "ID." the `@bayou/hooks-server` value `Hooks.theOne.bearerTokens`
- * can be used to control ID derivation (and general validation) of bearer token
- * strings.
+ * to be its "ID." {@link @bayou/config-server/Network#bearerTokens} can be used
+ * to control ID derivation (and general validation) of bearer token strings.
  */
 export default class BearerToken extends BaseKey {
   /**
@@ -47,13 +46,13 @@ export default class BearerToken extends BaseKey {
   constructor(secretToken) {
     TString.minLen(secretToken, 32);
 
-    if (!Hooks.theOne.bearerTokens.isToken(secretToken)) {
+    if (!Network.bearerTokens.isToken(secretToken)) {
       // We don't include any real detail in the error message, as that might
       // inadvertently leak a secret into the logs.
       throw Errors.badValue('(hidden)', 'secret token');
     }
 
-    super('*', Hooks.theOne.bearerTokens.tokenId(secretToken));
+    super('*', Network.bearerTokens.tokenId(secretToken));
 
     /** {string} Secret token. */
     this._secretToken = secretToken;

--- a/local-modules/@bayou/api-server/package.json
+++ b/local-modules/@bayou/api-server/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/codec": "local",
+    "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
-    "@bayou/hooks-server": "local",
     "@bayou/promise-util": "local",
     "@bayou/see-all": "local",
     "@bayou/typecheck": "local",

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -12,7 +12,6 @@ import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Network } from '@bayou/config-server';
 import { Dirs, ProductInfo } from '@bayou/env-server';
-import { Hooks } from '@bayou/hooks-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
 
@@ -65,7 +64,7 @@ export default class Application extends CommonBase {
     this._bindRoot();
     (async () => {
       for (;;) {
-        await Hooks.theOne.bearerTokens.whenRootTokensChange();
+        await Network.bearerTokens.whenRootTokensChange();
         log.info('Root tokens updated.');
         this._bindRoot();
       }
@@ -202,12 +201,13 @@ export default class Application extends CommonBase {
 
   /**
    * Maintains up-to-date bindings for the `rootAccess` object, based on the
-   * root token(s) reported via `@bayou/hooks-server.bearerTokens`. This
-   * includes a promise-chain-based ongoing update mechanism.
+   * root token(s) reported via
+   * {@link @bayou/config-server/Network#bearerTokens}. This includes a
+   * promise-chain-based ongoing update mechanism.
    */
   _bindRoot() {
     const context = this._context;
-    const rootTokens = Hooks.theOne.bearerTokens.rootTokens;
+    const rootTokens = Network.bearerTokens.rootTokens;
 
     if (BearerToken.sameArrays(rootTokens, this._rootTokens)) {
       // No actual change. Note the fact.

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -10,6 +10,7 @@ import ws from 'ws';
 import { BearerToken, Context, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
+import { Network } from '@bayou/config-server';
 import { Dirs, ProductInfo } from '@bayou/env-server';
 import { Hooks } from '@bayou/hooks-server';
 import { Logger } from '@bayou/see-all';
@@ -118,7 +119,7 @@ export default class Application extends CommonBase {
    */
   async start(pickPort = false) {
     const server     = this._server;
-    const port       = pickPort ? 0 : Hooks.theOne.listenPort;
+    const port       = pickPort ? 0 : Network.listenPort;
     const resultPort = await ServerUtil.listen(server, port);
 
     log.info(`Application server port: ${resultPort}`);

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -4,14 +4,15 @@
 
 import { BearerToken } from '@bayou/api-server';
 import { Delay } from '@bayou/promise-util';
-import { Singleton } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 /**
- * Base class for and default implementation of `Hooks.bearerTokens`, which
- * notably serves as documentation for the required methods. See
- * `@bayou/api-server.BearerToken` for more details.
+ * Base class for and default implementation of
+ * {@link @bayou/hooks-server/Hooks#bearerTokens}, which notably serves as
+ * documentation for the required methods. See
+ * {@link @bayou/api-server#BearerToken} for more details.
  */
-export default class BearerTokens extends Singleton {
+export default class BearerTokens extends CommonBase {
   /**
    * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
    * token (whether or not it actually grants any access). This will only ever

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -4,9 +4,9 @@
 
 import { SplitKey } from '@bayou/api-common';
 import { Context } from '@bayou/api-server';
+import { Network } from '@bayou/config-server';
 import { DocumentId } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
-import { Hooks } from '@bayou/hooks-server';
 import { AuthorId } from '@bayou/ot-common';
 import { Logger } from '@bayou/see-all';
 
@@ -47,7 +47,7 @@ export default class RootAccess {
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 
-    const url     = `${Hooks.theOne.baseUrl}/api`;
+    const url     = `${Network.baseUrl}/api`;
     const session = fileComplex.makeNewSession(authorId, this._randomId.bind(this));
     const key     = new SplitKey(url, session.getSessionId());
     this._context.add(key, session);

--- a/local-modules/@bayou/app-setup/index.js
+++ b/local-modules/@bayou/app-setup/index.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Application from './Application';
+import BearerTokens from './BearerTokens';
 import Monitor from './Monitor';
 
-export { Application, Monitor };
+export { Application, BearerTokens, Monitor };

--- a/local-modules/@bayou/app-setup/package.json
+++ b/local-modules/@bayou/app-setup/package.json
@@ -15,7 +15,6 @@
     "@bayou/doc-common": "local",
     "@bayou/doc-server": "local",
     "@bayou/env-server": "local",
-    "@bayou/hooks-server": "local",
     "@bayou/ot-common": "local",
     "@bayou/see-all": "local",
     "@bayou/see-all-server": "local",

--- a/local-modules/@bayou/app-setup/package.json
+++ b/local-modules/@bayou/app-setup/package.json
@@ -8,6 +8,7 @@
     "@bayou/app-common": "local",
     "@bayou/client-bundle": "local",
     "@bayou/codec": "local",
+    "@bayou/config-server": "local",
     "@bayou/deps-ansi-color": "local",
     "@bayou/deps-express": "local",
     "@bayou/deps-util-common": "local",

--- a/local-modules/@bayou/app-setup/tests/test_BearerTokens.js
+++ b/local-modules/@bayou/app-setup/tests/test_BearerTokens.js
@@ -6,20 +6,26 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken } from '@bayou/api-server';
-import { BearerTokens } from '@bayou/hooks-server';
+import { BearerTokens } from '@bayou/app-setup';
 
-const BEARER_TOKENS = BearerTokens.theOne;
+describe('@bayou/app-setup/BearerTokens', () => {
+  describe('constructor', () => {
+    it('should succeed', () => {
+      assert.doesNotThrow(() => new BearerTokens());
+    });
+  });
 
-describe('@bayou/hooks-server/BearerTokens', () => {
-  describe('isToken(tokenString)', () => {
+  describe('isToken()', () => {
     it('should accept any value', () => {
-      assert.isTrue(BEARER_TOKENS.isToken('abc123'));
+      const bt = new BearerTokens();
+      assert.isTrue(bt.isToken('abc123'));
     });
   });
 
   describe('.rootTokens', () => {
-    it('should return an array of BearerToken', () => {
-      const tokens = BEARER_TOKENS.rootTokens;
+    it('should be an array of `BearerToken` instances', () => {
+      const bt     = new BearerTokens();
+      const tokens = bt.rootTokens;
 
       assert.isArray(tokens);
 
@@ -29,10 +35,11 @@ describe('@bayou/hooks-server/BearerTokens', () => {
     });
   });
 
-  describe('tokenId(tokenString)', () => {
+  describe('tokenId()', () => {
     it('should return the first 16 characters of the string passed to it', () => {
+      const bt              = new BearerTokens();
       const fakeTokenString = 'abcdefghijklmnopqrstuvwxyz';
-      const tokenId = BEARER_TOKENS.tokenId(fakeTokenString);
+      const tokenId         = bt.tokenId(fakeTokenString);
 
       assert.strictEqual(tokenId, fakeTokenString.slice(0, 16));
     });
@@ -40,7 +47,8 @@ describe('@bayou/hooks-server/BearerTokens', () => {
 
   describe('whenRootTokensChange()', () => {
     it('should return a promise', () => {
-      const changePromise = BEARER_TOKENS.whenRootTokensChange();
+      const bt            = new BearerTokens();
+      const changePromise = bt.whenRootTokensChange();
 
       assert.property(changePromise, 'then');
       assert.isFunction(changePromise.then);

--- a/local-modules/@bayou/config-common-default/isAuthorId.js
+++ b/local-modules/@bayou/config-common-default/isAuthorId.js
@@ -7,7 +7,7 @@ import { TString } from '@bayou/typecheck';
 /**
  * Implementation of standard configuration point.
  *
- * This implementation  requires that author IDs have no more than 32 characters
+ * This implementation requires that author IDs have no more than 32 characters
  * and only use ASCII alphanumerics plus dash (`-`) and underscore (`_`).
  *
  * @param {string} id The (alleged) author ID to check.

--- a/local-modules/@bayou/config-common-default/isDocumentId.js
+++ b/local-modules/@bayou/config-common-default/isDocumentId.js
@@ -12,7 +12,7 @@ import { TString } from '@bayou/typecheck';
  * (`_`).
  *
  * @param {string} id The (alleged) document ID to check.
- * @returns {boolen} `true` iff `id` is syntactically valid.
+ * @returns {boolean} `true` iff `id` is syntactically valid.
  */
 export default function isDocumentId(id) {
   TString.check(id);

--- a/local-modules/@bayou/config-common/isDocumentId.js
+++ b/local-modules/@bayou/config-common/isDocumentId.js
@@ -13,7 +13,7 @@ import { use } from '@bayou/injecty';
  * and underscore (`_`).
  *
  * @param {string} id The (alleged) document ID to check.
- * @returns {boolen} `true` iff `id` is syntactically valid.
+ * @returns {boolean} `true` iff `id` is syntactically valid.
  */
 export default function isDocumentId(id) {
   return use.isDocumentId(id);

--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { BearerTokens } from '@bayou/app-setup';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
@@ -16,6 +17,17 @@ export default class Network extends UtilityClass {
    */
   static get baseUrl() {
     return `http://localhost:${this.listenPort}`;
+  }
+
+  /**
+   * {BearerTokens} Implementation of standard configuration point.
+   */
+  static get bearerTokens() {
+    if (!this._bearerTokens) {
+      this._bearerTokens = new BearerTokens();
+    }
+
+    return this._bearerTokens;
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -1,0 +1,36 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from '@bayou/util-common';
+
+/**
+ * Utility functionality regarding the network configuration of a server.
+ */
+export default class Network extends UtilityClass {
+  /**
+   * {string} Implementation of standard configuration point.
+   *
+   * This implementation defines this as `http://localhost:N` where `N` is the
+   * value of {@link #listenPort}.
+   */
+  static get baseUrl() {
+    return `http://localhost:${this.listenPort}`;
+  }
+
+  /**
+   * {Int} Implementation of standard configuration point. This implementation
+   * defines it as `8080`.
+   */
+  static get listenPort() {
+    return 8080;
+  }
+
+  /**
+   * {Int|null} Implementation of standard configuration point. This
+   * implementation defines it as `8888`.
+   */
+  static get monitorPort() {
+    return 8888;
+  }
+}

--- a/local-modules/@bayou/config-server-default/README.md
+++ b/local-modules/@bayou/config-server-default/README.md
@@ -1,0 +1,5 @@
+@bayou/config-server-default
+============================
+
+This module contains all the default implementations for the configuration
+points defined by `@bayou/config-server`.

--- a/local-modules/@bayou/config-server-default/index.js
+++ b/local-modules/@bayou/config-server-default/index.js
@@ -4,6 +4,7 @@
 
 import { inject } from '@bayou/injecty';
 
+import Network from './Network';
 import isFileId from './isFileId';
 import isRunningInDevelopment from './isRunningInDevelopment';
 
@@ -11,11 +12,13 @@ import isRunningInDevelopment from './isRunningInDevelopment';
  * Injects all of the definitions here into the global configuration.
  */
 function injectAll() {
+  inject.Network                = Network;
   inject.isFileId               = isFileId;
   inject.isRunningInDevelopment = isRunningInDevelopment;
 }
 
 export {
+  Network,
   injectAll,
   isFileId,
   isRunningInDevelopment

--- a/local-modules/@bayou/config-server-default/index.js
+++ b/local-modules/@bayou/config-server-default/index.js
@@ -1,0 +1,22 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { inject } from '@bayou/injecty';
+
+import isFileId from './isFileId';
+import isRunningInDevelopment from './isRunningInDevelopment';
+
+/**
+ * Injects all of the definitions here into the global configuration.
+ */
+function injectAll() {
+  inject.isFileId               = isFileId;
+  inject.isRunningInDevelopment = isRunningInDevelopment;
+}
+
+export {
+  injectAll,
+  isFileId,
+  isRunningInDevelopment
+};

--- a/local-modules/@bayou/config-server-default/isFileId.js
+++ b/local-modules/@bayou/config-server-default/isFileId.js
@@ -1,0 +1,18 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { isDocumentId } from '@bayou/config-common';
+
+/**
+ * Implementation of standard configuration point.
+ *
+ * This implementation defers to the configured function
+ * {@link @bayou/config-common#isDocumentId}.
+ *
+ * @param {string} id The (alleged) file ID to check.
+ * @returns {boolean} `true` iff `id` is syntactically valid.
+ */
+export default function isFileId(id) {
+  return isDocumentId(id);
+}

--- a/local-modules/@bayou/config-server-default/isRunningInDevelopment.js
+++ b/local-modules/@bayou/config-server-default/isRunningInDevelopment.js
@@ -1,0 +1,14 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+/**
+ * Implementation of standard configuration point.
+ *
+ * This implementation always returns `true`.
+ *
+ * @returns {boolean} `true`, always.
+ */
+export default function isRunningInDevelopment() {
+  return true;
+}

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@bayou/config-server-default",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "@bayou/config-common": "local"
+  }
+}

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
 
   "dependencies": {
+    "@bayou/app-setup": "local",
     "@bayou/config-common": "local",
     "@bayou/config-server": "local"
   }

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
 
   "dependencies": {
-    "@bayou/config-common": "local"
+    "@bayou/config-common": "local",
+    "@bayou/config-server": "local"
   }
 }

--- a/local-modules/@bayou/config-server-default/tests/test_Network.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Network.js
@@ -5,12 +5,19 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
+import { BearerTokens } from '@bayou/app-setup';
 import { Network } from '@bayou/config-server-default';
 
 describe('@bayou/config-server-default/Network', () => {
   describe('.baseUrl', () => {
     it('should be `http://localhost:8080`', () => {
       assert.strictEqual(Network.baseUrl, 'http://localhost:8080');
+    });
+  });
+
+  describe('.bearerTokens', () => {
+    it('should return an instance of `BearerTokens`', () => {
+      assert.instanceOf(Network.bearerTokens, BearerTokens);
     });
   });
 

--- a/local-modules/@bayou/config-server-default/tests/test_Network.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Network.js
@@ -1,0 +1,28 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Network } from '@bayou/config-server-default';
+
+describe('@bayou/config-server-default/Network', () => {
+  describe('.baseUrl', () => {
+    it('should be `http://localhost:8080`', () => {
+      assert.strictEqual(Network.baseUrl, 'http://localhost:8080');
+    });
+  });
+
+  describe('.listenPort', () => {
+    it('should be `8080`', () => {
+      assert.strictEqual(Network.listenPort, 8080);
+    });
+  });
+
+  describe('.monitorPort', () => {
+    it('should be `8888`', () => {
+      assert.strictEqual(Network.monitorPort, 8888);
+    });
+  });
+});

--- a/local-modules/@bayou/config-server-default/tests/test_isFileId.js
+++ b/local-modules/@bayou/config-server-default/tests/test_isFileId.js
@@ -5,24 +5,24 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { isDocumentId } from '@bayou/config-common-default';
+import { isFileId } from '@bayou/config-server-default';
 
-describe('@bayou/config-common-default', () => {
-  describe('isDocumentId()', () => {
+describe('@bayou/config-server-default', () => {
+  describe('isFileId()', () => {
     it('should accept 32-character alphanum ASCII strings', () => {
-      assert.isTrue(isDocumentId('123abc7890ABC456789012'));
+      assert.isTrue(isFileId('123abc7890ABC456789012'));
     });
 
     it('should allow underscores and hyphens', () => {
-      assert.isTrue(isDocumentId('123456789_123456789-12'));
+      assert.isTrue(isFileId('123456789_123456789-12'));
     });
 
     it('should not allow non-ASCII characters', () => {
-      assert.isFalse(isDocumentId('123456789•123456789•12'));
+      assert.isFalse(isFileId('123456789•123456789•12'));
     });
 
     it('should not allow non-alphanum characters', () => {
-      assert.isFalse(isDocumentId('123456789\t123456789+12'));
+      assert.isFalse(isFileId('123456789\t123456789+12'));
     });
   });
 });

--- a/local-modules/@bayou/config-server-default/tests/test_isRunningInDevelopment.js
+++ b/local-modules/@bayou/config-server-default/tests/test_isRunningInDevelopment.js
@@ -1,0 +1,16 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { isRunningInDevelopment } from '@bayou/config-server-default';
+
+describe('@bayou/config-server-default', () => {
+  describe('isRunningInDevelopment()', () => {
+    it('should return `true`', () => {
+      assert.isTrue(isRunningInDevelopment());
+    });
+  });
+});

--- a/local-modules/@bayou/config-server/Network.js
+++ b/local-modules/@bayou/config-server/Network.js
@@ -18,6 +18,14 @@ export default class Network extends UtilityClass {
   }
 
   /**
+   * {BearerTokens} The object which validates and authorizes bearer tokens.
+   * See that (base / default) class for details.
+   */
+  static get bearerTokens() {
+    return use.Network.bearerTokens;
+  }
+
+  /**
    * {Int} The local port to listen for connections on.
    *
    * **Note:** This can get overridden when running the system for the purposes

--- a/local-modules/@bayou/config-server/Network.js
+++ b/local-modules/@bayou/config-server/Network.js
@@ -1,0 +1,38 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { use } from '@bayou/injecty';
+import { UtilityClass } from '@bayou/util-common';
+
+/**
+ * Utility functionality regarding the network configuration of a server.
+ */
+export default class Network extends UtilityClass {
+  /**
+   * {string} The base URL to use when constructing URLs to point at the
+   * public-facing (set of) machine(s) which front for this server.
+   */
+  static get baseUrl() {
+    return use.Network.baseUrl;
+  }
+
+  /**
+   * {Int} The local port to listen for connections on.
+   *
+   * **Note:** This can get overridden when running the system for the purposes
+   * of unit testing, so it isn't safe to rely on it to always reflect what's
+   * running.
+   */
+  static get listenPort() {
+    return use.Network.listenPort;
+  }
+
+  /**
+   * {Int|null} The local port to use for internal monitoring, or `null` to
+   * not expose monitoring endpoints.
+   */
+  static get monitorPort() {
+    return use.Network.monitorPort;
+  }
+}

--- a/local-modules/@bayou/config-server/README.md
+++ b/local-modules/@bayou/config-server/README.md
@@ -1,0 +1,12 @@
+@bayou/config-server
+====================
+
+This module contains convenient accessors (and documentation) for all the
+injected configuration that is required just on the serve sides of the system.
+
+**Note:** The implementation of this module intentionally defers grabbing
+injected configuration until the moment of use, so as to give the main
+application the maximum possible amount of time and leeway to set things up.
+
+**TODO:** This module is extremely boilerplate-y, and should instead be
+table-driven by utility functionality in `@bayou/injecty` (to be written).

--- a/local-modules/@bayou/config-server/index.js
+++ b/local-modules/@bayou/config-server/index.js
@@ -2,10 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import Network from './Network';
 import isFileId from './isFileId';
 import isRunningInDevelopment from './isRunningInDevelopment';
 
 export {
+  Network,
   isFileId,
   isRunningInDevelopment
 };

--- a/local-modules/@bayou/config-server/index.js
+++ b/local-modules/@bayou/config-server/index.js
@@ -1,0 +1,11 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import isFileId from './isFileId';
+import isRunningInDevelopment from './isRunningInDevelopment';
+
+export {
+  isFileId,
+  isRunningInDevelopment
+};

--- a/local-modules/@bayou/config-server/isFileId.js
+++ b/local-modules/@bayou/config-server/isFileId.js
@@ -1,0 +1,16 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { use } from '@bayou/injecty';
+
+/**
+ * Checks whether the given value is syntactically valid as a file ID.
+ * This method is only ever called with a non-empty string.
+ *
+ * @param {string} id The (alleged) file ID to check.
+ * @returns {boolean} `true` iff `id` is syntactically valid.
+ */
+export default function isFileId(id) {
+  return use.isFileId(id);
+}

--- a/local-modules/@bayou/config-server/isRunningInDevelopment.js
+++ b/local-modules/@bayou/config-server/isRunningInDevelopment.js
@@ -1,0 +1,19 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { use } from '@bayou/injecty';
+
+/**
+ * Checks to see if this server is running in a "development" environment,
+ * returning an indication of the fact. A development environment is notable
+ * in that it notices when source files change (and acts accordingly), has
+ * `/debug` endpoints enabled, and may be less secure in other ways as a
+ * tradeoff for higher internal visibility, that is, higher debugability.
+ *
+ * @returns {boolean} `true` if this server is running in a development
+ *   environment, or `false` if not.
+ */
+export default function isRunningInDevelopment() {
+  return use.isRunningInDevelopment();
+}

--- a/local-modules/@bayou/config-server/package.json
+++ b/local-modules/@bayou/config-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@bayou/config-server",
+  "version": "1.0.0",
+
+  "dependencies": {
+    "@bayou/injecty": "local"
+  }
+}

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -5,7 +5,7 @@
 import is_running from 'is-running';
 import http from 'http';
 
-import { Hooks } from '@bayou/hooks-server';
+import { Network } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Errors, Singleton } from '@bayou/util-common';
 
@@ -25,7 +25,7 @@ export default class ServerEnv extends Singleton {
    * is always an `http://localhost/` URL.
    */
   get loopbackUrl() {
-    return `http://localhost:${Hooks.theOne.listenPort}`;
+    return `http://localhost:${Network.listenPort}`;
   }
 
   /**

--- a/local-modules/@bayou/env-server/package.json
+++ b/local-modules/@bayou/env-server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
 
   "dependencies": {
+    "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/hooks-server": "local",
     "@bayou/proppy": "local",

--- a/local-modules/@bayou/env-server/tests/test_ProductInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_ProductInfo.js
@@ -12,11 +12,6 @@ describe('@bayou/env-server/ProductInfo', () => {
   describe('.INFO', () => {
     it('should return an object full of product info', () => {
       const info = ProductInfo.theOne.INFO;
-
-      // TODO: This list of keys is currently an amalgam of those from Bayou
-      // and those from a privately-used overlay. Ugh. Not good. This should
-      // probably be broken out into two separate tests so that each
-      // environment's expected contributions can be tested independently.
       const productKeys = ['name', 'version', 'commit_id', 'commit_date', 'build_date'];
 
       assert.doesNotThrow(() => TObject.withExactKeys(info, productKeys));

--- a/local-modules/@bayou/file-store/FileId.js
+++ b/local-modules/@bayou/file-store/FileId.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Hooks } from '@bayou/hooks-server';
+import { isFileId } from '@bayou/config-server';
 import { Errors, UtilityClass } from '@bayou/util-common';
 
 /**
@@ -30,7 +30,7 @@ export default class FileId extends UtilityClass {
   static check(value) {
     if (   (typeof value !== 'string')
         || (value.length === 0)
-        || !Hooks.theOne.isFileId(value)) {
+        || !isFileId(value)) {
       throw Errors.badValue(value, FileId);
     }
 

--- a/local-modules/@bayou/file-store/package.json
+++ b/local-modules/@bayou/file-store/package.json
@@ -4,9 +4,9 @@
 
   "dependencies": {
     "@bayou/codec": "local",
+    "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/file-store-ot": "local",
-    "@bayou/hooks-server": "local",
     "@bayou/promise-util": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/hooks-server/Hooks.js
+++ b/local-modules/@bayou/hooks-server/Hooks.js
@@ -5,7 +5,6 @@
 import path from 'path';
 
 import { LocalFileStore } from '@bayou/file-store-local';
-import { isDocumentId } from '@bayou/config-common';
 import { Singleton } from '@bayou/util-common';
 
 import BearerTokens from './BearerTokens';
@@ -96,36 +95,6 @@ export default class Hooks extends Singleton {
    */
   findVarDirectory(baseDir) {
     return path.join(baseDir, 'var');
-  }
-
-  /**
-   * Checks whether the given value is syntactically valid as a file ID.
-   * This method is only ever called with a non-empty string.
-   *
-   * The default implementation of this method defers to the configured function
-   * {@link @bayou/config-common#isDocumentId}.
-   *
-   * @param {string} id The (alleged) file ID to check.
-   * @returns {boolen} `true` iff `id` is syntactically valid.
-   */
-  isFileId(id) {
-    return isDocumentId(id);
-  }
-
-  /**
-   * Checks to see if this server is running in a "development" environment,
-   * returning an indication of the fact. A development environment is notable
-   * in that it notices when source files change (and acts accordingly), has
-   * `/debug` endpoints enabled, and may be less secure in other ways as a
-   * tradeoff for higher internal visibility, that is, higher debugability.
-   *
-   * The default implementation of this method always returns `true`.
-   *
-   * @returns {boolean} `true` if this server is running in a development
-   *   environment, or `false` if not.
-   */
-  isRunningInDevelopment() {
-    return true;
   }
 
   /**

--- a/local-modules/@bayou/hooks-server/Hooks.js
+++ b/local-modules/@bayou/hooks-server/Hooks.js
@@ -7,8 +7,6 @@ import path from 'path';
 import { LocalFileStore } from '@bayou/file-store-local';
 import { Singleton } from '@bayou/util-common';
 
-import BearerTokens from './BearerTokens';
-
 /**
  * Hooks into various server operations. This is meant to make it easy for
  * complete products to customize Bayou without overlaying the original
@@ -20,19 +18,6 @@ export default class Hooks extends Singleton {
    */
   constructor() {
     super();
-
-    /**
-     * {BearerTokens} Unique system-wide instance for managing bearer tokens.
-     */
-    this._bearerTokens = new BearerTokens();
-  }
-
-  /**
-   * {BearerTokens} The object which validates and authorizes bearer tokens.
-   * See that (base / default) class for details.
-   */
-  get bearerTokens() {
-    return this._bearerTokens;
   }
 
   /**

--- a/local-modules/@bayou/hooks-server/Hooks.js
+++ b/local-modules/@bayou/hooks-server/Hooks.js
@@ -28,17 +28,6 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {string} The base URL to use when constructing URLs to point at the
-   * public-facing (set of) machine(s) which front for this server.
-   *
-   * The default value for this is `http://localhost:N` where `N` is the value
-   * of {@link #listenPort}.
-   */
-  get baseUrl() {
-    return `http://localhost:${this.listenPort}`;
-  }
-
-  /**
    * {BearerTokens} The object which validates and authorizes bearer tokens.
    * See that (base / default) class for details.
    */

--- a/local-modules/@bayou/hooks-server/Hooks.js
+++ b/local-modules/@bayou/hooks-server/Hooks.js
@@ -17,6 +17,18 @@ import BearerTokens from './BearerTokens';
  */
 export default class Hooks extends Singleton {
   /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {BearerTokens} Unique system-wide instance for managing bearer tokens.
+     */
+    this._bearerTokens = new BearerTokens();
+  }
+
+  /**
    * {string} The base URL to use when constructing URLs to point at the
    * public-facing (set of) machine(s) which front for this server.
    *
@@ -32,7 +44,7 @@ export default class Hooks extends Singleton {
    * See that (base / default) class for details.
    */
   get bearerTokens() {
-    return BearerTokens.theOne;
+    return this._bearerTokens;
   }
 
   /**

--- a/local-modules/@bayou/hooks-server/Hooks.js
+++ b/local-modules/@bayou/hooks-server/Hooks.js
@@ -31,29 +31,6 @@ export default class Hooks extends Singleton {
   }
 
   /**
-   * {Int} The local port to listen for connections on by default. This
-   * typically but does not _necessarily_ match the values returned by
-   * {@link #baseUrl}. It won't match in cases where this server runs behind a
-   * reverse proxy, for example. It also won't match when the system is brought
-   * up in `test` mode, as that mode will pick an arbitrary port to listen on.
-   *
-   * This (default) implementation of the property always returns `8080`.
-   */
-  get listenPort() {
-    return 8080;
-  }
-
-  /**
-   * {Int|null} The local port to use for internal monitoring, or `null` to
-   * not expose monitoring endpoints.
-   *
-   * This (default) implementation of the property always returns `8888`.
-   */
-  get monitorPort() {
-    return 8888;
-  }
-
-  /**
    * Determines the location of the "var" (variable / mutable data) directory,
    * returning an absolute path to it. (This is where, for example, log files
    * are stored.) The directory need not exist; the system will take care of

--- a/local-modules/@bayou/hooks-server/index.js
+++ b/local-modules/@bayou/hooks-server/index.js
@@ -9,7 +9,6 @@
 
 import { DataUtil, DeferredLoader } from '@bayou/util-common';
 
-import BearerTokens from './BearerTokens';
 import default_document from './default-document';
 
 const Hooks = DeferredLoader.makeProxy(
@@ -20,4 +19,4 @@ const Hooks = DeferredLoader.makeProxy(
 
 const DEFAULT_DOCUMENT = DataUtil.deepFreeze(default_document);
 
-export { DEFAULT_DOCUMENT, BearerTokens, Hooks };
+export { DEFAULT_DOCUMENT, Hooks };

--- a/local-modules/@bayou/hooks-server/tests/test_Hooks.js
+++ b/local-modules/@bayou/hooks-server/tests/test_Hooks.js
@@ -20,10 +20,4 @@ describe('@bayou/hooks-server/Hooks', () => {
       assert.instanceOf(Hooks.theOne.fileStore, BaseFileStore);
     });
   });
-
-  describe('.listenPort', () => {
-    it('should return the documented value', () => {
-      assert.strictEqual(Hooks.theOne.listenPort, 8080);
-    });
-  });
 });

--- a/local-modules/@bayou/hooks-server/tests/test_Hooks.js
+++ b/local-modules/@bayou/hooks-server/tests/test_Hooks.js
@@ -6,15 +6,9 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseFileStore } from '@bayou/file-store';
-import { BearerTokens, Hooks } from '@bayou/app-setup';
+import { Hooks } from '@bayou/app-setup';
 
 describe('@bayou/hooks-server/Hooks', () => {
-  describe('.bearerTokens', () => {
-    it('should return an instance of `BearerTokens`', () => {
-      assert.instanceOf(Hooks.theOne.bearerTokens, BearerTokens);
-    });
-  });
-
   describe('.fileStore', () => {
     it('should return an instance of BaseFileStore', () => {
       assert.instanceOf(Hooks.theOne.fileStore, BaseFileStore);

--- a/local-modules/@bayou/hooks-server/tests/test_Hooks.js
+++ b/local-modules/@bayou/hooks-server/tests/test_Hooks.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseFileStore } from '@bayou/file-store';
-import { Hooks } from '@bayou/app-setup';
+import { Hooks } from '@bayou/hooks-server';
 
 describe('@bayou/hooks-server/Hooks', () => {
   describe('.fileStore', () => {

--- a/local-modules/@bayou/hooks-server/tests/test_Hooks.js
+++ b/local-modules/@bayou/hooks-server/tests/test_Hooks.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseFileStore } from '@bayou/file-store';
-import { BearerTokens, Hooks } from '@bayou/hooks-server';
+import { BearerTokens, Hooks } from '@bayou/app-setup';
 
 describe('@bayou/hooks-server/Hooks', () => {
   describe('.bearerTokens', () => {
@@ -21,7 +21,7 @@ describe('@bayou/hooks-server/Hooks', () => {
     });
   });
 
-  describe('isFileId(id)', () => {
+  describe('isFileId()', () => {
     it('should accept 32-character alphanum ASCII strings', () => {
       assert.isTrue(Hooks.theOne.isFileId('123abc7890ABC456789012'));
     });

--- a/local-modules/@bayou/hooks-server/tests/test_Hooks.js
+++ b/local-modules/@bayou/hooks-server/tests/test_Hooks.js
@@ -21,24 +21,6 @@ describe('@bayou/hooks-server/Hooks', () => {
     });
   });
 
-  describe('isFileId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
-      assert.isTrue(Hooks.theOne.isFileId('123abc7890ABC456789012'));
-    });
-
-    it('should allow underscores and hyphens', () => {
-      assert.isTrue(Hooks.theOne.isFileId('123456789_123456789-12'));
-    });
-
-    it('should not allow non-ASCII characters', () => {
-      assert.isFalse(Hooks.theOne.isFileId('123456789•123456789•12'));
-    });
-
-    it('should not allow non-alphanum characters', () => {
-      assert.isFalse(Hooks.theOne.isFileId('123456789\t123456789+12'));
-    });
-  });
-
   describe('.listenPort', () => {
     it('should return the documented value', () => {
       assert.strictEqual(Hooks.theOne.listenPort, 8080);

--- a/local-modules/@bayou/main-server/index.js
+++ b/local-modules/@bayou/main-server/index.js
@@ -3,7 +3,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { injectAll } from '@bayou/config-common-default';
+import { Common_injectAll } from '@bayou/config-common-default';
+import { Server_injectAll } from '@bayou/config-server-default';
 import { Server } from '@bayou/server-top';
+
+function injectAll() {
+  Common_injectAll();
+  Server_injectAll();
+}
 
 Server.runAndExit(process.argv, injectAll);

--- a/local-modules/@bayou/main-server/index.js
+++ b/local-modules/@bayou/main-server/index.js
@@ -3,8 +3,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Common_injectAll } from '@bayou/config-common-default';
-import { Server_injectAll } from '@bayou/config-server-default';
+import { injectAll as Common_injectAll } from '@bayou/config-common-default';
+import { injectAll as Server_injectAll } from '@bayou/config-server-default';
 import { Server } from '@bayou/server-top';
 
 function injectAll() {

--- a/local-modules/@bayou/main-server/index.js
+++ b/local-modules/@bayou/main-server/index.js
@@ -3,13 +3,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { injectAll as Common_injectAll } from '@bayou/config-common-default';
-import { injectAll as Server_injectAll } from '@bayou/config-server-default';
+import { injectAll as common_injectAll } from '@bayou/config-common-default';
+import { injectAll as server_injectAll } from '@bayou/config-server-default';
 import { Server } from '@bayou/server-top';
 
 function injectAll() {
-  Common_injectAll();
-  Server_injectAll();
+  common_injectAll();
+  server_injectAll();
 }
 
 Server.runAndExit(process.argv, injectAll);

--- a/local-modules/@bayou/main-server/package.json
+++ b/local-modules/@bayou/main-server/package.json
@@ -8,6 +8,7 @@
 
   "dependencies": {
     "@bayou/config-common-default": "local",
+    "@bayou/config-server-default": "local",
     "@bayou/server-top": "local"
   }
 }

--- a/local-modules/@bayou/server-top/Action.js
+++ b/local-modules/@bayou/server-top/Action.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { Application, Monitor } from '@bayou/app-setup';
 import { ClientBundle } from '@bayou/client-bundle';
-import { isRunningInDevelopment } from '@bayou/config-server';
+import { Network, isRunningInDevelopment } from '@bayou/config-server';
 import { DevMode } from '@bayou/dev-mode';
 import { Dirs, ProductInfo, ServerEnv } from '@bayou/env-server';
 import { Hooks } from '@bayou/hooks-server';
@@ -105,7 +105,7 @@ export default class Action extends CommonBase {
     let port;
 
     if (alreadyRunning) {
-      port = Hooks.theOne.listenPort;
+      port = Network.listenPort;
       log.info(
         'NOTE: There is a server already running on this machine. The client test run\n' +
         '      will issue requests to it instead of trying to build a new test bundle.');
@@ -256,7 +256,7 @@ export default class Action extends CommonBase {
     const result = theApp.start(pickPort);
 
     if (doMonitor) {
-      const monitorPort = Hooks.theOne.monitorPort;
+      const monitorPort = Network.monitorPort;
       if (monitorPort !== null) {
         try {
           const monitor = new Monitor(theApp, monitorPort);

--- a/local-modules/@bayou/server-top/Action.js
+++ b/local-modules/@bayou/server-top/Action.js
@@ -7,6 +7,7 @@ import path from 'path';
 
 import { Application, Monitor } from '@bayou/app-setup';
 import { ClientBundle } from '@bayou/client-bundle';
+import { isRunningInDevelopment } from '@bayou/config-server';
 import { DevMode } from '@bayou/dev-mode';
 import { Dirs, ProductInfo, ServerEnv } from '@bayou/env-server';
 import { Hooks } from '@bayou/hooks-server';
@@ -155,7 +156,7 @@ export default class Action extends CommonBase {
    *   code on failure.
    */
   async _run_devIfAppropriate() {
-    if (Hooks.theOne.isRunningInDevelopment()) {
+    if (isRunningInDevelopment()) {
       return this._run_dev();
     } else {
       return this._run_production();

--- a/scripts/clean
+++ b/scripts/clean
@@ -70,7 +70,7 @@ done
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--out=<dir>]"
+    echo "${progName} [<opt> ...]"
     echo '  Clean the project output.'
     echo ''
     echo '  --create'

--- a/scripts/lint
+++ b/scripts/lint
@@ -82,7 +82,7 @@ fi
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--out=<dir>] [--overlay=<dir>] [--] [<file-or-dir> ...]"
+    echo "${progName} [<opt> ...] [--] [<file-or-dir> ...]"
     echo '  Run the linter on the indicated files or directories. With nothing'
     echo '  specified, runs over the entire project (including overlay source'
     echo '  if indicated).'

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -70,7 +70,7 @@ done
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--out=<dir>] [--client] [--client-bundle] [--server]"
+    echo "${progName} [<opt> ...]"
     echo '  Runs the project tests. If no specific tests are specified, runs all'
     echo '  of them.'
     echo ''


### PR DESCRIPTION
This PR is the first of at least two PRs which aim to retire `hooks-server` in favor of the new DI-ish approach. It covers a bit more than half of the configurable properties defined by the system.

**Bonus:** DRYed out some of the script usage messages.