### PR TITLE
Better checking of file IDs.

### DIFF
--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -235,7 +235,15 @@ describe('@bayou/doc-server/BaseControl', () => {
       async function test(timeout, expect, msg) {
         await assert.isRejected(control.appendChange(change, timeout), /to_be_expected/, `${msg} rejection check`);
         assert.instanceOf(actualFileChange, FileChange, `${msg}: instance check`);
-        assert.strictEqual(actualTimeout, expect, `${msg}: timeout value check`);
+
+        // This is a little squishy, because we're dealing with real wall time
+        // here (that is, time is not mocked out): We accept any received
+        // timeout value which is non-negative and no more than 10ms less than
+        // the expected value.
+        const expectMin = Math.max(0, expect - 10);
+        const expectMax = expect;
+        assert.isAtLeast(actualTimeout, expectMin, `${msg}: timeout minimum value check`);
+        assert.isAtMost(actualTimeout, expectMax, `${msg}: timeout maximum value check`);
       }
 
       await test(null, Timeouts.MAX_TIMEOUT_MSEC, '#1');

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -232,21 +232,21 @@ describe('@bayou/doc-server/BaseControl', () => {
         get: () => new MockSnapshot(100, [[`snap_blort_${100}`]])
       });
 
-      async function test(timeout, expect) {
-        await assert.isRejected(control.appendChange(change, timeout), /to_be_expected/);
-        assert.instanceOf(actualFileChange, FileChange);
-        assert.strictEqual(actualTimeout, expect);
+      async function test(timeout, expect, msg) {
+        await assert.isRejected(control.appendChange(change, timeout), /to_be_expected/, `${msg} rejection check`);
+        assert.instanceOf(actualFileChange, FileChange, `${msg}: instance check`);
+        assert.strictEqual(actualTimeout, expect, `${msg}: timeout value check`);
       }
 
-      await test(null, Timeouts.MAX_TIMEOUT_MSEC);
-      await test(0, Timeouts.MIN_TIMEOUT_MSEC);
-      await test(9999999999, Timeouts.MAX_TIMEOUT_MSEC);
-      await test(Timeouts.MAX_TIMEOUT_MSEC, Timeouts.MAX_TIMEOUT_MSEC);
-      await test(Timeouts.MIN_TIMEOUT_MSEC + 1, Timeouts.MIN_TIMEOUT_MSEC + 1);
-      await test(Timeouts.MAX_TIMEOUT_MSEC - 1, Timeouts.MAX_TIMEOUT_MSEC - 1);
+      await test(null, Timeouts.MAX_TIMEOUT_MSEC, '#1');
+      await test(0, Timeouts.MIN_TIMEOUT_MSEC, '#2');
+      await test(9999999999, Timeouts.MAX_TIMEOUT_MSEC, '#3');
+      await test(Timeouts.MAX_TIMEOUT_MSEC, Timeouts.MAX_TIMEOUT_MSEC, '#4');
+      await test(Timeouts.MIN_TIMEOUT_MSEC + 1, Timeouts.MIN_TIMEOUT_MSEC + 1, '#5');
+      await test(Timeouts.MAX_TIMEOUT_MSEC - 1, Timeouts.MAX_TIMEOUT_MSEC - 1, '#6');
 
       for (let i = Timeouts.MIN_TIMEOUT_MSEC; i < Timeouts.MAX_TIMEOUT_MSEC; i += 987) {
-        await test(i, i);
+        await test(i, i, `loop at ${i}`);
       }
     });
 

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -68,6 +68,22 @@ export default class LocalFileStore extends BaseFileStore {
   }
 
   /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} fileId The ID of the file to query.
+   * @returns {object} Information about the file (or would-be file).
+   */
+  async _impl_getFileInfo(fileId) {
+    const filePath = this._filePath(fileId);
+    const exists   = await fse.pathExists(filePath);
+
+    return {
+      valid: true, // This module has no additional ID validity requirements.
+      exists
+    };
+  }
+
+  /**
    * Ensures the file storage directory exists. This will only ever check once
    * (on first file construction attempt), which notably means that things will
    * break if something removes the file storage directory without restarting

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -72,7 +72,7 @@ export default class BaseFileStore extends Singleton {
   async getFileInfo(fileId) {
     FileId.check(fileId);
 
-    const result = this._impl_getFileInfo(fileId);
+    const result = await this._impl_getFileInfo(fileId);
 
     TObject.withExactKeys(result, ['exists','valid']);
 

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -22,20 +22,19 @@ import FileId from './FileId';
  */
 export default class BaseFileStore extends Singleton {
   /**
-   * Checks a file ID for validity. Returns regularly (with no value) if all is
-   * well, or throws an error if the ID is invalid. Only ever called on a
-   * non-empty string.
+   * Checks a file ID for full validity, beyond simply checking the syntax of
+   * the ID. Returns the given ID if all is well, or throws an error if the ID
+   * is invalid.
    *
-   * This implementation is a no-op. Subclasses may choose to override this if
-   * there is any validation required beyond the syntactic validation of
-   * `FileId.check()`.
-   *
-   * @param {string} fileId_unused The file ID to validate. Only ever passed
-   *   as a value that has been validated by `FileId.check()`.
-   * @throws {Error} Arbitrary error indicating an invalid file ID.
+   * @param {string} fileId The file ID to validate, which must be a
+   *   syntactically valid ID, per {@link Storage#isFileId}.
+   * @returns {string} `fileId` if it is indeed valid.
+   * @throws {Error} `badData` error indicating an invalid file ID.
    */
-  async _impl_checkFileId(fileId_unused) {
-    // This space intentionally left blank.
+  async checkFileId(fileId) {
+    const info = await this.getFileInfo(fileId);
+
+    return info.valid;
   }
 
   /**
@@ -47,8 +46,7 @@ export default class BaseFileStore extends Singleton {
    * @returns {BaseFile} Accessor for the file in question.
    */
   async getFile(fileId) {
-    FileId.check(fileId);
-    await this._impl_checkFileId(fileId);
+    await this.checkFileId(fileId);
     return BaseFile.check(await this._impl_getFile(fileId));
   }
 
@@ -82,8 +80,8 @@ export default class BaseFileStore extends Singleton {
   }
 
   /**
-   * Main implementation of `getFile()`. Only ever called with a known-valid
-   * `fileId`.
+   * Main implementation of {@link #getFile}. Only ever called with a `fileId`
+   * for which {@link #getFileInfo} reports `valid: true`.
    *
    * @abstract
    * @param {string} fileId The ID of the file to access.
@@ -94,8 +92,8 @@ export default class BaseFileStore extends Singleton {
   }
 
   /**
-   * Main implementation of `getFileId()`. Only ever called with a known-valid
-   * `fileId`.
+   * Main implementation of {@link #getFileInfo}. Only ever called with a
+   * syntactically valid `fileId`.
    *
    * @abstract
    * @param {string} fileId The ID of the file to query.


### PR DESCRIPTION
This PR fills in code to check the back-end for validity of file IDs, along with having a place to move file existence checks to (because the method in question is likely to be removed from `BaseFile`'s API).

**Bonus:** Tweaked the test of `BaseControl.appendChange()` to handle the fact that wall time actually progresses during the test. (We could get spurious failures before.)