### PR TITLE
Simplify `Context`'s API.

### DIFF
--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -7,8 +7,9 @@ import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
 import ApiLog from './ApiLog';
-import MetaHandler from './MetaHandler';
 import Context from './Context';
+import MetaHandler from './MetaHandler';
+import Target from './Target';
 
 /** {Logger} Logger. */
 const log = new Logger('api');
@@ -61,9 +62,11 @@ export default class Connection extends CommonBase {
     /** {ApiLog} The API logger to use. */
     this._apiLog = new ApiLog(this._log, context.tokenAuthorizer);
 
-    // We add a `meta` binding to the initial set of targets, which is specific
-    // to this instance/connection.
-    this._context.addEvergreen('meta', new MetaHandler(this));
+    // Add a `meta` binding to the initial set of targets, which is specific to
+    // this instance/connection.
+    const metaTarget = new Target('meta', new MetaHandler(this));
+    metaTarget.setEvergreen();
+    this._context.addTarget(metaTarget);
 
     this._log.event.open();
   }

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -126,17 +126,6 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Removes the target binding for the given ID. It is an error to try to
-   * remove a nonexistent binding.
-   *
-   * @param {string} id The ID of the binding to remove.
-   */
-  deleteId(id) {
-    this.get(id); // This will throw if `id` isn't bound.
-    this._map.delete(id);
-  }
-
-  /**
    * Gets the target associated with the indicated ID. This will throw an
    * error if the so-identified target does not exist.
    *

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -108,12 +108,6 @@ export default class Context extends CommonBase {
    * well as those authorized by virtue of this method being passed a valid
    * authority-bearing token (in string form).
    *
-   * **Note:** This is the only method on this class which understands how to
-   * authorize bearer tokens. This is also the only `get*` method on this class
-   * which is asynchronous. (It has to be asynchronous because token
-   * authorization is asynchronous.) **TODO:** This situation is confusing and
-   * should be cleaned up, one way or another.
-   *
    * @param {string} idOrToken The target ID or a bearer token (in string form)
    *   which authorizes access to a target.
    * @returns {Target} The so-identified or so-authorized target.
@@ -181,7 +175,7 @@ export default class Context extends CommonBase {
    * @param {string} id The target ID.
    * @returns {Target} The so-identified target.
    */
