### PR TITLE
Logging tweak

### DIFF
--- a/local-modules/@bayou/see-all/LogRecord.js
+++ b/local-modules/@bayou/see-all/LogRecord.js
@@ -510,6 +510,8 @@ export default class LogRecord extends CommonBase {
 
     if (!this.isEvent()) {
       throw Errors.badUse('Requires an event instance.');
+    } else if (!DataUtil.isDeepFrozen(payload.args)) {
+      throw Errors.badValue(payload, 'deep-frozen data');
     }
 
     return new LogRecord(timeMsec, stack, tag, payload);

--- a/local-modules/@bayou/see-all/tests/test_LogRecord.js
+++ b/local-modules/@bayou/see-all/tests/test_LogRecord.js
@@ -95,7 +95,14 @@ describe('@bayou/see-all/LogRecord', () => {
       assert.throws(() => { lr.withEvent(f); });
     });
 
-    it('operates as expected on an event log', () => {
+    it('is an error to pass a payload that is not frozen data', () => {
+      const lr = LogRecord.forMessage(123, 'trace', new LogTag('taggaroo'), 'info', 'boop');
+      const f  = new Functor('x', ['this', 'array', 'is', 'not', 'frozen']);
+
+      assert.throws(() => { lr.withEvent(f); });
+    });
+
+    it('operates as expected on an event log, given a valid value', () => {
       const LOG_TAG = new LogTag('taggaroo');
       const lr      = LogRecord.forEvent(123321, 'zorch', LOG_TAG, new Functor('x', 1, 2));
       const f       = new Functor('y', 'z');


### PR DESCRIPTION
This is a small follow-on PR to my last one, fixing a couple bits. Specifically, when I added `LogRecord.withEvent()` I broke the guarantee that event payloads are immutable-data-only (as opposed to possibly having mutable state including being non-plain objects). Fixed!