### PR TITLE
Define the document schema separately from the product version.

### DIFF
--- a/local-modules/@bayou/doc-common/TheModule.js
+++ b/local-modules/@bayou/doc-common/TheModule.js
@@ -25,6 +25,21 @@ import PropertySnapshot from './PropertySnapshot';
  */
 export default class TheModule extends UtilityClass {
   /**
+   * {string} Schema version string which uniquely identifies the structure of
+   * documents and their constituent parts. Any time the formats change in an
+   * way that is incompatible with pre-existing code, this value needs to be
+   * changed, so that code can fail fast rather than silently corrupt documents.
+   *
+   * **Note:** The form of this string is `<year>-<seq>` where `<year>` is the
+   * calendar year in which the format change was made, and `<seq>` is a
+   * three-digit sequence number starting with `001`. (Three digits and not one
+   * or two, so that it isn't mistaken for a month.)
+   */
+  static get SCHEMA_VERSION() {
+    return '2018-001';
+  }
+
+  /**
    * Registers this module's encodable classes with a given codec registry.
    *
    * @param {Registry} registry Codec registry to register with.

--- a/local-modules/@bayou/doc-server/SchemaHandler.js
+++ b/local-modules/@bayou/doc-server/SchemaHandler.js
@@ -2,9 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { ProductInfo } from '@bayou/env-server';
+import { TheModule as docCommon_TheModule } from '@bayou/doc-common';
 import { TransactionSpec } from '@bayou/file-store-ot';
-import { TString } from '@bayou/typecheck';
 
 import BaseDataManager from './BaseDataManager';
 import Paths from './Paths';
@@ -27,7 +26,7 @@ export default class SchemaHandler extends BaseDataManager {
     super(fileAccess, 'schema');
 
     /** {string} The document schema version to use and expect. */
-    this._schemaVersion = TString.nonEmpty(ProductInfo.theOne.INFO.version);
+    this._schemaVersion = docCommon_TheModule.SCHEMA_VERSION;
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/package.json
+++ b/local-modules/@bayou/doc-server/package.json
@@ -5,7 +5,6 @@
     "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/doc-common": "local",
-    "@bayou/env-server": "local",
     "@bayou/file-store": "local",
     "@bayou/file-store-ot": "local",
     "@bayou/ot-common": "local",


### PR DESCRIPTION
Because of all the following, the product version will now be getting updated on a regular basis:

* We're about to be in the business of regularly publishing npm modules of the project source.
* Each such publication requires changing the version of the module.
* Module versions are set up to track the product version.
* That arrangement makes sense.

Up until now, the product version was _also_ used to identify the document schema, that is, the format of all the bits and pieces that make up a document. this _used_ to make sense, because the document schema was a quickly-moving target, but at this point its evolution has slowed down.

So, this PR introduces a new definition just for the document schema version, which only has to be updated when the schema actually changes, instead of getting updated as "collateral damage" any time the product version changes (which happens for any number of other reasons).

As before, the system as it currently stands has no means of recognizing (or translating between) multiple document schemata; it's simply the case that it will accept the current one and reject all others. Ultimately, we will have to build server-side code to accept multiple schemata, at least in terms of what gets stored durably to a DB, and possibly to be able to talk to out-of-date clients. That work, though, will wait for another day.