### PR TITLE
Work-in-progress on npm publishing

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -51,7 +51,7 @@ mainServer=''
 # Path to the product info file, if specified.
 productInfoPath=''
 
-# Options to pass to `out-dir-setup`.
+# Options to pass to `set-up-out`.
 outOpts=()
 
 while true; do

--- a/scripts/build
+++ b/scripts/build
@@ -60,6 +60,9 @@ while true; do
         --clean)
             outOpts+=("$1")
             ;;
+        --copy-sources)
+            buildProjects=(copy-sources)
+            ;;
         --extra-modules=?*)
             extraModulesDir="${1#*=}"
             ;;
@@ -102,10 +105,13 @@ if (( ${showHelp} || ${argError} )); then
     echo ''
     echo '  --clean'
     echo '    Start from a clean build.'
+    echo '  --copy-sources'
+    echo '    Just copy source files into the output directory. (Do no other build'
+    echo '    steps.)'
     echo '  --extra-modules=<dir>'
     echo '    Find additional local module sources in directory <dir>.'
     echo '  --linter'
-    echo '    Just build the linter.'
+    echo '    Just build the linter. (Do no other build steps.)'
     echo '  --out=<dir>'
     echo '    Place output in directory <dir>.'
     echo '  --main-client=<name>'
@@ -469,6 +475,13 @@ function build-client {
 # Builds the compiler (transpiler) code.
 function build-compiler {
     do-install compiler || return 1
+}
+
+# "Builds" the `copy-sources` target.
+function build-copy-sources {
+    # This is a no-op because sources always get copied for all build targets,
+    # before calling through to the `build-*` functions.
+    :
 }
 
 # Builds the code linter.

--- a/scripts/build
+++ b/scripts/build
@@ -22,6 +22,9 @@ function init-prog {
 }
 init-prog
 
+# Pull in the build system helper library.
+. "${progDir}/lib/include-build.sh"
+
 
 #
 # Argument parsing
@@ -137,45 +140,6 @@ sourceMapName='source-map.txt'
 # List of all mapping files.
 mappingFiles=()
 
-# Helper for `check-environment-dependencies` which validates one dependency.
-function check-dependency {
-    local name="$1"
-    local versionCmd="$2"
-    local match="$3"
-
-    # Extract just the command name, and verify that it exists at all.
-
-    local cmdName=''
-    if [[ ${versionCmd} =~ ^([^ ]+) ]]; then
-        cmdName="${BASH_REMATCH[1]}"
-    else
-        # **Note:* This indicates a bug in this script, not a problem with the
-        # environment.
-        echo "Could not determine commmand name for ${name}." 1>&2
-        exit 1
-    fi
-
-    if ! which "${cmdName}" >/dev/null 2>&1; then
-        echo "Missing required command for ${name}: ${cmdName}" 1>&2
-        exit 1
-    fi
-
-    local version="$(${versionCmd} 2>&1)"
-    if ! grep -q -e "${match}" <<< "${version}"; then
-        echo "Unsupported version of ${name}: ${version}" 1>&2
-        exit 1
-    fi
-}
-
-# Checks the versions of our various expected-installed dependencies, notably
-# including Node and npm.
-function check-environment-dependencies {
-    check-dependency 'Node' 'node --version' '^v\([89]\|10\)\.'
-    check-dependency 'npm' 'npm --version' '^[56]\.'
-    check-dependency 'jq' 'jq --version' '^jq-1\.'
-    check-dependency 'rsync' 'rsync --version' '.' # No actual version check.
-}
-
 # Calls `rsync` so as to do an all-local (not actually remote) "archive" copy
 # (preserving permissions, modtimes, etc.).
 #
@@ -194,41 +158,6 @@ function rsync-archive {
     # so only the file sizes come into play, and it's very easy to have a file
     # size coincidence.)
     rsync --archive --ignore-times "$@"
-}
-
-# Sets up the build output directory, including cleaning it out or creating it,
-# as necessary. This also sets `finalDir` and `modulesDir` relative to the
-# output directory.
-function set-up-out {
-    outDir="$(${progDir}/lib/out-dir-setup "${outOpts[@]}")"
-    if (( $? != 0 )); then
-        return 1
-    fi
-
-    # Where the final built artifacts go.
-    finalDir="${outDir}/final"
-
-    # Where local module source directories go as an intermediate build step.
-    modulesDir="${outDir}/local-modules"
-}
-
-# Helper for `local-module-names` which finds package (node module) directories
-# under the given directory. It prints the partial path to each such found
-# directory.
-function find-package-directories {
-    local dir="$1"
-
-    # Parens to preserve original CWD. `awk` command to strip the leading `./`
-    # and trailing `/package.json` from the results of the `find` command.
-    (cd "${dir}"; find . -type f -name package.json) \
-        | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }'
-}
-
-# Gets a list of all the local module names. The output is a series of lines,
-# one per module. This only works after module sources have been copied to the
-# `out` directory.
-function local-module-names {
-    find-package-directories "${modulesDir}"
 }
 
 # Adds a source directory mapping for a module. The first argument is the
