### PR TITLE
Auth root tokens the new way.

### DIFF
--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -197,6 +197,8 @@ export default class Context extends CommonBase {
       const targetObject = await tokenAuth.targetFromToken(token);
 
       if (targetObject === null) {
+        // The `tokenAuth` told us that `token` didn't actually grant any
+        // authority.
         throw this._targetError(idOrToken);
       }
 

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -185,7 +185,7 @@ export default class Context extends CommonBase {
           return already;
         } else {
           // The secrets don't match. This will happen, for example, when a
-          // malicious actors tries to probe for a key.
+          // malicious actor tries to probe for a key.
           throw this._targetError(idOrToken);
         }
       }

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -43,9 +43,7 @@ export default class AppAuthorizer extends TokenAuthorizer {
    *   granted.
    */
   async _impl_targetFromToken(token) {
-    console.log('======= auth', token);
     const authority = await Auth.tokenAuthority(token);
-    console.log('======= auth got', authority);
 
     if (authority.type === Auth.TYPE_root) {
       return this._application.rootAccess;

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -9,6 +9,7 @@ import { DocumentId } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
 import { AuthorId } from '@bayou/ot-common';
 import { Logger } from '@bayou/see-all';
+import { CommonBase } from '@bayou/util-common';
 
 /** Logger. */
 const log = new Logger('root-access');
@@ -17,7 +18,7 @@ const log = new Logger('root-access');
  * "Root access" object. This is the object which is protected by the root
  * bearer token(s).
  */
-export default class RootAccess {
+export default class RootAccess extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -25,8 +26,12 @@ export default class RootAccess {
    *   that is, where auth-controlled resources end up getting bound.
    */
   constructor(context) {
+    super();
+
     /** {Context} The API context to use. */
     this._context = Context.check(context);
+
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -4,7 +4,6 @@
 
 import { BearerToken } from '@bayou/api-common';
 import { BaseAuth } from '@bayou/config-server';
-import { Delay } from '@bayou/promise-util';
 import { Errors } from '@bayou/util-common';
 
 /**
@@ -96,20 +95,5 @@ export default class Auth extends BaseAuth {
     // **Note:** We redact the value to reduce the likelihood of leaking
     // security-sensitive info.
     throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
-  }
-
-  /**
-   * Implementation of standard configuration point.
-   *
-   * This implementation returns a promise that always resolves after ten
-   * minutes, even though this implementation never updates the root tokens.
-   * This is done so that the update logic gets excercised in the default
-   * configuration.
-   *
-   * @returns {Promise<true>} Promise that resolves in ten minutes.
-   */
-  static whenRootTokensChange() {
-    const CHANGE_FREQUENCY_MSEC = 10 * 60 * 60 * 1000;
-    return Delay.resolve(CHANGE_FREQUENCY_MSEC);
   }
 }

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -13,6 +13,13 @@ import { Errors } from '@bayou/util-common';
 const TOKEN_REGEX = /^(tok-[0-9a-f]{16})([0-9a-f]{16})$/;
 
 /**
+ * {string} The one well-known root token. This obviously-insecure arrangement
+ * is just for this module, the default server configuration module, which is
+ * only supposed to be used in development, not real production.
+ */
+const THE_ROOT_TOKEN = 'tok-00000000000000000000000000000000';
+
+/**
  * Utility functionality regarding the network configuration of a server.
  */
 export default class Auth extends BaseAuth {
@@ -24,9 +31,7 @@ export default class Auth extends BaseAuth {
    * portion.
    */
   static get rootTokens() {
-    const tokenString = 'tok-00000000000000000000000000000000';
-
-    return Object.freeze([Auth.tokenFromString(tokenString)]);
+    return Object.freeze([Auth.tokenFromString(THE_ROOT_TOKEN)]);
   }
 
   /**
@@ -55,10 +60,8 @@ export default class Auth extends BaseAuth {
   static async tokenAuthority(token) {
     BearerToken.check(token);
 
-    for (const t of Auth.rootTokens) {
-      if (t.sameToken(token)) {
-        return { type: Auth.TYPE_root };
-      }
+    if (token.secretToken === THE_ROOT_TOKEN) {
+      return { type: Auth.TYPE_root };
     }
 
     return { type: Auth.TYPE_none };

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken } from '@bayou/api-common';
+import { BaseAuth } from '@bayou/config-server';
 import { Auth } from '@bayou/config-server-default';
 
 /**
@@ -23,6 +24,10 @@ const EXAMPLE_TOKEN = 'tok-00000000000000001123456789abcdef';
 const ROOT_TOKEN = 'tok-00000000000000000000000000000000';
 
 describe('@bayou/config-server-default/Auth', () => {
+  it('inherits from `BaseAuth`', () => {
+    assert.isTrue(Auth.prototype instanceof BaseAuth);
+  });
+
   describe('.rootTokens', () => {
     it('should be an array of `BearerToken` instances', () => {
       const tokens = Auth.rootTokens;

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -38,6 +38,11 @@ describe('@bayou/config-server-default/Auth', () => {
         assert.instanceOf(token, BearerToken);
       }
     });
+
+    it('should have only the one well-known token in it', () => {
+      assert.lengthOf(Auth.rootTokens, 1);
+      assert.strictEqual(Auth.rootTokens[0].secretToken, ROOT_TOKEN);
+    });
   });
 
   describe('isToken()', () => {

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -99,13 +99,4 @@ describe('@bayou/config-server-default/Auth', () => {
       assert.strictEqual(Auth.tokenId(token), id);
     });
   });
-
-  describe('whenRootTokensChange()', () => {
-    it('should return a promise', () => {
-      const changePromise = Auth.whenRootTokensChange();
-
-      assert.property(changePromise, 'then');
-      assert.isFunction(changePromise.then);
-    });
-  });
 });

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -15,9 +15,6 @@ export default class Auth extends BaseAuth {
    * to the system. The value of this property &mdash; that is, the array it
    * refers to &mdash; may change over time, but the contents of any given array
    * yielded from this property are guaranteed to be frozen.
-   *
-   * **TODO:** This property should be removed, when all clients instead use
-   * {@link #tokenAuthority}.
    */
   static get rootTokens() {
     return use.Auth.rootTokens;

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -18,8 +18,6 @@ export default class Auth extends BaseAuth {
    *
    * **TODO:** This property should be removed, when all clients instead use
    * {@link #tokenAuthority}.
-   *
-   * @see #whenRootTokensChange
    */
   static get rootTokens() {
     return use.Auth.rootTokens;
@@ -85,20 +83,5 @@ export default class Auth extends BaseAuth {
    */
   static tokenId(tokenString) {
     return use.Auth.tokenId(tokenString);
-  }
-
-  /**
-   * Returns a promise which becomes resolved (to `true`) the next time that
-   * the array of {@link #rootTokens} changes, or (on the margin) could
-   * _conceivably_ have changed.
-   *
-   * **TODO:** This method should be removed, when all clients use
-   * {@link #tokenAuthority} instead of {@link #rootTokens}.
-   *
-   * @returns {Promise<true>} Promise that resolves when {@link #rootTokens}
-   *   should be checked for update.
-   */
-  static whenRootTokensChange() {
-    return use.Auth.whenRootTokensChange();
   }
 }

--- a/local-modules/@bayou/config-server/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server/tests/test_Auth.js
@@ -1,0 +1,14 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Auth, BaseAuth } from '@bayou/config-server';
+
+describe('@bayou/config-server/Auth', () => {
+  it('inherits from `BaseAuth`', () => {
+    assert.isTrue(Auth.prototype instanceof BaseAuth);
+  });
+});

--- a/local-modules/@bayou/config-server/tests/test_BaseAuth.js
+++ b/local-modules/@bayou/config-server/tests/test_BaseAuth.js
@@ -1,0 +1,33 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { BaseAuth } from '@bayou/config-server';
+
+describe('@bayou/config-server/BaseAuth', () => {
+  describe('.TYPE_*', () => {
+    const items = ['root', 'none'];
+
+    for (const item of items) {
+      const name = `TYPE_${item}`;
+      describe(`.${name}`, () => {
+        it('should be a string', () => {
+          assert.isString(BaseAuth[name]);
+        });
+      });
+    }
+
+    it('should have unique values for all items', () => {
+      const set = new Set();
+      for (const item of items) {
+        const name = `TYPE_${item}`;
+        set.add(BaseAuth[name]);
+      }
+
+      assert.strictEqual(set.size, items.length);
+    });
+  });
+});


### PR DESCRIPTION
The main thing going on in this PR is that root tokens now get authorized using `Auth.tokenAuthority()` instead of by virtue of the top-level application explicitly adding those tokens to the default `Context`. Most of the rest of this PR is tweakage in support of that aim and cleanup thereby enabled.
