### PR TITLE
New configuration for back-end data validation

### DIFF
--- a/local-modules/@bayou/config-common-default/IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/IdSyntax.js
@@ -2,42 +2,31 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from '@bayou/typecheck';
+import { DefaultIdSyntax } from '@bayou/id-syntax-default';
 import { BaseIdSyntax } from '@bayou/config-common';
 
 /**
- * Utility functionality regarding ID strings.
+ * Utility functionality regarding ID strings. This implementation uses the
+ * default definitions provided by {@link @bayou/id-syntax-default}.
  */
 export default class IdSyntax extends BaseIdSyntax {
   /**
    * Implementation of standard configuration point.
    *
-   * This implementation requires that author IDs have no more than 32
-   * characters and only use ASCII alphanumerics plus dash (`-`) and underscore
-   * (`_`).
-   *
    * @param {string} id The (alleged) author ID to check.
    * @returns {boolean} `true` iff `id` is syntactically valid.
    */
   static isAuthorId(id) {
-    TString.check(id);
-
-    return /^[-_a-zA-Z0-9]{1,32}$/.test(id);
+    return DefaultIdSyntax.isAuthorId(id);
   }
 
   /**
    * Implementation of standard configuration point.
    *
-   * This implementation requires that document IDs have no more than 32
-   * characters and only use ASCII alphanumerics plus dash (`-`) and underscore
-   * (`_`).
-   *
    * @param {string} id The (alleged) document ID to check.
    * @returns {boolean} `true` iff `id` is syntactically valid.
    */
   static isDocumentId(id) {
-    TString.check(id);
-
-    return /^[-_a-zA-Z0-9]{1,32}$/.test(id);
+    return DefaultIdSyntax.isDocumentId(id);
   }
 }

--- a/local-modules/@bayou/config-common-default/package.json
+++ b/local-modules/@bayou/config-common-default/package.json
@@ -3,8 +3,8 @@
     "quill-delta": "^3.6.2",
 
     "@bayou/config-common": "local",
+    "@bayou/id-syntax-default": "local",
     "@bayou/injecty": "local",
-    "@bayou/typecheck": "local",
     "@bayou/util-common": "local"
   }
 }

--- a/local-modules/@bayou/config-server-default/Storage.js
+++ b/local-modules/@bayou/config-server-default/Storage.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BodyDelta } from '@bayou/doc-common';
+import { LocalDataStore } from '@bayou/data-store-local';
 import { LocalFileStore } from '@bayou/file-store-local';
 import { UtilityClass } from '@bayou/util-common';
 
@@ -24,6 +25,13 @@ export default class Storage extends UtilityClass {
       ['text', 'a-rowin\'', { italic: true }],
       ['text', '.\n']
     ]);
