### PR TITLE
Detect when the Node version used to build isn't the same as the one used to run.

### DIFF
--- a/etc/bin-src/run
+++ b/etc/bin-src/run
@@ -28,9 +28,10 @@ init-prog
 # Helper functions
 #
 
-# Emits an error both as a JSON blob to stdout (which will perhaps get picked up
-# by the logging infrastructure) and as a human-oriented simple printout to
-# stderr.
+# Emits an error both as a JSON blob to stdout (in the same format as is used
+# in the main product, so it has a chance to get ingested by any logging
+# infrastructure which happens to be running) and as a human-oriented simple
+# printout to stderr.
 function report-error {
     local text="$*"
 

--- a/etc/bin-src/run
+++ b/etc/bin-src/run
@@ -28,6 +28,23 @@ init-prog
 # Helper functions
 #
 
+# Emits an error both as a JSON blob to stdout (which will perhaps get picked up
+# by the logging infrastructure) and as a human-oriented simple printout to
+# stderr.
+function report-error {
+    local text="$*"
+
+    echo "${text}" 1>&2
+
+    cat <<EOF
+{
+    "timeMsec": $(date '+%s000'),
+    "tag": ["outer-run"],
+    "message": "${text}"
+}
+EOF
+}
+
 # Helper for `check-environment-dependencies` which validates one dependency.
 function check-dependency {
     local name="$1"
@@ -42,18 +59,18 @@ function check-dependency {
     else
         # **Note:* This indicates a bug in this script, not a problem with the
         # environment.
-        echo "Could not determine commmand name for ${name}." 1>&2
+        report-error "Could not determine commmand name for ${name}."
         exit 1
     fi
 
     if ! which "${cmdName}" >/dev/null 2>&1; then
-        echo "Missing required command for ${name}: ${cmdName}" 1>&2
+        report-error "Missing required command for ${name}: ${cmdName}"
         exit 1
     fi
 
     local version="$(${versionCmd} 2>&1)"
     if ! grep -q -e "${match}" <<< "${version}"; then
-        echo "Unsupported version of ${name}: ${version}" 1>&2
+        report-error "Unsupported version of ${name}: ${version}"
         exit 1
     fi
 }
@@ -63,11 +80,39 @@ function check-environment-dependencies {
     check-dependency 'Node' 'node --version' '^v\([89]\|10\)\.'
 }
 
+# Matches the version of Node against the one used to build the product. This
+# augments (does not replace) the Node check in
+# `check-environment-dependencies` (above).
+function check-node-versions {
+    local infoLine="$(cat "${baseDir}/product-info.txt" | grep '^node_version')"
+    local buildVersion runVersion
+
+    if [[ ${infoLine} =~ =' '*([0-9]+) ]]; then
+        buildVersion="${BASH_REMATCH[1]}"
+    else
+        report-error "Missing node_version metadata in the product info file."
+        exit 1
+    fi
+
+    if [[ $(node --version) =~ ^v([0-9]+) ]]; then
+        runVersion="${BASH_REMATCH[1]}"
+    else
+        report-error "Could not determine installed Node version."
+        exit 1
+    fi
+
+    if [[ ${buildVersion} != ${runVersion} ]]; then
+        report-error "Mismatched Node major versions: Built with v${buildVersion}; running with v${runVersion}."
+        exit 1
+    fi
+}
 
 #
 # Main script
 #
 
 check-environment-dependencies
+check-node-versions
+
 cd "${baseDir}/server"
 exec node node_modules/.bin/bayou-server --prog-name="${progName}" "$@"

--- a/local-modules/@bayou/env-server/tests/test_ProductInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_ProductInfo.js
@@ -12,7 +12,9 @@ describe('@bayou/env-server/ProductInfo', () => {
   describe('.INFO', () => {
     it('should return an object full of product info', () => {
       const info = ProductInfo.theOne.INFO;
-      const productKeys = ['name', 'version', 'commit_id', 'commit_date', 'build_date'];
+      const productKeys = [
+        'name', 'version', 'commit_id', 'commit_date', 'build_date', 'node_version'
+      ];
 
       assert.doesNotThrow(() => TObject.withExactKeys(info, productKeys));
     });

--- a/scripts/build
+++ b/scripts/build
@@ -435,6 +435,13 @@ function build-product-info {
     # `git log` command, above.
     local buildDate="build_date = '$(date '+%Y-%m-%d %H:%M:%S %z')'"
 
+    # The version of Node that was used for the build. This is important because
+    # the version of Node used to _run_ the product needs to be the same major
+    # version. (Most specifically, the native module API needs to be compatible,
+    # but having a matching major version is a reasonably conservative expansion
+    # from there.)
+    local nodeVersion="node_version = $(node --version | sed -e 's/^v//g')"
+
     mkdir -p "$(dirname "${outFile}")"
 
     # Combine the static info file from the source with the additional info
@@ -445,6 +452,7 @@ function build-product-info {
         echo '# The following lines were added automatically by the build script.'
         echo "${commitInfo}"
         echo "${buildDate}"
+        echo "${nodeVersion}"
     ) > "${outFile}"
 }
 


### PR DESCRIPTION
Because the project uses a native module on the server, and because the native module ABI varies between major Node versions, we always need to build and run using the same major version of Node. Before this PR, when there was a mismatch, the `node` invocation would die with an obscure message to stderr immediately upon startup. _With_ this PR, there's a new preflight check in the `run` script, which will emit a more sensible error message.