### PR TITLE
Optionally stop serving code.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -185,22 +185,25 @@ export default class Application extends CommonBase {
   }
 
   /**
-   * Sets up the static asset routes, including serving JS client code, but only
-   * if configured to do so. Notably, in a production configuration, it is
-   * reasonably likely that these routes should not be added.
+   * Sets up the static asset routes, including serving JS client code, but the
+   * latter only if configured to do so. Notably, in a production configuration,
+   * it is reasonably likely that code-serving routes should not be added.
    */
   _addStaticRoutes() {
     const app = this._app;
 
-    // Map Quill files into `/static/quill`. This is used for CSS files but not
-    // for the JS code; the JS code is included in the overall JS bundle file.
-    app.use('/static/quill',
-      express.static(path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/quill/dist')));
+    if (Deployment.shouldServeClientCode()) {
+      // Map Quill files into `/static/quill`. This is used for CSS files but
+      // not for the JS code; the JS code is included in the overall JS bundle
+      // file.
+      app.use('/static/quill',
+        express.static(path.resolve(Dirs.theOne.CLIENT_DIR, 'node_modules/quill/dist')));
 
-    // Use the client bundler (which uses Webpack) to serve JS bundles. The
-    // `:name` parameter gets interpreted by the client bundler to select which
-    // bundle to serve.
-    app.get('/static/js/:name.bundle.js', new ClientBundle().requestHandler);
+      // Use the client bundler (which uses Webpack) to serve JS bundles. The
+      // `:name` parameter gets interpreted by the client bundler to select
+      // which bundle to serve.
+      app.get('/static/js/:name.bundle.js', new ClientBundle().requestHandler);
+    }
 
     // Use the configuration point to determine which directories to serve
     // HTML files and other static assets from. This includes (but is not

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -23,6 +23,18 @@ export default class Deployment extends UtilityClass {
   /**
    * Implementation of standard configuration point.
    *
+   * This implementation is a no-op.
+   *
+   * @param {@bayou/top-server/Action} action_unused The action that is about to
+   *   be run.
+   */
+  static aboutToRun(action_unused) {
+    // This space intentionally left blank.
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
    * This implementation returns the base product directory (the argument), with
    * `/var` appended.
    *
@@ -43,17 +55,5 @@ export default class Deployment extends UtilityClass {
    */
   static isRunningInDevelopment() {
     return true;
-  }
-
-  /**
-   * Implementation of standard configuration point.
-   *
-   * This implementation is a no-op.
-   *
-   * @param {@bayou/top-server/Action} action_unused The action that is about to
-   *   be run.
-   */
-  static aboutToRun(action_unused) {
-    // This space intentionally left blank.
   }
 }

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -56,4 +56,15 @@ export default class Deployment extends UtilityClass {
   static isRunningInDevelopment() {
     return true;
   }
+
+  /**
+   * Implementation of standard configuration point.
+   *
+   * This implementation always returns `true`.
+   *
+   * @returns {boolean} `true`, always.
+   */
+  static shouldServeClientCode() {
+    return true;
+  }
 }

--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -68,4 +68,16 @@ export default class Deployment extends UtilityClass {
   static isRunningInDevelopment() {
     return use.Deployment.isRunningInDevelopment();
   }
+
+  /**
+   * Checks to see if this server should serve code assets (most notably client
+   * JavaScript bundles). It is typical (but not necessary) for this to be
+   * `true` in development environments and `false` in production environments.
+   *
+   * @returns {boolean} `true` if this server should server code assets, or
+   *   `false` if not.
+   */
+  static shouldServeClientCode() {
+    return use.Deployment.shouldServeClientCode();
+  }
 }

--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -21,6 +21,20 @@ export default class Deployment extends UtilityClass {
   }
 
   /**
+   * Performs any setup needed prior to running either a server per se or one
+   * of the server actions (such as running a unit test). This gets called
+   * _after_ the very lowest layer of the system is set up (e.g. the Babel
+   * runtime) and _after_ the logging system is ready, and _before_ everything
+   * else.
+   *
+   * @param {@bayou/top-server/Action} action The action that is about to be
+   *   run.
+   */
+  static aboutToRun(action) {
+    use.Deployment.aboutToRun(action);
+  }
+
+  /**
    * Determines the location of the "var" (variable / mutable data) directory,
    * returning an absolute path to it. (This is where, for example, log files
    * are stored.) The directory need not exist; the system will take care of
@@ -53,19 +67,5 @@ export default class Deployment extends UtilityClass {
    */
   static isRunningInDevelopment() {
     return use.Deployment.isRunningInDevelopment();
-  }
-
-  /**
-   * Performs any setup needed prior to running either a server per se or one
-   * of the server actions (such as running a unit test). This gets called
-   * _after_ the very lowest layer of the system is set up (e.g. the Babel
-   * runtime) and _after_ the logging system is ready, and _before_ everything
-   * else.
-   *
-   * @param {@bayou/top-server/Action} action The action that is about to be
-   *   run.
-   */
-  static aboutToRun(action) {
-    use.Deployment.aboutToRun(action);
   }
 }


### PR DESCRIPTION
This PR adds a configuration point which enables / disables the serving of code assets. It's expected that many production-configured instances will _not_ want to serve code directly.