### PR TITLE
Logging and debugging

### DIFF
--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -78,6 +78,15 @@ export default class BaseKey extends CommonBase {
   }
 
   /**
+   * {string} Printable and security-safe (i.e. redacted if necessary) form of
+   * the token. This includes an "ASCII ellipsis" (`...`) if to indicate
+   * redaction.
+   */
+  get printableId() {
+    return this._impl_printableId();
+  }
+
+  /**
    * Gets a challenge response. This is used as a tactic for two sides of a
    * connection to authenticate each other without ever having to provide a
    * shared secret directly over a connection.
@@ -121,7 +130,7 @@ export default class BaseKey extends CommonBase {
 
     return (opts.depth < 0)
       ? `${name} {...}`
-      : `${name} { ${this._url} ${this._impl_printableId()} }`;
+      : `${name} { ${this._url} ${this.printableId} }`;
   }
 
   /**
@@ -154,7 +163,8 @@ export default class BaseKey extends CommonBase {
   /**
    * Gets the printable form of the ID. This defaults to the same as `.id`,
    * but subclasses can override this if they want to produce something
-   * different.
+   * different. If the form has any redaction, it should use `...` (an ASCII
+   * ellipsis) to indicate that fact.
    *
    * @returns {string} The printable form of the ID.
    */

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -79,4 +79,15 @@ export default class Message extends CommonBase {
   get targetId() {
     return this._targetId;
   }
+
+  /**
+   * Returns a new instance just like `this` except with the `targetId` as
+   * given.
+   *
+   * @param {string} targetId The new target ID.
+   * @returns {Message} An appropriately-constructed instance.
+   */
+  withTargetId(targetId) {
+    return new Message(this._id, targetId, this._payload);
+  }
 }

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -6,7 +6,7 @@ import { TString } from '@bayou/typecheck';
 import { Errors, UtilityClass } from '@bayou/util-common';
 
 /** {RegExp} Regular expression which matches valid target IDs. */
-const VALID_TARGET_ID_REGEX = /^[-_a-zA-Z0-9]{1,64}$/;
+const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,64}$/;
 
 /**
  * Type representation of target IDs. The values themselves are always just

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Network } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
 
@@ -56,7 +57,7 @@ export default class ApiLog extends CommonBase {
     }
 
     // Details to log. **TODO:** This will ultimately need to redact some
-    // information from `msg` and `response`.
+    // information in the response.
 
     details.endTime = Date.now();
 
@@ -78,11 +79,13 @@ export default class ApiLog extends CommonBase {
    * @param {Message} msg Incoming message.
    */
   incomingMessage(msg) {
-    const details = { msg, startTime: Date.now() };
+    const details = {
+      msg: ApiLog._redactMessage(msg),
+      startTime: Date.now()
+    };
 
     this._pending.set(msg, details);
 
-    // TODO: This will ultimately need to redact some information.
     this._log.event.apiReceived(details);
   }
 
@@ -101,7 +104,24 @@ export default class ApiLog extends CommonBase {
       error:     response.originalError
     };
 
-    // TODO: This will ultimately need to redact some information.
+    // **TODO:** This will ultimately need to redact some information beyond
+    // what `_redactMessage()` might have done.
     this._log.event.apiReturned(details);
