### PR TITLE
More author token stuff.

### DIFF
--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -96,6 +96,26 @@ export default class TokenMint extends CommonBase {
   }
 
   /**
+   * Gets the information associated with the given token. If the token was not
+   * minted by or registered to this instance, this returns `null`.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {*} The information associated with `token`, or `null` if `token`
+   *   is unknown to this instance.
+   */
+  getInfoOrNull(token) {
+    BearerToken.check(token);
+
+    const found = this._allTokens.get(token.id);
+
+    if ((found === undefined) || !found.token.sameToken(token)) {
+      return null;
+    }
+
+    return found.info;
+  }
+
+  /**
    * Indicates whether this instance knows about the indicated token, because it
    * was either minted by or registered to this instance. The check is performed
    * based on the string forms of the tokens, which means it is possible to pass

--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -85,7 +85,11 @@ export default class TokenMint extends CommonBase {
       ? sequenceGenerator()
       : TFunction.chcekCallable(randomFn);
 
-    /** {Map<string, BearerToken>} Map from token IDs to minted instances. */
+    /**
+     * {Map<string, object>} Map from token IDs to objects which bind `token`
+     * (the token instance) and `info` (the arbitrary info associated with the
+     * token).
+     */
     this._allTokens = new Map();
 
     Object.freeze(this);
