### PR TITLE
Author tokens.

### DIFF
--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -53,16 +53,16 @@ export default class TokenMint extends CommonBase {
    * Constructs an instance.
    *
    * @param {string} tag The tag to use on all tokens minted by this instance.
-   * @param {Int} [idLength = 16] The length of the ID portion of tokens minted
+   * @param {Int} [idLength = 8] The length of the ID portion of tokens minted
    *   by this instance, in digits.
-   * @param {Int} [secretLength = 16] The length of the secret portion of tokens
+   * @param {Int} [secretLength = 8] The length of the secret portion of tokens
    *   minted by this instance, in digits.
    * @param {function|null} [randomFn = null] Function to use to produce
    *   "random" numbers, or `null` to &mdash; predictably but obviously
    *   insecurely &mdash; use a simple sequence. Each call to `randomFn()` is
    *   expected to return a 32-bit integer.
    */
-  constructor(tag, idLength = 16, secretLength = 16, randomFn = null) {
+  constructor(tag, idLength = 8, secretLength = 8, randomFn = null) {
     super();
 
     /** {string} The tag to use on all tokens minted by this instance. */

--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -1,0 +1,174 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BearerToken } from '@bayou/api-common';
+import { TFunction, TInt, TString } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+/**
+ * Returns a function which returns sequential integers. Functions returned by
+ * this function are used as the default value for `randomFn` in the
+ * {@link TokenMint} constructor.
+ *
+ * @returns {function} A function as described above.
+ */
+function sequenceGenerator() {
+  let next = 0;
+
+  function sequence() {
+    const result = next;
+
+    next++;
+    if (next > 0xffffffff) {
+      next = 0;
+    }
+
+    return result;
+  }
+
+  return sequence;
+}
+
+/**
+ * "Mint" which can be used to generate instances of {@link BearerToken} which
+ * all adhere to a partially configurable pattern. Instances keep track of the
+ * tokens they've minted, both to prevent reuse of IDs and to allow full
+ * validation. This class also provides a method to register tokens created via
+ * other means, so as to avoid reusing the IDs of those tokens.
+ *
+ * The pattern of the full token form used by this class is
+ * `<tag>-<id>-<secret>`, where `<tag>` is an arbitrary but fixed string of
+ * lowercase characters, and where `<id>` and `<secret>` are both lowercase
+ * hexadecimal numbers of configurable length.
+ *
+ * **Note:** This class is mostly intended for use in a development
+ * configuration, but it is possible to use it in a simple production
+ * deployment (e.g. one that doesn't need to deal with communicating tokens
+ * across multiple back-end machines, nor one that wishes to have tokens be more
+ * durable than OS processes).
+ */
+export default class TokenMint extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} tag The tag to use on all tokens minted by this instance.
+   * @param {Int} [idLength = 16] The length of the ID portion of tokens minted
+   *   by this instance, in digits.
+   * @param {Int} [secretLength = 16] The length of the secret portion of tokens
+   *   minted by this instance, in digits.
+   * @param {function|null} [randomFn = null] Function to use to produce
+   *   "random" numbers, or `null` to &mdash; predictably but obviously
+   *   insecurely &mdash; use a simple sequence. Each call to `randomFn()` is
+   *   expected to return a 32-bit integer.
+   */
+  constructor(tag, idLength = 16, secretLength = 16, randomFn = null) {
+    super();
+
+    /** {string} The tag to use on all tokens minted by this instance. */
+    this._tag = TString.check(tag);
+
+    /**
+     * {Int} The length of the ID portion of tokens minted by this instance, in
+     * digits.
+     */
+    this._idLength = TInt.nonNegative(idLength);
+
+    /**
+     * {Int} The length of the secret portion of tokens minted by this instance,
+     * in digits.
+     */
+    this._secretLength = TInt.nonNegative(secretLength);
+
+    /** {function} Function to use to produce "random" numbers. */
+    this._randomFn = (randomFn === null)
+      ? sequenceGenerator()
+      : TFunction.chcekCallable(randomFn);
+
+    /** {Map<string, BearerToken>} Map from token IDs to minted instances. */
+    this._allTokens = new Map();
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Indicates whether this instance knows about the indicated token, because it
+   * was either minted by or registered to this isntance. The check is performed
+   * based on the string forms of the tokens, which means it is possible to pass
+   * a {@link BearerToken} that (in terms of `===`) wasn't returned by or
+   * registered to this instance which will result in a `true` return from this
+   * method.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {boolean} `true` iff this instance minted `token`.
+   */
+  hasToken(token) {
+    BearerToken.check(token);
+
+    const found = this._allTokens.get(token.id);
+
+    return (found !== undefined) && found.sameToken(token);
+  }
+
+  /**
+   * Mints and returns a new token.
+   *
+   * @returns {BearerToken} A freshly-generated token.
+   */
+  mintToken() {
+    const id     = this._randomId();
+    const secret = this._hexString(this._secretLength);
+    const token  = new BearerToken(id, `${id}-${secret}`);
+
+    this._allTokens.set(id, token);
+    return token;
+  }
+
+  /**
+   * Registers a token which wasn't minted by this instance.
+   *
+   * @param {BearerToken} token The token to register.
+   */
+  registerToken(token) {
+    const already = this._allTokens.get(token.id);
+
+    if (already !== undefined) {
+      throw Errors.badUse(`Duplicate token: ${token.printableId}`);
+    }
+
+    this._allTokens.set(token.id, token);
+  }
+
+  /**
+   * Generates a random string of lowercase hexadecimal digits of the given
+   * length, using this instance's {@link #_randomFn}.
+   *
+   * @param {Int} length The desired length.
+   * @returns {string} Random string of digits of length `length`.
+   */
+  _hexString(length) {
+    let result = '';
+
+    while (result.length < length) {
+      result += this._randomFn().toString(16).padStart(8, '0');
+    }
+
+    return result.slice(0, length);
+  }
+
+  /**
+   * Generates a random ID, including the tag. The result is guaranteed not to
+   * correspond to an already-minted token.
+   *
+   * @returns {string} New randomly-generated ID.
+   */
+  _randomId() {
+    for (;;) {
+      const result = `${this._tag}-${this._hexString(this._idLength)}`;
+
+      if (!this._allTokens.has(result)) {
+        return result;
+      }
+    }
+  }
+}

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -7,6 +7,15 @@ import Context from './Context';
 import PostConnection from './PostConnection';
 import Target from './Target';
 import TokenAuthorizer from './TokenAuthorizer';
+import TokenMint from './TokenMint';
 import WsConnection from './WsConnection';
 
-export { Connection, Context, PostConnection, Target, TokenAuthorizer, WsConnection };
+export {
+  Connection,
+  Context,
+  PostConnection,
+  Target,
+  TokenAuthorizer,
+  TokenMint,
+  WsConnection
+};

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -49,7 +49,7 @@ export default class AppAuthorizer extends TokenAuthorizer {
       return this._application.rootAccess;
     }
 
-    // No other token type grants authority... yet.
+    // No other token types grant authority... yet.
     return null;
   }
 

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -10,14 +10,14 @@ import { Errors } from '@bayou/util-common';
  * {RegEx} Expression that matches properly-formed tokens. The ID and secret
  * portions are each a separate matching group.
  */
