### PR TITLE
 Make `*{File,Data}Store` not be singletons.

### DIFF
--- a/local-modules/@bayou/config-server-default/Storage.js
+++ b/local-modules/@bayou/config-server-default/Storage.js
@@ -40,6 +40,11 @@ export default class Storage extends UtilityClass {
    * version of the class.
    */
   static get fileStore() {
-    return LocalFileStore.theOne;
+    if (this._fileStore === undefined) {
+      /** {LocalFileStore} Unique instance of this class. */
+      this._fileStore = new LocalFileStore();
+    }
+
+    return this._fileStore;
   }
 }

--- a/local-modules/@bayou/config-server-default/Storage.js
+++ b/local-modules/@bayou/config-server-default/Storage.js
@@ -31,7 +31,12 @@ export default class Storage extends UtilityClass {
    * {LocalDataStore} Implementation of standard configuration point.
    */
   static get dataStore() {
-    return LocalDataStore.theOne;
+    if (this._dataStore === undefined) {
+      /** {LocalDataStore} Unique instance of this class. */
+      this._dataStore = new LocalDataStore();
+    }
+
+    return this._dataStore;
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/tests/test_Storage.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Storage.js
@@ -22,12 +22,28 @@ describe('@bayou/config-server-default/Storage', () => {
       assert.isObject(Storage.dataStore);
       assert.instanceOf(Storage.dataStore, LocalDataStore);
     });
+
+    it('should return the same actual object on every access', () => {
+      const store = Storage.dataStore;
+
+      for (let i = 0; i < 10; i++) {
+        assert.strictEqual(Storage.dataStore, store, `#${i}`);
+      }
+    });
   });
 
   describe('.fileStore', () => {
     it('should be an instance of `LocalFileStore`', () => {
       assert.isObject(Storage.fileStore);
       assert.instanceOf(Storage.fileStore, LocalFileStore);
+    });
+
+    it('should return the same actual object on every access', () => {
+      const store = Storage.fileStore;
+
+      for (let i = 0; i < 10; i++) {
+        assert.strictEqual(Storage.fileStore, store, `#${i}`);
+      }
     });
   });
 });

