### PR TITLE
Add compilation of JS sources as an optional step in the npm publication process.

### DIFF
--- a/local-modules/@bayou/main-compiler/index.js
+++ b/local-modules/@bayou/main-compiler/index.js
@@ -37,6 +37,17 @@ const BROWSER_VERSIONS = [
   'Safari >= 11'
 ];
 
+/**
+ * {object} The Babel `env` preset. We have to refer to this (and other presets)
+ * in the configs below as resolved objects and not just names, specifically
+ * because Babel &mdash; goodness knows why &mdash; does preset name resolution
+ * relative to the source files being compiled.
+ */
+const BABEL_PRESET_ENV = require.resolve('babel-preset-env');
+
+/** {object} The Babel `react` preset. See above for rationale. */
+const BABEL_PRESET_REACT = require.resolve('babel-preset-react');
+
 /** {object<string,object>} Map from configuration names to Babel configs. */
 const BABEL_CONFIGS = {
   'client': Object.freeze({
@@ -44,12 +55,12 @@ const BABEL_CONFIGS = {
 
     presets: [
       [
-        'env',
+        BABEL_PRESET_ENV,
         {
           targets: { browsers: BROWSER_VERSIONS }
         }
       ],
-      ['react']
+      [BABEL_PRESET_REACT]
     ]
   }),
 
@@ -58,7 +69,7 @@ const BABEL_CONFIGS = {
 
     presets: [
       [
-        'env',
+        BABEL_PRESET_ENV,
         {
           targets: {
             browsers: BROWSER_VERSIONS,
@@ -66,7 +77,7 @@ const BABEL_CONFIGS = {
           }
         }
       ],
-      ['react']
+      [BABEL_PRESET_REACT]
     ]
   }),
 
@@ -75,7 +86,7 @@ const BABEL_CONFIGS = {
 
     presets: [
       [
-        'env',
+        BABEL_PRESET_ENV,
         { targets: { node: NODE_VERSION } }
       ]
     ]

--- a/local-modules/@bayou/main-compiler/index.js
+++ b/local-modules/@bayou/main-compiler/index.js
@@ -231,7 +231,12 @@ function compileFile(inputFile, outputFile) {
   try {
     inputStat = fs.statSync(inputFile);
     outputStat = fs.statSync(outputFile);
-    if (inputStat.mtimeMs <= outputStat.mtimeMs) {
+
+    // The `!==` check makes it so that we always compile files when the input
+    // and output directories are the same. (That is, the mtime test makes no
+    // sense in this case, and we have to assume the intention is to always
+    // compile.)
+    if ((inputFile !== outputFile) && (inputStat.mtimeMs <= outputStat.mtimeMs)) {
       console.log(chalk.gray.bold('Unchanged:'), chalk.gray(pathToLog));
       return;
     }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.0.8
+version = 1.0.9

--- a/scripts/build
+++ b/scripts/build
@@ -360,7 +360,8 @@ function build-server {
         fi
     done
 
-    "${compile}" "--in-dir=${fromDir}" "--out-dir=${toDir}" "${srcDirs[@]}" \
+    "${compile}" "--in-dir=${fromDir}" "--out-dir=${toDir}" --server \
+        "${srcDirs[@]}" \
     || return 1
 
     # Copy everything else over to the final `server` directory as-is. We use

--- a/scripts/build
+++ b/scripts/build
@@ -37,7 +37,7 @@ argError=0
 showHelp=0
 
 # List of subprojects to build.
-buildProjects=(compiler server client bin product-info)
+buildProjects=()
 
 # Directory in which to find additional local modules, if any.
 extraModulesDir=''
@@ -63,14 +63,17 @@ while true; do
         --clean)
             outOpts+=("$1")
             ;;
+        --compiler)
+            buildProjects+=(compiler)
+            ;;
         --copy-sources)
-            buildProjects=(copy-sources)
+            buildProjects+=(copy-sources)
             ;;
         --extra-modules=?*)
             extraModulesDir="${1#*=}"
             ;;
         --linter)
-            buildProjects=(linter)
+            buildProjects+=(linter)
             ;;
         --out=?*)
             outOpts+=("$1")
@@ -100,21 +103,33 @@ while true; do
     shift
 done
 
+if (( ${#buildProjects[@]} == 0 )); then
+    # Default set of things to build when no explicit targets are specified.
+    buildProjects=(compiler server client bin product-info)
+fi
+
 if (( ${showHelp} || ${argError} )); then
     echo 'Usage:'
     echo ''
     echo "${progName} [<opt> ...]"
-    echo '  Build the project.'
+    echo '  Build the project. If no target options are specified (e.g. `--linter`)'
+    echo '  this performs a full build.'
     echo ''
+    echo 'Target options:'
+    echo '  --compiler'
+    echo '    Build the compiler (transpiler).'
+    echo '  --copy-sources'
+    echo '    Just copy source files into the output directory. This is implied by'
+    echo '    by the other target options, but sometimes you might want to just do'
+    echo '    this by itself.'
+    echo '  --linter'
+    echo '    Build the linter.'
+    echo ''
+    echo 'Other options:'
     echo '  --clean'
     echo '    Start from a clean build.'
-    echo '  --copy-sources'
-    echo '    Just copy source files into the output directory. (Do no other build'
-    echo '    steps.)'
     echo '  --extra-modules=<dir>'
     echo '    Find additional local module sources in directory <dir>.'
-    echo '  --linter'
-    echo '    Just build the linter. (Do no other build steps.)'
     echo '  --out=<dir>'
     echo '    Place output in directory <dir>.'
     echo '  --main-client=<name>'

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -154,6 +154,13 @@ fi
 # Helper functions
 #
 
+# Performs compilation of JS sources in the given directory.
+function compile-sources {
+    local dir="$1"
+
+    "${compile}" --in-dir="${dir}" --publish .
+}
+
 # Performs name mapping on the source(ish) files in the given directory.
 function do-name-mapping {
     local dir="$1"
@@ -342,7 +349,7 @@ function process-module {
     fi
 
     if (( ${compileSource} )); then
-        echo '======= COMPILE HERE!!!' 1>&2
+        compile-sources "${toDir}"
     fi
 }
 
@@ -430,6 +437,17 @@ function write-default-readme {
 
 set-up-out "${outOpts[@]}" || exit 1
 make-name-map || exit 1
+
+compile='<unneeded>'
+if (( ${compileSource} )); then
+    # Find the script to invoke the Babel compiler (provided by the `compiler`
+    # subproject).
+    compile="$(find "${outDir}/compiler" -name 'bayou-compile')"
+    if [[ ${compile} == '' ]]; then
+        echo 'Could not find compiler script.' 1>&2
+        return 1
+    fi
+fi
 
 # Validate the base JSON.
 if [[ ${packageBaseJson} != '' ]]; then

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -158,7 +158,8 @@ fi
 function compile-sources {
     local dir="$1"
 
-    "${compile}" --in-dir="${dir}" --publish .
+    "${compile}" --in-dir="${dir}" --publish . || return 1
+    echo ''
 }
 
 # Performs name mapping on the source(ish) files in the given directory.

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -256,7 +256,7 @@ function make-name-map {
     # of the above mappings.
     nameMapJson+=$'  "": ""\n}\n'
 
-    nameMapProgram=(jq --raw-input --raw-output --slurp "${jqProgram}")
+    nameMapProgram=(jq --raw-input --raw-output "${jqProgram}")
 }
 
 # Determines the output module name for the given input module name.

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -333,6 +333,10 @@ function process-module {
     ' < "${fromDir}/package.json" > "${toDir}/package.json" \
     || return 1
 
+    if [[ ! -r "${toDir}/README.md" ]]; then
+        write-default-readme "${toName}" "${toDir}"
+    fi
+
     if [[ ${#nameMap[@]} != 0 ]]; then
         do-name-mapping "${toDir}" || return 1
     fi
@@ -405,6 +409,19 @@ function publish-modules {
         echo "${#errors[@]} error${plural}." 1>&2
         return 1
     fi
+}
+
+# Writes a default README file for the given module, into the given directory.
+function write-default-readme {
+    local name="$1"
+    local dir="$2"
+
+    (
+        echo "${name}"
+        echo "${name}" | sed -e 's/./=/g' # A row of equalses under the name.
+        echo ''
+        echo 'Subcomponent of the larger project.'
+    ) > "${dir}/README.md"
 }
 
 #

--- a/scripts/lib/build-npm-modules
+++ b/scripts/lib/build-npm-modules
@@ -45,6 +45,9 @@ showHelp=0
 # Options to pass to `set-up-out`.
 outOpts=()
 
+# Should the source files get compiled (transpiled)?
+compileSource=0
+
 # JSON text for the base contents of `package.json`, if any.
 packageBaseJson='{}'
 
@@ -65,6 +68,9 @@ while true; do
         -h|--help)
             showHelp=1
             break
+            ;;
+        --compile)
+            compileSource=1
             ;;
         --dry-run|--verbose)
             publishOpts+=("$1")
@@ -114,6 +120,9 @@ if (( ${showHelp} || ${argError} )); then
     echo "${progName} [<opt> ...]"
     echo '  Convert modules into publication form, and optionally publish them.'
     echo ''
+    echo '  --compile'
+    echo '    If specified, runs the Babel compiler on JS sources, instead of'
+    echo '    publishing original sources.'
     echo '  --dry-run'
     echo '    Passed through to `npm publish` when using `--publish`.'
     echo '  --out=<dir>'
@@ -144,6 +153,22 @@ fi
 #
 # Helper functions
 #
+
+# Performs name mapping on the source(ish) files in the given directory.
+function do-name-mapping {
+    local dir="$1"
+    local fileName
+
+    (cd "${dir}"; find . -type f \
+        '(' -name '*.js' -o -name '*.less' -o -name '*.md' ')') |
+    while read -r fileName; do
+        local fromFile="${dir}/${fileName}"
+        local toFile="${dir}/${fileName}-new"
+
+        "${nameMapProgram[@]}" < "${fromFile}" > "${toFile}" || return 1
+        mv "${toFile}" "${fromFile}" || return 1
+    done
+}
 
 # Helper for `make-name-map` which produces the translation for one module, if
 # it is in fact rescoped.
@@ -188,9 +213,9 @@ function calc-name-map-entry {
 # `nameMapProgram[@]` (`jq` invocation which transforms source text).
 #
 # The `nameMapProgram` uses `jq` as a "sed but with better regex
-# semantics." **Note #1**: `jq` uses the PCRE library. **Note #2:**
-# Unfortunately, backslashes need to be doubled because `jq` doesn't have syntax
-# for regex literals.
+# semantics." **Note #1**: `jq` uses the PCRE library for regex syntax. **Note
+# #2:** Unfortunately, backslashes need to be doubled because `jq` doesn't have
+# direct syntax for regex literals.
 function make-name-map {
     nameMap=()
     nameMapJson=$'{\n'
@@ -308,23 +333,13 @@ function process-module {
     ' < "${fromDir}/package.json" > "${toDir}/package.json" \
     || return 1
 
-    if [[ ${#nameMap[@]} == 0 ]]; then
-        # No module name mappings, so nothing more to do.
-        return
+    if [[ ${#nameMap[@]} != 0 ]]; then
+        do-name-mapping "${toDir}" || return 1
     fi
 
-    # Because there are module name mappings, go through each source file and
-    # perform replacements.
-
-    local fileName
-    (cd "${fromDir}"; find . -type f \
-        '(' -name '*.js' -o -name '*.less' -o -name '*.md' ')') |
-    while read -r fileName; do
-        local fromFile="${fromDir}/${fileName}"
-        local toFile="${toDir}/${fileName}"
-
-        "${nameMapProgram[@]}" < "${fromFile}" > "${toFile}"
-    done
+    if (( ${compileSource} )); then
+        echo '======= COMPILE HERE!!!' 1>&2
+    fi
 }
 
 # Determines the product version from the info file.


### PR DESCRIPTION
The main point of this PR is to add a `--compile` option to the `build-npm-modules` script, which causes it to run all of the JS code to get processed by Babel with a configuration suitable for both client and server use (since published modules could conceivably used in either context, and because it seemed too weird to have the modules get compiled in three different ways depending on context). Some additional details:

* Added a `--compile` option to the main `build` script, so that the Babel compiler wrapper could be built without also doing the rest of the build. This also meant doing a little restructuring of the `build` script.
* Added three target-specifying options to our Babel compiler wrapper, `client` `publish` and `server`. `server` was all we ever did before. `publish` is what the npm stuff now uses. `client` is there for completeness.
* Fixed a bug in the compiler wrapper that was revealed by the new use case.
* Worked around a bug in `jq` that I discovered while doing all this. We were running into it before, but it only became blatant when we started running the compiler over the particular file that triggered the bug (and became invalid JS source because of it). <https://github.com/stedolan/jq/issues/1696>