+  }
+
+  /**
+   * {LocalDataStore} Implementation of standard configuration point.
+   */
+  static get dataStore() {
+    return LocalDataStore.theOne;
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/package.json
+++ b/local-modules/@bayou/config-server-default/package.json
@@ -4,6 +4,7 @@
     "@bayou/assets-client": "local",
     "@bayou/config-common-default": "local",
     "@bayou/config-server": "local",
+    "@bayou/data-store-local": "local",
     "@bayou/doc-common": "local",
     "@bayou/file-store-local": "local",
     "@bayou/injecty": "local",

--- a/local-modules/@bayou/config-server-default/tests/test_Storage.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Storage.js
@@ -7,12 +7,19 @@ import { describe, it } from 'mocha';
 
 import { Storage } from '@bayou/config-server-default';
 import { BodyDelta } from '@bayou/doc-common';
+import { LocalDataStore } from '@bayou/data-store-local';
 import { LocalFileStore } from '@bayou/file-store-local';
 
 describe('@bayou/config-server-default/Storage', () => {
   describe('.DEFAULT_DOCUMENT_BODY', () => {
     it('should be an instance of `BodyDelta`', () => {
       assert.instanceOf(Storage.DEFAULT_DOCUMENT_BODY, BodyDelta);
+    });
+  });
+
+  describe('.dataStore', () => {
+    it('should be an instance of `LocalDataStore`', () => {
+      assert.instanceOf(Storage.dataStore, LocalDataStore);
     });
   });
 

--- a/local-modules/@bayou/config-server/Storage.js
+++ b/local-modules/@bayou/config-server/Storage.js
@@ -17,6 +17,18 @@ export default class Storage extends UtilityClass {
   }
 
   /**
+   * {@bayou/data-store/BaseDataStore} Provider of access to the basic "data
+   * store" of the underlying system, for everything other than file storage
+   * (the latter which is handled by {@link #fileStore}). This includes
+   * information such as what users and documents exist, whether IDs (beyond
+   * being syntactically valid) are valid in the context of the rest of the data
+   * stored by the system, and so on.
+   */
+  static get dataStore() {
+    return use.Storage.dataStore;
+  }
+
+  /**
    * {@bayou/file-store/BaseFileStore} The object which provides access to file
    * storage (roughly speaking, the filesystem to store the "files" this system
    * deals with).

--- a/local-modules/@bayou/data-store-local/LocalDataStore.js
+++ b/local-modules/@bayou/data-store-local/LocalDataStore.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseDataStore } from '@bayou/data-store';
+import { DefaultIdSyntax } from '@bayou/id-syntax-default';
 
 /**
  * Data storage implementation that is maximally accepting of IDs (e.g. all
@@ -37,9 +38,7 @@ export default class LocalDataStore extends BaseDataStore {
    *   or `false` if not.
    */
   _impl_isAuthorId(authorId) {
-    // **TODO:** `config-common-default/IdSyntax` should get extracted from that
-    // module and then used here.
-    return /^[-_a-zA-Z0-9]{1,32}$/.test(authorId);
+    return DefaultIdSyntax.isAuthorId(authorId);
   }
 
   /**
@@ -50,8 +49,6 @@ export default class LocalDataStore extends BaseDataStore {
    *   ID, or `false` if not.
    */
   _impl_isDocumentId(documentId) {
-    // **TODO:** `config-common-default/IdSyntax` should get extracted from that
-    // module and then used here.
-    return /^[-_a-zA-Z0-9]{1,32}$/.test(documentId);
+    return DefaultIdSyntax.isDocumentId(documentId);
   }
 }

--- a/local-modules/@bayou/data-store-local/LocalDataStore.js
+++ b/local-modules/@bayou/data-store-local/LocalDataStore.js
@@ -1,0 +1,57 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseDataStore } from '@bayou/data-store';
+
+/**
+ * Data storage implementation that is maximally accepting of IDs (e.g. all
+ * authors exist).
+ */
+export default class LocalDataStore extends BaseDataStore {
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} authorId_unused The ID of the author to query.
+   * @returns {object} Information about the author (or would-be author).
+   */
+  async _impl_getAuthorInfo(authorId_unused) {
+    return { valid: true, exists: true };
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} documentId The ID of the document to query.
+   * @returns {object} Information about the document (or would-be document).
+   */
+  async _impl_getDocumentInfo(documentId) {
+    return { valid: true, exists: true, fileId: documentId };
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} authorId The alleged author ID.
+   * @returns {boolean} `true` if `authorId` is a syntactically valid author ID,
+   *   or `false` if not.
+   */
+  _impl_isAuthorId(authorId) {
+    // **TODO:** `config-common-default/IdSyntax` should get extracted from that
+    // module and then used here.
+    return /^[-_a-zA-Z0-9]{1,32}$/.test(authorId);
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} documentId The alleged document ID.
+   * @returns {boolean} `true` if `documentId` is a syntactically valid document
+   *   ID, or `false` if not.
+   */
+  _impl_isDocumentId(documentId) {
+    // **TODO:** `config-common-default/IdSyntax` should get extracted from that
+    // module and then used here.
+    return /^[-_a-zA-Z0-9]{1,32}$/.test(documentId);
+  }
+}

--- a/local-modules/@bayou/data-store-local/index.js
+++ b/local-modules/@bayou/data-store-local/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import LocalDataStore from './LocalDataStore';
+
+export { LocalDataStore };

--- a/local-modules/@bayou/data-store-local/package.json
+++ b/local-modules/@bayou/data-store-local/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@bayou/data-store": "local"
-  }
+    "@bayou/data-store": "local",
+    "@bayou/id-syntax-default": "local"
+ }
 }