--- a/local-modules/@bayou/config-server-default/tests/test_Storage.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Storage.js
@@ -19,12 +19,14 @@ describe('@bayou/config-server-default/Storage', () => {
 
   describe('.dataStore', () => {
     it('should be an instance of `LocalDataStore`', () => {
+      assert.isObject(Storage.dataStore);
       assert.instanceOf(Storage.dataStore, LocalDataStore);
     });
   });
 
   describe('.fileStore', () => {
     it('should be an instance of `LocalFileStore`', () => {
+      assert.isObject(Storage.fileStore);
       assert.instanceOf(Storage.fileStore, LocalFileStore);
     });
   });

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -3,23 +3,15 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
-import { Errors, Singleton } from '@bayou/util-common';
+import { CommonBase, Errors } from '@bayou/util-common';
 
 /**
  * Base class for data storage access. An instance of (a concrete subclass of)
  * this class is responsible for mitigating access to all of the data stored in
  * the underlying system, _except_ for file data (the latter which is managed by
  * the module {@link @bayou/file-store}).
- *
- * **Note:** This is a subclass of `Singleton`, that is, the system is set up
- * to only ever expect there to be one data store instance. (Technically, this
- * inheritence relationship allows for the possibility of having singleton
- * instances of several subclasses of this class, but in practice that's not
- * what happens.) **TODO:** To make unit testing more feasible, this should
- * probably just be a regular class, not a singleton. We should fix this and
- * {@link @bayou/file-store/BaseFileStore} at the same time.
  */
-export default class BaseDataStore extends Singleton {
+export default class BaseDataStore extends CommonBase {
   /**
    * Checks the syntax of a value alleged to be an author ID. Returns the given
    * value if it's a syntactically correct author ID. Otherwise, throws an

--- a/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
+++ b/local-modules/@bayou/data-store/tests/test_BaseDataStore.js
@@ -33,7 +33,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         for (const value of NON_STRINGS) {
           assert.throws(() => obj.checkAuthorIdSyntax(value), /badValue/, inspect(value));
         }
@@ -48,7 +48,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AcceptsNone.theOne;
+        const obj = new AcceptsNone();
         assert.throws(() => obj.checkAuthorIdSyntax('florp'), /badValue/);
         assert.strictEqual(gotId, 'florp');
       });
@@ -62,7 +62,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AcceptsAll.theOne;
+        const obj = new AcceptsAll();
         assert.strictEqual(obj.checkAuthorIdSyntax('zorch'), 'zorch');
         assert.strictEqual(gotId, 'zorch');
       });
@@ -78,7 +78,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         await assert.isRejected(obj.checkExistingAuthorId('xyz'), /woop/);
         assert.strictEqual(gotId, 'xyz');
       });
@@ -92,21 +92,21 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = NeverValid.theOne;
+        const obj = new NeverValid();
         await assert.isRejected(obj.checkExistingAuthorId('pdq'), /badData/);
         assert.strictEqual(gotId, 'pdq');
       });
 
       it('calls `getAuthorInfo()` and converts `exists: false` to an error', async () => {
         let gotId = null;
-        class NeverValid extends BaseDataStore {
+        class NeverExists extends BaseDataStore {
           async getAuthorInfo(id) {
             gotId = id;
             return { valid: true, exists: false };
           }
         }
 
-        const obj = NeverValid.theOne;
+        const obj = new NeverExists();
         await assert.isRejected(obj.checkExistingAuthorId('nine-one-four'), /badData/);
         assert.strictEqual(gotId, 'nine-one-four');
       });
@@ -120,7 +120,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AlwaysValid.theOne;
+        const obj = new AlwaysValid();
 
         const result = await obj.checkExistingAuthorId('yes');
         assert.strictEqual(result, 'yes');
@@ -136,7 +136,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         for (const value of NON_STRINGS) {
           await assert.isRejected(obj.getAuthorInfo(value), /badValue/, inspect(value));
         }
@@ -155,7 +155,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         await assert.isRejected(obj.getAuthorInfo('boop'), /badValue/);
         assert.strictEqual(gotId, 'boop');
       });
@@ -173,7 +173,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj    = AcceptsAll.theOne;
+        const obj    = new AcceptsAll();
         const result = await obj.getAuthorInfo('beep');
         assert.deepEqual(result, { exists: true, valid: true });
         assert.strictEqual(gotId, 'beep');
@@ -190,7 +190,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         for (const value of NON_STRINGS) {
           assert.throws(() => obj.checkDocumentIdSyntax(value), /badValue/, inspect(value));
         }
@@ -205,7 +205,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AcceptsNone.theOne;
+        const obj = new AcceptsNone();
         assert.throws(() => obj.checkDocumentIdSyntax('florp'), /badValue/);
         assert.strictEqual(gotId, 'florp');
       });
@@ -219,7 +219,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AcceptsAll.theOne;
+        const obj = new AcceptsAll();
         assert.strictEqual(obj.checkDocumentIdSyntax('zorch'), 'zorch');
         assert.strictEqual(gotId, 'zorch');
       });
@@ -235,7 +235,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         await assert.isRejected(obj.checkExistingDocumentId('xyz'), /woop/);
         assert.strictEqual(gotId, 'xyz');
       });
@@ -249,21 +249,21 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = NeverValid.theOne;
+        const obj = new NeverValid();
         await assert.isRejected(obj.checkExistingDocumentId('pdq'), /badData/);
         assert.strictEqual(gotId, 'pdq');
       });
 
       it('calls `getDocumentInfo()` and converts `exists: false` to an error', async () => {
         let gotId = null;
-        class NeverValid extends BaseDataStore {
+        class NeverExists extends BaseDataStore {
           async getDocumentInfo(id) {
             gotId = id;
             return { valid: true, exists: false, fileId: null };
           }
         }
 
-        const obj = NeverValid.theOne;
+        const obj = new NeverExists();
         await assert.isRejected(obj.checkExistingDocumentId('nine-one-four'), /badData/);
         assert.strictEqual(gotId, 'nine-one-four');
       });
@@ -277,7 +277,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = AlwaysValid.theOne;
+        const obj = new AlwaysValid();
 
         const result = await obj.checkExistingDocumentId('yes');
         assert.strictEqual(result, 'yes');
@@ -293,7 +293,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         for (const value of NON_STRINGS) {
           await assert.isRejected(obj.getDocumentInfo(value), /badValue/, inspect(value));
         }
@@ -312,7 +312,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj = Throws.theOne;
+        const obj = new Throws();
         await assert.isRejected(obj.getDocumentInfo('boop'), /badValue/);
         assert.strictEqual(gotId, 'boop');
       });
@@ -330,7 +330,7 @@ describe('@bayou/data-store/BaseDataStore', () => {
           }
         }
 
-        const obj    = AcceptsAll.theOne;
+        const obj    = new AcceptsAll();
         const result = await obj.getDocumentInfo('beep');
         assert.deepEqual(result, { exists: true, valid: true, fileId: 'whatever' });
         assert.strictEqual(gotId, 'beep');

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFileStore.js
@@ -8,13 +8,9 @@ import { before, describe, it } from 'mocha';
 import { LocalFileStore } from '@bayou/file-store-local';
 
 describe('@bayou/file-store-local/LocalFileStore', () => {
-  // **TODO:** It's probably wrong for `BaseFileStore` to inherit from
-  // `Singleton`. It was a reasonable idea at the time, but it does make some
-  // things awkward. In particular right here, it means you can't instantiate a
-  // fresh instance for each test.
   let lfs = null;
   before(() => {
-    lfs = LocalFileStore.theOne;
+    lfs = new LocalFileStore();
   });
 
   describe('isFileId()', () => {

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
-import { Errors, Singleton } from '@bayou/util-common';
+import { CommonBase, Errors } from '@bayou/util-common';
 
 import BaseFile from './BaseFile';
 
@@ -12,14 +12,8 @@ import BaseFile from './BaseFile';
  * interface when dealing with the high-level "files" of this system. Subclasses
  * must override several methods defined by this class, as indicated in the
  * documentation. Methods to override are all named with the prefix `_impl_`.
- *
- * **Note:** This is a subclass of `Singleton`, that is, the system is set up
- * to only ever expect there to be one file store instance. (Technically, this
- * inheritence relationship allows for the possibility of having singleton
- * instances of several subclasses of this class, but in practice that's not
- * what happens.)
  */
-export default class BaseFileStore extends Singleton {
+export default class BaseFileStore extends CommonBase {
   /**
    * Checks a file ID for full validity, beyond simply checking the syntax of
    * the ID. Returns the given ID if all is well, or throws an error if the ID


### PR DESCRIPTION
As our system has evolved, the use of singleton classes has become increasingly problematic. The biggest problem is that they make it harder to test the system (e.g. because all the unit tests in a single run have to use the same instance of any given singleton class, whereas it's better to construct a new instance for each test). It also makes system configuration more difficult, in that singleton constructors can't take arguments.

We now have a configuration system that sits in a great place to hold the de facto system singletons — that is, the instances of the classes that _should_ only be instantiated once in a real run of the system — whether or not those are actually "marked" in the class hierarchy as singletons per se. This PR takes advantage of the arrangement, "de-singletonizing" the base store classes in `file-store` and `data-store` (and their concrete implementations). This now means it's reasonable to add constructor arguments to these classes, when prudent. I didn't add any in this PR, but I suspect we'll want to do so in the near future.