### PR TITLE
More work on author tokens.

### DIFF
--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseKey } from '@bayou/api-common';
+import { BaseKey, TargetId } from '@bayou/api-common';
 import { TObject, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
@@ -41,9 +41,8 @@ export default class Target extends CommonBase {
     this._key = (idOrKey instanceof BaseKey) ? idOrKey : null;
 
     /** {string} The target ID. */
-    this._id = (this._key === null)
-      ? TString.check(idOrKey)
-      : this._key.id;
+    this._id = TargetId.check(
+      (this._key === null) ? TString.check(idOrKey) : this._key.id);
 
     /** {object} The target object. */
     this._target = TObject.check(target);

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -24,26 +24,25 @@ export default class Target extends CommonBase {
   /**
    * Constructs an instance which wraps the given object.
    *
-   * @param {string|BaseKey} nameOrKey Either the name of the target (if
+   * @param {string|BaseKey} idOrKey Either the ID of the target (if
    *   uncontrolled) _or_ the key which controls access to the target. In the
-   *   former case, the target's `id` is taken to be the given name. In the
    *   latter case, the target's `id` is considered to be the same as the key's
    *   `id`.
    * @param {object} target Object to provide access to.
    * @param {Schema|null} schema `target`'s schema, if already known.
    */
-  constructor(nameOrKey, target, schema = null) {
+  constructor(idOrKey, target, schema = null) {
     super();
 
     /**
      * {BaseKey|null} The access key, or `null` if this is an uncontrolled
      * target.
      */
-    this._key = (nameOrKey instanceof BaseKey) ? nameOrKey : null;
+    this._key = (idOrKey instanceof BaseKey) ? idOrKey : null;
 
     /** {string} The target ID. */
     this._id = (this._key === null)
-      ? TString.check(nameOrKey)
+      ? TString.check(idOrKey)
       : this._key.id;
 
     /** {object} The target object. */

--- a/local-modules/@bayou/api-server/TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/TokenAuthorizer.js
@@ -12,6 +12,15 @@ import { CommonBase, Errors } from '@bayou/util-common';
  */
 export default class TokenAuthorizer extends CommonBase {
   /**
+   * {string} Prefix which when prepended to an arbitrary ID string is
+   * guaranteed to result in string for which {@link #isToken} is `false`. This
+   * is used by {@link Context} when generating non-token IDs.
+   */
+  get nonTokenPrefix() {
+    return TString.check(this._impl_nonTokenPrefix);
+  }
+
+  /**
    * Indicates whether the given string is in the valid token syntax as used by
    * this class.
    *
@@ -71,6 +80,16 @@ export default class TokenAuthorizer extends CommonBase {
     const result = this._impl_tokenFromString(tokenString);
 
     return BearerToken.check(result);
+  }
+
+  /**
+   * {string} Subclass-specific implementation of {@link #nonTokenPrefix}.
+   * Subclasses must override this getter.
+   *
+   * @abstract
+   */
+  get _impl_nonTokenPrefix() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -28,6 +28,13 @@ export default class AppAuthorizer extends TokenAuthorizer {
 
   /**
    * @override
+   */
+  get _impl_nonTokenPrefix() {
+    return Auth.nonTokenPrefix;
+  }
+
+  /**
+   * @override
    * @param {string} tokenString The alleged token string.
    * @returns {boolean} `true` iff `tokenString` has valid token syntax.
    */

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -6,6 +6,7 @@ import { TokenAuthorizer } from '@bayou/api-server';
 import { Auth } from '@bayou/config-server';
 
 import Application from './Application';
+import AuthorAccess from './AuthorAccess';
 
 /**
  * Application-specific implementation of {@link TokenAuthorizer}.
@@ -52,12 +53,21 @@ export default class AppAuthorizer extends TokenAuthorizer {
   async _impl_targetFromToken(token) {
     const authority = await Auth.tokenAuthority(token);
 
-    if (authority.type === Auth.TYPE_root) {
-      return this._application.rootAccess;
-    }
+    switch (authority.type) {
+      case Auth.TYPE_root: {
+        return this._application.rootAccess;
+      }
 
-    // No other token types grant authority... yet.
-    return null;
+      case Auth.TYPE_author: {
+        return new AuthorAccess(authority.authorId, this._application.context);
+      }
+
+      default: {
+        // No other token types grant authority. (As of this writing, there
+        // aren't actually any other token types at all.)
+        return null;
+      }
+    }
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -82,6 +82,13 @@ export default class Application extends CommonBase {
   }
 
   /**
+   * {Context} The top-level ID / token binding context.
+   */
+  get context() {
+    return this._context;
+  }
+
+  /**
    * {RootAccess} The "root access" object. This is the object which tokens
    * bearing {@link Auth#TYPE_root} authority grant access to.
    */

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -49,6 +49,17 @@ export default class AuthorAccess extends CommonBase {
    * session on the given document. If the document doesn't exist, this will
    * cause it to be created.
    *
+   * **TODO:** Context binding ought to happen at a different layer of the
+   * system. Maybe something like: An API method implementation can return an
+   * instance of a new class `BindResult` which gets noticed by `api-server`
+   * during API dispatch, which causes it to perform binding. This method would
+   * then return a session object (`fileComplex.makeNewSession(...)`) wrapped in
+   * an instance of that new class. This arrangement would mean that this class
+   * won't have to explicitly know about a context, nor even have to worry about
+   * generating IDs. Further upstream / parallel simplifications will also be
+   * possible, such as (a) a similar change to `RootAccess`, and (b) the
+   * possibility of un-exposing `_context` from `Application`.
+   *
    * @param {string} docId ID of the document which the resulting bound object
    *   allows access to.
    * @returns {string} ID within the API context which refers to the

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -1,0 +1,73 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Context, Target } from '@bayou/api-server';
+import { DocumentId } from '@bayou/doc-common';
+import { DocServer } from '@bayou/doc-server';
+import { AuthorId } from '@bayou/ot-common';
+import { Logger } from '@bayou/see-all';
+import { CommonBase } from '@bayou/util-common';
+
+/** Logger. */
+const log = new Logger('author-access');
+
+/**
+ * "Author access" object. Each instance of this class corresponds to a
+ * particular author (user who is authorized to view and edit documents), and it
+ * is through instances of this class that users ultimately exercise that
+ * authority.
+ */
+export default class AuthorAccess extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} authorId ID of the author on whose behalf this instance
+   *  acts.
+   * @param {Context} context The API context that is managed by this instance,
+   *   that is, where auth-controlled resources end up getting bound.
+   */
+  constructor(authorId, context) {
+    super();
+
+    /**
+     * {string} authorId ID of the author on whose behalf this instance acts.
+     */
+    this._authorId = AuthorId.check(authorId);
+
+    /** {Context} The API context to use. */
+    this._context = Context.check(context);
+
+    /** {Logger} Logger for this instance. */
+    this._log = log.withContext(authorId);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Adds a binding to this instance's associated context for a new editing
+   * session on the given document. If the document doesn't exist, this will
+   * cause it to be created.
+   *
+   * @param {string} docId ID of the document which the resulting bound object
+   *   allows access to.
+   * @returns {string} ID within the API context which refers to the
+   *   newly-created session.
+   */
+  async makeSession(docId) {
+    DocumentId.check(docId);
+
+    const fileComplex = await DocServer.theOne.getFileComplex(docId);
+
+    const sessionId = this._context.randomId();
+    const session   = fileComplex.makeNewSession(this._authorId, sessionId);
+    this._context.addTarget(new Target(sessionId, session));
+
+    log.info(
+      'New session.\n',
+      `  doc:        ${docId}\n`,
+      `  session id: ${sessionId}`);
+
+    return sessionId;
+  }
+}

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -52,9 +52,10 @@ export default class RootAccess extends CommonBase {
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 
-    const url     = `${Network.baseUrl}/api`;
-    const session = fileComplex.makeNewSession(authorId, this._randomId.bind(this));
-    const key     = new SplitKey(url, session.getSessionId());
+    const url       = `${Network.baseUrl}/api`;
+    const sessionId = this._context.randomSplitKeyId();
+    const session   = fileComplex.makeNewSession(authorId, sessionId);
+    const key       = new SplitKey(url, sessionId);
     this._context.addTarget(new Target(key, session));
 
     log.info(

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -67,21 +67,4 @@ export default class RootAccess extends CommonBase {
 
     return key;
   }
-
-  /**
-   * Makes and returns a random ID that isn't already used.
-   *
-   * @returns {string} A random ID.
-   */
-  _randomId() {
-    for (;;) {
-      const result = SplitKey.randomId();
-      if (!this._context.hasId(result)) {
-        return result;
-      }
-
-      // We managed to get an ID collision. Unlikely, but it can happen. So,
-      // just iterate and try again.
-    }
-  }
 }

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -42,6 +42,13 @@ tokenMint.registerToken(THE_ROOT_TOKEN, Object.freeze({ type: BaseAuth.TYPE_root
  */
 export default class Auth extends BaseAuth {
   /**
+   * {string} Implementation of standard configuration point.
+   */
+  static get nonTokenPrefix() {
+    return 'local-';
+  }
+
+  /**
    * {array<BearerToken>} Implementation of standard configuration point.
    *
    * This implementation &mdash; obviously insecurely &mdash; just returns

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -32,6 +32,15 @@ describe('@bayou/config-server-default/Auth', () => {
     assert.isTrue(Auth.prototype instanceof BaseAuth);
   });
 
+  describe('.nonTokenPrefix', () => {
+    it('should be a short but nonempty lowercase alpha string, ending with a dash', () => {
+      const prefix = Auth.nonTokenPrefix;
+
+      assert.isString(prefix, prefix);
+      assert.isTrue(/^[a-z]{1,6}-$/.test(prefix), prefix);
+    });
+  });
+
   describe('.rootTokens', () => {
     it('should be an array of `BearerToken` instances', () => {
       const tokens = Auth.rootTokens;

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -11,6 +11,14 @@ import BaseAuth from './BaseAuth';
  */
 export default class Auth extends BaseAuth {
   /**
+   * {string} Prefix which when prepended to an arbitrary ID string is
+   * guaranteed to result in string for which {@link #isToken} is `false`.
+   */
+  static get nonTokenPrefix() {
+    return use.Auth.nonTokenPrefix;
+  }
+
+  /**
    * {array<BearerToken>} Frozen array of bearer tokens which grant root access
    * to the system. The value of this property &mdash; that is, the array it
    * refers to &mdash; may change over time, but the contents of any given array

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -8,7 +8,7 @@ import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { Storage } from '@bayou/config-server';
 import { DocumentId } from '@bayou/doc-common';
 import { Logger } from '@bayou/see-all';
-import { TFunction, TString } from '@bayou/typecheck';
+import { TString } from '@bayou/typecheck';
 import { Singleton } from '@bayou/util-common';
 
 import DocSession from './DocSession';

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -154,25 +154,13 @@ export default class DocServer extends Singleton {
    *
    * @param {FileComplex} fileComplex Main complex to attach to.
    * @param {string} authorId ID for the author.
-   * @param {function} makeSessionId Function to generate a random session ID.
+   * @param {string} sessionId ID for the session.
    * @returns {DocSession} A newly-constructed session.
    */
-  _makeNewSession(fileComplex, authorId, makeSessionId) {
+  _makeNewSession(fileComplex, authorId, sessionId) {
     FileComplex.check(fileComplex);
     TString.nonEmpty(authorId);
-    TFunction.checkCallable(makeSessionId);
-
-    // Make a unique session ID.
-    let sessionId;
-    for (;;) {
-      sessionId = makeSessionId();
-      if (!this._sessions.get(sessionId)) {
-        break;
-      }
-
-      // We managed to get an ID collision. Unlikely, but it can happen. So,
-      // just iterate and try again.
-    }
+    TString.nonEmpty(sessionId);
 
     const result = new DocSession(fileComplex, sessionId, authorId);
     const reaper = this._sessionReaper(fileComplex, sessionId);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -63,14 +63,11 @@ export default class FileComplex extends BaseComplexMember {
    * Makes a new author-associated session for this instance.
    *
    * @param {string} authorId ID for the author.
-   * @param {function} makeSessionId No-argument function which should return a
-   *   randomly-generated string to use as a session ID. This will get called
-   *   more than once if the string happens to be a duplicate in the namespace
-   *   for session IDs.
+   * @param {string} sessionId ID for the session.
    * @returns {DocSession} A newly-constructed session.
    */
-  makeNewSession(authorId, makeSessionId) {
-    return DocServer.theOne._makeNewSession(this, authorId, makeSessionId);
+  makeNewSession(authorId, sessionId) {
+    return DocServer.theOne._makeNewSession(this, authorId, sessionId);
   }
 
   /**


### PR DESCRIPTION
This PR adds an `AuthorAccess` class, which parallels the pre-existing `RootAccess` class. Just like `RootAccess` is the class that gets control when a method is invoked over the API using a root token, `AuthorAccess` is what gets called upon to act on behalf of the author represented in an author token. As with the previous couple PRs in this series, this is another one in which most of the code is still just latently sitting there not doing much of anything other than taking up disk space. Specifically, we don't yet have a path by which someone running the app (on the browser, etc.) can end up with an author token, and barring such a token the code here won't get called.

The _one_ thing that runs differently with this PR is the way that root tokens cause new sessions to get bound. This used to be a bit of a convoluted mess to account for possible asynchronous behavior which never actually happened. This is in the _old_ session setup code, which is of course on its way out. I reworked the code not so much as a permanent fix — the whole method in question will ultimately be removed — but rather to enable simplifications in other code that will make follow-on PRs just a bit simpler.