--- a/local-modules/@bayou/data-store-local/package.json
+++ b/local-modules/@bayou/data-store-local/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@bayou/data-store": "local"
+  }
+}

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -1,0 +1,246 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TBoolean, TObject, TString } from '@bayou/typecheck';
+import { Errors, Singleton } from '@bayou/util-common';
+
+/**
+ * Base class for data storage access. An instance of (a concrete subclass of)
+ * this class is responsible for mitigating access to all of the data stored in
+ * the underlying system, _except_ for file data (the latter which is managed by
+ * the module {@link @bayou/file-store}).
+ *
+ * **Note:** This is a subclass of `Singleton`, that is, the system is set up
+ * to only ever expect there to be one data store instance. (Technically, this
+ * inheritence relationship allows for the possibility of having singleton
+ * instances of several subclasses of this class, but in practice that's not
+ * what happens.) **TODO:** To make unit testing more feasible, this should
+ * probably just be a regular class, not a singleton. We should fix this and
+ * {@link @bayou/file-store/BaseFileStore} at the same time.
+ */
+export default class BaseDataStore extends Singleton {
+  /**
+   * Checks an author ID for full validity, beyond simply checking the syntax of
+   * the ID. Returns the given ID if all is well, or throws an error if the ID
+   * is invalid.
+   *
+   * @param {string} authorId The author ID to validate, which must be a
+   *   syntactically valid ID, per {@link #isAuthorId}.
+   * @returns {string} `authorId` if it is indeed valid.
+   * @throws {Error} `badData` error indicating an invalid file ID.
+   */
+  async checkAuthorId(authorId) {
+    const info = await this.getAuthorInfo(authorId);
+
+    if (!info.valid) {
+      throw Errors.badData(`Invalid author ID: \`${authorId}\``);
+    }
+
+    return authorId;
+  }
+
+  /**
+   * Checks a document ID for full validity, beyond simply checking the syntax
+   * of the ID. Returns the given ID if all is well, or throws an error if the
+   * ID is invalid.
+   *
+   * @param {string} documentId The document ID to validate, which must be a
+   *   syntactically valid ID, per {@link #isDocumentId}.
+   * @returns {string} `documentId` if it is indeed valid.
+   * @throws {Error} `badData` error indicating an invalid file ID.
+   */
+  async checkDocumentId(documentId) {
+    const info = await this.getDocumentInfo(documentId);
+
+    if (!info.valid) {
+      throw Errors.badData(`Invalid document ID: \`${documentId}\``);
+    }
+
+    return documentId;
+  }
+
+  /**
+   * Checks the syntax of a value alleged to be an author ID. Returns the given
+   * value if it's a syntactically correct author ID. Otherwise, throws an
+   * error.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is indeed valid.
+   * @throws {Error} `badValue` error indicating a syntactically invalid author
+   *   ID.
+   */
+  checkAuthorIdSyntax(value) {
+    if (!this.isAuthorId(value)) {
+      throw Errors.badValue(value, String, 'author ID');
+    }
+
+    return value;
+  }
+
+  /**
+   * Checks the syntax of a value alleged to be a document ID. Returns the given
+   * value if it's a syntactically correct document ID. Otherwise, throws an
+   * error.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is indeed valid.
+   * @throws {Error} `badValue` error indicating a syntactically invalid
+   *   document ID.
+   */
+  checkDocumentIdSyntax(value) {
+    if (!this.isDocumentId(value)) {
+      throw Errors.badValue(value, String, 'document ID');
+    }
+
+    return value;
+  }
+
+  /**
+   * Gets information about the indicated author. Given a valid ID &mdash; that
+   * is, a string for which {@link #isAuthorId} returns `true` &mdash; this
+   * returns an object with the following bindings:
+   *
+   * `valid` &mdash; A boolean indicating whether the ID is truly valid with
+   *   regard to the storage system. That is, it is possible for `isAuthorId()`
+   *   to return `true` yet this be `false`, because it might only be in the
+   *   underlying storage layer that full validity can be determined.
+   * `exists` &mdash; A boolean indicating whether or not the author currently
+   *   exists in the system.
+   *
+   * It is an error if the given `authorId` is not a syntactically valid ID, as
+   * determined by `isAuthorId()`.
+   *
+   * @param {string} authorId The ID of the author.
+   * @returns {object} Object with bindings as indicated above, describing the
+   *   author (or would-be author) with ID `id`.
+   */
+  async getAuthorInfo(authorId) {
+    this.checkAuthorIdSyntax(authorId);
+
+    const result = await this._impl_getAuthorInfo(authorId);
+
+    TObject.withExactKeys(result, ['exists', 'valid']);
+    TBoolean.check(result.exists);
+    TBoolean.check(result.valid);
+
+    return result;
+  }
+
+  /**
+   * Gets information about the indicated document. Given a valid ID &mdash;
+   * that is, a string for which {@link #isDocumentId} returns `true` &mdash;
+   * this returns an object with the following bindings:
+   *
+   * `valid` &mdash; A boolean indicating whether the ID is truly valid with
+   *   regard to the storage system. That is, it is possible for
+   *   `isDocumentId()` to return `true` yet this be `false`, because it might
+   *   only be in the underlying storage layer that full validity can be
+   *   determined.
+   * `exists` &mdash; A boolean indicating whether or not the document currently
+   *   exists in the system.
+   * `fileId` &mdash; If the document exists, the corresponding file ID string
+   *   to use when interacting with {@link @bayou/file-store}, or `null` when
+   *   `exists === false`.
+   *
+   * It is an error if the given `documentId` is not a syntactically valid ID,
+   * as determined by `isDocumentId()`.
+   *
+   * @param {string} documentId The ID of the document.
+   * @returns {object} Object with bindings as indicated above, describing the
+   *   document (or would-be document) with ID `id`.
+   */
+  async getDocumentInfo(documentId) {
+    this.checkDocumentIdSyntax(documentId);
+
+    const result = await this._impl_getDocumentInfo(documentId);
+
+    TObject.withExactKeys(result, ['exists', 'valid', 'fileId']);
+    TBoolean.check(result.exists);
+    TBoolean.check(result.valid);
+    TString.orNull(result.fileId);
+
+    return result;
+  }
+
+  /**
+   * Checks a given value to see if it's a syntactically valid author ID. To be
+   * an author ID, the value must pass a syntax check defined by the concrete
+   * subclass.
+   *
+   * @param {*} value Value to check.
+   * @returns {boolean} `true` if `fileId` is a syntactically valid file ID, or
+   *   `false` if not.
+   */
+  isAuthorId(value) {
+    TString.check(value);
+
+    return TBoolean.check(this._impl_isAuthorId(value));
+  }
+
+  /**
+   * Main implementation of {@link #getAuthorInfo}. Only ever called with a
+   * syntactically valid `authorId`.
+   *
+   * @abstract
+   * @param {string} authorId The ID of the author to query.
+   * @returns {object} Information about the author (or would-be author).
+   */
+  async _impl_getAuthorInfo(authorId) {
+    this._mustOverride(authorId);
+  }
+
+  /**
+   * Main implementation of {@link #getDocumentInfo}. Only ever called with a
+   * syntactically valid `documentId`.
+   *
+   * @abstract
+   * @param {string} documentId The ID of the document to query.
+   * @returns {object} Information about the document (or would-be document).
+   */
+  async _impl_getDocumentInfo(documentId) {
+    this._mustOverride(documentId);
+  }
+
+  /**
+   * Main implementation of {@link #isAuthorId}. Only ever called with a string
+   * argument.
+   *
+   * **Note:** There is a related configuration hook
+   * {@link @bayou/config-common/IdSyntax#isAuthorId}, which ends up getting
+   * used on the client side as well as on the server side, in code that is more
+   * "at arm's length" from the storage layer. It is expected that concrete
+   * subclasses will commonly use the same code for that and this. At a minimum,
+   * the syntax accepted here ought to be highly overlapping with what ends up
+   * defined in that hook.
+   *
+   * @abstract
+   * @param {string} authorId The alleged author ID.
+   * @returns {boolean} `true` if `authorId` is a syntactically valid author ID,
+   *   or `false` if not.
+   */
+  _impl_isAuthorId(authorId) {
+    this._mustOverride(authorId);
+  }
+
+  /**
+   * Main implementation of {@link #isDocumentId}. Only ever called with a
+   * string argument.
+   *
+   * **Note:** There is a related configuration hook
+   * {@link @bayou/config-common/IdSyntax#isDocumentId}, which ends up getting
+   * used on the client side as well as on the server side, in code that is more
+   * "at arm's length" from the storage layer. It is expected that concrete
+   * subclasses will commonly use the same code for that and this. At a minimum,
+   * the syntax accepted here ought to be highly overlapping with what ends up
+   * defined in that hook.
+   *
+   * @abstract
+   * @param {string} documentId The alleged document ID.
+   * @returns {boolean} `true` if `documentId` is a syntactically valid document
+   *   ID, or `false` if not.
+   */
+  _impl_isDocumentId(documentId) {
+    this._mustOverride(documentId);
+  }
+}

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -169,13 +169,28 @@ export default class BaseDataStore extends Singleton {
    * subclass.
    *
    * @param {*} value Value to check.
-   * @returns {boolean} `true` if `fileId` is a syntactically valid file ID, or
-   *   `false` if not.
+   * @returns {boolean} `true` if `value` is a syntactically valid author ID,
+   *   or `false` if not.
    */
   isAuthorId(value) {
     TString.check(value);
 
     return TBoolean.check(this._impl_isAuthorId(value));
+  }
+
+  /**
+   * Checks a given value to see if it's a syntactically valid document ID. To
+   * be a document ID, the value must pass a syntax check defined by the
+   * concrete subclass.
+   *
+   * @param {*} value Value to check.
+   * @returns {boolean} `true` if `value` is a syntactically valid document ID,
+   *   or `false` if not.
+   */
+  isDocumentId(value) {
+    TString.check(value);
+
+    return TBoolean.check(this._impl_isDocumentId(value));
   }
 
   /**

--- a/local-modules/@bayou/data-store/index.js
+++ b/local-modules/@bayou/data-store/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseDataStore from './BaseDataStore';
+
+export { BaseDataStore };

--- a/local-modules/@bayou/data-store/package.json
+++ b/local-modules/@bayou/data-store/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@bayou/typecheck": "local",
+    "@bayou/util-common": "local"
+  }
+}

--- a/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
+++ b/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
@@ -1,0 +1,320 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { BaseDataStore } from '@bayou/data-store';
+
+/** {array<*>} Array of non-strings. */
+const NON_STRINGS = [
+  undefined,
+  null,
+  false,
+  true,
+  1,
+  [],
+  {},
+  ['abc'],
+  [123],
+  { x: 'abc' },
+  new Map()
+];
+
+describe('@bayou/data-store/BaseDataStore', () => {
+  describe('author ID methods', () => {
+    describe('checkAuthorId()', () => {
+      it('calls `getAuthorInfo()` and transparently rethrows errors', async () => {
+        let gotId = null;
+        class Throws extends BaseDataStore {
+          async getAuthorInfo(id) {
+            gotId = id;
+            throw new Error('woop');
+          }
+        }
+
+        const obj = Throws.theOne;
+        await assert.isRejected(obj.checkAuthorId('xyz'), /woop/);
+        assert.strictEqual(gotId, 'xyz');
+      });
+
+      it('calls `getAuthorInfo()` and converts `valid: false` to an error', async () => {
+        let gotId = null;
+        class NeverValid extends BaseDataStore {
+          async getAuthorInfo(id) {
+            gotId = id;
+            return { valid: false, exists: false };
+          }
+        }
+
+        const obj = NeverValid.theOne;
+        await assert.isRejected(obj.checkAuthorId('pdq'), /badData/);
+        assert.strictEqual(gotId, 'pdq');
+      });
+
+      it('calls `getAuthorInfo()` and accepts `valid: true`', async () => {
+        let gotId = null;
+        class AlwaysValid extends BaseDataStore {
+          async getAuthorInfo(id) {
+            gotId = id;
+            return { valid: true, exists: (id === 'yes') };
+          }
+        }
+
+        const obj = AlwaysValid.theOne;
+
+        const resultYes = await obj.checkAuthorId('yes');
+        assert.strictEqual(resultYes, 'yes');
+        assert.strictEqual(gotId, 'yes');
+
+        const resultNo = await obj.checkAuthorId('no');
+        assert.strictEqual(resultNo, 'no');
+        assert.strictEqual(gotId, 'no');
+      });
+    });
+
+    describe('checkAuthorIdSyntax()', () => {
+      it('rejects non-strings without calling through to the impl', () => {
+        class Throws extends BaseDataStore {
+          _impl_isAuthorId(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        for (const value of NON_STRINGS) {
+          assert.throws(() => obj.checkAuthorIdSyntax(value), /badValue/, inspect(value));
+        }
+      });
+
+      it('calls through to `isAuthorId()` and respects a `false` response', () => {
+        let gotId = null;
+        class AcceptsNone extends BaseDataStore {
+          isAuthorId(id) {
+            gotId = id;
+            return false;
+          }
+        }
+
+        const obj = AcceptsNone.theOne;
+        assert.throws(() => obj.checkAuthorIdSyntax('florp'), /badValue/);
+        assert.strictEqual(gotId, 'florp');
+      });
+
+      it('calls through to `isAuthorId()` and respects a `true` response', () => {
+        let gotId = null;
+        class AcceptsAll extends BaseDataStore {
+          isAuthorId(id) {
+            gotId = id;
+            return true;
+          }
+        }
+
+        const obj = AcceptsAll.theOne;
+        assert.strictEqual(obj.checkAuthorIdSyntax('zorch'), 'zorch');
+        assert.strictEqual(gotId, 'zorch');
+      });
+    });
+
+    describe('getAuthorInfo()', () => {
+      it('rejects non-strings without calling through to the impl', async () => {
+        class Throws extends BaseDataStore {
+          async _impl_getAuthorInfo(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        for (const value of NON_STRINGS) {
+          await assert.isRejected(obj.getAuthorInfo(value), /badValue/, inspect(value));
+        }
+      });
+
+      it('rejects syntactically invalid strings without calling through to the impl', async () => {
+        let gotId = null;
+        class Throws extends BaseDataStore {
+          isAuthorId(id) {
+            gotId = id;
+            return false;
+          }
+
+          async _impl_getAuthorInfo(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        await assert.isRejected(obj.getAuthorInfo('boop'), /badValue/);
+        assert.strictEqual(gotId, 'boop');
+      });
+
+      it('calls through to the impl when given a valid ID', async () => {
+        let gotId = null;
+        class AcceptsAll extends BaseDataStore {
+          isAuthorId(id) {
+            gotId = id;
+            return true;
+          }
+
+          async _impl_getAuthorInfo(id_unused) {
+            return { exists: true, valid: true };
+          }
+        }
+
+        const obj    = AcceptsAll.theOne;
+        const result = await obj.getAuthorInfo('beep');
+        assert.deepEqual(result, { exists: true, valid: true });
+        assert.strictEqual(gotId, 'beep');
+      });
+    });
+  });
+
+  describe('document ID methods', () => {
+    describe('checkDocumentId()', () => {
+      it('calls `getDocumentInfo()` and transparently rethrows errors', async () => {
+        let gotId = null;
+        class Throws extends BaseDataStore {
+          async getDocumentInfo(id) {
+            gotId = id;
+            throw new Error('woop');
+          }
+        }
+
+        const obj = Throws.theOne;
+        await assert.isRejected(obj.checkDocumentId('xyz'), /woop/);
+        assert.strictEqual(gotId, 'xyz');
+      });
+
+      it('calls `getDocumentInfo()` and converts `valid: false` to an error', async () => {
+        let gotId = null;
+        class NeverValid extends BaseDataStore {
+          async getDocumentInfo(id) {
+            gotId = id;
+            return { valid: false, exists: false, fileId: 'whatever' };
+          }
+        }
+
+        const obj = NeverValid.theOne;
+        await assert.isRejected(obj.checkDocumentId('pdq'), /badData/);
+        assert.strictEqual(gotId, 'pdq');
+      });
+
+      it('calls `getDocumentInfo()` and accepts `valid: true`', async () => {
+        let gotId = null;
+        class AlwaysValid extends BaseDataStore {
+          async getDocumentInfo(id) {
+            gotId = id;
+            return { valid: true, exists: (id === 'yes'), fileId: 'whatever' };
+          }
+        }
+
+        const obj = AlwaysValid.theOne;
+
+        const resultYes = await obj.checkDocumentId('yes');
+        assert.strictEqual(resultYes, 'yes');
+        assert.strictEqual(gotId, 'yes');
+
+        const resultNo = await obj.checkDocumentId('no');
+        assert.strictEqual(resultNo, 'no');
+        assert.strictEqual(gotId, 'no');
+      });
+    });
+
+    describe('checkDocumentIdSyntax()', () => {
+      it('rejects non-strings without calling through to the impl', () => {
+        class Throws extends BaseDataStore {
+          _impl_isDocumentId(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        for (const value of NON_STRINGS) {
+          assert.throws(() => obj.checkDocumentIdSyntax(value), /badValue/, inspect(value));
+        }
+      });
+
+      it('calls through to `isDocumentId()` and respects a `false` response', () => {
+        let gotId = null;
+        class AcceptsNone extends BaseDataStore {
+          isDocumentId(id) {
+            gotId = id;
+            return false;
+          }
+        }
+
+        const obj = AcceptsNone.theOne;
+        assert.throws(() => obj.checkDocumentIdSyntax('florp'), /badValue/);
+        assert.strictEqual(gotId, 'florp');
+      });
+
+      it('calls through to `isDocumentId()` and respects a `true` response', () => {
+        let gotId = null;
+        class AcceptsAll extends BaseDataStore {
+          isDocumentId(id) {
+            gotId = id;
+            return true;
+          }
+        }
+
+        const obj = AcceptsAll.theOne;
+        assert.strictEqual(obj.checkDocumentIdSyntax('zorch'), 'zorch');
+        assert.strictEqual(gotId, 'zorch');
+      });
+    });
+
+    describe('getDocumentInfo()', () => {
+      it('rejects non-strings without calling through to the impl', async () => {
+        class Throws extends BaseDataStore {
+          async _impl_getDocumentInfo(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        for (const value of NON_STRINGS) {
+          await assert.isRejected(obj.getDocumentInfo(value), /badValue/, inspect(value));
+        }
+      });
+
+      it('rejects syntactically invalid strings without calling through to the impl', async () => {
+        let gotId = null;
+        class Throws extends BaseDataStore {
+          isDocumentId(id) {
+            gotId = id;
+            return false;
+          }
+
+          async _impl_getDocumentInfo(id_unused) {
+            throw new Error('should-not-be-called');
+          }
+        }
+
+        const obj = Throws.theOne;
+        await assert.isRejected(obj.getDocumentInfo('boop'), /badValue/);
+        assert.strictEqual(gotId, 'boop');
+      });
+
+      it('calls through to the impl when given a valid ID', async () => {
+        let gotId = null;
+        class AcceptsAll extends BaseDataStore {
+          isDocumentId(id) {
+            gotId = id;
+            return true;
+          }
+
+          async _impl_getDocumentInfo(id_unused) {
+            return { exists: true, valid: true, fileId: 'whatever' };
+          }
+        }
+
+        const obj    = AcceptsAll.theOne;
+        const result = await obj.getDocumentInfo('beep');
+        assert.deepEqual(result, { exists: true, valid: true, fileId: 'whatever' });
+        assert.strictEqual(gotId, 'beep');
+      });
+    });
+  });
+});

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -9,6 +9,7 @@ import { Codec } from '@bayou/codec';
 import { Dirs } from '@bayou/env-server';
 import { BaseFileStore, FileCache } from '@bayou/file-store';
 import { TheModule as fileStoreOt_TheModule } from '@bayou/file-store-ot';
+import { DefaultIdSyntax } from '@bayou/id-syntax-default';
 import { Logger } from '@bayou/see-all';
 
 import LocalFile from './LocalFile';
@@ -84,17 +85,15 @@ export default class LocalFileStore extends BaseFileStore {
   }
 
   /**
-   * Implementation as required by the superclass.
-   *
-   * This implementation requires that file IDs have no more than 32 characters
-   * and only use ASCII alphanumerics plus dash (`-`) and underscore (`_`).
+   * Implementation as required by the superclass. This implementation defers
+   * to the module {@link @bayou/id-syntax-default}.
    *
    * @param {string} fileId The alleged file ID.
    * @returns {boolean} `true` if `fileId` is a syntactically valid file ID, or
    *   `false` if not.
    */
   _impl_isFileId(fileId) {
-    return /^[-_a-zA-Z0-9]{1,32}$/.test(fileId);
+    return DefaultIdSyntax.isFileId(fileId);
   }
 
   /**

--- a/local-modules/@bayou/file-store-local/package.json
+++ b/local-modules/@bayou/file-store-local/package.json
@@ -5,6 +5,7 @@
     "@bayou/env-server": "local",
     "@bayou/file-store": "local",
     "@bayou/file-store-ot": "local",
+    "@bayou/id-syntax-default": "local",
     "@bayou/promise-util": "local",
     "@bayou/see-all": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -95,7 +95,9 @@ export default class BaseFileStore extends Singleton {
 
     const result = await this._impl_getFileInfo(fileId);
 
-    TObject.withExactKeys(result, ['exists','valid']);
+    TObject.withExactKeys(result, ['exists', 'valid']);
+    TBoolean.check(result.exists);
+    TBoolean.check(result.valid);
 
     return result;
   }
@@ -106,7 +108,7 @@ export default class BaseFileStore extends Singleton {
    * subclass.
    *
    * @param {*} value Value to check.
-   * @returns {boolean} `true` if `fileId` is a syntactically valid file ID, or
+   * @returns {boolean} `true` if `value` is a syntactically valid file ID, or
    *   `false` if not.
    */
   isFileId(value) {

--- a/local-modules/@bayou/id-syntax-default/DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/DefaultIdSyntax.js
@@ -1,0 +1,66 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from '@bayou/typecheck';
+
+/**
+ * {RexExp} Expression which is used to match all of the ID types.
+ *
+ * **TODO:** Consider using prefixes on each ID by type (e.g., `file-`), just so
+ * that they're unambiguous. Might help catch some bugs.
+ */
+const ID_REGEX = /^[-_a-zA-Z0-9]{1,32}$/;
+
+/**
+ * Default ID syntax definitions. See module `README.md` for more details.
+ */
+export default class DefaultIdSyntax {
+  /**
+   * Default implementation of author ID syntax checking.
+   *
+   * This implementation requires that author IDs have no more than 32
+   * characters and only use ASCII alphanumerics plus dash (`-`) and underscore
+   * (`_`).
+   *
+   * @param {string} id The (alleged) author ID to check.
+   * @returns {boolean} `true` iff `id` is syntactically valid.
+   */
+  static isAuthorId(id) {
+    TString.check(id);
+
+    return ID_REGEX.test(id);
+  }
+
+  /**
+   * Default implementation of document ID syntax checking.
+   *
+   * This implementation requires that document IDs have no more than 32
+   * characters and only use ASCII alphanumerics plus dash (`-`) and underscore
+   * (`_`).
+   *
+   * @param {string} id The (alleged) document ID to check.
+   * @returns {boolean} `true` iff `id` is syntactically valid.
+   */
+  static isDocumentId(id) {
+    TString.check(id);
+
+    return ID_REGEX.test(id);
+  }
+
+  /**
+   * Default implementation of file ID syntax checking.
+   *
+   * This implementation requires that file IDs have no more than 32
+   * characters and only use ASCII alphanumerics plus dash (`-`) and underscore
+   * (`_`).
+   *
+   * @param {string} id The (alleged) file ID to check.
+   * @returns {boolean} `true` iff `id` is syntactically valid.
+   */
+  static isFileId(id) {
+    TString.check(id);
+
+    return ID_REGEX.test(id);
+  }
+}

--- a/local-modules/@bayou/id-syntax-default/README.md
+++ b/local-modules/@bayou/id-syntax-default/README.md
@@ -1,0 +1,13 @@
+@bayou/id-syntax-default
+========================
+
+Default definitions of syntax for all the kinds of IDs used by the system. This
+is separate from `config-*-default`, for a couple reasons:
+
+* Non-default configured implementations might still want to use these &mdash;
+  quite reasonable &mdash; definitions.
+
+* `data-store-local` needs these definitions. Though it's part of the default
+  configuration, it can be used in other configurations too, and if that's done,
+  we don't want to force the (rest of the) default configuration code to also be
+  pulled in.

--- a/local-modules/@bayou/id-syntax-default/index.js
+++ b/local-modules/@bayou/id-syntax-default/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import DefaultIdSyntax from './DefaultIdSyntax';
+
+export { DefaultIdSyntax };

--- a/local-modules/@bayou/id-syntax-default/package.json
+++ b/local-modules/@bayou/id-syntax-default/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@bayou/typecheck": "local",
+    "@bayou/util-common": "local"
+  }
+}

--- a/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
@@ -1,0 +1,97 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { DefaultIdSyntax } from '@bayou/id-syntax-default';
+
+/** {array<*>} Array of non-strings. */
+const NON_STRINGS = [
+  undefined,
+  null,
+  false,
+  true,
+  1,
+  [],
+  {},
+  ['T00-U00'],
+  ['T00-F00'],
+  { x: 'abc' },
+  new Map()
+];
+
+describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
+  describe('isAuthorId()', () => {
+    it('should accept 32-character alphanum ASCII strings', () => {
+      assert.isTrue(DefaultIdSyntax.isAuthorId('123abc7890ABC456789012'));
+    });
+
+    it('should allow underscores and hyphens', () => {
+      assert.isTrue(DefaultIdSyntax.isAuthorId('123456789_123456789-12'));
+    });
+
+    it('should not allow non-ASCII characters', () => {
+      assert.isFalse(DefaultIdSyntax.isAuthorId('123456789•123456789•12'));
+    });
+
+    it('should not allow non-alphanum characters', () => {
+      assert.isFalse(DefaultIdSyntax.isAuthorId('123456789\t123456789+12'));
+    });
+
+    it('should throw an error given a non-string argument', () => {
+      for (const id of NON_STRINGS) {
+        assert.throws(() => DefaultIdSyntax.isAuthorId(id), /badValue/, id);
+      }
+    });
+  });
+
+  describe('isDocumentId()', () => {
+    it('should accept 32-character alphanum ASCII strings', () => {
+      assert.isTrue(DefaultIdSyntax.isDocumentId('123abc7890ABC456789012'));
+    });
+
+    it('should allow underscores and hyphens', () => {
+      assert.isTrue(DefaultIdSyntax.isDocumentId('123456789_123456789-12'));
+    });
+
+    it('should not allow non-ASCII characters', () => {
+      assert.isFalse(DefaultIdSyntax.isDocumentId('123456789•123456789•12'));
+    });
+
+    it('should not allow non-alphanum characters', () => {
+      assert.isFalse(DefaultIdSyntax.isDocumentId('123456789\t123456789+12'));
+    });
+
+    it('should throw an error given a non-string argument', () => {
+      for (const id of NON_STRINGS) {
+        assert.throws(() => DefaultIdSyntax.isDocumentId(id), /badValue/, id);
+      }
+    });
+  });
+
+  describe('isFileId()', () => {
+    it('should accept 32-character alphanum ASCII strings', () => {
+      assert.isTrue(DefaultIdSyntax.isFileId('123abc7890ABC456789012'));
+    });
+
+    it('should allow underscores and hyphens', () => {
+      assert.isTrue(DefaultIdSyntax.isFileId('123456789_123456789-12'));
+    });
+
+    it('should not allow non-ASCII characters', () => {
+      assert.isFalse(DefaultIdSyntax.isFileId('123456789•123456789•12'));
+    });
+
+    it('should not allow non-alphanum characters', () => {
+      assert.isFalse(DefaultIdSyntax.isFileId('123456789\t123456789+12'));
+    });
+
+    it('should throw an error given a non-string argument', () => {
+      for (const id of NON_STRINGS) {
+        assert.throws(() => DefaultIdSyntax.isFileId(id), /badValue/, id);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This PR has a lot of lines in it, but it all boils down to something pretty simple: We need a way to take author and document IDs coming in from the client, and send them to a back-endier back end (that is, our _server's_ back end) to tell us about those IDs. E.g., we can tell whether an author ID is _syntactically_ valid, but we have to ask _something_ to tell us whether the ID corresponds to a real user.

This PR only contains one use of the new API, which is to use it to convert document IDs to file IDs. This had been an implicit no-op before — that is, file IDs and document IDs are implemented as having a one-to-one identity mapping — but now it's an _explicit_ no-op. Maybe this is a bit off in the weeds, but I figure that, in a sense, it's a "pun" to act as if these two kinds of IDs are necessarily the same, and it might even be worth making them explicitly different (e.g. by prefixing) as a way potentially catch bugs, at least in the long run. (In the short term, there's been no real harm in treating them as interchangeable, but it's reasonable to expect there to be a future where there are files that exist that don't directly correspond to documents as currently imagined.)

Future PRs will start to use the new API more productively.