### PR TITLE
Last licks on overlay build stuff

### DIFF
--- a/doc/customization.md
+++ b/doc/customization.md
@@ -66,14 +66,9 @@ Bayou is set up to make it straightforward to customize. Salient details:
     or `main-server` module (both of which are pretty small), and then edit to
     provide alternate configuration.
 
-  * Because no amount of explicit configuration hooks will ever turn out to be
-    fully adequate, any original source file at all can be overridden with a
-    replacement. This probably means a lot of copy-paste code duplication, but
-    it will at least unblock progress while still allowing the upstream source
-    to remain unforked. Should you find yourself in need of this facility,
-    please do not hesitate to file an issue, as this is a good indicator that
-    the project is in need of a refactoring, and possibly a new configuration
-    point, to cover the use case in question.
+    Should you find yourself in need of configuration beyond what is already
+    provided, please file an issue (or submit a PR) to add a new configuration
+    class or new member of an existing configuration class.
 
 - - - - - - - - - -
 

--- a/doc/customization.md
+++ b/doc/customization.md
@@ -45,9 +45,9 @@ Bayou is set up to make it straightforward to customize. Salient details:
   * The `build` script has the following options, which in concert enable a
     variety of customization possibilities:
 
-    * `--overlay=<dir>` &mdash; Specifies a directory to use for additional
-      source files and/or replacements for source files which exist in the base
-      project.
+    * `--extra-modules=<dir>` &mdash; Specifies a directory in which to find the
+      source for additional local modules, such as the ones specified in the
+      `--main-*` options (and their dependencies).
 
     * `--main-client=<name>` and `--main-server=<name>` &mdash; These specify
       the names of the modules to use as the main entry points into the client

--- a/scripts/build
+++ b/scripts/build
@@ -36,8 +36,8 @@ showHelp=0
 # List of subprojects to build.
 buildProjects=(compiler server client bin product-info)
 
-# Overlay source directory, if any.
-overlayDir=''
+# Directory in which to find additional local modules, if any.
+extraModulesDir=''
 
 # Name of the `main` module for the client, if specified.
 mainClient=''
@@ -60,14 +60,14 @@ while true; do
         --clean)
             outOpts+=("$1")
             ;;
+        --extra-modules=?*)
+            extraModulesDir="${1#*=}"
+            ;;
         --linter)
             buildProjects=(linter)
             ;;
         --out=?*)
             outOpts+=("$1")
-            ;;
-        --overlay=?*)
-            overlayDir="${1#*=}"
             ;;
         --main-client=?*)
             mainClient="${1#*=}"
@@ -102,12 +102,12 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo '  --clean'
     echo '    Start from a clean build.'
+    echo '  --extra-modules=<dir>'
+    echo '    Find additional local module sources in directory <dir>.'
     echo '  --linter'
     echo '    Just build the linter.'
     echo '  --out=<dir>'
     echo '    Place output in directory <dir>.'
-    echo '  --overlay=<dir>'
-    echo '    Find overlay source in directory <dir>.'
     echo '  --main-client=<name>'
     echo '    Name of the main module for the client.'
     echo '  --main-server=<name>'
