### PR TITLE
More support for npm publishing.

### DIFF
--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 0.37.1
+version = 1.0.0

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -354,7 +354,7 @@ if [[ $? != 0 ]]; then
     exit 1
 fi
 
-publishDir="${outDir}/for-publication"
+publishDir="$(publish-dir)"
 mkdir -p "${publishDir}" || exit 1
 
 echo "Processing modules for publication..."

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -72,6 +72,19 @@ function local-module-names {
     find-package-directories "${modulesDir}"
 }
 
+# Gets a list of all the names of modules that are ready for publishing. This
+# only works after `build-npm-modules` has been run.
+function publishable-module-names {
+    local publishDir="${outDir}/for-publication"
+
+    if [[ ! (-d ${publishDir} && -r ${publishDir}) ]]; then
+        echo "Cannot read publishable module directory: ${publishDir}" 1>&2
+        return 1
+    fi
+
+    find-package-directories "${publishDir}"
+}
+
 # Calls `rsync` so as to do an all-local (not actually remote) "archive" copy
 # (preserving permissions, modtimes, etc.).
 #

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -72,10 +72,16 @@ function local-module-names {
     find-package-directories "${modulesDir}"
 }
 
+# Gets (prints out) the name of the directory under `out` where modules for
+# npm publication get written. This only works after `set-up-out` has been run.
+function publish-dir {
+    echo "${outDir}/for-publication"
+}
+
 # Gets a list of all the names of modules that are ready for publishing. This
 # only works after `build-npm-modules` has been run.
 function publishable-module-names {
-    local publishDir="${outDir}/for-publication"
+    local publishDir="$(publish-dir)"
 
     if [[ ! (-d ${publishDir} && -r ${publishDir}) ]]; then
         echo "Cannot read publishable module directory: ${publishDir}" 1>&2


### PR DESCRIPTION
This PR has a bit more support for doing npm publishing.

In addition, this PR bumps the product version to 1.0.0, because (a) that's the version used when publishing modules, (b) semver rules are wonky for version 0.*, and (c) we don't want to impose wonkiness on our esteemed coworkers.