### PR TITLE
Add configurable token-based auth to session contexts.

### DIFF
--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -29,6 +29,26 @@ import TargetId from './TargetId';
  */
 export default class BaseKey extends CommonBase {
   /**
+   * Redacts a string for use in error messages and logging. This is generally
+   * done in error-handling code which expects that its string argument _might_
+   * be security-sensitive.
+   *
+   * @param {string} origString The original string.
+   * @returns {string} The redacted form.
+   */
+  static redactString(origString) {
+    TString.check(origString);
+
+    if (origString.length >= 24) {
+      return `${origString.slice(0, 16)}...`;
+    } else if (origString.length >= 12) {
+      return `${origString.slice(0, 8)}...`;
+    } else {
+      return '...';
+    }
+  }
+
+  /**
    * Constructs an instance with the indicated parts. Subclasses should override
    * methods as described in the documentation.
    *

--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -2,8 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseKey } from '@bayou/api-common';
 import { TString } from '@bayou/typecheck';
+
+import BaseKey from './BaseKey';
 
 /**
  * Bearer token, which is a kind of key where the secret portion is sent

--- a/local-modules/@bayou/api-common/index.js
+++ b/local-modules/@bayou/api-common/index.js
@@ -4,6 +4,7 @@
 
 import TheModule from './TheModule';
 import BaseKey from './BaseKey';
+import BearerToken from './BearerToken';
 import CodableError from './CodableError';
 import ConnectionError from './ConnectionError';
 import Message from './Message';
@@ -14,6 +15,7 @@ import TargetId from './TargetId';
 export {
   TheModule,
   BaseKey,
+  BearerToken,
   CodableError,
   ConnectionError,
   Message,

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -27,6 +27,35 @@ class FakeKey extends BaseKey {
 }
 
 describe('@bayou/api-common/BaseKey', () => {
+  describe('redactString()', () => {
+    it('should fully redact strings of length 11 or shorter', () => {
+      const FULL_STRING   = '1234567890x';
+      const EXPECT_STRING = '...';
+
+      for (let i = 0; i < FULL_STRING.length; i++) {
+        assert.strictEqual(BaseKey.redactString(FULL_STRING.slice(0, i)), EXPECT_STRING, `length ${i}`);
+      }
+    });
+
+    it('should drop all but the first 8 characters of strings of length 12 through 23', () => {
+      const FULL_STRING   = '1234567890abcdefghijklm';
+      const EXPECT_STRING = '12345678...';
+
+      for (let i = 12; i < FULL_STRING.length; i++) {
+        assert.strictEqual(BaseKey.redactString(FULL_STRING.slice(0, i)), EXPECT_STRING, `length ${i}`);
+      }
+    });
+
+    it('should drop all but the first 16 characters of strings of length 24 or greater', () => {
+      const FULL_STRING   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyz';
+      const EXPECT_STRING = 'ABCDEFGHIJKLMNOP...';
+
+      for (let i = 24; i < FULL_STRING.length; i++) {
+        assert.strictEqual(BaseKey.redactString(FULL_STRING.slice(0, i)), EXPECT_STRING, `length ${i}`);
+      }
+    });
+  });
+
   describe('constructor', () => {
     it('should throw an error given a URL with auth', () => {
       assert.throws(() => new BaseKey('http://foo@example.com/', VALID_ID));

--- a/local-modules/@bayou/api-common/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-common/tests/test_BearerToken.js
@@ -5,11 +5,11 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BearerToken } from '@bayou/api-server';
+import { BearerToken } from '@bayou/api-common';
 
-describe('@bayou/api-server/BearerToken', () => {
+describe('@bayou/api-common/BearerToken', () => {
   describe('constructor()', () => {
-    it('should return a frozen instance of BearerToken', () => {
+    it('should return a frozen instance of the class', () => {
       const token = new BearerToken('x', 'y');
 
       assert.instanceOf(token, BearerToken);
@@ -27,13 +27,13 @@ describe('@bayou/api-server/BearerToken', () => {
   });
 
   describe('sameToken()', () => {
-    it('should return false when passed `null`', () => {
+    it('should return `false` when passed `null`', () => {
       const token = new BearerToken('x', 'y');
 
       assert.isFalse(token.sameToken(null));
     });
 
-    it('should return false when passed `undefined`', () => {
+    it('should return `false` when passed `undefined`', () => {
       const token = new BearerToken('x', 'y');
 
       assert.isFalse(token.sameToken(undefined));
@@ -74,7 +74,7 @@ describe('@bayou/api-server/BearerToken', () => {
       assert.isFalse(BearerToken.sameArrays(array1, array2));
     });
 
-    it('should throw an Error if given arrays that contain things other than `BearerToken`s', () => {
+    it('should throw an error if given arrays that contain things other than `BearerToken`s', () => {
       const token = new BearerToken('a', '1');
 
       const array1 = [token, 'a'];

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -2,9 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Auth } from '@bayou/config-server';
 import { BaseLogger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
+
+import TokenAuthorizer from './TokenAuthorizer';
 
 /**
  * Handler of the logging of API calls.
@@ -14,18 +15,17 @@ export default class ApiLog extends CommonBase {
    * Constructs an instance.
    *
    * @param {Logger} log Logger to use.
-   * @param {Auth} [auth = Auth] Auth configuration to use. This is allowed as a
-   *   constructor argument _just_ to make it straightforward to unit test this
-   *   class.
+   * @param {TokenAuthorizer} tokenAuth Token authorizer. Just used for token
+   *   parsing (to handle redaction).
    */
-  constructor(log, auth = Auth) {
+  constructor(log, tokenAuth) {
     super();
 
     /** {BaseLogger} Logger to use. */
     this._log = BaseLogger.check(log);
 
-    /** {Auth} Auth configuration to use. */
-    this._auth = auth; // TODO: Consider type checking. (But that means defining a new base class.)
+    /** {TokenAuthorizer} Token authorizer. Just used for token parsing. */
+    this._tokenAuth = TokenAuthorizer.check(tokenAuth);
 
     /**
      * {Map<Message,object>} Map from messages that haven't yet been completely
@@ -125,8 +125,8 @@ export default class ApiLog extends CommonBase {
   _redactMessage(msg) {
     const targetId = msg.targetId;
 
-    if (this._auth.isToken(targetId)) {
-      const token = this._auth.tokenFromString(targetId);
+    if (this._tokenAuth.isToken(targetId)) {
+      const token = this._tokenAuth.tokenFromString(targetId);
       msg = msg.withTargetId(token.printableId);
     }
 

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ConnectionError, Message, Response } from '@bayou/api-common';
-import { Auth } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
@@ -211,22 +210,6 @@ export default class Connection extends CommonBase {
       throw ConnectionError.connection_closed(this._connectionId, 'Connection closed.');
     }
 
-    let target = context.getUncontrolledOrNull(idOrToken);
-
-    if (target !== null) {
-      return target;
-    }
-
-    if (Auth.isToken(idOrToken)) {
-      const token = Auth.tokenFromString(idOrToken);
-      target = context.getOrNull(token.id);
-      if ((target !== null) && token.sameToken(target.key)) {
-        return target;
-      }
-    }
-
-    // We _don't_ include the passed argument, as that might end up revealing
-    // secret info.
-    throw Errors.badUse('Invalid target.');
+    return context.getAuthorizedTarget(idOrToken);
   }
 }

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -59,7 +59,7 @@ export default class Connection extends CommonBase {
     this._log = log.withAddedContext(this._connectionId);
 
     /** {ApiLog} The API logger to use. */
-    this._apiLog = new ApiLog(this._log);
+    this._apiLog = new ApiLog(this._log, context.tokenAuthorizer);
 
     // We add a `meta` binding to the initial set of targets, which is specific
     // to this instance/connection.

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -58,6 +58,11 @@ export default class Context extends CommonBase {
     return this._codec;
   }
 
+  /** {TokenAuthorized} The token authorizer to use. */
+  get tokenAuthorizer() {
+    return this._tokenAuth;
+  }
+
   /**
    * Adds a new target to this instance. This will throw an error if there is
    * already another target with the same ID. This is a convenience for calling

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -209,7 +209,17 @@ export default class Context extends CommonBase {
     // It's not a bearer token (or this instance doesn't deal with bearer tokens
     // at all). The ID can only validly refer to an uncontrolled target.
 
-    return this.getUncontrolled(idOrToken);
+    const result = this.getOrNull(idOrToken);
+
+    if ((result === null) || (result.key !== null)) {
+      // This uses the default error message ("unknown target") even when it's
+      // due to a target existing but being controlled, so as not to reveal that
+      // the ID corresponds to an existing token (which is arguably a security
+      // leak).
+      throw this._targetError(idOrToken);
+    }
+
+    return result;
   }
 
   /**
@@ -241,26 +251,6 @@ export default class Context extends CommonBase {
     TString.check(id);
     const result = this._map.get(id);
     return (result !== undefined) ? result : null;
-  }
-
-  /**
-   * Gets the target associated with the indicated ID, but only if it is
-   * uncontrolled (that is, no auth required). This will throw an error if the
-   * so-identified target does not exist.
-   *
-   * @param {string} id The target ID.
-   * @returns {Target} The so-identified target.
-   */
-  getUncontrolled(id) {
-    const result = this.get(id);
-
-    if (result.key !== null) {
-      // This uses the default error message so as not to reveal that this ID
-      // corresponds to a token.
-      throw this._targetError(id);
-    }
-
-    return result;
   }
 
   /**

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -58,7 +58,7 @@ export default class Context extends CommonBase {
     return this._codec;
   }
 
-  /** {TokenAuthorized} The token authorizer to use. */
+  /** {TokenAuthorizer} The token authorizer to use. */
   get tokenAuthorizer() {
     return this._tokenAuth;
   }

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -264,19 +264,6 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Gets the target associated with the indicated ID, but only if it is
-   * uncontrolled (that is, no auth required).
-   *
-   * @param {string} id The target ID.
-   * @returns {Target|null} The so-identified target if it is in fact bound and
-   *   uncontrolled, or `null` if it is either unbound or access-controlled.
-   */
-  getUncontrolledOrNull(id) {
-    const result = this.getOrNull(id);
-    return ((result !== null) && (result.key === null)) ? result : null;
-  }
-
-  /**
    * Returns an indication of whether or not this instance has a binding for
    * the given ID.
    *

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -111,7 +111,7 @@ export default class Context extends CommonBase {
    * @returns {Context} The newly-cloned instance.
    */
   clone() {
-    const result = new Context(this._codec);
+    const result = new Context(this._codec, this._tokenAuth);
 
     for (const t of this._map.values()) {
       result.addTarget(t);

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -19,10 +19,11 @@ const log = new Logger('api');
 const IDLE_TIME_MSEC = 20 * 60 * 1000; // Twenty minutes.
 
 /**
- * Binding context for an API server or session therein. This is mostly just a
- * map from IDs to `Target` instances, along with reasonably straightforward
- * accessor and update methods. In addition, this is what knows which {@link
- * Codec} to use.
+ * Binding context for an API server or session therein. Instances of this class
+ * are used to map from IDs to `Target` instances, including targets which are
+ * ephemerally bound to the session as well as ones that are authorized via
+ * bearer tokens. In addition, this class is used to hold the knowledge of which
+ * {@link Codec} to use for a session.
  */
 export default class Context extends CommonBase {
   /**

--- a/local-modules/@bayou/api-server/TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/TokenAuthorizer.js
@@ -1,0 +1,115 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BearerToken } from '@bayou/api-common';
+import { TBoolean, TObject, TString } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+/**
+ * Abstract class for mapping tokens to objects which embody the powers
+ * authorized by those tokens.
+ */
+export default class TokenAuthorizer extends CommonBase {
+  /**
+   * Indicates whether the given string is in the valid token syntax as used by
+   * this class.
+   *
+   * @param {string} tokenString The alleged token string.
+   * @returns {boolean} `true` iff `tokenString` has valid token syntax.
+   */
+  isToken(tokenString) {
+    TString.check(tokenString);
+
+    return TBoolean.check(this._impl_isToken(tokenString));
+  }
+
+  /**
+   * Given a token in either object or string form, gets a corresponding
+   * "target" object which can be used to exercise the authority granted by the
+   * token. This method returns `null` if the token does not grant any
+   * authority. A non-`null` return value can be used as a target object,
+   * suitable for exposing (proxying) on an API connection.
+   *
+   * **Note:** This is defined to be an `async` method, on the expectation that
+   * in a production configuration, it might require network activity (e.g.
+   * querying a different service) to make an authorization determination.
+   *
+   * @param {string|BearerToken} token Token to look up. If given a string, this
+   *   method automatically converts it to a {@link BearerToken} via a call to
+   *   {@link #tokenFromString}.
+   * @returns {object|null} If `token` grants any authority, an object which
+   *   exposes the so-authorized functionality, or `null` if no authority is
+   *   granted.
+   */
+  async targetFromToken(token) {
+    if (typeof token === 'string') {
+      token = this.tokenFromString(token);
+    }
+
+    const result = await this._impl_targetFromToken(token);
+
+    return (result === null) ? null : TObject.check(result);
+  }
+
+  /**
+   * Constructs a {@link api-server.BearerToken} from the given string. The
+   * result is a {@link BearerToken} instance but does _not_ necessarily convey
+   * any authority / authorization.
+   *
+   * @param {string} tokenString The token string. It is only valid to pass a
+   *   value for which {@link #isToken} returns `true`.
+   * @returns {BearerToken} An appropriately-constructed instance.
+   */
+  tokenFromString(tokenString) {
+    if (!this.isToken(tokenString)) {
+      // Redact the token string in the error to avoid leaking
+      // security-sensitive information.
+      throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
+    }
+
+    const result = this._impl_tokenFromString(tokenString);
+
+    return BearerToken.check(result);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #isToken}. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   * @param {string} tokenString The alleged token string.
+   * @returns {boolean} `true` iff `tokenString` has valid token syntax.
+   */
+  _impl_isToken(tokenString) {
+    return this._mustOverride(tokenString);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #targetFromToken}. Subclasses
+   * must override this method.
+   *
+   * @abstract
+   * @param {BearerToken} token Token to look up. Guaranteed to be a valid
+   *   {@link BearerToken} instance.
+   * @returns {object|null} If `token` grants any authority, an object which
+   *   exposes the so-authorized functionality, or `null` if no authority is
+   *   granted.
+   */
+  async _impl_targetFromToken(token) {
+    return this._mustOverride(token);
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #tokenFromString}. Subclasses
+   * must override this method.
+   *
+   * @abstract
+   * @param {string} tokenString The alleged token string. It is guaranteed that
+   *   this is a string for which {@link #isToken} returned `true`.
+   * @returns {BearerToken} An appropriately-constructed instance.
+   */
+  _impl_tokenFromString(tokenString) {
+    return this._mustOverride(tokenString);
+  }
+}

--- a/local-modules/@bayou/api-server/TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/TokenAuthorizer.js
@@ -49,7 +49,7 @@ export default class TokenAuthorizer extends CommonBase {
 
     const result = await this._impl_targetFromToken(token);
 
-    return (result === null) ? null : TObject.check(result);
+    return TObject.orNull(result);
   }
 
   /**

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -6,6 +6,7 @@ import Connection from './Connection';
 import Context from './Context';
 import PostConnection from './PostConnection';
 import Target from './Target';
+import TokenAuthorizer from './TokenAuthorizer';
 import WsConnection from './WsConnection';
 
-export { Connection, Context, PostConnection, Target, WsConnection };
+export { Connection, Context, PostConnection, Target, TokenAuthorizer, WsConnection };

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -2,11 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BearerToken from './BearerToken';
 import Connection from './Connection';
 import Context from './Context';
 import PostConnection from './PostConnection';
 import Target from './Target';
 import WsConnection from './WsConnection';
 
-export { BearerToken, Connection, Context, PostConnection, Target, WsConnection };
+export { Connection, Context, PostConnection, Target, WsConnection };

--- a/local-modules/@bayou/api-server/package.json
+++ b/local-modules/@bayou/api-server/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "@bayou/api-common": "local",
     "@bayou/codec": "local",
-    "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/promise-util": "local",
     "@bayou/see-all": "local",

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -5,8 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Message } from '@bayou/api-common';
-import { BearerToken } from '@bayou/api-server';
+import { BearerToken, Message } from '@bayou/api-common';
 import { MockLogger } from '@bayou/see-all/mocks';
 import { Functor } from '@bayou/util-common';
 

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken, Message } from '@bayou/api-common';
+import { TokenAuthorizer } from '@bayou/api-server';
 import { MockLogger } from '@bayou/see-all/mocks';
 import { Functor } from '@bayou/util-common';
 
@@ -13,15 +14,15 @@ import { Functor } from '@bayou/util-common';
 import ApiLog from '../ApiLog';
 
 /**
- * Partial mock of {@link config-server.Auth}. Only includes what's required for
- * testing.
+ * Partial and simple implementation of {@link TokenAuthorizer}. Only includes
+ * what's required for testing.
  */
-class MockAuth {
-  static isToken(string) {
+class MockTokenAuthorizer extends TokenAuthorizer {
+  isToken(string) {
     return /^token-/.test(string);
   }
 
-  static tokenFromString(string) {
+  tokenFromString(string) {
     const match = string.match(/^token-(.*)$/);
     const id    = `id-${match[1]}`;
 
@@ -32,10 +33,11 @@ class MockAuth {
 describe('@bayou/api-server/ApiLog', () => {
   describe('incomingMessage()', () => {
     it('should log the redacted form of target when the target is a token', () => {
-      const logger = new MockLogger();
-      const apiLog = new ApiLog(logger, MockAuth);
-      const token  = MockAuth.tokenFromString('token-123xyz');
-      const msg    = new Message(123, token.secretToken, new Functor('x', 'y'));
+      const logger  = new MockLogger();
+      const tokAuth = new MockTokenAuthorizer();
+      const apiLog  = new ApiLog(logger, tokAuth);
+      const token   = tokAuth.tokenFromString('token-123xyz');
+      const msg     = new Message(123, token.secretToken, new Functor('x', 'y'));
 
       apiLog.incomingMessage(msg);
 

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -1,0 +1,55 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TokenAuthorizer } from '@bayou/api-server';
+import { Auth } from '@bayou/config-server';
+
+/**
+ * Application-specific implementation of {@link TokenAuthorizer}.
+ *
+ * **TODO:** As currently written, this just forwards token parsing onward to
+ * the configured {@link Auth} class, but leaves actual authorization as a stub.
+ * Eventually, this is where root tokens should get handled, allowing the
+ * removal of same from `Application`.
+ */
+export default class AppAuthorizer extends TokenAuthorizer {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    Object.freeze(this);
+  }
+
+  /**
+   * @override
+   * @param {string} tokenString The alleged token string.
+   * @returns {boolean} `true` iff `tokenString` has valid token syntax.
+   */
+  _impl_isToken(tokenString) {
+    return Auth.isToken(tokenString);
+  }
+
+  /**
+   * @override
+   * @param {BearerToken} token_unused Token to look up.
+   * @returns {object|null} If `token` grants any authority, an object which
+   *   exposes the so-authorized functionality, or `null` if no authority is
+   *   granted.
+   */
+  async _impl_targetFromToken(token_unused) {
+    // **TODO:** See class header comment.
+    return null;
+  }
+
+  /**
+   * @override
+   * @param {string} tokenString The alleged token string.
+   * @returns {BearerToken} An appropriately-constructed instance.
+   */
+  _impl_tokenFromString(tokenString) {
+    return Auth.tokenFromString(tokenString);
+  }
+}

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -16,6 +16,7 @@ import { Dirs, ProductInfo } from '@bayou/env-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
 
+import AppAuthorizer from './AppAuthorizer';
 import DebugTools from './DebugTools';
 import RequestLogger from './RequestLogger';
 import RootAccess from './RootAccess';
@@ -44,7 +45,7 @@ export default class Application extends CommonBase {
      * {Context} All of the objects we provide access to via the API, along with
      * other objects of use to the server.
      */
-    this._context = new Context(codec);
+    this._context = new Context(codec, new AppAuthorizer());
     this._context.startAutomaticIdleCleanup();
 
     /**

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -7,7 +7,8 @@ import http from 'http';
 import path from 'path';
 import ws from 'ws';
 
-import { BearerToken, Context, PostConnection, WsConnection } from '@bayou/api-server';
+import { BearerToken } from '@bayou/api-common';
+import { Context, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Auth, Deployment, Network } from '@bayou/config-server';

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -3,8 +3,9 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BearerToken } from '@bayou/api-server';
+import { BaseAuth } from '@bayou/config-server';
 import { Delay } from '@bayou/promise-util';
-import { Errors, UtilityClass } from '@bayou/util-common';
+import { Errors } from '@bayou/util-common';
 
 /**
  * {RegEx} Expression that matches properly-formed tokens. The ID and secret
@@ -15,7 +16,7 @@ const TOKEN_REGEX = /^(tok-[0-9a-f]{16})([0-9a-f]{16})$/;
 /**
  * Utility functionality regarding the network configuration of a server.
  */
-export default class Auth extends UtilityClass {
+export default class Auth extends BaseAuth {
   /**
    * {array<BearerToken>} Implementation of standard configuration point.
    *
@@ -40,6 +41,28 @@ export default class Auth extends UtilityClass {
    */
   static isToken(tokenString) {
     return TOKEN_REGEX.test(tokenString);
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
+   * This implementation &mdash; obviously insecurely &mdash; hard-codes a
+   * particular token to have "root" authority, specifically a token consisting
+   * of all zeroes in the numeric portion.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {object} Representation of the authority granted by `token`.
+   */
+  static async tokenAuthority(token) {
+    BearerToken.check(token);
+
+    for (const t of Auth.rootTokens) {
+      if (t.sameToken(token)) {
+        return { type: Auth.TYPE_root };
+      }
+    }
+
+    return { type: Auth.TYPE_none };
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -93,18 +93,9 @@ export default class Auth extends BaseAuth {
       return match[1];
     }
 
-    // **Note:** We redact the value to avoid the likelihood of leaking
+    // **Note:** We redact the value to reduce the likelihood of leaking
     // security-sensitive info.
-
-    if (tokenString.length >= 24) {
-      tokenString = `${tokenString.slice(0, 16)}...`;
-    } else if (tokenString.length >= 12) {
-      tokenString = `${tokenString.slice(0, 8)}...`;
-    } else {
-      tokenString = '...';
-    }
-
-    throw Errors.badValue(tokenString, 'bearer token');
+    throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken } from '@bayou/api-server';
+import { BearerToken } from '@bayou/api-common';
 import { BaseAuth } from '@bayou/config-server';
 import { Delay } from '@bayou/promise-util';
 import { Errors } from '@bayou/util-common';

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BearerToken } from '@bayou/api-server';
+import { BearerToken } from '@bayou/api-common';
 import { Auth } from '@bayou/config-server-default';
 
 /**

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -3,12 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { use } from '@bayou/injecty';
-import { UtilityClass } from '@bayou/util-common';
+
+import BaseAuth from './BaseAuth';
 
 /**
  * Authorization-related functionality.
  */
-export default class Auth extends UtilityClass {
+export default class Auth extends BaseAuth {
   /**
    * {array<BearerToken>} Frozen array of bearer tokens which grant root access
    * to the system. The value of this property &mdash; that is, the array it
@@ -30,6 +31,32 @@ export default class Auth extends UtilityClass {
    */
   static isToken(tokenString) {
     return use.Auth.isToken(tokenString);
+  }
+
+  /**
+   * Gets the authority / authorization that is granted by the given
+   * {@link BearerToken}. The result is a plain object which binds at least
+   * `type` to the type of authority. Per type, the following are the other
+   * possible bindings:
+   *
+   * * `Auth.TYPE_none` &mdash; No other bindings. The token doesn't actually
+   *   grant any authority.
+   * * `Auth.TYPE_root` &mdash; No other bindings. The token is a "root" token,
+   *   which grants full system access. (This sort of token is how a trusted
+   *   back-end system communicates with this server.)
+   *
+   * **Note:** This is defined to be an `async` method, on the expectation that
+   * in a production configuration, it might require network activity (e.g.
+   * querying a different service) to make an authorization determination.
+   *
+   * **TODO:** Consider having an `expirationTime` binding.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {object} Plain object with bindings as described above,
+   *   representing the authority granted by `token`.
+   */
+  static async tokenAuthority(token) {
+    return use.Auth.tokenAuthority(token);
   }
 
   /**

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -33,7 +33,9 @@ export default class Auth extends UtilityClass {
   }
 
   /**
-   * Constructs a {@link api-server.BearerToken} from the given string.
+   * Constructs a {@link api-server.BearerToken} from the given string. The
+   * result is a {@link BearerToken} instance but does _not_ necessarily convey
+   * any authority / authorization.
    *
    * @param {string} tokenString The token. It is only valid to pass a value for
    *   which {@link #isToken} returns `true`.

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -16,6 +16,9 @@ export default class Auth extends BaseAuth {
    * refers to &mdash; may change over time, but the contents of any given array
    * yielded from this property are guaranteed to be frozen.
    *
+   * **TODO:** This property should be removed, when all clients instead use
+   * {@link #tokenAuthority}.
+   *
    * @see #whenRootTokensChange
    */
   static get rootTokens() {
@@ -88,6 +91,9 @@ export default class Auth extends BaseAuth {
    * Returns a promise which becomes resolved (to `true`) the next time that
    * the array of {@link #rootTokens} changes, or (on the margin) could
    * _conceivably_ have changed.
+   *
+   * **TODO:** This method should be removed, when all clients use
+   * {@link #tokenAuthority} instead of {@link #rootTokens}.
    *
    * @returns {Promise<true>} Promise that resolves when {@link #rootTokens}
    *   should be checked for update.

--- a/local-modules/@bayou/config-server/BaseAuth.js
+++ b/local-modules/@bayou/config-server/BaseAuth.js
@@ -1,0 +1,19 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { UtilityClass } from '@bayou/util-common';
+
+/**
+ * Base class for {@link Auth} (in this module) and its configured
+ * implementations. This isn't much of a real base class, so much as a
+ * reasonable way to define constants needed by the configured implementations
+ * and the clients of this configuration.
+ */
+export default class BaseAuth extends UtilityClass {
+  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  static get TYPE_none() { return 'none'; }
+
+  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  static get TYPE_root() { return 'root'; }
+}

--- a/local-modules/@bayou/config-server/index.js
+++ b/local-modules/@bayou/config-server/index.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Auth from './Auth';
+import BaseAuth from './BaseAuth';
 import Deployment from './Deployment';
 import Logging from './Logging';
 import Network from './Network';
@@ -10,6 +11,7 @@ import Storage from './Storage';
 
 export {
   Auth,
+  BaseAuth,
   Deployment,
   Logging,
   Network,

--- a/local-modules/@bayou/typecheck/TObject.js
+++ b/local-modules/@bayou/typecheck/TObject.js
@@ -30,18 +30,21 @@ export default class TObject extends UtilityClass {
    * `null`.
    *
    * @param {*} value Value to check.
+   * @param {object|null} [clazz = null] Class (constructor) that `value` must
+   *   be an instance of, or `null` if there is no class requirement.
    * @returns {object|null} `value`.
    */
-  static orNull(value) {
+  static orNull(value, clazz = null) {
     if (value === null) {
       return null;
     }
 
     try {
-      return TObject.check(value);
+      return TObject.check(value, clazz);
     } catch (e) {
       // Throw a higher-fidelity error.
-      throw Errors.badValue(value, 'Object|null');
+      const name = (clazz === null) ? 'Object' : `class ${clazz.name}`;
+      throw Errors.badValue(value, `${name}|null`);
     }
   }
 

--- a/local-modules/@bayou/typecheck/TObject.js
+++ b/local-modules/@bayou/typecheck/TObject.js
@@ -26,6 +26,26 @@ export default class TObject extends UtilityClass {
   }
 
   /**
+   * Checks a value which must either be of type `Object` or the exact value
+   * `null`.
+   *
+   * @param {*} value Value to check.
+   * @returns {object|null} `value`.
+   */
+  static orNull(value) {
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return TObject.check(value);
+    } catch (e) {
+      // Throw a higher-fidelity error.
+      throw Errors.badValue(value, 'Object|null');
+    }
+  }
+
+  /**
    * Checks that a value is of type `Object` and is furthermore a plain object,
    * which is to say, not any of an array, a function, or an instance of a class
    * other than `Object` itself.

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -10,11 +10,14 @@ import { TObject } from '@bayou/typecheck';
 describe('@bayou/typecheck/TObject', () => {
   describe('check(value)', () => {
     it('should return the provided value when passed an object', () => {
-      const value = { a: 1, b: 2 };
-      const func  = () => 123;
+      function test(value) {
+        assert.strictEqual(TObject.check(value), value);
+      }
 
-      assert.strictEqual(TObject.check(value), value);
-      assert.strictEqual(TObject.check(func),  func);
+      test({ a: 1, b: 2 });
+      test([1, 2, 3]);
+      test(() => 123);
+      test(new Map());
     });
 
     it('should throw an Error when passed anything other than an object', () => {
@@ -48,6 +51,30 @@ describe('@bayou/typecheck/TObject', () => {
     it('should throw an Error when passed anything other than an object', () => {
       assert.throws(() => TObject.check(null, Object));
       assert.throws(() => TObject.check(54,   Object));
+    });
+  });
+
+  describe('orNull()', () => {
+    it('should return the provided value when passed an object', () => {
+      function test(value) {
+        assert.strictEqual(TObject.orNull(value), value);
+      }
+
+      test({ a: 1, b: 2 });
+      test([1, 2, 3]);
+      test(() => 123);
+      test(new Map());
+    });
+
+    it('should return `null` when passed `null`', () => {
+      assert.isNull(TObject.orNull(null));
+    });
+
+    it('should throw an Error when passed anything other than an object or `null`', () => {
+      assert.throws(() => TObject.check(undefined));
+      assert.throws(() => TObject.check(false));
+      assert.throws(() => TObject.check(54));
+      assert.throws(() => TObject.check('this better not work'));
     });
   });
 

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -54,7 +54,7 @@ describe('@bayou/typecheck/TObject', () => {
     });
   });
 
-  describe('orNull()', () => {
+  describe('orNull(value)', () => {
     it('should return the provided value when passed an object', () => {
       function test(value) {
         assert.strictEqual(TObject.orNull(value), value);
@@ -71,10 +71,41 @@ describe('@bayou/typecheck/TObject', () => {
     });
 
     it('should throw an Error when passed anything other than an object or `null`', () => {
-      assert.throws(() => TObject.check(undefined));
-      assert.throws(() => TObject.check(false));
-      assert.throws(() => TObject.check(54));
-      assert.throws(() => TObject.check('this better not work'));
+      assert.throws(() => TObject.orNull(undefined));
+      assert.throws(() => TObject.orNull(false));
+      assert.throws(() => TObject.orNull(54));
+      assert.throws(() => TObject.orNull('this better not work'));
+    });
+  });
+
+  describe('orNull(value, clazz)', () => {
+    it('should return the provided value when passed an object of a matching class', () => {
+      function test(value, clazz) {
+        assert.strictEqual(TObject.orNull(value, clazz), value);
+      }
+
+      test({ a: 1, b: 2 }, Object);
+      test([1, 2, 3],      Array);
+      test([1, 2, 3],      Object);
+      test(() => 123,      Function);
+      test(new Map(),      Map);
+      test(new Map(),      Object);
+    });
+
+    it('should return `null` when passed a `null` value, no matter what class is passed', () => {
+      assert.isNull(TObject.orNull(null, Object));
+      assert.isNull(TObject.orNull(null, Set));
+    });
+
+    it('should throw an Error when passed an object of a non-matching class', () => {
+      assert.throws(() => TObject.orNull(new Map(), Set));
+      assert.throws(() => TObject.orNull(new Set(), Map));
+    });
+
+    it('should throw an Error when passed anything other than an object or `null`', () => {
+      assert.throws(() => TObject.orNull(false,   Boolean));
+      assert.throws(() => TObject.orNull(914,     Number));
+      assert.throws(() => TObject.orNull('florp', String));
     });
   });
 


### PR DESCRIPTION
This PR represents an intermediate state of affairs, where we are still handling root tokens _mostly_ in the old way, but we now have the code in place to start handling it in a new way that allows for other non-root tokens to also be used, including the possibility of making a cross-service (network) call to authorize tokens. The new code paths are used _just_ for token parsing but not for actual authentication yet. Some details:

* New configuration point `Auth.tokenAuthority()` which will ultimately be where authorization decisions are made.
* Added new abstract class `TokenAuthorizer` which gets passed as a construction parameter to `api-server.Context`. This is how token-specific knowledge is now encapsulated within `api-server`.
* Implemented a concrete subclass of `TokenAuthorizer` in `app-setup`. Per above, this only implements token parsing and not actual authorization. Eventually, this will start using `Auth.tokenAuthority()`, and at the same time `app-setup` will stop adding root tokens directly to the main app context.
* Made the target-lookup path in `api-server` be fully `async`, to be ready for a `TokenAuthorizer` that makes cross-service calls to perform authorization.

Administrivia:

* Moved `BearerToken` from `api-server` into `api-common`. It stopped being server-specific when it lost the ability to parse strings into tokens.
* DRYed out a bunch of token redaction code.
* Added `TObject.orNull()` as a parallel to the other type-checking `orNull()`s.