### PR TITLE
More work on the "bad compose" error. 

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -656,7 +656,7 @@ export default class BodyClient extends StateMachine {
     // it's arguably a safer way to reference the snapshot in question. By
     // inspection -- today! -- it doesn't look like the sort of hazard described
     // above could ever happen in practice, but the choice below may help avoid
-    // future bugs, in the face of possible later changes to this class.)
+    // future bugs, in the face of possible later changes to this class.
     (async () => {
       try {
         const value = await this._sessionProxy.body_update(baseSnapshot.revNum, delta);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.0.10
+version = 1.0.11


### PR DESCRIPTION
This PR makes one tweak (with long-winded explanation) and adds a bit of validation code, both which aim to help with the "bad compose" error we've been intermittently running into.

I added the new validation specifically because we are seeing snapshots that come in that appear to violate Quill's usual invariants. It's not totally clear whether we end up with these because Quill itself is handing them to us as such, or if we're managing to mangle them somewhere along the way. But in either case, the new checks should get us to error out more promptly, which will hopefully land us in a better position to diagnose the situation further.