@@ -93,7 +97,7 @@ export default class TokenMint extends CommonBase {
 
   /**
    * Indicates whether this instance knows about the indicated token, because it
-   * was either minted by or registered to this isntance. The check is performed
+   * was either minted by or registered to this instance. The check is performed
    * based on the string forms of the tokens, which means it is possible to pass
    * a {@link BearerToken} that (in terms of `===`) wasn't returned by or
    * registered to this instance which will result in a `true` return from this
@@ -107,36 +111,40 @@ export default class TokenMint extends CommonBase {
 
     const found = this._allTokens.get(token.id);
 
-    return (found !== undefined) && found.sameToken(token);
+    return (found !== undefined) && found.token.sameToken(token);
   }
 
   /**
-   * Mints and returns a new token.
+   * Mints and returns a new token, optionally associating arbitrary info with
+   * it.
    *
+   * @param {*} [info = null] Information to associate with the token.
    * @returns {BearerToken} A freshly-generated token.
    */
-  mintToken() {
+  mintToken(info = null) {
     const id     = this._randomId();
     const secret = this._hexString(this._secretLength);
     const token  = new BearerToken(id, `${id}-${secret}`);
 
-    this._allTokens.set(id, token);
+    this._allTokens.set(id, { info, token });
     return token;
   }
 
   /**
-   * Registers a token which wasn't minted by this instance.
+   * Registers a token which wasn't minted by this instance, optionally
+   * associating arbitrary info with it.
    *
    * @param {BearerToken} token The token to register.
+   * @param {*} [info = null] Information to associate with `token`.
    */
-  registerToken(token) {
+  registerToken(token, info = null) {
     const already = this._allTokens.get(token.id);
 
     if (already !== undefined) {
       throw Errors.badUse(`Duplicate token: ${token.printableId}`);
     }
 
-    this._allTokens.set(token.id, token);
+    this._allTokens.set(token.id, { info, token });
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -34,15 +34,8 @@ const THE_ROOT_TOKEN =
  */
 const tokenMint = new TokenMint('autr');
 
-/**
- * {Map<string,object>} Map from token ID strings to objects which are suitable
- * as the return value from {@link Auth#tokenAuthority} (see which).
- */
-const tokenAuths = new Map();
-
 // Set up the well-known root token.
-tokenMint.registerToken(THE_ROOT_TOKEN);
-tokenAuths.set(THE_ROOT_TOKEN_ID, Object.freeze({ type: BaseAuth.TYPE_root }));
+tokenMint.registerToken(THE_ROOT_TOKEN, Object.freeze({ type: BaseAuth.TYPE_root }));
 
 /**
  * Utility functionality regarding the network configuration of a server.
@@ -74,14 +67,10 @@ export default class Auth extends BaseAuth {
     // circular dependency. **TODO:** Sort this out.
     TString.check(authorId);
 
-    const result = tokenMint.mintToken();
-
-    tokenAuths.set(result.id, Object.freeze({
-      type:  Auth.TYPE_author,
+    return tokenMint.mintToken(Object.freeze({
+      type: Auth.TYPE_author,
       authorId
     }));
-
-    return result;
   }
 
   /**
@@ -112,11 +101,9 @@ export default class Auth extends BaseAuth {
   static async tokenAuthority(token) {
     BearerToken.check(token);
 
-    if (!tokenMint.hasToken(token)) {
-      return { type: Auth.TYPE_none };
-    }
+    const found = tokenMint.getInfoOrNull(token);
 
-    return tokenAuths.get(token.id);
+    return (found === null) ? { type: Auth.TYPE_none } : found;
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -69,7 +69,7 @@ export default class Auth extends BaseAuth {
    * @param {string} authorId ID for the author.
    * @returns {BearerToken} Token which grants author access.
    */
-  static getAuthorToken(authorId) {
+  static async getAuthorToken(authorId) {
     // **Note:** Actually checking for `AuthorId` syntax would introduce a
     // circular dependency. **TODO:** Sort this out.
     TString.check(authorId);

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -50,28 +50,28 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('getAuthorToken()', () => {
-    it('should return a `BearerToken` when given a valid author ID', () => {
-      const t = Auth.getAuthorToken('some-author');
+    it('should return a `BearerToken` when given a valid author ID', async () => {
+      const t = await Auth.getAuthorToken('some-author');
 
       assert.instanceOf(t, BearerToken);
     });
 
-    it('should always return a new token even given the same ID', () => {
-      const t1 = Auth.getAuthorToken('florp');
-      const t2 = Auth.getAuthorToken('florp');
+    it('should always return a new token even given the same ID', async () => {
+      const t1 = await Auth.getAuthorToken('florp');
+      const t2 = await Auth.getAuthorToken('florp');
 
       assert.isFalse(t1.sameToken(t2));
     });
 
-    it('should return a token whose full string conforms to `isToken()`', () => {
-      const t = Auth.getAuthorToken('some-author');
+    it('should return a token whose full string conforms to `isToken()`', async () => {
+      const t = await Auth.getAuthorToken('some-author');
 
       assert.isTrue(Auth.isToken(t.secretToken));
     });
 
     it('should return a token which elicits a correct response from `tokenAuthority()`', async () => {
       const AUTHOR_ID = 'that-author';
-      const t         = Auth.getAuthorToken(AUTHOR_ID);
+      const t         = await Auth.getAuthorToken(AUTHOR_ID);
       const authority = await Auth.tokenAuthority(t);
       const expect    = {
         type:     Auth.TYPE_author,

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -25,12 +25,16 @@ export default class Auth extends BaseAuth {
    * indicated author ID. This throws an error if it is not possible to make
    * such a token.
    *
+   * **Note:** This is defined to be an `async` method, on the expectation that
+   * in a production configuration, it might require network activity (e.g.
+   * making a request of a different service) to make a valid token.
+   *
    * @param {string} authorId ID for the author, which must be in the syntax
    *   defined by {@link ot-common.AuthorId}.
    * @returns {BearerToken} Token which grants access for the author (user)
    *   whose ID is `authorId`.
    */
-  static getAuthorToken(authorId) {
+  static async getAuthorToken(authorId) {
     return use.Auth.getAuthorToken(authorId);
   }
 


### PR DESCRIPTION
A couple author token bits here:

* Made `Auth.getAuthorToken()` `async`, because maybe we want to have it be able to do networking.

* Added functionality to `TokenMint` to make it easier to do the sort of fakery we do in `config-server-default`.