### PR TITLE
Add some debugging spew

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -651,6 +651,9 @@ export default class BodyClient extends StateMachine {
         const value = await this._sessionProxy.body_update(this._snapshot.revNum, delta);
         this.q_gotUpdate(delta, value);
       } catch (e) {
+        // **TODO:** Remove this logging once we figure out why we're seeing
+        // this error.
+        this._log.event.badCompose(this._snapshot, delta);
         this.q_apiError('body_update', e);
       }
     })();

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -4,10 +4,17 @@
 
 import { Text } from '@bayou/config-common';
 import { BaseDelta } from '@bayou/ot-common';
+import { Logger } from '@bayou/see-all';
 import { TBoolean, TObject } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import BodyOp from './BodyOp';
+
+/**
+ * {Logger} Logger for this module. **Note:** Just used for some temporary
+ * debugging stuff.
+ */
+const log = new Logger('body-delta');
 
 /**
  * Always-frozen list of body OT operations. This uses Quill's `Delta` class to
@@ -150,6 +157,11 @@ export default class BodyDelta extends BaseDelta {
     // layers.
 
     if (wantDocument && !result.isDocument()) {
+      // **TODO:** Remove this logging once we track down why we're seeing this
+      // error.
+      log.event.badComposeOrig(this, other, result);
+      log.event.badComposeQuill(quillThis.ops, quillOther.ops, quillResult.ops);
+
       throw Errors.badUse('Inappropriate `other` for composition given `wantDocument === true`.');
     }
 

--- a/local-modules/@bayou/doc-common/package.json
+++ b/local-modules/@bayou/doc-common/package.json
@@ -3,6 +3,7 @@
     "@bayou/codec": "local",
     "@bayou/config-common": "local",
     "@bayou/ot-common": "local",
+    "@bayou/see-all": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local",
     "grapheme-splitter": "^1.0.2"

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -606,7 +606,18 @@ export default class BaseControl extends BaseDataManager {
 
     // Compose the implied expected result. This has the effect of validating
     // the contents of `delta`.
-    const expectedSnapshot = baseSnapshot.compose(change);
+
+    // Original line:
+    //   const expectedSnapshot = baseSnapshot.compose(change);
+    // **TODO:** Remove the following extra-loggy version of the above once we
+    // figure out why we're seeing errors.
+    let expectedSnapshot;
+    try {
+      expectedSnapshot = baseSnapshot.compose(change);
+    } catch (e) {
+      this.log.event.badComposeChange(change);
+      throw e;
+    }
 
     // This makes sure we have syntactic and semantic validation for any change.
     // It will validate based on the subclass implementaton.


### PR DESCRIPTION
We've seen `BodyDelta.compose()` throw the ``Inappropriate `other`...`` message a few times, and we're definitely not expecting it. This PR adds a handful of logging calls to try to elucidate what's going on.