@@ -613,8 +542,8 @@ function avoid-simultaneous-builds {
 # Main script
 #
 
-check-environment-dependencies || exit 1
-set-up-out || exit 1
+check-build-dependencies || exit 1
+set-up-out "${outOpts[@]}" || exit 1
 
 # Make sure only one build is running in any given output directory.
 avoid-simultaneous-builds || exit 1

--- a/scripts/build
+++ b/scripts/build
@@ -140,26 +140,6 @@ sourceMapName='source-map.txt'
 # List of all mapping files.
 mappingFiles=()
 
-# Calls `rsync` so as to do an all-local (not actually remote) "archive" copy
-# (preserving permissions, modtimes, etc.).
-#
-# **Note:** We use `rsync` and not `cp` (even though this is a totally local
-# operation) because it has well-defined behavior when copying a tree on top of
-# another tree and also knows how to create directories as needed.
-#
-# **Note:** Trailing slashes on source directory names are significant to
-# `rsync`. This is salient at some of the use sites.
-function rsync-archive {
-    # **Note:** We turn off file-sameness checking, which is irrelevant for this
-    # use and is furthermore counterproductive, in that it can cause a failure
-    # to copy when two non-identical files happen to match in both size and
-    # timestamp. (This has happened in practice. When running a build on a
-    # freshly checked-out source tree, many many files have the same timestamps,
-    # so only the file sizes come into play, and it's very easy to have a file
-    # size coincidence.)
-    rsync --archive --ignore-times "$@"
-}
-
 # Adds a source directory mapping for a module. The first argument is the
 # absolute path to the source and the second argument is the module name.
 function add-module-mapping {

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Converts the module sources in `out` into a form which is appropriate to hand
+# off to `npm publish`.
+#
+
+# Set `progName` to the program name, `progDir` to its directory, and `baseDir`
+# to `progDir`'s directory. Follows symlinks.
+function init-prog {
+    local newp p="$0"
+
+    while newp="$(readlink "$p")"; do
+        [[ ${newp} =~ ^/ ]] && p="${newp}" || p="$(dirname "$p")/${newp}"
+    done
+
+    progName="${p##*/}"
+    progDir="$(cd "$(dirname "$p")"; /bin/pwd -P)"
+    baseDir="$(cd "${progDir}/.."; /bin/pwd -P)"
+}
+init-prog
+
+
+#
+# Argument parsing
+#
+
+# Error during argument processing?
+argError=0
+
+# Need help?
+showHelp=0
+
+# Options to pass to `out-dir-setup`.
+outOpts=()
+
+# Extra options passed to the command.
+extraOpts=()
+
+while true; do
+    case $1 in
+        -h|--help)
+            showHelp=1
+            break
+            ;;
+        --out=?*)
+            outOpts+=("$1")
+            extraOpts+=("$1")
+            ;;
+        --) # End of all options
+            shift
+            break
+            ;;
+        -?*)
+            echo "Unknown option: $1" 1>&2
+            argError=1
+            break
+            ;;
+        *)  # Default case: No more options, break out of the loop.
+            break
+    esac
+
+    shift
+done
+
+if (( ${showHelp} || ${argError} )); then
+    echo 'Usage:'
+    echo ''
+    echo "${progName} [<opt> ...]"
+    echo '  Convert modules into publication form.'
+    echo ''
+    echo '  --out=<dir>'
+    echo '    Directory where built output goes and also where the module sources are found.'
+    echo ''
+    echo "${progName} [--help | -h]"
+    echo '  Display this message.'
+    exit ${argError}
+fi
+
+
+#
+# Helper functions
+#
+
+
+#
+# Main script
+#
+
+echo 'TODO!'
+exit 1

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -146,12 +146,23 @@ function process-module {
         --arg name "${name}" \
         --arg version "${productVersion}" \
     '
+        def fix_dep:
+            if (.value == "local")
+                then .value = $version
+                else .
+            end
+        ;
+
         .name = $name |
         .version = $version |
         .description = "Subcomponent of larger project." |
         .license = "UNLICENSED" |
         .author = "Several authors." |
-        .repository = "NONE"
+        .repository = "NONE" |
+        if has("dependencies")
+            then .dependencies |= with_entries(fix_dep)
+            else .
+        end
     ' < "${fromDir}/package.json" > "${toDir}/package.json" \
     || return 1
 }

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -23,6 +23,14 @@ function init-prog {
 }
 init-prog
 