@@ -238,7 +238,7 @@ function add-module-mapping {
     if [[ -r ${dirInfoFile} ]]; then
         # The directory has been created before (probably in an earlier run of
         # this script). Verify the constraint that a module is only in the base
-        # project or overlay but not both.
+        # project or extra modules directory but not both.
         local already="$(cat "${dirInfoFile}")"
         if [[ ${already} != ${sourceDir} ]]; then
             echo "Multiple sources for module: ${moduleName}" 1>&2
@@ -252,23 +252,25 @@ function add-module-mapping {
 }
 
 # Adds a directory mapping for the source of each local module, including those
-# defined by the base project as well as by the overlay (if any).
+# defined by the base project as well as in the extra modules directory (if
+# any).
 function add-package-directory-mappings {
     local basePath="${baseDir}/local-modules"
-    local overlayPath="${overlayDir}/local-modules"
     local d
 
     for d in $(find-package-directories "${basePath}"); do
         add-module-mapping "${basePath}/${d}" "${d}" || return 1
     done
 
-    for d in $(find-package-directories "${overlayPath}"); do
-        add-module-mapping "${overlayPath}/${d}" "${d}" || return 1
-    done
+    if [[ ${extraModulesDir} != '' ]]; then
+        for d in $(find-package-directories "${extraModulesDir}"); do
+            add-module-mapping "${extraModulesDir}/${d}" "${d}" || return 1
+        done
+    fi
 }
 
 # Copies the server and client source directories into `out`, including the
-# overlay contents (if any).
+# contents of the extra modules directory (if any).
 function copy-sources {
     echo 'Copying sources...'
 

--- a/scripts/build
+++ b/scripts/build
@@ -215,17 +215,10 @@ function find-package-directories {
 }
 
 # Gets a list of all the local module names. The output is a series of lines,
-# one per module.
+# one per module. This only works after module sources have been copied to the
+# `out` directory.
 function local-module-names {
-    local basePath="${baseDir}/local-modules"
-    local overlayPath="${overlayDir}/local-modules"
-
-    (
-        find-package-directories "${basePath}"
-        if [[ (${overlayDir} != '') && -e "${overlayPath}" ]]; then
-            find-package-directories "${overlayPath}"
-        fi
-    ) | sort -u
+    find-package-directories "${outDir}/local-modules"
 }
 
 # Adds a source directory mapping for a module. The first argument is the

--- a/scripts/build
+++ b/scripts/build
@@ -277,11 +277,11 @@ function copy-sources {
     # For each mapping file, copy all of the specified source files, but don't
     # include directories that themselves have separately-specified maps; those
     # get handled in their own iterations of this loop.
-    local mapFile dir excludes sources s delArg
+    local mapFile
     for mapFile in "${mappingFiles[@]}"; do
-        dir="$(dirname "${mapFile}")"
+        local dir="$(dirname "${mapFile}")"
 
-        excludes=($(
+        local excludes=($(
             # Exclude the source map files themselves.
             echo "--exclude=${sourceMapName}"
 
@@ -293,14 +293,8 @@ function copy-sources {
                 | awk '{ printf("--exclude=/%s\n", substr($1, 3)); }'
         ))
 
-        # Copy the first mapped directory entirely, including removing deleted
-        # files. Then copy the rest -- the overlays -- without deleting.
-        sources=($(cat "${mapFile}"))
-        delArg=(--delete)
-        for s in "${sources[@]}"; do
-            rsync-archive "${delArg[@]}" "${excludes[@]}" "${s}/" "${dir}"
-            delArg=()
-        done
+        local source="$(cat "${mapFile}")"
+        rsync-archive --delete "${excludes[@]}" "${source}/" "${dir}"
     done
 
     echo 'Copying sources... done.'

--- a/scripts/build
+++ b/scripts/build
@@ -214,63 +214,59 @@ function find-package-directories {
         | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }'
 }
 
-# Gets a list of all the local module names, or with `--path` a list of all
-# source paths to local modules. The output is a series of lines, one per
-# module.
+# Gets a list of all the local module names. The output is a series of lines,
+# one per module.
 function local-module-names {
-    local path=0
     local basePath="${baseDir}/local-modules"
     local overlayPath="${overlayDir}/local-modules"
 
-    if [[ $1 == '--path' ]]; then
-        # Kinda janky: This makes a recursive call _without_ this option and
-        # post-processes the result.
-        local-module-names | awk '{ print "local-modules/" $0 }'
-    else
-        (
-            find-package-directories "${basePath}"
-            if [[ (${overlayDir} != '') && -e "${overlayPath}" ]]; then
-                find-package-directories "${overlayPath}"
-            fi
-        ) | sort -u
-    fi
+    (
+        find-package-directories "${basePath}"
+        if [[ (${overlayDir} != '') && -e "${overlayPath}" ]]; then
+            find-package-directories "${overlayPath}"
+        fi
+    ) | sort -u
 }
 
-# Adds a new directory mapping under the output directory pointing back to the
-# original source location(s). This includes handling an overlay if it exists.
-function add-directory-mapping {
-    local dirName="$1"
-    local dirInfoFile="${outDir}/${dirName}/${sourceMapName}"
-
-    mkdir -p "$(dirname "${dirInfoFile}")"
-
-    (
-        # Note: Some directories _only_ exist in the overlay, so we check for
-        # existence of it before adding it to the mapping.
-        if [[ -e "${baseDir}/${dirName}" ]]; then
-            echo "${baseDir}/${dirName}"
-        fi
-
-        if [[ ${overlayDir} != '' && -e "${overlayDir}/${dirName}" ]]; then
-            echo "${overlayDir}/${dirName}"
-        fi
-    ) > "${dirInfoFile}"
+# Adds a source directory mapping for a module. The first argument is the
+# absolute path to the source and the second argument is the module name.
+function add-module-mapping {
+    local sourceDir="$1"
+    local moduleName="$2"
+    local targetDir="${outDir}/local-modules/${moduleName}"
+    local dirInfoFile="${targetDir}/${sourceMapName}"
 
     mappingFiles+=("${dirInfoFile}")
+
+    if [[ -r ${dirInfoFile} ]]; then
+        # The directory has been created before (probably in an earlier run of
+        # this script). Verify the constraint that a module is only in the base
+        # project or overlay but not both.
+        local already="$(cat "${dirInfoFile}")"
+        if [[ ${already} != ${sourceDir} ]]; then
+            echo "Multiple sources for module: ${moduleName}" 1>&2
+            return 1
+        fi
+        return
+    fi
+
+    mkdir -p "${targetDir}"
+    echo "${sourceDir}" > "${dirInfoFile}"
 }
 
-# Adds directory mappings for each subdirectory of `local-modules` which
-# appears to be a package (node module), as inferred by the existence of a
-# `package.json` file. This includes handling of overlays if they exist.
-#
-# **Note:** This arranges for a separate mapping file per local module, instead
-# of just a single mapping for all of `local-modules`, because the contents of
-# each subdirectory can end up getting overlaid differently, and because in the
-# final executed result the `local-modules` directory doesn't even exist.
+# Adds a directory mapping for the source of each local module, including those
+# defined by the base project as well as by the overlay (if any).
 function add-package-directory-mappings {
-    local n
-    for n in $(local-module-names --path); do
-        add-directory-mapping "${n}"
+    local basePath="${baseDir}/local-modules"
+    local overlayPath="${overlayDir}/local-modules"
+    local d
+
+    for d in $(find-package-directories "${basePath}"); do
+        add-module-mapping "${basePath}/${d}" "${d}" || return 1
+    done
+
+    for d in $(find-package-directories "${overlayPath}"); do
+        add-module-mapping "${overlayPath}/${d}" "${d}" || return 1
     done
 }
 

--- a/scripts/build
+++ b/scripts/build
@@ -190,16 +190,20 @@ function rsync-archive {
     rsync --archive --ignore-times "$@"
 }
 
-# Sets up the output directory, including cleaning it out or creating it, as
-# necessary. This also sets `finalDir` to the directory under `outDir` for the
-# final built product.
+# Sets up the build output directory, including cleaning it out or creating it,
+# as necessary. This also sets `finalDir` and `modulesDir` relative to the
+# output directory.
 function set-up-out {
     outDir="$(${progDir}/lib/out-dir-setup "${outOpts[@]}")"
     if (( $? != 0 )); then
         return 1
     fi
 
+    # Where the final built artifacts go.
     finalDir="${outDir}/final"
+
+    # Where local module source directories go as an intermediate build step.
+    modulesDir="${outDir}/local-modules"
 }
 
 # Helper for `local-module-names` which finds package (node module) directories
@@ -218,7 +222,7 @@ function find-package-directories {
 # one per module. This only works after module sources have been copied to the
 # `out` directory.
 function local-module-names {
-    find-package-directories "${outDir}/local-modules"
+    find-package-directories "${modulesDir}"
 }
 
 # Adds a source directory mapping for a module. The first argument is the
@@ -226,7 +230,7 @@ function local-module-names {
 function add-module-mapping {
     local sourceDir="$1"
     local moduleName="$2"
-    local targetDir="${outDir}/local-modules/${moduleName}"
+    local targetDir="${modulesDir}/${moduleName}"
     local dirInfoFile="${targetDir}/${sourceMapName}"
 
     mappingFiles+=("${dirInfoFile}")
@@ -348,7 +352,7 @@ function do-install {
     # that it lists the transitive closure of external module dependencies.
     echo "${subprojectName}:" 'Copying local-module dependencies...'
     "${progDir}/lib/copy-local-dependencies" \
-        --local-modules="${outDir}/local-modules" "${toDir}" \
+        --local-modules="${modulesDir}" "${toDir}" \
     || return 1
 
     if [[ -r ${npmPackageJson} ]] \

--- a/scripts/develop
+++ b/scripts/develop
@@ -60,11 +60,11 @@ while true; do
         --clean)
             doClean=1
             ;;
+        --extra-modules=?*)
+            buildOpts+=("$1");
+            ;;
         --out=?*)
             outDir="${1#*=}"
-            ;;
-        --overlay=?*)
-            buildOpts+=("$1");
             ;;
         --main-client=?*)
             buildOpts+=("$1");
@@ -99,14 +99,14 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo '  --clean'
     echo '    Do an initial clean build.'
-    echo '  --out=<dir>'
-    echo '    Find (and place) build output in directory <dir>.'
-    echo '  --overlay=<dir>'
-    echo '    Find overlay source in directory <dir>.'
+    echo '  --extra-modules=<dir>'
+    echo '    Find additional local module sources in directory <dir>.'
     echo '  --main-client=<name>'
     echo '    Name of the main module for the client.'
     echo '  --main-server=<name>'
     echo '    Name of the main module for the server.'
+    echo '  --out=<dir>'
+    echo '    Find (and place) build output in directory <dir>.'
     echo '  --product-info=<path>'
     echo '    Filesystem path to the product info file.'
     echo ''

--- a/scripts/lib/out-dir-setup
+++ b/scripts/lib/out-dir-setup
@@ -90,7 +90,7 @@ done
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
-    echo "${progName} [--clean] [--out=<dir>] [--overlay=<dir>]"
+    echo "${progName} [<opt> ...]"
     echo '  Sets up and/or cleans the built output directory. Prints the'
     echo '  absolute path of the output directory. This uses a default output'
     echo '  directory relative to the project base if `--out=` is not'

--- a/scripts/lint
+++ b/scripts/lint
@@ -36,11 +36,11 @@ showHelp=0
 # Option for the output directory, if any.
 outDirOpt=()
 
-# Option for the overlay source directory, if any.
-overlayDirOpt=()
+# Option for the extra modules source directory, if any.
+extraModulesOpt=()
 
-# Overlay source directory, if any.
-overlayDir=''
+# Extra modules source directory, if any.
+extraModulesDir=''
 
 while true; do
     case $1 in
@@ -48,12 +48,12 @@ while true; do
             showHelp=1
             break
             ;;
+        --extra-modules=?*)
+            extraModulesDir="${1#*=}"
+            extraModulesOpt=("$1")
+            ;;
         --out=?*)
             outDirOpt=("$1")
-            ;;
-        --overlay=?*)
-            overlayDir="${1#*=}"
-            overlayDirOpt=("$1")
             ;;
         --) # End of all options
             shift
@@ -74,8 +74,8 @@ done
 args=("$@")
 if (( ${#args[@]} == 0 )); then
     args=("${baseDir}")
-    if [[ ${overlayDir} != '' ]]; then
-        args+=("${overlayDir}")
+    if [[ ${extraModulesDir} != '' ]]; then
+        args+=("${extraModulesDir}")
     fi
 fi
 
@@ -84,13 +84,13 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo "${progName} [<opt> ...] [--] [<file-or-dir> ...]"
     echo '  Run the linter on the indicated files or directories. With nothing'
-    echo '  specified, runs over the entire project (including overlay source'
-    echo '  if indicated).'
+    echo '  specified, runs over the entire project (including extra module'
+    echo '  source if indicated).'
     echo ''
+    echo '  --extra-modules=<dir>'
+    echo '    Find additional local module sources in directory <dir>.'
     echo '  --out=<dir>'
     echo '    Place output (built linter tool) in directory <dir>.'
-    echo '  --overlay=<dir>'
-    echo '    Find overlay source in directory <dir>.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -109,7 +109,7 @@ fi
 
 lintDir="${outDir}/linter"
 
-"${progDir}/build" "${outDirOpt[@]}" "${overlayDirOpt[@]}" --linter || exit 1
+"${progDir}/build" "${outDirOpt[@]}" "${extraModulesOpt[@]}" --linter || exit 1
 
 "${lintDir}/node_modules/.bin/eslint" \
     --cache --cache-location "${lintDir}/cache" \


### PR DESCRIPTION
Possibly in the territory of "gilding the lily," this PR more fully retires the old source overlay mechanism. A build's source now consists of a base set of modules and an "extra" set of modules, where it is no longer legal to smash together two directories (one from each set) to form a partially-overlaid module source directory.

There is one further opportunity for code simplification that's still on the table after this, which is to make `DevMode.js` not have to deal with the possibility of partial overlay.