-  getControlled(id) {
+  async getControlled(id) {
     const result = this._getOrNull(id);
 
     if ((result === null) || (result.key === null)) {
@@ -193,7 +187,9 @@ export default class Context extends CommonBase {
 
   /**
    * Returns an indication of whether or not this instance has a binding for
-   * the given ID.
+   * the given ID. **Note:** This will find already-authorized bearer tokens,
+   * but it will _not_ perform authorization given a never-before-encountered
+   * bearer token.
    *
    * @param {string} id The target ID.
    * @returns {boolean} `true` iff `id` is bound.
@@ -210,7 +206,7 @@ export default class Context extends CommonBase {
    *
    * @param {string} id The ID of the target whose key is to be removed.
    */
-  removeControl(id) {
+  async removeControl(id) {
     const target = this.getControlled(id);
     this._map.set(id, target.withoutKey());
   }

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -151,7 +151,7 @@ export default class Context extends CommonBase {
    * **Note:** This is the only method on this class which understands how to
    * authorize bearer tokens. This is also the only `get*` method on this class
    * which is asynchronous. (It has to be asynchronous because token
-   * authorization) is asynchronous. **TODO:** This situation is confusing and
+   * authorization is asynchronous.) **TODO:** This situation is confusing and
    * should be cleaned up, one way or another.
    *
    * @param {string} idOrToken The target ID or a bearer token (in string form)

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -70,20 +70,6 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Adds a new target to this instance. This will throw an error if there is
-   * already another target with the same ID. This is a convenience for calling
-   * `map.addTarget(new Target(id, obj))`.
-   *
-   * @param {string|BaseKey} nameOrKey Either the name of the target (if
-   *   uncontrolled) _or_ the key which controls access to the target. See the
-   *   docs for `Target.add()` for more details.
-   * @param {object} obj Object to ultimately call on.
-   */
-  add(nameOrKey, obj) {
-    this.addTarget(new Target(nameOrKey, obj));
-  }
-
-  /**
    * Adds an already-constructed `Target` to the map. This will throw an error
    * if there is already another target with the same ID.
    *

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -79,7 +79,7 @@ export default class Context extends CommonBase {
     Target.check(target);
     const id = target.id;
 
-    if (this._map.get(id) !== undefined) {
+    if (this._getOrNull(id) !== null) {
       throw this._targetError(id, 'Duplicate target');
     }
 

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -70,10 +70,12 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Adds an already-constructed `Target` to the map. This will throw an error
-   * if there is already another target with the same ID.
+   * Adds a {@link Target} to this instance's map of same. The given `target`
+   * must not have an ID that is already represented in the map.
    *
    * @param {Target} target Target to add.
+   * @throws {Error} Thrown if `target.id` is already represented in the target
+   *   map.
    */
   addTarget(target) {
     Target.check(target);

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -126,23 +126,6 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Gets the target associated with the indicated ID. This will throw an
-   * error if the so-identified target does not exist.
-   *
-   * @param {string} id The target ID.
-   * @returns {Target} The so-identified target.
-   */
-  get(id) {
-    const result = this.getOrNull(id);
-
-    if (!result) {
-      throw this._targetError(id);
-    }
-
-    return result;
-  }
-
-  /**
    * Gets an authorized target. This will find _uncontrolled_ (already
    * authorized) targets that were previously added via {@link #addTarget} as
    * well as those authorized by virtue of this method being passed a valid

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -148,7 +148,7 @@ export default class Context extends CommonBase {
 
     if ((tokenAuth !== null) && tokenAuth.isToken(idOrToken)) {
       const token   = tokenAuth.tokenFromString(idOrToken);
-      const already = this.getOrNull(token.id);
+      const already = this._getOrNull(token.id);
 
       if (already !== null) {
         // We've seen this token ID previously in this context / session.
@@ -183,7 +183,7 @@ export default class Context extends CommonBase {
     // It's not a bearer token (or this instance doesn't deal with bearer tokens
     // at all). The ID can only validly refer to an uncontrolled target.
 
-    const result = this.getOrNull(idOrToken);
+    const result = this._getOrNull(idOrToken);
 
     if ((result === null) || (result.key !== null)) {
       // This uses the default error message ("unknown target") even when it's
@@ -205,26 +205,13 @@ export default class Context extends CommonBase {
    * @returns {Target} The so-identified target.
    */
   getControlled(id) {
-    const result = this.get(id);
+    const result = this._getOrNull(id);
 
-    if (result.key === null) {
+    if ((result === null) || (result.key === null)) {
       throw this._targetError(id, 'Not a controlled target');
     }
 
     return result;
-  }
-
-  /**
-   * Gets the target associated with the indicated ID, or `null` if the
-   * so-identified target does not exist.
-   *
-   * @param {string} id The target ID.
-   * @returns {Target|null} The so-identified target, or `null` if unbound.
-   */
-  getOrNull(id) {
-    TString.check(id);
-    const result = this._map.get(id);
-    return (result !== undefined) ? result : null;
   }
 
   /**
@@ -235,7 +222,7 @@ export default class Context extends CommonBase {
    * @returns {boolean} `true` iff `id` is bound.
    */
   hasId(id) {
-    return this.getOrNull(id) !== null;
+    return this._getOrNull(id) !== null;
   }
 
   /**
@@ -282,6 +269,20 @@ export default class Context extends CommonBase {
     // We run the callback at a fraction of the overall idle timeout so as to
     // be a bit more prompt with the cleanup.
     setInterval(() => { this.idleCleanup(); }, IDLE_TIME_MSEC / 4);
+  }
+
+  /**
+   * Gets the target associated with the indicated ID, or `null` if the
+   * so-identified target does not exist. This only checks this instance's
+   * `_map`; it does _not_ try to do token authorization.
+   *
+   * @param {string} id The target ID.
+   * @returns {Target|null} The so-identified target, or `null` if unbound.
+   */
+  _getOrNull(id) {
+    TString.check(id);
+    const result = this._map.get(id);
+    return (result === undefined) ? null : result;
   }
 
   /**

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -47,7 +47,7 @@ export default class MetaHandler {
    * @param {string} challenge The challenge string.
    * @param {string} response The challenge response.
    */
-  authWithChallengeResponse(challenge, response) {
+  async authWithChallengeResponse(challenge, response) {
     TString.check(challenge);
     TString.check(response);
 
@@ -67,7 +67,7 @@ export default class MetaHandler {
 
     // The main action: Replace the target for `id` with an equivalent one
     // except without auth control.
-    this._connection.context.removeControl(id);
+    await this._connection.context.removeControl(id);
 
     this._log.event.authedChallenge(id, challenge);
   }
@@ -95,8 +95,8 @@ export default class MetaHandler {
    *   as to remove key control for the target, in the context of the current
    *   session.
    */
-  makeChallenge(id) {
-    const target = this._connection.context.getControlled(id);
+  async makeChallenge(id) {
+    const target = await this._connection.context.getControlled(id);
 
     let challengePair;
     for (;;) {

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -56,7 +56,7 @@ export default class Target extends CommonBase {
      * {Int|'evergreen'} Timestamp (msec) when the `target` was last accessed or
      * called, or the string constant `evergreen` to indicate a target that
      * should never be considered idle. This is used to drive automated cleanup
-     * of idle targets in binding contexts.
+     * of idle targets mapped by instances of {@link api-server.Context}.
      */
     this._lastAccess = Date.now();
 

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -44,7 +44,6 @@ export default class Application extends CommonBase {
      */
     this._context =
       new Context(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
-    this._context.startAutomaticIdleCleanup();
 
     /**
      * {RootAccess} The "root access" object. This is the object which tokens

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { SplitKey } from '@bayou/api-common';
-import { Context } from '@bayou/api-server';
+import { Context, Target } from '@bayou/api-server';
 import { Network } from '@bayou/config-server';
 import { DocumentId } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
@@ -55,13 +55,13 @@ export default class RootAccess extends CommonBase {
     const url     = `${Network.baseUrl}/api`;
     const session = fileComplex.makeNewSession(authorId, this._randomId.bind(this));
     const key     = new SplitKey(url, session.getSessionId());
-    this._context.add(key, session);
+    this._context.addTarget(new Target(key, session));
 
     log.info(
       'Newly-authorized access.\n',
       `  author:  ${authorId}\n`,
       `  doc:     ${docId}\n`,
-      `  key id:  ${key.id}\n`, // The ID is safe to log (not security-sensitive).
+      `  key id:  ${key.printableId}\n`, // This is safe to log (not security-sensitive).
       `  key url: ${key.url}`);
 
     return key;


### PR DESCRIPTION
This PR simplifies the API of `Context`. Main details:

* Removed all the `get*()` variants that weren't used.
* Made all of the remaining `get*()` variants be `async`. (Specifically, fixed the one remaining method that wasn't already `async`.) This was done for API consistency more than because of algorithmic necessity.
* Removed two of the three `add*()` variants, by inlining/un-factoring the one-each of the two removed methods.
* Built idle-cleanup into the main code paths, instead of having it as a "sidecar." The old arrangement hadn't actually worked for a while (because only the top-level `Context` had idle cleanup done on it).

**Note:** The idle-cleanup stuff really needs more work, or perhaps — probably? still not sure — just needs to get replaced wholesale, especially in that we're moving to a bearer-token-authed world, and the thing that matters there is promptly respecting tokens' authed-ness (like, don't respect a token that's been retired). In any case, I'm hoping the simplifications done in this PR will make whatever the next move will be a bit easier to write.

**Also Note:** (The branch name notwithstanding)`Target` still has a concept of being "evergreen." This is _only_ used to make sure that the `meta` binding (which comes with every connection "for free") won't ever become invalid. This should almost certainly be achieved in a different way.