+# Move `baseDir` and `prodDir` up one layer (not done above because the above is
+# boilerplate).
+progDir="${baseDir}"
+baseDir="$(cd "${baseDir}/.."; /bin/pwd -P)"
+
+# Pull in the build system helper library.
+. "${progDir}/lib/include-build.sh"
+
 
 #
 # Argument parsing
@@ -34,11 +42,11 @@ argError=0
 # Need help?
 showHelp=0
 
-# Options to pass to `out-dir-setup`.
+# Options to pass to `set-up-out`.
 outOpts=()
 
-# Extra options passed to the command.
-extraOpts=()
+# Path to the product info file.
+productInfoPath=''
 
 while true; do
     case $1 in
@@ -46,9 +54,14 @@ while true; do
             showHelp=1
             break
             ;;
+        --clean)
+            outOpts+=("$1")
+            ;;
         --out=?*)
             outOpts+=("$1")
-            extraOpts+=("$1")
+            ;;
+        --product-info=?*)
+            productInfoPath="${1#*=}"
             ;;
         --) # End of all options
             shift
@@ -66,14 +79,24 @@ while true; do
     shift
 done
 
+if [[ ${productInfoPath} == '' ]]; then
+    echo 'Missing required option: --product-info' 1>&2
+    argError=1
+fi
+
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
     echo "${progName} [<opt> ...]"
     echo '  Convert modules into publication form.'
     echo ''
+    echo '  --clean'
+    echo '    Start from a clean build.'
     echo '  --out=<dir>'
-    echo '    Directory where built output goes and also where the module sources are found.'
+    echo '    Directory where built output goes and also where the module sources are'
+    echo '    found.'
+    echo '  --product-info=<path>'
+    echo '    Filesystem path to the product info file. This "option" must be included.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -85,10 +108,37 @@ fi
 # Helper functions
 #
 
