### PR TITLE
Bump schema version (and product version)

### DIFF
--- a/local-modules/@bayou/doc-common/TheModule.js
+++ b/local-modules/@bayou/doc-common/TheModule.js
@@ -36,7 +36,7 @@ export default class TheModule extends UtilityClass {
    * or two, so that it isn't mistaken for a month.)
    */
   static get SCHEMA_VERSION() {
-    return '2018-001';
+    return '2018-002';
   }
 
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.0.11
+version = 1.0.12


### PR DESCRIPTION
An earlier PR introduced body snapshot validation that ensures that docs end with a newline. As it turns out, we have some saved docs floating around that violate the constraint. This PR bumps the schema version, which avoids getting confused by those docs.