-const TOKEN_REGEX = /^(root-[0-9a-f]{16})([0-9a-f]{16})$/;
+const TOKEN_REGEX = /^(root-[0-9a-f]{16})-([0-9a-f]{16})$/;
 
 /**
  * {string} The one well-known root token. This obviously-insecure arrangement
  * is just for this module, the default server configuration module, which is
  * only supposed to be used in development, not real production.
  */
-const THE_ROOT_TOKEN = 'root-00000000000000000000000000000000';
+const THE_ROOT_TOKEN = 'root-0000000000000000-0000000000000000';
 
 /**
  * Utility functionality regarding the network configuration of a server.

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -10,14 +10,14 @@ import { Errors } from '@bayou/util-common';
  * {RegEx} Expression that matches properly-formed tokens. The ID and secret
  * portions are each a separate matching group.
  */
-const TOKEN_REGEX = /^(tok-[0-9a-f]{16})([0-9a-f]{16})$/;
+const TOKEN_REGEX = /^(root-[0-9a-f]{16})([0-9a-f]{16})$/;
 
 /**
  * {string} The one well-known root token. This obviously-insecure arrangement
  * is just for this module, the default server configuration module, which is
  * only supposed to be used in development, not real production.
  */
-const THE_ROOT_TOKEN = 'tok-00000000000000000000000000000000';
+const THE_ROOT_TOKEN = 'root-00000000000000000000000000000000';
 
 /**
  * Utility functionality regarding the network configuration of a server.

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -4,20 +4,40 @@
 
 import { BearerToken } from '@bayou/api-common';
 import { BaseAuth } from '@bayou/config-server';
+import { TInt, TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 /**
- * {RegEx} Expression that matches properly-formed tokens. The ID and secret
- * portions are each a separate matching group.
+ * {RegEx} Expression that matches properly-formed tokens. The type, ID, and
+ * secret portions are each a separate matching group.
  */