+# Determines the product version from the info file.
+function product-version {
+    if [[ ! (-r ${productInfoPath} && -f ${productInfoPath}) ]]; then
+        echo "Not readable: ${productInfoPath}" 1>&2
+        return 1
+    fi
+
+    local line="$(grep '^ *version *=' < "${productInfoPath}")"
+
+    if [[ ${line} =~ ^\ *version\ *=\ *([^\ ]*) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo "Could not determine product version." 1>&2
+        return 1
+    fi
+}
+
 
 #
 # Main script
 #
 
-echo 'TODO!'
+set-up-out "${outOpts[@]}" || exit 1
+
+productVersion="$(product-version)"
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+for name in $(local-module-names); do
+    echo "TODO!!! ${name}"
+done
+
 exit 1

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -127,8 +127,33 @@ function product-version {
 
 # Processes the named module, producing a version suitable for publication.
 function process-module {
-    echo "TODO!!! ${name}"
-    return 1
+    local name="$1"
+    local fromDir="${modulesDir}/${name}"
+    local toDir="${publishDir}/${name}"
+
+    mkdir -p "${toDir}" || return 1
+
+    # Start with a fresh copy of the module source. **Note:** `source-map.txt`
+    # files are from the build process and are used for the "live development"
+    # system; they shouldn't end up getting published, so we exclude them from
+    # the copy.
+    rsync-archive --delete --exclude=source-map.txt \
+        "${fromDir}/" "${toDir}" \
+    || return 1
+
+    # Rework the `package.json` file.
+    jq \
+        --arg name "${name}" \
+        --arg version "${productVersion}" \
+    '
+        .name = $name |
+        .version = $version |
+        .description = "Subcomponent of larger project." |
+        .license = "UNLICENSED" |
+        .author = "Several authors." |
+        .repository = "NONE"
+    ' < "${fromDir}/package.json" > "${toDir}/package.json" \
+    || return 1
 }
 
 

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -125,6 +125,12 @@ function product-version {
     fi
 }
 
+# Processes the named module, producing a version suitable for publication.
+function process-module {
+    echo "TODO!!! ${name}"
+    return 1
+}
+
 
 #
 # Main script
@@ -137,8 +143,14 @@ if [[ $? != 0 ]]; then
     exit 1
 fi
 
+publishDir="${outDir}/for-publication"
+mkdir -p "${publishDir}" || exit 1
+
+echo "Processing modules for publication..."
+
 for name in $(local-module-names); do
-    echo "TODO!!! ${name}"
+    echo "${name}"
+    process-module "${name}" || exit 1
 done
 
-exit 1
+echo "Done!"

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -1,0 +1,84 @@
+#
+# Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Script library (to include via `.`) containing common build system logic.
+# This assumes that `baseDir` and `progDir` have been set up using the usual
+# boilerplate.
+#
+
+# Helper for `check-build-dependencies` which validates one dependency.
+function check-dependency {
+    local name="$1"
+    local versionCmd="$2"
+    local match="$3"
+
+    # Extract just the command name, and verify that it exists at all.
+
+    local cmdName=''
+    if [[ ${versionCmd} =~ ^([^ ]+) ]]; then
+        cmdName="${BASH_REMATCH[1]}"
+    else
+        # **Note:* This indicates a bug in this script, not a problem with the
+        # environment.
+        echo "Could not determine commmand name for ${name}." 1>&2
+        exit 1
+    fi
+
+    if ! which "${cmdName}" >/dev/null 2>&1; then
+        echo "Missing required command for ${name}: ${cmdName}" 1>&2
+        exit 1
+    fi
+
+    local version="$(${versionCmd} 2>&1)"
+    if ! grep -q -e "${match}" <<< "${version}"; then
+        echo "Unsupported version of ${name}: ${version}" 1>&2
+        exit 1
+    fi
+}
+
+# Checks the versions of our various expected-installed dependencies, notably
+# including Node and npm.
+function check-build-dependencies {
+    check-dependency 'Node' 'node --version' '^v\([89]\|10\)\.'
+    check-dependency 'npm' 'npm --version' '^[56]\.'
+    check-dependency 'jq' 'jq --version' '^jq-1\.'
+    check-dependency 'rsync' 'rsync --version' '.' # No actual version check.
+}
+
+# Helper for `local-module-names` which finds package (node module) directories
+# under the given directory. It prints the partial path to each such found
+# directory.
+function find-package-directories {
+    local dir="$1"
+
+    # Parens to preserve original CWD. `awk` command to strip the leading `./`
+    # and trailing `/package.json` from the results of the `find` command.
+    (cd "${dir}"; find . -type f -name package.json) \
+        | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }'
+}
+
+# Gets a list of all the local module names. The output is a series of lines,
+# one per module. This only works after module sources have been copied to the
+# `out` directory.
+function local-module-names {
+    find-package-directories "${modulesDir}"
+}
+
+# Sets up the build output directory, including cleaning it out or creating it,
+# as necessary. This also sets `finalDir` and `modulesDir` relative to the
+# output directory. See `out-dir-setup` in this directory for details on the
+# arguments which can be passed here.
+function set-up-out {
+    outDir="$(${progDir}/lib/out-dir-setup "$@")"
+    if (( $? != 0 )); then
+        return 1
+    fi
+
+    # Where the final built artifacts go.
+    finalDir="${outDir}/final"
+
+    # Where local module source directories go as an intermediate build step.
+    modulesDir="${outDir}/local-modules"
+}

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -56,7 +56,8 @@ function find-package-directories {
     # Parens to preserve original CWD. `awk` command to strip the leading `./`
     # and trailing `/package.json` from the results of the `find` command.
     (cd "${dir}"; find . -type f -name package.json) \
-        | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }'
+        | awk '{ gsub(/^\.\/|\/package\.json$/, ""); print $0; }' \
+        | sort
 }
 
 # Gets a list of all the local module names. The output is a series of lines,

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -67,6 +67,26 @@ function local-module-names {
     find-package-directories "${modulesDir}"
 }
 
+# Calls `rsync` so as to do an all-local (not actually remote) "archive" copy
+# (preserving permissions, modtimes, etc.).
+#
+# **Note:** We use `rsync` and not `cp` (even though this is a totally local
+# operation) because it has well-defined behavior when copying a tree on top of
+# another tree and also knows how to create directories as needed.
+#
+# **Note:** Trailing slashes on source directory names are significant to
+# `rsync`. This is salient at some of the use sites.
+function rsync-archive {
+    # **Note:** We turn off file-sameness checking, which is irrelevant for this
+    # use and is furthermore counterproductive, in that it can cause a failure
+    # to copy when two non-identical files happen to match in both size and
+    # timestamp. (This has happened in practice. When running a build on a
+    # freshly checked-out source tree, many many files have the same timestamps,
+    # so only the file sizes come into play, and it's very easy to have a file
+    # size coincidence.)
+    rsync --archive --ignore-times "$@"
+}
+
 # Sets up the build output directory, including cleaning it out or creating it,
 # as necessary. This also sets `finalDir` and `modulesDir` relative to the
 # output directory. See `out-dir-setup` in this directory for details on the


### PR DESCRIPTION
This PR adds a new build script `build-npm-modules` which does something like what you probably think it does, given its name. There's more to do before we'll actually be able to pull the trigger and start publishing modules, but this is a solid start for the effort.

Most of the diffs in this PR are actually from me having extracted some utility functionality from the main `build` script into a new helper library.