### PR TITLE
 Become more lenient about the URLs used for API requests/sessions.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -181,6 +181,10 @@ export default class Application extends CommonBase {
       const url = info.req.url;
       const ok  = (url === '/api') || (url === '/api/');
 
+      // **Note:** The `ws` module docs indicate that it _sometimes_ calls the
+      // verifier function with a `cb` argument. If it does, and if the main
+      // result is `false`, it wants the `cb` to be passed additional arguments
+      // to refine the error.
       if (cb !== null) {
         if (ok) {
           cb(true);

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -179,7 +179,7 @@ export default class Application extends CommonBase {
 
     const wsVerify = (info, cb = null) => {
       const url = info.req.url;
-      const ok = (url === '/api') || (url === '/api/');
+      const ok  = (url === '/api') || (url === '/api/');
 
       if (cb !== null) {
         if (ok) {


### PR DESCRIPTION
We're seeing inconsistency in the URL used for API sessions, including seeing evidence in the logs that are both ambiguous about what clients are sending _and_ about what the server is (and isn't) accepting. It's not entirely clear why, but also it's really kinda NBD that it's happening. So, rather than fret too much about where the discrepancy is, this PR makes the server more lenient, explicitly allowing both POSTs and websocket sessions at the endpoint `/api/` in addition to `/api` (the latter of which was what we originally were set up to accept).