-const TOKEN_REGEX = /^(root-[0-9a-f]{16})-([0-9a-f]{16})$/;
+const TOKEN_REGEX = /^(root|autr)-([0-9a-f]{16})-([0-9a-f]{16})$/;
+
+/**
+ * {string} ID of the one well-known root token. See {@link #THE_ROOT_TOKEN}
+ * for more discussion.
+ */
+const THE_ROOT_TOKEN_ID = 'root-0000000000000000';
 
 /**
  * {string} The one well-known root token. This obviously-insecure arrangement
  * is just for this module, the default server configuration module, which is
  * only supposed to be used in development, not real production.
  */
-const THE_ROOT_TOKEN = 'root-0000000000000000-0000000000000000';
+const THE_ROOT_TOKEN = `${THE_ROOT_TOKEN_ID}-0000000000000000`;
+
+/** {string} Type prefix used for author tokens. */
+const AUTHOR_TOKEN_TYPE = 'autr';
+
+/**
+ * {Map<string,object>} Map from token ID strings to objects which are suitable
+ * as the return value from {@link Auth#tokenAuthority} (see which), with the
+ * addition of a binding `token` to hold the actual token object.
+ */
+const ALL_TOKENS = new Map();
+
+/** {Int} Next ID to assign to a token. */
+let nextTokenId = 1;
 
 /**
  * Utility functionality regarding the network configuration of a server.
@@ -37,8 +57,40 @@ export default class Auth extends BaseAuth {
   /**
    * Implementation of standard configuration point.
    *
-   * This implementation requires strings of lowercase hex, of exactly 32
-   * characters.
+   * This implementation succeeds for any valid author ID and always returns a
+   * newly-created token. It caches every token token created, such that it can
+   * subsequently be found by {@link #tokenAuthority}.
+   *
+   * @param {string} authorId ID for the author.
+   * @returns {BearerToken} Token which grants author access.
+   */
+  static getAuthorToken(authorId) {
+    // **Note:** Actually checking for `AuthorId` syntax would introduce a
+    // circular dependency. **TODO:** Sort this out.
+    TString.check(authorId);
+
+    // **Note:** `^ 1` just so the ID and secret aren't exactly the same.
+    const idString = `${AUTHOR_TOKEN_TYPE}-${Auth._hex16(nextTokenId)}`;
+    const secretString = Auth._hex16(nextTokenId ^ 1);
+
+    const result = new BearerToken(idString, `${idString}-${secretString}`);
+
+    ALL_TOKENS.set(idString, Object.freeze({
+      type:  Auth.TYPE_author,
+      token: result,
+      authorId
+    }));
+
+    nextTokenId++;
+    return result;
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
+   * This implementation requires strings that have the general form of
+   * `<type>-<id>-<secret>`, where `<type>` is four lowercase characters, and
+   * the other two parts are each 16 lowercase hexadecimal digits.
    *
    * @param {string} tokenString The alleged token.
    * @returns {boolean} `true` iff `tokenString` is valid token syntax.
@@ -51,8 +103,8 @@ export default class Auth extends BaseAuth {
    * Implementation of standard configuration point.
    *
    * This implementation &mdash; obviously insecurely &mdash; hard-codes a
-   * particular token to have "root" authority, specifically a token consisting
-   * of all zeroes in the numeric portion.
+   * particular token to have "root" authority. See {@link #THE_ROOT_TOKEN},
+   * above, for more info.
    *
    * @param {BearerToken} token The token in question.
    * @returns {object} Representation of the authority granted by `token`.
@@ -60,11 +112,20 @@ export default class Auth extends BaseAuth {
   static async tokenAuthority(token) {
     BearerToken.check(token);
 
-    if (token.secretToken === THE_ROOT_TOKEN) {
-      return { type: Auth.TYPE_root };
+    const found = ALL_TOKENS.get(token.id);
+
+    if ((found === undefined) || !found.token.sameToken(token)) {
+      // Either we didn't find a token with a matching ID, or we found such a
+      // token, but it has a different secret than `token` has.
+      return { type: Auth.TYPE_none };
     }
 
-    return { type: Auth.TYPE_none };
+    // Clone the `found` object, and remove `token` from the clone (as it's not
+    // supposed to be returned from this method).
+
+    const result = Object.assign({}, found);
+    delete result.token;
+    return result;
   }
 
   /**
@@ -81,8 +142,7 @@ export default class Auth extends BaseAuth {
   /**
    * Implementation of standard configuration point.
    *
-   * This implementation just returns the first 16 characters of the given
-   * string.
+   * This implementation returns the type and ID sections (dash-separated).
    *
    * @param {string} tokenString The token.
    * @returns {string} The ID portion.
@@ -92,11 +152,30 @@ export default class Auth extends BaseAuth {
 
     if (match) {
       // It is a proper token.
-      return match[1];
+      return `${match[1]}-${match[2]}`;
     }
 
     // **Note:** We redact the value to reduce the likelihood of leaking
     // security-sensitive info.
     throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
   }
+
+  /**
+   * Converts the given number into lowercase hexadecimal, left-padded with
+   * zeroes.
+   *
+   * @param {Int} n Number to convert.
+   * @returns {string} Sixteen hexadecimal digits.
+   */
+  static _hex16(n) {
+    TInt.check(n);
+
+    return n.toString(16).padStart(16, '0');
+  }
 }
+
+// Set up the well-known root token.
+ALL_TOKENS.set(THE_ROOT_TOKEN_ID, Object.freeze({
+  type:  Auth.TYPE_root,
+  token: new BearerToken(THE_ROOT_TOKEN_ID, THE_ROOT_TOKEN)
+}));

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -12,13 +12,13 @@ import { Errors } from '@bayou/util-common';
  * {RegEx} Expression that matches properly-formed tokens. The type, ID, and
  * secret portions are each a separate matching group.
  */
-const TOKEN_REGEX = /^(root|autr)-([0-9a-f]{16})-([0-9a-f]{16})$/;
+const TOKEN_REGEX = /^(root|autr)-([0-9a-f]{8})-([0-9a-f]{8})$/;
 
 /**
  * {string} ID of the one well-known root token. See {@link #THE_ROOT_TOKEN}
  * for more discussion.
  */
-const THE_ROOT_TOKEN_ID = 'root-0000000000000000';
+const THE_ROOT_TOKEN_ID = 'root-00000000';
 
 /**
  * {BearerToken} The one well-known root token. This obviously-insecure value is
@@ -26,7 +26,7 @@ const THE_ROOT_TOKEN_ID = 'root-0000000000000000';
  * only supposed to be used in development, and not for real production.
  */
 const THE_ROOT_TOKEN =
-  new BearerToken(THE_ROOT_TOKEN_ID, `${THE_ROOT_TOKEN_ID}-0000000000000000`);
+  new BearerToken(THE_ROOT_TOKEN_ID, `${THE_ROOT_TOKEN_ID}-00000000`);
 
 /**
  * {TokenMint} Mint which creates author tokens and also knows about the root

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -12,7 +12,7 @@ import { Auth } from '@bayou/config-server-default';
 /**
  * {string} Valid token string which is not expected to ever bear any authority.
  */
-const EXAMPLE_TOKEN = 'tok-00000000000000001123456789abcdef';
+const EXAMPLE_TOKEN = 'root-00000000000000001123456789abcdef';
 
 /**
  * {string} The well-known root token used by this module.
@@ -21,7 +21,7 @@ const EXAMPLE_TOKEN = 'tok-00000000000000001123456789abcdef';
  * have a single well-known root token. Any real deployment of this project will
  * (had better!) use a _different_ configuration module.
  */
-const ROOT_TOKEN = 'tok-00000000000000000000000000000000';
+const ROOT_TOKEN = 'root-00000000000000000000000000000000';
 
 describe('@bayou/config-server-default/Auth', () => {
   it('inherits from `BaseAuth`', () => {
@@ -51,11 +51,15 @@ describe('@bayou/config-server-default/Auth', () => {
     });
 
     it('should reject non-token syntax', () => {
-      assert.isFalse(Auth.isToken('zzz-0000000000000001123456789abcdef'));
       assert.isFalse(Auth.isToken('0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('tok-z0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('tok-00000000000000001123456789abcdef1'));
-      assert.isFalse(Auth.isToken('tok-0000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('-0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('z-0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('zz-0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('zzz-0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('zzzz-0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('root-z0000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('root-00000000000000001123456789abcdef1'));
+      assert.isFalse(Auth.isToken('root-0000000000000000-1123456789abcdef'));
     });
   });
 
@@ -88,7 +92,7 @@ describe('@bayou/config-server-default/Auth', () => {
 
   describe('tokenFromString()', () => {
     it('should construct a token with the expected parts, given a valid token', () => {
-      const id    = 'tok-0123456776543210';
+      const id    = 'root-0123456776543210';
       const full  = `${id}aaaaaaaaaaaaaaa1`;
       const token = Auth.tokenFromString(full);
 
@@ -99,7 +103,7 @@ describe('@bayou/config-server-default/Auth', () => {
 
   describe('tokenId()', () => {
     it('should extract the ID of a valid token', () => {
-      const id    = 'tok-0123456776543210';
+      const id    = 'root-0123456776543210';
       const token = `${id}bbbbbbbbbbbbbbbb`;
       assert.strictEqual(Auth.tokenId(token), id);
     });

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -45,6 +45,39 @@ describe('@bayou/config-server-default/Auth', () => {
     });
   });
 
+  describe('getAuthorToken()', () => {
+    it('should return a `BearerToken` when given a valid author ID', () => {
+      const t = Auth.getAuthorToken('some-author');
+
+      assert.instanceOf(t, BearerToken);
+    });
+
+    it('should always return a new token even given the same ID', () => {
+      const t1 = Auth.getAuthorToken('florp');
+      const t2 = Auth.getAuthorToken('florp');
+
+      assert.isFalse(t1.sameToken(t2));
+    });
+
+    it('should return a token whose full string conforms to `isToken()`', () => {
+      const t = Auth.getAuthorToken('some-author');
+
+      assert.isTrue(Auth.isToken(t.secretToken));
+    });
+
+    it('should return a token which elicits a correct response from `tokenAuthority()`', async () => {
+      const AUTHOR_ID = 'that-author';
+      const t         = Auth.getAuthorToken(AUTHOR_ID);
+      const authority = await Auth.tokenAuthority(t);
+      const expect    = {
+        type:     Auth.TYPE_author,
+        authorId: AUTHOR_ID
+      };
+
+      assert.deepEqual(authority, expect);
+    });
+  });
+
   describe('isToken()', () => {
     it('should accept token syntax', () => {
       assert.isTrue(Auth.isToken(ROOT_TOKEN));

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -10,9 +10,13 @@ import { BaseAuth } from '@bayou/config-server';
 import { Auth } from '@bayou/config-server-default';
 
 /**
- * {string} Valid token string which is not expected to ever bear any authority.
+ * {array<string>} Valid token strings which are not expected to ever bear any
+ * authority.
  */
-const EXAMPLE_TOKEN = 'root-0000000000000000-1123456789abcdef';
+const EXAMPLE_TOKENS = [
+  'root-0000000000000000-1123456789abcdef',
+  'autr-00000000000000ff-aaabbbcccdddeeef'
+];
 
 /**
  * {string} The well-known root token used by this module.
@@ -81,7 +85,10 @@ describe('@bayou/config-server-default/Auth', () => {
   describe('isToken()', () => {
     it('should accept token syntax', () => {
       assert.isTrue(Auth.isToken(ROOT_TOKEN));
-      assert.isTrue(Auth.isToken(EXAMPLE_TOKEN));
+
+      for (const t of EXAMPLE_TOKENS) {
+        assert.isTrue(Auth.isToken(t), t);
+      }
     });
 
     it('should reject non-token syntax', () => {
@@ -111,14 +118,20 @@ describe('@bayou/config-server-default/Auth', () => {
       await test('florp');
       await test([1, 2]);
       await test(new Map());
-      await test(EXAMPLE_TOKEN); // Requires a token object, not a string.
+      await test(EXAMPLE_TOKENS[0]); // Requires a token object, not a string.
     });
 
     it('should indicate "no auth" for an unknown token', async () => {
-      const token = Auth.tokenFromString(EXAMPLE_TOKEN);
-      const auth  = await Auth.tokenAuthority(token);
+      async function test(t) {
+        const token = Auth.tokenFromString(t);
+        const auth  = await Auth.tokenAuthority(token);
 
-      assert.deepEqual(auth, { type: Auth.TYPE_none });
+        assert.deepEqual(auth, { type: Auth.TYPE_none });
+      }
+
+      for (const t of EXAMPLE_TOKENS) {
+        await test(t);
+      }
     });
 
     it('should indicate "root auth" for the staticly-known root token', async () => {

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -12,7 +12,7 @@ import { Auth } from '@bayou/config-server-default';
 /**
  * {string} Valid token string which is not expected to ever bear any authority.
  */
-const EXAMPLE_TOKEN = 'root-00000000000000001123456789abcdef';
+const EXAMPLE_TOKEN = 'root-0000000000000000-1123456789abcdef';
 
 /**
  * {string} The well-known root token used by this module.
@@ -21,7 +21,7 @@ const EXAMPLE_TOKEN = 'root-00000000000000001123456789abcdef';
  * have a single well-known root token. Any real deployment of this project will
  * (had better!) use a _different_ configuration module.
  */
-const ROOT_TOKEN = 'root-00000000000000000000000000000000';
+const ROOT_TOKEN = 'root-0000000000000000-0000000000000000';
 
 describe('@bayou/config-server-default/Auth', () => {
   it('inherits from `BaseAuth`', () => {
@@ -47,19 +47,23 @@ describe('@bayou/config-server-default/Auth', () => {
 
   describe('isToken()', () => {
     it('should accept token syntax', () => {
+      assert.isTrue(Auth.isToken(ROOT_TOKEN));
       assert.isTrue(Auth.isToken(EXAMPLE_TOKEN));
     });
 
     it('should reject non-token syntax', () => {
-      assert.isFalse(Auth.isToken('0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('-0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('z-0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('zz-0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('zzz-0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('zzzz-0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('root-z0000000000000001123456789abcdef'));
-      assert.isFalse(Auth.isToken('root-00000000000000001123456789abcdef1'));
-      assert.isFalse(Auth.isToken('root-0000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('-000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('z-000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('zz-000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('zzz-000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('zzzz-000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('root-000000000000000-1123456789abcdef-'));
+      assert.isFalse(Auth.isToken('root-000000000000000-1123456789abcdef-1'));
+      assert.isFalse(Auth.isToken('root-z000000000000000-1123456789abcdef'));
+      assert.isFalse(Auth.isToken('root-0000000000000000-1123456789abcdef1'));
+      assert.isFalse(Auth.isToken('root-00000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('root-1-2'));
     });
   });
 
@@ -72,6 +76,8 @@ describe('@bayou/config-server-default/Auth', () => {
       await test(undefined);
       await test(null);
       await test('florp');
+      await test([1, 2]);
+      await test(new Map());
       await test(EXAMPLE_TOKEN); // Requires a token object, not a string.
     });
 
@@ -93,7 +99,7 @@ describe('@bayou/config-server-default/Auth', () => {
   describe('tokenFromString()', () => {
     it('should construct a token with the expected parts, given a valid token', () => {
       const id    = 'root-0123456776543210';
-      const full  = `${id}aaaaaaaaaaaaaaa1`;
+      const full  = `${id}-aaaaaaaaaaaaaaa1`;
       const token = Auth.tokenFromString(full);
 
       assert.strictEqual(token.id, id);
@@ -104,7 +110,7 @@ describe('@bayou/config-server-default/Auth', () => {
   describe('tokenId()', () => {
     it('should extract the ID of a valid token', () => {
       const id    = 'root-0123456776543210';
-      const token = `${id}bbbbbbbbbbbbbbbb`;
+      const token = `${id}-bbbbbbbbbbbbbbbb`;
       assert.strictEqual(Auth.tokenId(token), id);
     });
   });

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -14,8 +14,8 @@ import { Auth } from '@bayou/config-server-default';
  * authority.
  */
 const EXAMPLE_TOKENS = [
-  'root-0000000000000000-1123456789abcdef',
-  'autr-00000000000000ff-aaabbbcccdddeeef'
+  'root-00000000-12345678',
+  'autr-000000ff-aaabbbcc'
 ];
 
 /**
@@ -25,7 +25,7 @@ const EXAMPLE_TOKENS = [
  * have a single well-known root token. Any real deployment of this project will
  * (had better!) use a _different_ configuration module.
  */
-const ROOT_TOKEN = 'root-0000000000000000-0000000000000000';
+const ROOT_TOKEN = 'root-00000000-00000000';
 
 describe('@bayou/config-server-default/Auth', () => {
   it('inherits from `BaseAuth`', () => {
@@ -92,17 +92,17 @@ describe('@bayou/config-server-default/Auth', () => {
     });
 
     it('should reject non-token syntax', () => {
-      assert.isFalse(Auth.isToken('000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('-000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('z-000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('zz-000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('zzz-000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('zzzz-000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('root-000000000000000-1123456789abcdef-'));
-      assert.isFalse(Auth.isToken('root-000000000000000-1123456789abcdef-1'));
-      assert.isFalse(Auth.isToken('root-z000000000000000-1123456789abcdef'));
-      assert.isFalse(Auth.isToken('root-0000000000000000-1123456789abcdef1'));
-      assert.isFalse(Auth.isToken('root-00000000000000001123456789abcdef'));
+      assert.isFalse(Auth.isToken('00000000-11234def0'));
+      assert.isFalse(Auth.isToken('-0000000-11234def'));
+      assert.isFalse(Auth.isToken('z-0000000-1123cdef'));
+      assert.isFalse(Auth.isToken('zz-0000000-1123cdef'));
+      assert.isFalse(Auth.isToken('zzz-0000000-1123cdef'));
+      assert.isFalse(Auth.isToken('zzzz-0000000-1123cdef'));
+      assert.isFalse(Auth.isToken('root-0000000-112bcdef-'));
+      assert.isFalse(Auth.isToken('root-0000000-11234def-1'));
+      assert.isFalse(Auth.isToken('root-z0000000-112bcdef'));
+      assert.isFalse(Auth.isToken('root-00000000-11abcdef1'));
+      assert.isFalse(Auth.isToken('root-000000001123cdef'));
       assert.isFalse(Auth.isToken('root-1-2'));
     });
   });
@@ -144,8 +144,8 @@ describe('@bayou/config-server-default/Auth', () => {
 
   describe('tokenFromString()', () => {
     it('should construct a token with the expected parts, given a valid token', () => {
-      const id    = 'root-0123456776543210';
-      const full  = `${id}-aaaaaaaaaaaaaaa1`;
+      const id    = 'root-01233210';
+      const full  = `${id}-aaaaaaa1`;
       const token = Auth.tokenFromString(full);
 
       assert.strictEqual(token.id, id);
@@ -155,8 +155,8 @@ describe('@bayou/config-server-default/Auth', () => {
 
   describe('tokenId()', () => {
     it('should extract the ID of a valid token', () => {
-      const id    = 'root-0123456776543210';
-      const token = `${id}-bbbbbbbbbbbbbbbb`;
+      const id    = 'root-01234210';
+      const token = `${id}-bbbbbbbb`;
       assert.strictEqual(Auth.tokenId(token), id);
     });
   });

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -21,6 +21,20 @@ export default class Auth extends BaseAuth {
   }
 
   /**
+   * Gets (makes or finds in a cache) an author token, associated with the
+   * indicated author ID. This throws an error if it is not possible to make
+   * such a token.
+   *
+   * @param {string} authorId ID for the author, which must be in the syntax
+   *   defined by {@link ot-common.AuthorId}.
+   * @returns {BearerToken} Token which grants access for the author (user)
+   *   whose ID is `authorId`.
+   */
+  static getAuthorToken(authorId) {
+    return use.Auth.getAuthorToken(authorId);
+  }
+
+  /**
    * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
    * token (whether or not it actually grants any access).
    *

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -42,6 +42,10 @@ export default class Auth extends BaseAuth {
    * * `Auth.TYPE_root` &mdash; No other bindings. The token is a "root" token,
    *   which grants full system access. (This sort of token is how a trusted
    *   back-end system communicates with this server.)
+   * * `Auth.TYPE_author` &mdash; Additional binding `authorId`, a string. The
+   *   token is an "author" (user) token, which grants the ability to perform
+   *   operations on behalf of the so-identified author. For example, such a
+   *   token allows the bearer to edit documents owned by that author.
    *
    * **Note:** This is defined to be an `async` method, on the expectation that
    * in a production configuration, it might require network activity (e.g.

--- a/local-modules/@bayou/config-server/BaseAuth.js
+++ b/local-modules/@bayou/config-server/BaseAuth.js
@@ -12,6 +12,9 @@ import { UtilityClass } from '@bayou/util-common';
  */
 export default class BaseAuth extends UtilityClass {
   /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  static get TYPE_author() { return 'author'; }
+
+  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
   static get TYPE_none() { return 'none'; }
 
   /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */

--- a/local-modules/@bayou/config-server/tests/test_BaseAuth.js
+++ b/local-modules/@bayou/config-server/tests/test_BaseAuth.js
@@ -9,7 +9,7 @@ import { BaseAuth } from '@bayou/config-server';
 
 describe('@bayou/config-server/BaseAuth', () => {
   describe('.TYPE_*', () => {
-    const items = ['root', 'none'];
+    const items = ['author', 'none', 'root'];
 
     for (const item of items) {
       const name = `TYPE_${item}`;


### PR DESCRIPTION
This PR introduces "author tokens" as a concept that is supported at the lower layers of the system, though they aren't actually used in any meaningful way yet. In this embodiment, author tokens are a kind of bearer token, but which convey the authority of an author (that is a user who can edit documents). Previous to this PR, the only kind of bearer tokens were "root" tokens, which are what's used for BE-to-BE communication.

A later PR will introduce the use of author tokens as the means of authentication from the front end (while still preserving the pre-existing `SplitKey` stuff for the time being).
