### PR TITLE
 Stop requiring source overlay to do asset overlay.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -9,9 +9,8 @@ import ws from 'ws';
 
 import { BearerToken, Context, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
-import { Assets } from '@bayou/assets-client';
 import { ClientBundle } from '@bayou/client-bundle';
-import { Network } from '@bayou/config-server';
+import { Deployment, Network } from '@bayou/config-server';
 import { Dirs, ProductInfo } from '@bayou/env-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
@@ -166,10 +165,13 @@ export default class Application extends CommonBase {
     // bundle to serve.
     app.get('/static/js/:name.bundle.js', new ClientBundle().requestHandler);
 
-    // Use the module `@bayou/assets-client` as the source of HTML files and
-    // other static assets. This includes the top-level `index.html` and
-    // `favicon`, as well as stuff under `static/`.
-    app.use('/', express.static(Assets.BASE_DIR));
+    // Use the configuration point to determine which directories to serve
+    // HTML files and other static assets from. This includes (but is not
+    // necessarily limited to) the top-level `index.html` and `favicon` files,
+    // as well as stuff explicitly under `static/`.
+    for (const dir of Deployment.ASSET_DIRS) {
+      app.use('/', express.static(dir));
+    }
 
     // Use the `@bayou/api-server` module to handle POST and websocket requests
     // at `/api`.

--- a/local-modules/@bayou/app-setup/package.json
+++ b/local-modules/@bayou/app-setup/package.json
@@ -3,7 +3,6 @@
     "@bayou/api-common": "local",
     "@bayou/api-server": "local",
     "@bayou/app-common": "local",
-    "@bayou/assets-client": "local",
     "@bayou/client-bundle": "local",
     "@bayou/codec": "local",
     "@bayou/config-server": "local",

--- a/local-modules/@bayou/assets-client/Assets.js
+++ b/local-modules/@bayou/assets-client/Assets.js
@@ -7,18 +7,18 @@ import path from 'path';
 import { UtilityClass } from '@bayou/util-common';
 
 /** {string} Absolute path to the `files` directory. */
-const BASE_DIR = path.resolve(__dirname, 'files');
+const DIR = path.resolve(__dirname, 'files');
 
 /**
- * Provider of static assets to serve to clients.
+ * Default provider of static assets to serve to clients.
  */
 export default class Assets extends UtilityClass {
   /**
-   * {string} Absolute filesystem path to the base asset directory. All files
-   * under this directory are expected to be servable to clients; that is, there
-   * should be no server-private files under that directory.
+   * {array<string>} Default implementation of the configuration
+   * {@link @bayou/config-server/Deployment#ASSET_DIRS}, which refers _just_ to
+   * the static assets within this module.
    */
-  static get BASE_DIR() {
-    return BASE_DIR;
+  static get DIRS() {
+    return [DIR];
   }
 }

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -17,7 +17,7 @@ export default class Deployment extends UtilityClass {
    * This implementation defers to the module {@link @bayou/assets-client}.
    */
   static get ASSET_DIRS() {
-    return [Assets.BASE_DIR];
+    return Assets.DIRS;
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -4,12 +4,22 @@
 
 import path from 'path';
 
+import { Assets } from '@bayou/assets-client';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
  * Utility functionality regarding the deployment configuration of a server.
  */
 export default class Deployment extends UtilityClass {
+  /**
+   * {array<string>} Implementation of standard configuration point.
+   *
+   * This implementation defers to the module {@link @bayou/assets-client}.
+   */
+  static get ASSET_DIRS() {
+    return [Assets.BASE_DIR];
+  }
+
   /**
    * Implementation of standard configuration point.
    *

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@bayou/app-setup": "local",
+    "@bayou/assets-client": "local",
     "@bayou/config-common": "local",
     "@bayou/config-server": "local",
     "@bayou/doc-common": "local",

--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -10,6 +10,17 @@ import { UtilityClass } from '@bayou/util-common';
  */
 export default class Deployment extends UtilityClass {
   /**
+   * {array<string>} Array of absolute filesystem paths to the asset directory
+   * trees, in priority order (earliest directory "overrides" later ones when
+   * two or more contain the same-named file). All files under these directories
+   * are expected to be servable to clients; that is, there should be no
+   * server-private files under them.
+   */
+  static get ASSET_DIRS() {
+    return use.Deployment.ASSET_DIRS;
+  }
+
+  /**
    * Determines the location of the "var" (variable / mutable data) directory,
    * returning an absolute path to it. (This is where, for example, log files
    * are stored.) The directory need not exist; the system will take care of

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.36.1
+version = 0.37.0


### PR DESCRIPTION
This PR cleans up the only remaining need in the source for the use of partial source overlay of a local module (as opposed to using the overlay to add new modules).

This PR includes a bump of the version number to commemorate both the overlay bit (above) and the prior work on evolving the configuration mechanism.