+  }
+
+  /**
+   * Performs redaction on a message, so as to avoid logging sensitive security
+   * and user-data details.
+   *
+   * @param {Message} msg The original message.
+   * @returns {Message} The redacted form.
+   */
+  static _redactMessage(msg) {
+    if (Network.bearerTokens.isToken(msg.id)) {
+      msg = msg.withId(Network.bearerTokens.printableId(msg.id));
+    }
+
+    // **TODO:** This will ultimately need to do more redaction.
+    return msg;
   }
 }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -117,8 +117,8 @@ export default class ApiLog extends CommonBase {
    * @returns {Message} The redacted form.
    */
   static _redactMessage(msg) {
-    if (Network.bearerTokens.isToken(msg.id)) {
-      msg = msg.withId(Network.bearerTokens.printableId(msg.id));
+    if (Network.bearerTokens.isToken(msg.targetId)) {
+      msg = msg.withTargetId(Network.bearerTokens.printableId(msg.targetId));
     }
 
     // **TODO:** This will ultimately need to do more redaction.

--- a/local-modules/@bayou/api-server/BearerToken.js
+++ b/local-modules/@bayou/api-server/BearerToken.js
@@ -97,7 +97,7 @@ export default class BearerToken extends BaseKey {
    * @returns {string} The printable form of the ID.
    */
   _impl_printableId() {
-    return `${this.id}...`;
+    return `${this.id}-...`;
   }
 
   /**

--- a/local-modules/@bayou/api-server/BearerToken.js
+++ b/local-modules/@bayou/api-server/BearerToken.js
@@ -40,11 +40,10 @@ export default class BearerToken extends BaseKey {
   /**
    * Constructs an instance with the indicated parts.
    *
-   * @param {string} secretToken Complete token. This must be a string of at
-   *   least 32 characters.
+   * @param {string} secretToken Complete token.
    */
   constructor(secretToken) {
-    TString.minLen(secretToken, 32);
+    TString.check(secretToken);
 
     if (!Network.bearerTokens.isToken(secretToken)) {
       // We don't include any real detail in the error message, as that might

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -178,7 +178,7 @@ export default class Connection extends CommonBase {
     // this call, log it, and return it for ulimate transmission back to the
     // caller.
 
-    const response = new Response(msg.id, result, error);
+    const response = new Response((msg === null) ? 0 : msg.id, result, error);
     const encodedResponse = this._codec.encodeJson(response);
 
     if (msg === null) {

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -222,6 +222,7 @@ export default class Connection extends CommonBase {
       return msg;
     }
 
+    console.log('=========', msg);
     return ConnectionError.connection_nonsense(
       this._connectionId, 'Did not receive `Message` object.');
   }

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -222,7 +222,6 @@ export default class Connection extends CommonBase {
       return msg;
     }
 
-    console.log('=========', msg);
     return ConnectionError.connection_nonsense(
       this._connectionId, 'Did not receive `Message` object.');
   }

--- a/local-modules/@bayou/api-server/PostConnection.js
+++ b/local-modules/@bayou/api-server/PostConnection.js
@@ -62,13 +62,14 @@ export default class PostConnection extends Connection {
   async _handleEnd() {
     this._log.event.receivedPost();
 
-    const msg = Buffer.concat(this._chunks).toString('utf8');
-    const response = await this.handleJsonMessage(msg);
+    const msg          = Buffer.concat(this._chunks).toString('utf8');
+    const response     = await this.handleJsonMessage(msg);
+    const responseText = `${response}\n`;
 
     this._res
       .status(200)
       .type('application/json')
-      .send(response);
+      .send(responseText);
     this.close();
   }
 
@@ -92,7 +93,8 @@ export default class PostConnection extends Connection {
    * @param {string} error Message to report.
    */
   _respond400(error) {
-    const payload = JSON.stringify({ id: -1, error });
+    const response     = { id: -1, error };
+    const responseText = `${JSON.stringify(response)}\n`;
 
     // Not logged as `.error()` because it's not an application error (at least
     // not on this side).
@@ -101,7 +103,7 @@ export default class PostConnection extends Connection {
     this._res
       .status(400)
       .type('application/json')
-      .send(payload);
+      .send(responseText);
   }
 
   /**

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -24,7 +24,7 @@ describe('@bayou/api-server/BearerToken', () => {
       assert.throws(() => new BearerToken(badToken));
     });
 
-    it('should return a frozen instane of BearerToken', () => {
+    it('should return a frozen instance of BearerToken', () => {
       const token = new BearerToken(exampleToken());
 
       assert.instanceOf(token, BearerToken);

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -10,7 +10,7 @@ import { BearerToken } from '@bayou/api-server';
 const SECRET_TOKEN = 'Setec-Astronomy-Setec-Astronomy-';
 
 describe('@bayou/api-server/BearerToken', () => {
-  describe('constructor(secret)', () => {
+  describe('constructor()', () => {
     it('should reject secrets with length < 32', () => {
       assert.throws(() => new BearerToken('Setec-Astronomy'));
     });
@@ -31,7 +31,7 @@ describe('@bayou/api-server/BearerToken', () => {
     });
   });
 
-  describe('sameToken(other)', () => {
+  describe('sameToken()', () => {
     it('should return false when passed `null`', () => {
       const token = new BearerToken(SECRET_TOKEN);
 
@@ -59,7 +59,7 @@ describe('@bayou/api-server/BearerToken', () => {
     });
   });
 
-  describe('sameArrays(array1, array2)', () => {
+  describe('sameArrays()', () => {
     it('should return `false` given arrays that are different lengths', () => {
       const token1 = new BearerToken(SECRET_TOKEN);
       const token2 = new BearerToken(SECRET_TOKEN);

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -6,17 +6,19 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken } from '@bayou/api-server';
-
-const SECRET_TOKEN = 'Setec-Astronomy-Setec-Astronomy-';
+import { Network } from '@bayou/config-server';
 
 describe('@bayou/api-server/BearerToken', () => {
+  const EXAMPLE_TOKEN = Network.bearerTokens.exampleToken;
+
   describe('constructor()', () => {
-    it('should reject secrets with length < 32', () => {
-      assert.throws(() => new BearerToken('Setec-Astronomy'));
+    it('should reject syntactically invalid secrets', () => {
+      const badToken = `bad-token-${EXAMPLE_TOKEN.slice(0, 8)}`;
+      assert.throws(() => new BearerToken(badToken));
     });
 
     it('should return a frozen instane of BearerToken', () => {
-      const token = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
 
       assert.instanceOf(token, BearerToken);
       assert.isFrozen(token);
@@ -25,35 +27,35 @@ describe('@bayou/api-server/BearerToken', () => {
 
   describe('.secretToken', () => {
     it('should return the token provided to the constructor', () => {
-      const token = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
 
-      assert.strictEqual(token.secretToken, SECRET_TOKEN);
+      assert.strictEqual(token.secretToken, EXAMPLE_TOKEN);
     });
   });
 
   describe('sameToken()', () => {
     it('should return false when passed `null`', () => {
-      const token = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
 
       assert.isFalse(token.sameToken(null));
     });
 
     it('should return false when passed `undefined`', () => {
-      const token = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
 
       assert.isFalse(token.sameToken(undefined));
     });
 
     it('should return `false` when passed a token with a different secret key', () => {
-      const token = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
       const other = new BearerToken('abcdefghijklmnopqrstuvwxyz012345');
 
       assert.isFalse(token.sameToken(other));
     });
 
     it('should return `true` when passed a token with the same secret key', () => {
-      const token = new BearerToken(SECRET_TOKEN);
-      const other = new BearerToken(SECRET_TOKEN);
+      const token = new BearerToken(EXAMPLE_TOKEN);
+      const other = new BearerToken(EXAMPLE_TOKEN);
 
       assert.isTrue(token.sameToken(other));
     });
@@ -61,10 +63,10 @@ describe('@bayou/api-server/BearerToken', () => {
 
   describe('sameArrays()', () => {
     it('should return `false` given arrays that are different lengths', () => {
-      const token1 = new BearerToken(SECRET_TOKEN);
-      const token2 = new BearerToken(SECRET_TOKEN);
-      const token3 = new BearerToken(SECRET_TOKEN);
-      const token4 = new BearerToken(SECRET_TOKEN);
+      const token1 = new BearerToken(EXAMPLE_TOKEN);
+      const token2 = new BearerToken(EXAMPLE_TOKEN);
+      const token3 = new BearerToken(EXAMPLE_TOKEN);
+      const token4 = new BearerToken(EXAMPLE_TOKEN);
 
       const array1 = [token1, token2, token3, token4];
       const array2 = [token1, token2, token3];
@@ -73,10 +75,10 @@ describe('@bayou/api-server/BearerToken', () => {
     });
 
     it('should throw an Error if given arrays that contain things other than BearerTokens', () => {
-      const token1 = new BearerToken(SECRET_TOKEN);
-      const token2 = new BearerToken(SECRET_TOKEN);
-      const token3 = new BearerToken(SECRET_TOKEN);
-      const token4 = new BearerToken(SECRET_TOKEN);
+      const token1 = new BearerToken(EXAMPLE_TOKEN);
+      const token2 = new BearerToken(EXAMPLE_TOKEN);
+      const token3 = new BearerToken(EXAMPLE_TOKEN);
+      const token4 = new BearerToken(EXAMPLE_TOKEN);
 
       const array1 = [token1, token2, token3, token4, 'a'];
       const array2 = [token1, token2, token3, token4, 'a'];
@@ -85,10 +87,10 @@ describe('@bayou/api-server/BearerToken', () => {
     });
 
     it('should return `true` given identically-constructed arrays of BearerTokens', () => {
-      const token1 = new BearerToken(SECRET_TOKEN);
-      const token2 = new BearerToken(SECRET_TOKEN);
-      const token3 = new BearerToken(SECRET_TOKEN);
-      const token4 = new BearerToken(SECRET_TOKEN);
+      const token1 = new BearerToken(EXAMPLE_TOKEN);
+      const token2 = new BearerToken(EXAMPLE_TOKEN);
+      const token3 = new BearerToken(EXAMPLE_TOKEN);
+      const token4 = new BearerToken(EXAMPLE_TOKEN);
 
       const array1 = [token1, token2, token3, token4];
       const array2 = [token1, token2, token3, token4];

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -20,7 +20,7 @@ function exampleToken() {
 describe('@bayou/api-server/BearerToken', () => {
   describe('constructor()', () => {
     it('should reject syntactically invalid secrets', () => {
-      const badToken = `bad-token-${exampleToken().slice(0, 8)}`;
+      const badToken = `~!bad!token!~${exampleToken().slice(0, 8)}`;
       assert.throws(() => new BearerToken(badToken));
     });
 

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -8,17 +8,24 @@ import { describe, it } from 'mocha';
 import { BearerToken } from '@bayou/api-server';
 import { Network } from '@bayou/config-server';
 
-describe('@bayou/api-server/BearerToken', () => {
-  const EXAMPLE_TOKEN = Network.bearerTokens.exampleToken;
+function exampleTokens() {
+  return Network.bearerTokens.exampleTokens;
+}
 
+function exampleToken() {
+  return exampleTokens()[0];
+}
+
+
+describe('@bayou/api-server/BearerToken', () => {
   describe('constructor()', () => {
     it('should reject syntactically invalid secrets', () => {
-      const badToken = `bad-token-${EXAMPLE_TOKEN.slice(0, 8)}`;
+      const badToken = `bad-token-${exampleToken().slice(0, 8)}`;
       assert.throws(() => new BearerToken(badToken));
     });
 
     it('should return a frozen instane of BearerToken', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
 
       assert.instanceOf(token, BearerToken);
       assert.isFrozen(token);
@@ -27,35 +34,35 @@ describe('@bayou/api-server/BearerToken', () => {
 
   describe('.secretToken', () => {
     it('should return the token provided to the constructor', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
 
-      assert.strictEqual(token.secretToken, EXAMPLE_TOKEN);
+      assert.strictEqual(token.secretToken, exampleToken());
     });
   });
 
   describe('sameToken()', () => {
     it('should return false when passed `null`', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
 
       assert.isFalse(token.sameToken(null));
     });
 
     it('should return false when passed `undefined`', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
 
       assert.isFalse(token.sameToken(undefined));
     });
 
     it('should return `false` when passed a token with a different secret key', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
-      const other = new BearerToken('abcdefghijklmnopqrstuvwxyz012345');
+      const token = new BearerToken(exampleTokens()[0]);
+      const other = new BearerToken(exampleTokens()[1]);
 
       assert.isFalse(token.sameToken(other));
     });
 
     it('should return `true` when passed a token with the same secret key', () => {
-      const token = new BearerToken(EXAMPLE_TOKEN);
-      const other = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
+      const other = new BearerToken(exampleToken());
 
       assert.isTrue(token.sameToken(other));
     });
@@ -63,10 +70,10 @@ describe('@bayou/api-server/BearerToken', () => {
 
   describe('sameArrays()', () => {
     it('should return `false` given arrays that are different lengths', () => {
-      const token1 = new BearerToken(EXAMPLE_TOKEN);
-      const token2 = new BearerToken(EXAMPLE_TOKEN);
-      const token3 = new BearerToken(EXAMPLE_TOKEN);
-      const token4 = new BearerToken(EXAMPLE_TOKEN);
+      const token1 = new BearerToken(exampleTokens()[0]);
+      const token2 = new BearerToken(exampleTokens()[1]);
+      const token3 = new BearerToken(exampleTokens()[0]);
+      const token4 = new BearerToken(exampleTokens()[1]);
 
       const array1 = [token1, token2, token3, token4];
       const array2 = [token1, token2, token3];
@@ -75,22 +82,19 @@ describe('@bayou/api-server/BearerToken', () => {
     });
 
     it('should throw an Error if given arrays that contain things other than BearerTokens', () => {
-      const token1 = new BearerToken(EXAMPLE_TOKEN);
-      const token2 = new BearerToken(EXAMPLE_TOKEN);
-      const token3 = new BearerToken(EXAMPLE_TOKEN);
-      const token4 = new BearerToken(EXAMPLE_TOKEN);
+      const token = new BearerToken(exampleToken());
 
-      const array1 = [token1, token2, token3, token4, 'a'];
-      const array2 = [token1, token2, token3, token4, 'a'];
+      const array1 = [token, 'a'];
+      const array2 = [token, 'a'];
 
       assert.throws(() => BearerToken.sameArrays(array1, array2));
     });
 
     it('should return `true` given identically-constructed arrays of BearerTokens', () => {
-      const token1 = new BearerToken(EXAMPLE_TOKEN);
-      const token2 = new BearerToken(EXAMPLE_TOKEN);
-      const token3 = new BearerToken(EXAMPLE_TOKEN);
-      const token4 = new BearerToken(EXAMPLE_TOKEN);
+      const token1 = new BearerToken(exampleTokens()[0]);
+      const token2 = new BearerToken(exampleTokens()[1]);
+      const token3 = new BearerToken(exampleTokens()[0]);
+      const token4 = new BearerToken(exampleTokens()[1]);
 
       const array1 = [token1, token2, token3, token4];
       const array2 = [token1, token2, token3, token4];

--- a/local-modules/@bayou/api-server/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerToken.js
@@ -9,7 +9,7 @@ import { BearerToken } from '@bayou/api-server';
 import { Network } from '@bayou/config-server';
 
 function exampleTokens() {
-  return Network.bearerTokens.exampleTokens;
+  return Network.exampleTokens;
 }
 
 function exampleToken() {

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -235,7 +235,7 @@ export default class Application extends CommonBase {
       }
       for (const t of rootTokens) {
         context.addEvergreen(t, this._rootAccess);
-        log.info('Accept root:', t);
+        log.info('Accept root:', t.printableId);
       }
       this._rootTokens = rootTokens;
     }

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -14,23 +14,28 @@ import { CommonBase } from '@bayou/util-common';
  */
 export default class BearerTokens extends CommonBase {
   /**
-   * {string} An example token string, which is syntactically valid but should
-   * _not_ actually grant access to anything in a production environment. This
-   * is intended for unit testing.
+   * {array<string>} An array of at least two example token strings, each of
+   * which is syntactically valid but should _not_ actually grant access to
+   * anything in a production environment. This is intended for unit testing.
    */
-  get exampleToken() {
-    return '0'.repeat(32);
+  get exampleTokens() {
+    return [
+      '00000000000000000000000000000000',
+      '10000000000000000000000000000001'
+    ];
   }
 
   /**
    * {array<BearerToken>} Array of bearer tokens which grant root access to the
    * system.
    *
-   * The (obviously insecure) default is that a token consisting of 32 zeroes
-   * grants access.
+   * The (obviously insecure) default is the array of {@link #exampleTokens}
+   * converted to `BearerToken` objects.
    */
   get rootTokens() {
-    return Object.freeze([new BearerToken(this.exampleToken)]);
+    const tokens = this.exampleTokens.map(t => new BearerToken(t));
+
+    return Object.freeze(tokens);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -14,6 +14,15 @@ import { CommonBase } from '@bayou/util-common';
  */
 export default class BearerTokens extends CommonBase {
   /**
+   * {string} An example token string, which is syntactically valid but should
+   * _not_ actually grant access to anything in a production environment. This
+   * is intended for unit testing.
+   */
+  get exampleToken() {
+    return '0'.repeat(32);
+  }
+
+  /**
    * {array<BearerToken>} Array of bearer tokens which grant root access to the
    * system.
    *
@@ -21,7 +30,7 @@ export default class BearerTokens extends CommonBase {
    * grants access.
    */
   get rootTokens() {
-    return Object.freeze([new BearerToken('0'.repeat(32))]);
+    return Object.freeze([new BearerToken(this.exampleToken)]);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -14,6 +14,17 @@ import { CommonBase } from '@bayou/util-common';
  */
 export default class BearerTokens extends CommonBase {
   /**
+   * {array<BearerToken>} Array of bearer tokens which grant root access to the
+   * system.
+   *
+   * The (obviously insecure) default is that a token consisting of 32 zeroes
+   * grants access.
+   */
+  get rootTokens() {
+    return Object.freeze([new BearerToken('0'.repeat(32))]);
+  }
+
+  /**
    * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
    * token (whether or not it actually grants any access).
    *
@@ -27,14 +38,16 @@ export default class BearerTokens extends CommonBase {
   }
 
   /**
-   * {array<BearerToken>} Array of bearer tokens which grant root access to the
-   * system.
+   * Returns the printable and security-safe form of the given token string.
+   * This should only be passed strings for which {@link #isToken} returns
+   * `true`. This is a convenient wrapper around an ultimate call to
+   * {@link @bayou/api-server/BearerToken#printableId}.
    *
-   * The (obviously insecure) default is that a token consisting of 32 zeroes
-   * grants access.
+   * @param {string} tokenString The string form of the token.
+   * @returns {string} Its printable and security-safe form.
    */
-  get rootTokens() {
-    return Object.freeze([new BearerToken('0'.repeat(32))]);
+  printableId(tokenString) {
+    return new BearerToken(tokenString).printableId;
   }
 
   /**

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -15,9 +15,7 @@ import { CommonBase } from '@bayou/util-common';
 export default class BearerTokens extends CommonBase {
   /**
    * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
-   * token (whether or not it actually grants any access). This will only ever
-   * get called on strings (per se) of at least 32 characters, so it is safe to
-   * assume those facts.
+   * token (whether or not it actually grants any access).
    *
    * The default implementation just returns `true`.
    *

--- a/local-modules/@bayou/app-setup/BearerTokens.js
+++ b/local-modules/@bayou/app-setup/BearerTokens.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BearerToken } from '@bayou/api-server';
+import { Network } from '@bayou/config-server';
 import { Delay } from '@bayou/promise-util';
 import { CommonBase } from '@bayou/util-common';
 
@@ -14,18 +15,6 @@ import { CommonBase } from '@bayou/util-common';
  */
 export default class BearerTokens extends CommonBase {
   /**
-   * {array<string>} An array of at least two example token strings, each of
-   * which is syntactically valid but should _not_ actually grant access to
-   * anything in a production environment. This is intended for unit testing.
-   */
-  get exampleTokens() {
-    return [
-      '00000000000000000000000000000000',
-      '10000000000000000000000000000001'
-    ];
-  }
-
-  /**
    * {array<BearerToken>} Array of bearer tokens which grant root access to the
    * system.
    *
@@ -33,7 +22,7 @@ export default class BearerTokens extends CommonBase {
    * converted to `BearerToken` objects.
    */
   get rootTokens() {
-    const tokens = this.exampleTokens.map(t => new BearerToken(t));
+    const tokens = Network.exampleTokens.map(t => new BearerToken(t));
 
     return Object.freeze(tokens);
   }

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -13,6 +13,7 @@ import { CommonBase } from '@bayou/util-common';
 import Application from './Application';
 import RequestLogger from './RequestLogger';
 import ServerUtil from './ServerUtil';
+import VarInfo from './VarInfo';
 
 /** {Logger} Logger. */
 const log = new Logger('app-monitor');
@@ -90,6 +91,18 @@ export default class Monitor extends CommonBase {
 
     app.get('/info', async (req_unused, res) => {
       const text = JSON.stringify(ProductInfo.theOne.INFO, null, 2);
+
+      res
+        .status(200)
+        .type('application/json; charset=utf-8')
+        .set('Cache-Control', 'no-cache, no-store, no-transform')
+        .send(text);
+    });
+
+    const varInfo = new VarInfo();
+    app.get('/var', async (req_unused, res) => {
+      const info = await varInfo.get();
+      const text = JSON.stringify(info, null, 2);
 
       res
         .status(200)

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -1,0 +1,37 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Network } from '@bayou/config-server';
+import { CommonBase } from '@bayou/util-common';
+
+
+/**
+ * "Variable" info (like, it varies and isn't just static to the system), which
+ * is provided via the internal monitoring server (see {@link Monitor}).
+ */
+export default class VarInfo extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Gets the latest variable info.
+   *
+   * @returns {object} A JSON-encodable object with all of the variable info.
+   */
+  async get() {
+    // **Note:** The string form of a bearer token is redacted, such that the
+    // secret portion is not represented.
+    const tokenIds = Network.bearerTokens.rootTokens.map(t => t.toString());
+
+    return {
+      rootTokens: tokenIds
+    };
+  }
+}

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -26,9 +26,9 @@ export default class VarInfo extends CommonBase {
    * @returns {object} A JSON-encodable object with all of the variable info.
    */
   async get() {
-    // **Note:** The string form of a bearer token is redacted, such that the
-    // secret portion is not represented.
-    const tokenIds = Network.bearerTokens.rootTokens.map(t => t.toString());
+    // **Note:** The "printable" form of a bearer token is redacted, such that
+    // the secret portion is not represented.
+    const tokenIds = Network.bearerTokens.rootTokens.map(t => t.printableId);
 
     return {
       pid:        process.pid,

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -31,6 +31,7 @@ export default class VarInfo extends CommonBase {
     const tokenIds = Network.bearerTokens.rootTokens.map(t => t.toString());
 
     return {
+      pid:        process.pid,
       rootTokens: tokenIds
     };
   }

--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -31,6 +31,16 @@ export default class Network extends UtilityClass {
   }
 
   /**
+   * {array<string>} Implementation of standard configuration point.
+   */
+  static get exampleTokens() {
+    return [
+      '00000000000000000000000000000000',
+      '10000000000000000000000000000001'
+    ];
+  }
+
+  /**
    * {Int} Implementation of standard configuration point. This implementation
    * defines it as `8080`.
    */

--- a/local-modules/@bayou/config-server/Network.js
+++ b/local-modules/@bayou/config-server/Network.js
@@ -26,6 +26,15 @@ export default class Network extends UtilityClass {
   }
 
   /**
+   * {array<string>} An array of at least two example token strings, each of
+   * which is syntactically valid but should _not_ actually grant access to
+   * anything in a production environment. This is intended for unit testing.
+   */
+  static get exampleTokens() {
+    return use.Network.exampleTokens;
+  }
+
+  /**
    * {Int} The local port to listen for connections on.
    *
    * **Note:** This can get overridden when running the system for the purposes


### PR DESCRIPTION
This PR does two main things, in service of debugging:

* Add a new `/var` endpoint on the monitor server, which returns "variable" information about the server. Of primary interest right now are the set of bearer token IDs that the server recognizes. I also put the PID there because it seemed like a reasonably useful thing to have.
* Start redacting the `targetId` of `Message` objects that are getting logged as part of the API logging, when they're bearer tokens.

**Note:** There is a bit of churn in this PR regarding how `BearerToken` gets tested, which was "collateral damage" from the rearrangement of code that made the second bullet item above possible.