### PR TITLE
Complain better… on two fronts.

### DIFF
--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -4,6 +4,7 @@
 
 import { Text } from '@bayou/config-common';
 import { BaseDelta } from '@bayou/ot-common';
+import { Logger } from '@bayou/see-all';
 import { TBoolean, TObject } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
@@ -49,7 +50,16 @@ export default class BodyDelta extends BaseDelta {
           // update what is returned from
           // {@link @bayou/config-common/Text#Delta} to match what Quill has as
           // its `quill-delta` dependency.
-          throw Errors.badUse('Divergent versions of `quill-delta` package.');
+
+          // **TODO:** Because reasons, this complaint has been demoted to
+          // from "actual error" to "stern warning," for the time being. The
+          // `throw` should be restored at the earliest opportunity.
+          //throw Errors.badUse('Divergent versions of `quill-delta` package.');
+          if (!BodyDelta._divergentComplaintMade) {
+            // NB: This is the only code in this module that uses `see-all`.
+            BodyDelta._divergentComplaintMade = true;
+            new Logger('doc-common').warn('Divergent versions of `quill-delta` package!');
+          }
         }
         throw e;
       }

--- a/local-modules/@bayou/doc-common/package.json
+++ b/local-modules/@bayou/doc-common/package.json
@@ -3,6 +3,7 @@
     "@bayou/codec": "local",
     "@bayou/config-common": "local",
     "@bayou/ot-common": "local",
+    "@bayou/see-all": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/see-all/AllSinks.js
+++ b/local-modules/@bayou/see-all/AllSinks.js
@@ -64,6 +64,15 @@ export default class AllSinks extends Singleton {
   }
 
   /**
+   * Main implementation of the exported method {@link SeeAll#canLog}.
+   *
+   * @returns {boolean} `true` iff it is safe to call logging methods.
+   */
+  canLog() {
+    return this._sinks.length !== 0;
+  }
+
+  /**
    * Constructs a structured-event instance of {@link LogRecord} based on
    * the given arguments and the current time, and calls `sinkLog(logRecord)` on
    * each of the registered sinks.

--- a/local-modules/@bayou/see-all/SeeAll.js
+++ b/local-modules/@bayou/see-all/SeeAll.js
@@ -19,4 +19,16 @@ export default class SeeAll extends Singleton {
   add(sink) {
     AllSinks.theOne.add(sink);
   }
+
+  /**
+   * Indicates if it is safe to call logging methods. This only returns `false`
+   * during the earliest part of system bootstrap, before any logging sinks have
+   * been added. As such, it's only necessary to call this if the code which
+   * wants to log _might_ be called very early.
+   *
+   * @returns {boolean} `true` iff it is safe to call logging methods.
+   */
+  canLog() {
+    return AllSinks.theOne.canLog();
+  }
 }

--- a/local-modules/@bayou/top-server/TopErrorHandler.js
+++ b/local-modules/@bayou/top-server/TopErrorHandler.js
@@ -5,7 +5,7 @@
 import { inspect } from 'util';
 
 import { Delay } from '@bayou/promise-util';
-import { Logger } from '@bayou/see-all';
+import { Logger, SeeAll } from '@bayou/see-all';
 import { UtilityClass } from '@bayou/util-common';
 
 /** {Logger} Logger for this file. */
@@ -31,7 +31,9 @@ export default class TopErrorHandler extends UtilityClass {
       }
       process.stderr.write('\n');
 
-      log.error('Unhandled promise rejection:', reason);
+      if (SeeAll.theOne.canLog()) {
+        log.error('Unhandled promise rejection:', reason);
+      }
 
       // Give the system a moment, so it has a chance to actually flush the log,
       // and then exit.
@@ -61,7 +63,9 @@ export default class TopErrorHandler extends UtilityClass {
     }
     process.stderr.write('\n');
 
-    log.error(`${label}:`, problem);
+    if (SeeAll.theOne.canLog()) {
+      log.error(`${label}:`, problem);
+    }
 
     // Give the system a moment, so it has a chance to actually flush the log,
     // and then exit.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.0.4
+version = 1.0.5


### PR DESCRIPTION
Two unrelated complaint-related bits:

* Don't try to use the logging facility when errors are caught early during system startup.

* Turn the error when we detect that there is more than one `quill-delta` in the system into a warning… for now. (a) It's not an urgent problem in practice _at the moment_, and (b) we need to sort some stuff out before we can reactivate it.

This PR bumps the product version, because we want to consume the latter item above in npm form sooner rather than later.