### PR TITLE
Use new ID validation stuff.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Context, Target } from '@bayou/api-server';
-import { IdSyntax } from '@bayou/config-common';
+import { Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
@@ -32,7 +32,7 @@ export default class AuthorAccess extends CommonBase {
     /**
      * {string} authorId ID of the author on whose behalf this instance acts.
      */
-    this._authorId = IdSyntax.checkAuthorId(authorId);
+    this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
 
     /** {Context} The API context to use. */
     this._context = Context.check(context);
@@ -65,7 +65,7 @@ export default class AuthorAccess extends CommonBase {
    *   newly-created session.
    */
   async makeSession(docId) {
-    IdSyntax.checkDocumentId(docId);
+    Storage.dataStore.checkDocumentIdSyntax(docId);
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -67,10 +67,10 @@ export default class AuthorAccess extends CommonBase {
   async makeSession(docId) {
     Storage.dataStore.checkDocumentIdSyntax(docId);
 
+    const sessionId   = this._context.randomId();
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
+    const session     = await fileComplex.makeNewSession(this._authorId, sessionId);
 
-    const sessionId = this._context.randomId();
-    const session   = fileComplex.makeNewSession(this._authorId, sessionId);
     this._context.addTarget(new Target(sessionId, session));
 
     log.info(

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -65,6 +65,9 @@ export default class AuthorAccess extends CommonBase {
    *   newly-created session.
    */
   async makeSession(docId) {
+    // We only check the document ID syntax here, because we can count on the
+    // call to `getFileComplex()` to do a full validity check as part of its
+    // work.
     Storage.dataStore.checkDocumentIdSyntax(docId);
 
     const sessionId   = this._context.randomId();

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -30,7 +30,10 @@ export default class AuthorAccess extends CommonBase {
     super();
 
     /**
-     * {string} authorId ID of the author on whose behalf this instance acts.
+     * {string} ID of the author on whose behalf this instance acts. This is
+     * only validated syntactically, because full validation requires
+     * asynchronous action (e.g., a round trip with the data storage system),
+     * and constructors aren't allowed to be `async`.
      */
     this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
 
@@ -72,7 +75,10 @@ export default class AuthorAccess extends CommonBase {
 
     const sessionId   = this._context.randomId();
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
-    const session     = await fileComplex.makeNewSession(this._authorId, sessionId);
+
+    // **Note:** This call includes data store back-end validation of the author
+    // ID.
+    const session = await fileComplex.makeNewSession(this._authorId, sessionId);
 
     this._context.addTarget(new Target(sessionId, session));
 

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -7,7 +7,7 @@ import { camelCase } from 'lodash';
 import { inspect } from 'util';
 
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
-import { IdSyntax } from '@bayou/config-common';
+import { Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';
 import { RecentSink } from '@bayou/see-all-server';
@@ -129,7 +129,7 @@ export default class DebugTools {
    */
   _check_authorId(req_unused, value) {
     try {
-      IdSyntax.checkAuthorId(value);
+      Storage.dataStore.checkAuthorIdSyntax(value);
     } catch (error) {
       // Augment error and rethrow.
       error.debugMsg = 'Bad value for `authorId`.';
@@ -145,7 +145,7 @@ export default class DebugTools {
    */
   _check_documentId(req_unused, value) {
     try {
-      IdSyntax.checkDocumentId(value);
+      Storage.dataStore.checkDocumentIdSyntax(value);
     } catch (error) {
       // Augment error and rethrow.
       error.debugMsg = 'Bad value for `documentId`.';

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -48,8 +48,8 @@ export default class RootAccess extends CommonBase {
     // These checks round-trip with the back-end to do full (not just syntactic)
     // validation.
     await Promise.all([
-      Storage.dataStore.checkAuthorId(authorId),
-      Storage.dataStore.checkDocumentId(docId)
+      Storage.dataStore.checkExistingAuthorId(authorId),
+      Storage.dataStore.checkExistingDocumentId(docId)
     ]);
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -56,7 +56,7 @@ export default class RootAccess extends CommonBase {
 
     const url       = `${Network.baseUrl}/api`;
     const sessionId = this._context.randomSplitKeyId();
-    const session   = fileComplex.makeNewSession(authorId, sessionId);
+    const session   = await fileComplex.makeNewSession(authorId, sessionId);
     const key       = new SplitKey(url, sessionId);
     this._context.addTarget(new Target(key, session));
 

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -4,8 +4,7 @@
 
 import { SplitKey } from '@bayou/api-common';
 import { Context, Target } from '@bayou/api-server';
-import { IdSyntax } from '@bayou/config-common';
-import { Network } from '@bayou/config-server';
+import { Network, Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
@@ -46,8 +45,12 @@ export default class RootAccess extends CommonBase {
    *   requested access.
    */
   async makeAccessKey(authorId, docId) {
-    IdSyntax.checkAuthorId(authorId);
-    IdSyntax.checkDocumentId(docId);
+    // These checks round-trip with the back-end to do full (not just syntactic)
+    // validation.
+    await Promise.all([
+      Storage.dataStore.checkAuthorId(authorId),
+      Storage.dataStore.checkDocumentId(docId)
+    ]);
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 

--- a/local-modules/@bayou/app-setup/package.json
+++ b/local-modules/@bayou/app-setup/package.json
@@ -5,7 +5,6 @@
     "@bayou/app-common": "local",
     "@bayou/client-bundle": "local",
     "@bayou/codec": "local",
-    "@bayou/config-common": "local",
     "@bayou/config-server": "local",
     "@bayou/deps-ansi-color": "local",
     "@bayou/deps-express": "local",

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -21,26 +21,6 @@ import { Errors, Singleton } from '@bayou/util-common';
  */
 export default class BaseDataStore extends Singleton {
   /**
-   * Checks an author ID for full validity, beyond simply checking the syntax of
-   * the ID. Returns the given ID if all is well, or throws an error if the ID
-   * is invalid.
-   *
-   * @param {string} authorId The author ID to validate, which must be a
-   *   syntactically valid ID, per {@link #isAuthorId}.
-   * @returns {string} `authorId` if it is indeed valid.
-   * @throws {Error} `badData` error indicating an invalid file ID.
-   */
-  async checkAuthorId(authorId) {
-    const info = await this.getAuthorInfo(authorId);
-
-    if (!info.valid) {
-      throw Errors.badData(`Invalid author ID: \`${authorId}\``);
-    }
-
-    return authorId;
-  }
-
-  /**
    * Checks the syntax of a value alleged to be an author ID. Returns the given
    * value if it's a syntactically correct author ID. Otherwise, throws an
    * error.
@@ -56,26 +36,6 @@ export default class BaseDataStore extends Singleton {
     }
 
     return value;
-  }
-
-  /**
-   * Checks a document ID for full validity, beyond simply checking the syntax
-   * of the ID. Returns the given ID if all is well, or throws an error if the
-   * ID is invalid.
-   *
-   * @param {string} documentId The document ID to validate, which must be a
-   *   syntactically valid ID, per {@link #isDocumentId}.
-   * @returns {string} `documentId` if it is indeed valid.
-   * @throws {Error} `badData` error indicating an invalid file ID.
-   */
-  async checkDocumentId(documentId) {
-    const info = await this.getDocumentInfo(documentId);
-
-    if (!info.valid) {
-      throw Errors.badData(`Invalid document ID: \`${documentId}\``);
-    }
-
-    return documentId;
   }
 
   /**
@@ -97,14 +57,16 @@ export default class BaseDataStore extends Singleton {
   }
 
   /**
-   * Like {@link #checkAuthorId} (see which), but also requires that the given
-   * ID correspond to an existing author.
+   * Checks an author ID for full validity, beyond simply checking the syntax of
+   * the ID, including requiring that it corresponds to an existing author.
+   * Returns the given ID if all is well, or throws an error if the ID is
+   * invalid in some way.
    *
    * @param {string} authorId The author ID to validate, which must be a
    *   syntactically valid ID, per {@link #isAuthorId}.
    * @returns {string} `authorId` if it is indeed valid and corresponds to an
-   *   existing user.
-   * @throws {Error} `badData` error indicating an invalid file ID.
+   *   existing author.
+   * @throws {Error} `badData` error indicating an invalid author ID.
    */
   async checkExistingAuthorId(authorId) {
     const info = await this.getAuthorInfo(authorId);
@@ -117,14 +79,16 @@ export default class BaseDataStore extends Singleton {
   }
 
   /**
-   * Like {@link #checkDocumentId} (see which), but also requires that the given
-   * ID correspond to an existing document.
+   * Checks a document ID for full validity, beyond simply checking the syntax
+   * of the ID, including requiring that it corresponds to an existing document.
+   * Returns the given ID if all is well, or throws an error if the ID is
+   * invalid in some way.
    *
    * @param {string} documentId The document ID to validate, which must be a
    *   syntactically valid ID, per {@link #isDocumentId}.
    * @returns {string} `documentId` if it is indeed valid and corresponds to an
    *   existing document.
-   * @throws {Error} `badData` error indicating an invalid file ID.
+   * @throws {Error} `badData` error indicating an invalid document ID.
    */
   async checkExistingDocumentId(documentId) {
     const info = await this.getDocumentInfo(documentId);

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -41,6 +41,24 @@ export default class BaseDataStore extends Singleton {
   }
 
   /**
+   * Checks the syntax of a value alleged to be an author ID. Returns the given
+   * value if it's a syntactically correct author ID. Otherwise, throws an
+   * error.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is indeed valid.
+   * @throws {Error} `badValue` error indicating a syntactically invalid author
+   *   ID.
+   */
+  checkAuthorIdSyntax(value) {
+    if (!this.isAuthorId(value)) {
+      throw Errors.badValue(value, String, 'author ID');
+    }
+
+    return value;
+  }
+
+  /**
    * Checks a document ID for full validity, beyond simply checking the syntax
    * of the ID. Returns the given ID if all is well, or throws an error if the
    * ID is invalid.
@@ -61,44 +79,6 @@ export default class BaseDataStore extends Singleton {
   }
 
   /**
-   * Like {@link #checkAuthorId} (see which), but also requires that the given
-   * ID correspond to an existing author.
-   *
-   * @param {string} authorId The author ID to validate, which must be a
-   *   syntactically valid ID, per {@link #isAuthorId}.
-   * @returns {string} `authorId` if it is indeed valid and corresponds to an
-   *   existing user.
-   * @throws {Error} `badData` error indicating an invalid file ID.
-   */
-  async checkExistingAuthorId(authorId) {
-    const info = await this.getAuthorInfo(authorId);
-
-    if (!(info.valid && info.exists)) {
-      throw Errors.badData(`Nonexistent author ID: \`${authorId}\``);
-    }
-
-    return authorId;
-  }
-
-  /**
-   * Checks the syntax of a value alleged to be an author ID. Returns the given
-   * value if it's a syntactically correct author ID. Otherwise, throws an
-   * error.
-   *
-   * @param {*} value Value to check.
-   * @returns {string} `value` if it is indeed valid.
-   * @throws {Error} `badValue` error indicating a syntactically invalid author
-   *   ID.
-   */
-  checkAuthorIdSyntax(value) {
-    if (!this.isAuthorId(value)) {
-      throw Errors.badValue(value, String, 'author ID');
-    }
-
-    return value;
-  }
-
-  /**
    * Checks the syntax of a value alleged to be a document ID. Returns the given
    * value if it's a syntactically correct document ID. Otherwise, throws an
    * error.
@@ -114,6 +94,46 @@ export default class BaseDataStore extends Singleton {
     }
 
     return value;
+  }
+
+  /**
+   * Like {@link #checkAuthorId} (see which), but also requires that the given
+   * ID correspond to an existing author.
+   *
+   * @param {string} authorId The author ID to validate, which must be a
+   *   syntactically valid ID, per {@link #isAuthorId}.
+   * @returns {string} `authorId` if it is indeed valid and corresponds to an
+   *   existing user.
+   * @throws {Error} `badData` error indicating an invalid file ID.
+   */
+  async checkExistingAuthorId(authorId) {
+    const info = await this.getAuthorInfo(authorId);
+
+    if (!(info.valid && info.exists)) {
+      throw Errors.badData(`Nonexistent author: \`${authorId}\``);
+    }
+
+    return authorId;
+  }
+
+  /**
+   * Like {@link #checkDocumentId} (see which), but also requires that the given
+   * ID correspond to an existing document.
+   *
+   * @param {string} documentId The document ID to validate, which must be a
+   *   syntactically valid ID, per {@link #isDocumentId}.
+   * @returns {string} `documentId` if it is indeed valid and corresponds to an
+   *   existing document.
+   * @throws {Error} `badData` error indicating an invalid file ID.
+   */
+  async checkExistingDocumentId(documentId) {
+    const info = await this.getDocumentInfo(documentId);
+
+    if (!(info.valid && info.exists)) {
+      throw Errors.badData(`Nonexistent document: \`${documentId}\``);
+    }
+
+    return documentId;
   }
 
   /**

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -61,6 +61,26 @@ export default class BaseDataStore extends Singleton {
   }
 
   /**
+   * Like {@link #checkAuthorId} (see which), but also requires that the given
+   * ID correspond to an existing author.
+   *
+   * @param {string} authorId The author ID to validate, which must be a
+   *   syntactically valid ID, per {@link #isAuthorId}.
+   * @returns {string} `authorId` if it is indeed valid and corresponds to an
+   *   existing user.
+   * @throws {Error} `badData` error indicating an invalid file ID.
+   */
+  async checkExistingAuthorId(authorId) {
+    const info = await this.getAuthorInfo(authorId);
+
+    if (!(info.valid && info.exists)) {
+      throw Errors.badData(`Nonexistent author ID: \`${authorId}\``);
+    }
+
+    return authorId;
+  }
+
+  /**
    * Checks the syntax of a value alleged to be an author ID. Returns the given
    * value if it's a syntactically correct author ID. Otherwise, throws an
    * error.

--- a/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
+++ b/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
@@ -25,56 +25,6 @@ const NON_STRINGS = [
 
 describe('@bayou/data-store/BaseDataStore', () => {
   describe('author ID methods', () => {
-    describe('checkAuthorId()', () => {
-      it('calls `getAuthorInfo()` and transparently rethrows errors', async () => {
-        let gotId = null;
-        class Throws extends BaseDataStore {
-          async getAuthorInfo(id) {
-            gotId = id;
-            throw new Error('woop');
-          }
-        }
-
-        const obj = Throws.theOne;
-        await assert.isRejected(obj.checkAuthorId('xyz'), /woop/);
-        assert.strictEqual(gotId, 'xyz');
-      });
-
-      it('calls `getAuthorInfo()` and converts `valid: false` to an error', async () => {
-        let gotId = null;
-        class NeverValid extends BaseDataStore {
-          async getAuthorInfo(id) {
-            gotId = id;
-            return { valid: false, exists: false };
-          }
-        }
-
-        const obj = NeverValid.theOne;
-        await assert.isRejected(obj.checkAuthorId('pdq'), /badData/);
-        assert.strictEqual(gotId, 'pdq');
-      });
-
-      it('calls `getAuthorInfo()` and accepts `valid: true`', async () => {
-        let gotId = null;
-        class AlwaysValid extends BaseDataStore {
-          async getAuthorInfo(id) {
-            gotId = id;
-            return { valid: true, exists: (id === 'yes') };
-          }
-        }
-
-        const obj = AlwaysValid.theOne;
-
-        const resultYes = await obj.checkAuthorId('yes');
-        assert.strictEqual(resultYes, 'yes');
-        assert.strictEqual(gotId, 'yes');
-
-        const resultNo = await obj.checkAuthorId('no');
-        assert.strictEqual(resultNo, 'no');
-        assert.strictEqual(gotId, 'no');
-      });
-    });
-
     describe('checkAuthorIdSyntax()', () => {
       it('rejects non-strings without calling through to the impl', () => {
         class Throws extends BaseDataStore {
@@ -232,56 +182,6 @@ describe('@bayou/data-store/BaseDataStore', () => {
   });
 
   describe('document ID methods', () => {
-    describe('checkDocumentId()', () => {
-      it('calls `getDocumentInfo()` and transparently rethrows errors', async () => {
-        let gotId = null;
-        class Throws extends BaseDataStore {
-          async getDocumentInfo(id) {
-            gotId = id;
-            throw new Error('woop');
-          }
-        }
-
-        const obj = Throws.theOne;
-        await assert.isRejected(obj.checkDocumentId('xyz'), /woop/);
-        assert.strictEqual(gotId, 'xyz');
-      });
-
-      it('calls `getDocumentInfo()` and converts `valid: false` to an error', async () => {
-        let gotId = null;
-        class NeverValid extends BaseDataStore {
-          async getDocumentInfo(id) {
-            gotId = id;
-            return { valid: false, exists: false, fileId: 'whatever' };
-          }
-        }
-
-        const obj = NeverValid.theOne;
-        await assert.isRejected(obj.checkDocumentId('pdq'), /badData/);
-        assert.strictEqual(gotId, 'pdq');
-      });
-
-      it('calls `getDocumentInfo()` and accepts `valid: true`', async () => {
-        let gotId = null;
-        class AlwaysValid extends BaseDataStore {
-          async getDocumentInfo(id) {
-            gotId = id;
-            return { valid: true, exists: (id === 'yes'), fileId: 'whatever' };
-          }
-        }
-
-        const obj = AlwaysValid.theOne;
-
-        const resultYes = await obj.checkDocumentId('yes');
-        assert.strictEqual(resultYes, 'yes');
-        assert.strictEqual(gotId, 'yes');
-
-        const resultNo = await obj.checkDocumentId('no');
-        assert.strictEqual(resultNo, 'no');
-        assert.strictEqual(gotId, 'no');
-      });
-    });
-
     describe('checkDocumentIdSyntax()', () => {
       it('rejects non-strings without calling through to the impl', () => {
         class Throws extends BaseDataStore {

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -2,10 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Storage } from '@bayou/config-server';
+import { HtmlExport, Storage } from '@bayou/config-server';
 import { BodyChange, BodyDelta, BodySnapshot } from '@bayou/doc-common';
 import { RevisionNumber } from '@bayou/ot-common';
-import { HtmlExport } from '@bayou/config-server';
 
 import DurableControl from './DurableControl';
 import Paths from './Paths';

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -176,7 +176,8 @@ export default class DocServer extends Singleton {
     FileComplex.check(fileComplex);
     TString.nonEmpty(sessionId);
 
-    Storage.dataStore.checkAuthorIdSyntax(authorId); // **TODO:** Should validate with the back end.
+    // This validates the ID with the back end.
+    await Storage.dataStore.checkAuthorId(authorId);
 
     const result = new DocSession(fileComplex, sessionId, authorId);
     const reaper = this._sessionReaper(fileComplex, sessionId);

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -172,7 +172,7 @@ export default class DocServer extends Singleton {
    * @param {string} sessionId ID for the session.
    * @returns {DocSession} A newly-constructed session.
    */
-  _makeNewSession(fileComplex, authorId, sessionId) {
+  async _makeNewSession(fileComplex, authorId, sessionId) {
     FileComplex.check(fileComplex);
     TString.nonEmpty(sessionId);
 

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -177,7 +177,7 @@ export default class DocServer extends Singleton {
     TString.nonEmpty(sessionId);
 
     // This validates the ID with the back end.
-    await Storage.dataStore.checkAuthorId(authorId);
+    await Storage.dataStore.checkExistingAuthorId(authorId);
 
     const result = new DocSession(fileComplex, sessionId, authorId);
     const reaper = this._sessionReaper(fileComplex, sessionId);

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { IdSyntax } from '@bayou/config-common';
+import { Storage } from '@bayou/config-server';
 import { BodyChange, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import { TString } from '@bayou/typecheck';
@@ -39,7 +39,7 @@ export default class DocSession extends CommonBase {
     this._sessionId = TString.nonEmpty(sessionId);
 
     /** {string} Author ID. */
-    this._authorId = IdSyntax.checkAuthorId(authorId);
+    this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
 
     /** {BodyControl} The underlying body content controller. */
     this._bodyControl = fileComplex.bodyControl;

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -66,7 +66,7 @@ export default class FileComplex extends BaseComplexMember {
    * @param {string} sessionId ID for the session.
    * @returns {DocSession} A newly-constructed session.
    */
-  makeNewSession(authorId, sessionId) {
+  async makeNewSession(authorId, sessionId) {
     return DocServer.theOne._makeNewSession(this, authorId, sessionId);
   }
 

--- a/local-modules/@bayou/doc-server/package.json
+++ b/local-modules/@bayou/doc-server/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "@bayou/app-common": "local",
     "@bayou/codec": "local",
-    "@bayou/config-common": "local",
     "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/doc-common": "local",


### PR DESCRIPTION
This PR changes all the server-specific code which does author and document ID validation to do so through `config-server.Storage.dataStore` and not `config-common.IdSyntax`. In addition, in places where it makes sense, the system will now make the `async` calls to perform full validation (not just syntax checking). As part of this, I changed the two `check*()` methods to also require the thing-being-referenced to exist, and renamed them to `checkExisting*()` to make the contract clearer.