### PR TITLE
Remove `.exampleTokens`.

### DIFF
--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -32,12 +32,13 @@ export default class Auth extends UtilityClass {
    * {array<BearerToken>} Implementation of standard configuration point.
    *
    * This implementation &mdash; obviously insecurely &mdash; just returns
-   * the {@link #exampleTokens} converted to {@link BearerToken} instances.
+   * an array with a single token consisting of all zeroes in the numeric
+   * portion.
    */
   static get rootTokens() {
-    const tokens = this.exampleTokens.map(t => Auth.tokenFromString(t));
+    const tokenString = 'tok-00000000000000000000000000000000';
 
-    return Object.freeze(tokens);
+    return Object.freeze([Auth.tokenFromString(tokenString)]);
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -17,18 +17,6 @@ const TOKEN_REGEX = /^(tok-[0-9a-f]{16})([0-9a-f]{16})$/;
  */
 export default class Auth extends UtilityClass {
   /**
-   * {array<string>} Implementation of standard configuration point.
-   *
-   * This implementation provides strings of 32 `0`s and 32 `1`s as examples.
-   */
-  static get exampleTokens() {
-    return Object.freeze([
-      'tok-00000000000000000000000000000000',
-      'tok-11111111111111111111111111111111'
-    ]);
-  }
-
-  /**
    * {array<BearerToken>} Implementation of standard configuration point.
    *
    * This implementation &mdash; obviously insecurely &mdash; just returns

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -9,19 +9,6 @@ import { BearerToken } from '@bayou/api-server';
 import { Auth } from '@bayou/config-server-default';
 
 describe('@bayou/config-server-default/Auth', () => {
-  describe('.exampleTokens', () => {
-    it('should be an array of strings that are all `isToken()`', () => {
-      const tokens = Auth.exampleTokens;
-
-      assert.isArray(tokens);
-
-      for (const token of tokens) {
-        assert.isString(token);
-        assert.isTrue(Auth.isToken(token));
-      }
-    });
-  });
-
   describe('.rootTokens', () => {
     it('should be an array of `BearerToken` instances', () => {
       const tokens = Auth.rootTokens;

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -10,17 +10,6 @@ import { UtilityClass } from '@bayou/util-common';
  */
 export default class Auth extends UtilityClass {
   /**
-   * {array<string>} A frozen array of at least two example token strings, each
-   * of which is syntactically valid but should _not_ actually grant access to
-   * anything in a production environment. This is intended for unit testing.
-   *
-   * **TODO:** It might be safe to remove this now. If so, do so!
-   */
-  static get exampleTokens() {
-    return use.Auth.exampleTokens;
-  }
-
-  /**
    * {array<BearerToken>} Frozen array of bearer tokens which grant root access
    * to the system. The value of this property &mdash; that is, the array it
    * refers to &mdash; may change over time, but the contents of any given array


### PR DESCRIPTION
With the earlier rework of the `BearerTokens` base class into the usual-for-this-project configuration class style of `config-server.Auth`, it was no longer necessary to have example tokens baked into the interface. (These were used to make it so that unit tests on the base class could use valid-as-configured tokens, without having to actually get hard-coded with that syntax.)