### PR TITLE
Move `BearerTokens` to `api-server`.

### DIFF
--- a/local-modules/@bayou/api-server/BearerTokens.js
+++ b/local-modules/@bayou/api-server/BearerTokens.js
@@ -2,10 +2,11 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken } from '@bayou/api-server';
 import { Network } from '@bayou/config-server';
 import { Delay } from '@bayou/promise-util';
 import { CommonBase } from '@bayou/util-common';
+
+import BearerToken from './BearerToken';
 
 /**
  * Base class for and default implementation of

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -3,10 +3,11 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import BearerToken from './BearerToken';
+import BearerTokens from './BearerTokens';
 import Connection from './Connection';
 import Context from './Context';
 import PostConnection from './PostConnection';
 import Target from './Target';
 import WsConnection from './WsConnection';
 
-export { BearerToken, Connection, Context, PostConnection, Target, WsConnection };
+export { BearerToken, BearerTokens, Connection, Context, PostConnection, Target, WsConnection };

--- a/local-modules/@bayou/api-server/tests/test_BearerTokens.js
+++ b/local-modules/@bayou/api-server/tests/test_BearerTokens.js
@@ -5,10 +5,9 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BearerToken } from '@bayou/api-server';
-import { BearerTokens } from '@bayou/app-setup';
+import { BearerToken, BearerTokens } from '@bayou/api-server';
 
-describe('@bayou/app-setup/BearerTokens', () => {
+describe('@bayou/api-server/BearerTokens', () => {
   describe('constructor', () => {
     it('should succeed', () => {
       assert.doesNotThrow(() => new BearerTokens());

--- a/local-modules/@bayou/app-setup/index.js
+++ b/local-modules/@bayou/app-setup/index.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Application from './Application';
-import BearerTokens from './BearerTokens';
 import Monitor from './Monitor';
 
-export { Application, BearerTokens, Monitor };
+export { Application, Monitor };

--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerTokens } from '@bayou/app-setup';
+import { BearerTokens } from '@bayou/api-server';
 import { UtilityClass } from '@bayou/util-common';
 
 /**

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@bayou/app-setup": "local",
+    "@bayou/api-server": "local",
     "@bayou/assets-client": "local",
     "@bayou/config-common": "local",
     "@bayou/config-server": "local",

--- a/local-modules/@bayou/config-server-default/tests/test_Network.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Network.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BearerTokens } from '@bayou/app-setup';
+import { BearerTokens } from '@bayou/api-server';
 import { Network } from '@bayou/config-server-default';
 
 describe('@bayou/config-server-default/Network', () => {


### PR DESCRIPTION
Just a targeted rearrangement of code to be a little more sensible, in advance of doing more in-depth work on `api-server`.
