### PR TITLE
DRY out the `package.json` files.

### DIFF
--- a/local-modules/@bayou/api-client/package.json
+++ b/local-modules/@bayou/api-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/api-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/see-all": "local",

--- a/local-modules/@bayou/api-common/package.json
+++ b/local-modules/@bayou/api-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/api-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/codec": "local",
     "@bayou/typecheck": "local",

--- a/local-modules/@bayou/api-server/package.json
+++ b/local-modules/@bayou/api-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/api-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/codec": "local",

--- a/local-modules/@bayou/app-common/package.json
+++ b/local-modules/@bayou/app-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/app-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/codec": "local",

--- a/local-modules/@bayou/app-setup/package.json
+++ b/local-modules/@bayou/app-setup/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/app-setup",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/api-server": "local",

--- a/local-modules/@bayou/assets-client/package.json
+++ b/local-modules/@bayou/assets-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/assets-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/client-bundle/package.json
+++ b/local-modules/@bayou/client-bundle/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/client-bundle",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-compiler": "local",
     "@bayou/deps-util-server": "local",

--- a/local-modules/@bayou/codec/package.json
+++ b/local-modules/@bayou/codec/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/codec",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/config-client-default/package.json
+++ b/local-modules/@bayou/config-client-default/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-client-default",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/injecty": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/config-client/package.json
+++ b/local-modules/@bayou/config-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/injecty": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/config-common-default/package.json
+++ b/local-modules/@bayou/config-common-default/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-common-default",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/injecty": "local",
     "@bayou/typecheck": "local",

--- a/local-modules/@bayou/config-common/package.json
+++ b/local-modules/@bayou/config-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/injecty": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-server-default",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/app-setup": "local",
     "@bayou/config-common": "local",

--- a/local-modules/@bayou/config-server/package.json
+++ b/local-modules/@bayou/config-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/config-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/injecty": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/data-model-client/package.json
+++ b/local-modules/@bayou/data-model-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/data-model-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-react": "local",
     "@bayou/doc-client": "local"

--- a/local-modules/@bayou/deps-ansi-color/package.json
+++ b/local-modules/@bayou/deps-ansi-color/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-ansi-color",
-  "version": "1.0.0",
-
   "dependencies": {
     "ansi-html": "^0.0.7",
     "chalk": "^2.4.1",

--- a/local-modules/@bayou/deps-compiler/package.json
+++ b/local-modules/@bayou/deps-compiler/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-compiler",
-  "version": "1.0.0",
-
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.0.0",

--- a/local-modules/@bayou/deps-express/package.json
+++ b/local-modules/@bayou/deps-express/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-express",
-  "version": "1.0.0",
-
   "dependencies": {
     "express": "^4.16.0",
     "ws": "^5.2.0"

--- a/local-modules/@bayou/deps-quill-client/package.json
+++ b/local-modules/@bayou/deps-quill-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-quill-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "quill": "^1.3.5",
 

--- a/local-modules/@bayou/deps-quill-common/package.json
+++ b/local-modules/@bayou/deps-quill-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-quill-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "quill-delta": "^3.6.2"
   }

--- a/local-modules/@bayou/deps-react/package.json
+++ b/local-modules/@bayou/deps-react/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-react",
-  "version": "1.0.0",
-
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",

--- a/local-modules/@bayou/deps-testing-common/package.json
+++ b/local-modules/@bayou/deps-testing-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-testing-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",

--- a/local-modules/@bayou/deps-testing-server/package.json
+++ b/local-modules/@bayou/deps-testing-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-testing-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "puppeteer": "^0.11.0"
   }

--- a/local-modules/@bayou/deps-util-common/package.json
+++ b/local-modules/@bayou/deps-util-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-util-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "lodash": "^4.17.10"
   }

--- a/local-modules/@bayou/deps-util-server/package.json
+++ b/local-modules/@bayou/deps-util-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/deps-util-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "chokidar": "^2.0.3",
     "content-type": "^1.0.4",

--- a/local-modules/@bayou/dev-mode/package.json
+++ b/local-modules/@bayou/dev-mode/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/dev-mode",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-util-server": "local",
     "@bayou/env-server": "local",

--- a/local-modules/@bayou/doc-client/package.json
+++ b/local-modules/@bayou/doc-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/doc-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/api-client": "local",
     "@bayou/api-common": "local",

--- a/local-modules/@bayou/doc-common/package.json
+++ b/local-modules/@bayou/doc-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/doc-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/codec": "local",
     "@bayou/config-common": "local",

--- a/local-modules/@bayou/doc-server/package.json
+++ b/local-modules/@bayou/doc-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/doc-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/app-common": "local",
     "@bayou/codec": "local",

--- a/local-modules/@bayou/env-client/package.json
+++ b/local-modules/@bayou/env-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/env-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/env-server/package.json
+++ b/local-modules/@bayou/env-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/env-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",

--- a/local-modules/@bayou/file-store-local/package.json
+++ b/local-modules/@bayou/file-store-local/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/file-store-local",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/codec": "local",
     "@bayou/deps-util-server": "local",

--- a/local-modules/@bayou/file-store-ot/package.json
+++ b/local-modules/@bayou/file-store-ot/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/file-store-ot",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/ot-common": "local",
     "@bayou/typecheck": "local",

