### PR TITLE
Allow for more leniency in the versions of Quill dependencies

### DIFF
--- a/local-modules/@bayou/deps-peers-client-default/README.md
+++ b/local-modules/@bayou/deps-peers-client-default/README.md
@@ -1,0 +1,12 @@
+@bayou/deps-peers-client-default
+================================
+
+This module just serves as a single location to hold all of the default peer
+dependencies that are client-specific.
+
+### What's this all about?
+
+Bayou is somewhat lenient in which versions of some packages it requires, but by
+default we want to track the latest version. We express this "tension" by
+specifying a lenient version under `peerDependencies` in `deps-*-client` and
+as a version that stays more up-to-date in _this_ module.

--- a/local-modules/@bayou/deps-peers-client-default/README.md
+++ b/local-modules/@bayou/deps-peers-client-default/README.md
@@ -7,6 +7,7 @@ dependencies that are client-specific.
 ### What's this all about?
 
 Bayou is somewhat lenient in which versions of some packages it requires, but by
-default we want to track the latest version. We express this "tension" by
+default we want to track the latest versions and indicate our belief of
+compatibility with those latest versions. We express this "tension" by
 specifying a lenient version under `peerDependencies` in `deps-*-client` and
 as a version that stays more up-to-date in _this_ module.

--- a/local-modules/@bayou/deps-peers-client-default/index.js
+++ b/local-modules/@bayou/deps-peers-client-default/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// This module serves only to hold common dependencies, so there's nothing to
+// export.
+module.exports = {};

--- a/local-modules/@bayou/deps-peers-client-default/package.json
+++ b/local-modules/@bayou/deps-peers-client-default/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
-    "quill": "^1.3.5"
+    "quill": "^1.3.5",
+
+    "@bayou/deps-peers-common-default": "local"
   }
 }

--- a/local-modules/@bayou/deps-peers-client-default/package.json
+++ b/local-modules/@bayou/deps-peers-client-default/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "quill": "^1.3.5"
+  }
+}

--- a/local-modules/@bayou/deps-peers-common-default/README.md
+++ b/local-modules/@bayou/deps-peers-common-default/README.md
@@ -7,6 +7,7 @@ dependencies that are applicable to both the client and server sides.
 ### What's this all about?
 
 Bayou is somewhat lenient in which versions of some packages it requires, but by
-default we want to track the latest version. We express this "tension" by
-specifying a lenient version under `peerDependencies` in `deps-*-common` and
+default we want to track the latest versions and indicate our belief of
+compatibility with those latest versions. We express this "tension" by
+specifying a lenient version under `peerDependencies` in `deps-*-client` and
 as a version that stays more up-to-date in _this_ module.

--- a/local-modules/@bayou/deps-peers-common-default/README.md
+++ b/local-modules/@bayou/deps-peers-common-default/README.md
@@ -1,0 +1,12 @@
+@bayou/deps-peers-client-default
+================================
+
+This module just serves as a single location to hold all of the default peer
+dependencies that are applicable to both the client and server sides.
+
+### What's this all about?
+
+Bayou is somewhat lenient in which versions of some packages it requires, but by
+default we want to track the latest version. We express this "tension" by
+specifying a lenient version under `peerDependencies` in `deps-*-common` and
+as a version that stays more up-to-date in _this_ module.

--- a/local-modules/@bayou/deps-peers-common-default/index.js
+++ b/local-modules/@bayou/deps-peers-common-default/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+// This module serves only to hold common dependencies, so there's nothing to
+// export.
+module.exports = {};

--- a/local-modules/@bayou/deps-peers-common-default/package.json
+++ b/local-modules/@bayou/deps-peers-common-default/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "quill-delta": "^3.6.2"
+  }
+}

--- a/local-modules/@bayou/deps-quill-client/package.json
+++ b/local-modules/@bayou/deps-quill-client/package.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "quill": "^1.3.5",
-
     "@bayou/deps-quill-common": "local"
   },
 

--- a/local-modules/@bayou/deps-quill-client/package.json
+++ b/local-modules/@bayou/deps-quill-client/package.json
@@ -3,5 +3,9 @@
     "quill": "^1.3.5",
 
     "@bayou/deps-quill-common": "local"
+  },
+
+  "peerDependencies": {
+    "quill": "^1.2.4"
   }
 }

--- a/local-modules/@bayou/deps-quill-common/package.json
+++ b/local-modules/@bayou/deps-quill-common/package.json
@@ -1,5 +1,5 @@
 {
-  "dependencies": {
-    "quill-delta": "^3.6.2"
+  "peerDependencies": {
+    "quill-delta": "^3.5.0"
   }
 }

--- a/local-modules/@bayou/main-client/package.json
+++ b/local-modules/@bayou/main-client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@bayou/config-client-default": "local",
     "@bayou/config-common-default": "local",
-    "@bayou/deps-peer-client-default": "local",
+    "@bayou/deps-peers-client-default": "local",
     "@bayou/top-client": "local"
   }
 }

--- a/local-modules/@bayou/main-client/package.json
+++ b/local-modules/@bayou/main-client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@bayou/config-client-default": "local",
     "@bayou/config-common-default": "local",
+    "@bayou/deps-peer-client-default": "local",
     "@bayou/top-client": "local"
   }
 }

--- a/local-modules/@bayou/main-server/package.json
+++ b/local-modules/@bayou/main-server/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@bayou/config-common-default": "local",
     "@bayou/config-server-default": "local",
+    "@bayou/deps-peers-common-default": "local",
     "@bayou/top-server": "local"
   }
 }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.0.1
+version = 1.0.2


### PR DESCRIPTION
This PR adds `peerDependencies` definitions for our two Quill-related dependencies which are fairly lenient in what versions they'll allow, and then adds stricter dependencies (that more closely track the latest) as non-peer `dependencies` which are defined at the top levels of the client and server module stacks.

What this does is allow the Bayou code to be more flexible in terms of dependencies when used as a _library_ while still making sure we can keep ratcheting up the versions of dependencies when building it as an independent product.