### PR TITLE
Two items which are only vaguely related.

### DIFF
--- a/local-modules/@bayou/codec/ItemCodec.js
+++ b/local-modules/@bayou/codec/ItemCodec.js
@@ -2,10 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Logger } from '@bayou/see-all';
 import { TArray, TFunction, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 import ConstructorCall from './ConstructorCall';
+
+/** {Logger} Logger for this module. */
+const log = new Logger('codec');
 
 /**
  * Handler for codable items of a particular class, type, or (in general) kind.
@@ -305,6 +309,7 @@ export default class ItemCodec extends CommonBase {
    */
   decode(payload, subDecode) {
     if (!this.canDecode(payload)) {
+      log.error('Cannot decode:', payload);
       throw Errors.badValue(payload, 'encoded payload');
     }
 
@@ -316,6 +321,7 @@ export default class ItemCodec extends CommonBase {
     const result = this._decode(payload, subDecode);
 
     if (!this.canEncode(result)) {
+      log.error('Cannot re-encode:', result);
       throw Errors.badUse('Invalid result from decoder.');
     }
 
@@ -335,6 +341,7 @@ export default class ItemCodec extends CommonBase {
    */
   encode(value, subEncode) {
     if (!this.canEncode(value)) {
+      log.error('Cannot encode:', value);
       throw Errors.badValue(value, 'encodable value');
     }
 
@@ -348,11 +355,13 @@ export default class ItemCodec extends CommonBase {
         TArray.check(result);
       } catch (e) {
         // Throw a higher-fidelity error.
+        log.error('Non-array encoding result:', result);
         throw Errors.badUse('Invalid encoding result (not an array).');
       }
 
       result = new ConstructorCall(new Functor(this._tag, ...result));
     } else if (ItemCodec.typeOf(result) !== encodedType) {
+      log.error(`Unexpected encoding result (expected type ${encodedType}):`, result);
       throw Errors.badUse('Invalid encoding result: ' +
         `got type ${ItemCodec.typeOf(result)}; expected type ${encodedType}`);
     }

--- a/local-modules/@bayou/codec/package.json
+++ b/local-modules/@bayou/codec/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@bayou/see-all": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -113,7 +113,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(noDeconstruct));
     });
 
-    it('should accept objects with an CODEC_TAG property and `deconstruct()` method', () => {
+    it('should accept objects with a `CODEC_TAG` property and `deconstruct()` method', () => {
       const fakeObject = new MockCodable();
 
       assert.doesNotThrow(() => encodeData(fakeObject));

--- a/local-modules/@bayou/testing-client/Tests.js
+++ b/local-modules/@bayou/testing-client/Tests.js
@@ -27,13 +27,16 @@ chai.use(chaiAsPromised);
  */
 export default class Tests extends UtilityClass {
   /**
-   * Runs all of the tests.
+   * Runs all of the tests, or all of the ones that pass the indicated filter.
    *
+   * @param {RegExp|null} [testFilter = null] Regular expression used on test
+   *   names.
    * @returns {number} The number of test failures as reported by the
    *   `mocha.run()` callback.
    */
-  static async runAll() {
+  static async runAll(testFilter = null) {
     const mocha = new Mocha({
+      grep:     testFilter || /./,
       reporter: EventReporter,
       ui:       'bdd'
     });

--- a/local-modules/@bayou/testing-server/ClientTests.js
+++ b/local-modules/@bayou/testing-server/ClientTests.js
@@ -26,9 +26,10 @@ export default class ClientTests extends UtilityClass {
    *   server (which might turn out to be in this process).
    * @param {string|null} testOut If non-`null`, filesystem path to write the
    *   test output to.
+   * @param {RegExp|null} testFilter Filter on test names.
    * @returns {boolean} `true` iff there were any test failures.
    */
-  static async run(port, testOut) {
+  static async run(port, testOut, testFilter) {
     // **TODO:** This whole arrangement is a bit hacky and should be improved.
 
     // Set up and start up headless Chrome (via Puppeteer).
@@ -59,7 +60,11 @@ export default class ClientTests extends UtilityClass {
 
     // Issue the request to load up the client tests.
 
-    const url = `http://localhost:${port}/debug/client-test`;
+    const regexParam = testFilter
+      ? `/${encodeURIComponent(testFilter.source)}`
+      : '';
+
+    const url = `http://localhost:${port}/debug/client-test${regexParam}`;
 
     log.info(`Issuing request to start test run:\n  ${url}`);
 

--- a/local-modules/@bayou/testing-server/ServerTests.js
+++ b/local-modules/@bayou/testing-server/ServerTests.js
@@ -30,16 +30,18 @@ export default class ServerTests extends UtilityClass {
    *
    * @param {string|null} testOut If non-`null`, filesystem path to write the
    *   test output to.
+   * @param {RegExp|null} testFilter Filter on test names.
    * @returns {boolean} `true` iff there were any test failures.
    */
-  static async run(testOut) {
+  static async run(testOut, testFilter) {
     const testFiles = TestFiles.allServerFiles();
 
     // The hacky arrangement with `reporterHolder` is how we exfiltrate the
     // reporter instance out of Mocha.
     const reporterHolder = [];
     const mocha = new Mocha({
-      reporter: CollectingReporter,
+      grep:            testFilter || /./,
+      reporter:        CollectingReporter,
       reporterOptions: { holder: reporterHolder }
     });
 

--- a/local-modules/@bayou/top-client/Client.js
+++ b/local-modules/@bayou/top-client/Client.js
@@ -55,12 +55,14 @@ export default class Client extends UtilityClass {
   static async runUnitTests(configFunction, testsClass) {
     Client._init(configFunction, 'Starting up testing environment...');
 
+    const testFilter = window.BAYOU_TEST_FILTER || null;
+
     const elem = document.createElement('p');
     elem.innerHTML = 'Running&hellip;';
     document.body.appendChild(elem);
 
     (async () => {
-      const failures = await testsClass.runAll();
+      const failures = await testsClass.runAll(testFilter);
 
       let msg;
       switch (failures) {

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -150,7 +150,8 @@ export default class Action extends CommonBase {
       await Delay.resolve(15 * 1000);
     }
 
-    const anyFailed = await ClientTests.run(port, this._options.testOut);
+    const anyFailed =
+      await ClientTests.run(port, this._options.testOut, this._options.testFilter);
 
     return anyFailed ? 1 : 0;
   }
@@ -213,7 +214,8 @@ export default class Action extends CommonBase {
    * @returns {Int} Standard process exit code.
    */
   async _run_serverTest() {
-    const anyFailed = await ServerTests.run(this._options.testOut || null);
+    const anyFailed =
+      await ServerTests.run(this._options.testOut, this._options.testFilter);
 
     return anyFailed ? 1 : 0;
   }

--- a/local-modules/@bayou/top-server/Options.js
+++ b/local-modules/@bayou/top-server/Options.js
@@ -56,6 +56,15 @@ export default class Options extends CommonBase {
   }
 
   /**
+   * {RegExp|null} Regular expression which must match a test name in order for
+   * that test to be run, or `null` if either this isn't a test run or all tests
+   * are to be run.
+   */
+  get testFilter() {
+    return this._options.testFilter;
+  }
+
+  /**
    * {string|null} Filesystem path naming a directory into which test results
    * should be placed, or `null` if either this isn't a test run or results
    * should merely be written to the console.
@@ -109,6 +118,8 @@ export default class Options extends CommonBase {
       '      JSON-encoded event records.',
       '    --prog-name=<name>',
       '      Name of this program, for use when reporting errors and diagnostics.',
+      '    --test-filter=<regex>',
+      '      When running tests, only run ones whose name matches the given regex.',
       '    --test-out=<path>',
       '      Where to write the output from a test run in addition to writing to the',
       '      console. (If not specified, will just write to the console.)',
@@ -134,6 +145,7 @@ export default class Options extends CommonBase {
       errorMessage: null,
       humanConsole: false,
       progName:     path.basename(argv[1]),
+      testFilter:   null,
       testOut:      null
     };
 
@@ -145,6 +157,7 @@ export default class Options extends CommonBase {
       ]),
       string: [
         'prog-name',
+        'test-filter',
         'test-out'
       ],
       alias: {
@@ -174,6 +187,17 @@ export default class Options extends CommonBase {
 
       gotAction = true;
       result.action = a;
+    }
+
+    const testFilter = opts['test-filter'];
+    if (testFilter) {
+      if (!/-test$/.test(result.action)) {
+        result.errorMessage =
+          'Cannot specify `--test-filter` except when running a `*-test` action.';
+        return result;
+      }
+
+      result.testFilter = new RegExp(testFilter);
     }
 
     const testOut = opts['test-out'];

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -36,6 +36,9 @@ showHelp=0
 # Output directory option, if any.
 outDirOpt=()
 
+# Unit test name filter, for use with `--client` and `--server` tests.
+testFilter=''
+
 # Which tests to run.
 tests=()
 
@@ -47,6 +50,9 @@ while true; do
             ;;
         --client|--client-bundle|--server)
             tests+=("${1#--}") # Strip off the `--` prefix.
+            ;;
+        --filter=*)
+            testFilter="${1#*=}"
             ;;
         --out=?*)
             outDirOpt+=("$1")
@@ -83,6 +89,10 @@ if (( ${showHelp} || ${argError} )); then
     echo '    stored.'
     echo '  --server'
     echo '    Run the server unit tests.'
+    echo '  --filter=<regex>'
+    echo '    Regex which matches unit test names. If specified, only unit tests'
+    echo '    that match the filter will be run. This uses JavaScript regex'
+    echo '    syntax.'
     echo ''
     echo "${progName} [--help | -h]"
     echo '  Display this message.'
@@ -162,6 +172,12 @@ runProduct="${outDir}/final/bin/run"
 # Directory for test output.
 testOutDir="${outDir}/test-results"
 
+# Extra argument for the unit test filter, if specified.
+testFilterArg=()
+if [[ ${testFilter} != '' ]]; then
+    testFilterArg=("--test-filter=${testFilter}")
+fi
+
 if [[ ! -e ${runProduct} ]]; then
     echo 'Could not find `run` script. Did you forget to build?' 1>&2
     exit 1
@@ -172,13 +188,13 @@ mkdir -p "${testOutDir}"
 for test in "${tests[@]}"; do
     case "${test}" in
         client)
-            run-test 'client-test.txt' "${runProduct}" --client-test
+            run-test 'client-test.txt' "${runProduct}" --client-test "${testFilterArg[@]}"
             ;;
         client-bundle)
             run-test --tee 'client-bundle.txt' "${runProduct}" --client-bundle
             ;;
         server)
-            run-test 'server-test.txt' "${runProduct}" --server-test
+            run-test 'server-test.txt' "${runProduct}" --server-test "${testFilterArg[@]}"
             ;;
     esac
 done


### PR DESCRIPTION
* Add some logging code in `codec` to help track down an intermittent problem we're seeing.
* Add a way to selectively run unit tests by filtering the names; works for both client and server code. This ultimately boils down to using Mocha's `grep` configuration option, but it had to be plumbed through N layers of our system so that we could say `./scripts/run-tests --client --filter=codec` (or what-have-you). I'd been meaning to get this done for quite a while.