--- a/local-modules/@bayou/file-store/package.json
+++ b/local-modules/@bayou/file-store/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/file-store",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/codec": "local",
     "@bayou/config-server": "local",

--- a/local-modules/@bayou/injecty/package.json
+++ b/local-modules/@bayou/injecty/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/injecty",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/main-client/package.json
+++ b/local-modules/@bayou/main-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/main-client",
-  "version": "1.0.0",
-
   "main": "index.js",
   "testMain": "testMain.js",
 

--- a/local-modules/@bayou/main-compiler/package.json
+++ b/local-modules/@bayou/main-compiler/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/main-compiler",
-  "version": "1.0.0",
-
   "bin": {
     "bayou-compile": "./index.js"
   },

--- a/local-modules/@bayou/main-linter/package.json
+++ b/local-modules/@bayou/main-linter/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/main-linter",
-  "version": "1.0.0",
-
   "dependencies": {
     "eslint": "^4.7.1",
     "eslint-plugin-react": "^7.4.0"

--- a/local-modules/@bayou/main-server/package.json
+++ b/local-modules/@bayou/main-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/main-server",
-  "version": "1.0.0",
-
   "bin": {
     "bayou-server": "./index.js"
   },

--- a/local-modules/@bayou/mocha-client-shim/package.json
+++ b/local-modules/@bayou/mocha-client-shim/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/mocha-client-shim",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-testing-common": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/ot-common/package.json
+++ b/local-modules/@bayou/ot-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/ot-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/codec": "local",
     "@bayou/config-common": "local",

--- a/local-modules/@bayou/promise-util/package.json
+++ b/local-modules/@bayou/promise-util/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/promise-util",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/proppy/package.json
+++ b/local-modules/@bayou/proppy/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/proppy",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/quill-util/package.json
+++ b/local-modules/@bayou/quill-util/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/quill-util",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-quill-client": "local",
     "@bayou/doc-common": "local",

--- a/local-modules/@bayou/see-all-client/package.json
+++ b/local-modules/@bayou/see-all-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/see-all-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/see-all": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/see-all-server/package.json
+++ b/local-modules/@bayou/see-all-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/see-all-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-ansi-color": "local",
     "@bayou/deps-util-common": "local",

--- a/local-modules/@bayou/see-all/package.json
+++ b/local-modules/@bayou/see-all/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/see-all",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/state-machine/package.json
+++ b/local-modules/@bayou/state-machine/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/state-machine",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/promise-util": "local",
     "@bayou/see-all": "local",

--- a/local-modules/@bayou/testing-client/package.json
+++ b/local-modules/@bayou/testing-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/testing-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-testing-common": "local",
     "@bayou/see-all": "local",

--- a/local-modules/@bayou/testing-common/package.json
+++ b/local-modules/@bayou/testing-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/testing-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/testing-server/package.json
+++ b/local-modules/@bayou/testing-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/testing-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-ansi-color": "local",
     "@bayou/deps-testing-common": "local",

--- a/local-modules/@bayou/top-client/package.json
+++ b/local-modules/@bayou/top-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/top-client",
-  "version": "1.0.0",
-
   "main": "index.js",
   "testMain": "tests/index.js",
 

--- a/local-modules/@bayou/top-server/package.json
+++ b/local-modules/@bayou/top-server/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/top-server",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/app-setup": "local",
     "@bayou/client-bundle": "local",

--- a/local-modules/@bayou/typecheck/package.json
+++ b/local-modules/@bayou/typecheck/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/typecheck",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-core": "local"
   }

--- a/local-modules/@bayou/ui-common/package.json
+++ b/local-modules/@bayou/ui-common/package.json
@@ -1,4 +1,2 @@
 {
-  "name": "@bayou/ui-common",
-  "version": "1.0.0"
 }

--- a/local-modules/@bayou/ui-components/package.json
+++ b/local-modules/@bayou/ui-components/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/ui-components",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-react": "local",
     "@bayou/doc-client": "local",

--- a/local-modules/@bayou/ui-embeds/package.json
+++ b/local-modules/@bayou/ui-embeds/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/ui-embeds",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/deps-react": "local",
     "@bayou/deps-util-common": "local"

--- a/local-modules/@bayou/util-client/package.json
+++ b/local-modules/@bayou/util-client/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/util-client",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/util-common/package.json
+++ b/local-modules/@bayou/util-common/package.json
@@ -1,7 +1,4 @@
 {
-  "name": "@bayou/util-common",
-  "version": "1.0.0",
-
   "dependencies": {
     "@bayou/typecheck": "local",
     "@bayou/util-core": "local"

--- a/local-modules/@bayou/util-core/package.json
+++ b/local-modules/@bayou/util-core/package.json
@@ -1,4 +1,1 @@
-{
-  "name": "@bayou/util-core",
-  "version": "1.0.0"
-}
+{ }


### PR DESCRIPTION
Another PR to prep for npm publication of internal modules. In this one, the project-internal `package.json` are all tweaked (mostly via `awk`, see below) to remove unnecessary redundant redundancy. When we start to publish these modules, the `package.json` files that we publish will be script-generated, and so we can add back anything we need, without introducing new boilerplate into the source.

`awk` script for the curious:

```awk
/^  "(name|version)":/ { got = 1; next }
got && $0 == "" { next }
{ got = 0; print }
```