### PR TITLE
Better server-side session handling.

### DIFF
--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -36,7 +36,7 @@ export default class DocServer extends Singleton {
     this._codec = appCommon_TheModule.fullCodec;
 
     /**
-     * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document
+     * {Map<string, Weak<FileComplex|Promise<FileComplex>>} Map from document
      * IDs to either a weak-reference or a promise to a `FileComplex`, for the
      * so-IDed document. During asynchrounous construction, the binding is to a
      * promise, and once constructed it becomes a weak reference. The weak

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -36,7 +36,7 @@ export default class DocServer extends Singleton {
     this._codec = appCommon_TheModule.fullCodec;
 
     /**
-     * {Map<string, Weak<FileComplex|Promise<FileComplex>>} Map from document
+     * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document
      * IDs to either a weak-reference or a promise to a `FileComplex`, for the
      * so-IDed document. During asynchrounous construction, the binding is to a
      * promise, and once constructed it becomes a weak reference. The weak

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -179,7 +179,7 @@ export default class DocServer extends Singleton {
     // This validates the ID with the back end.
     await Storage.dataStore.checkExistingAuthorId(authorId);
 
-    const result = new DocSession(fileComplex, sessionId, authorId);
+    const result = new DocSession(fileComplex, authorId, sessionId);
     const reaper = this._sessionReaper(fileComplex, sessionId);
 
     this._sessions.set(sessionId, weak(result, reaper));

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -37,9 +37,9 @@ export default class DocServer extends Singleton {
 
     /**
      * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document
-     * IDs to either a weak-reference or a promise to a `FileComplex`, for the
-     * so-IDed document. During asynchrounous construction, the binding is to a
-     * promise, and once constructed it becomes a weak reference. The weak
+     * IDs to either a weak-reference or a promise to a {@link FileComplex}, for
+     * the so-IDed document. During asynchrounous construction, the binding is
+     * to a promise, and once constructed it becomes a weak reference. The weak
      * reference is made because we don't want its presence here to preclude it
      * from getting GC'ed.
      */

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -25,21 +25,21 @@ export default class DocSession extends CommonBase {
    *
    * @param {fileComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
+   * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} sessionId Session ID for this instance, which is expected
    *   to be guaranteed unique by whatever service it is that generates it.
-   * @param {string} authorId The author this instance acts on behalf of.
    */
-  constructor(fileComplex, sessionId, authorId) {
+  constructor(fileComplex, authorId, sessionId) {
     super();
 
     /** {FileComplex} File complex that this instance is part of. */
     this._fileComplex = FileComplex.check(fileComplex);
 
-    /** {string} Session ID. */
-    this._sessionId = TString.nonEmpty(sessionId);
-
     /** {string} Author ID. */
     this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
+
+    /** {string} Session ID. */
+    this._sessionId = TString.nonEmpty(sessionId);
 
     /** {BodyControl} The underlying body content controller. */
     this._bodyControl = fileComplex.bodyControl;

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -2,12 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import weak from 'weak';
+
 import { Storage } from '@bayou/config-server';
 import { TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import BaseComplexMember from './BaseComplexMember';
-import DocServer from './DocServer';
+import DocSession from './DocSession';
 import FileAccess from './FileAccess';
 import FileBootstrap from './FileBootstrap';
 
@@ -35,6 +37,15 @@ export default class FileComplex extends BaseComplexMember {
      * most directly stored.
      */
     this._bootstrap = new FileBootstrap(this._fileAccess);
+
+    /**
+     * {Map<string, Weak<DocSession>>} Map from session IDs to corresponding
+     * weak-reference-wrapped {@link DocSession} instances. The weak reference
+     * is made because we don't want a session's presence in the map to keep it
+     * from getting GC'ed. And we _need_ the map here, so that we can find
+     * existing active sessions.
+     */
+    this._sessions = new Map();
 
     Object.freeze(this);
   }
@@ -71,7 +82,9 @@ export default class FileComplex extends BaseComplexMember {
    * @returns {DocSession} A newly-constructed session.
    */
   async makeNewSession(authorId, sessionId) {
-    Storage.dataStore.checkAuthorIdSyntax(authorId);
+    // This validates the ID with the back end.
+    await Storage.dataStore.checkExistingAuthorId(authorId);
+
     TString.nonEmpty(sessionId);
 
     // Ensure that the session ID doesn't correspond to a pre-existing session.
@@ -82,18 +95,31 @@ export default class FileComplex extends BaseComplexMember {
       throw Errors.badData(`Attempt to create session with already-used ID: \`${sessionId}\``);
     }
 
-    return DocServer.theOne._makeNewSession(this, authorId, sessionId);
+    const result = new DocSession(this, authorId, sessionId);
+    const reaper = this._sessionReaper(sessionId);
+
+    this._sessions.set(sessionId, weak(result, reaper));
+    return result;
   }
 
   /**
-   * Indicates that a particular session was reaped (GC'ed). This is a "friend"
-   * method which gets called by `DocServer`.
+   * Returns a weak reference callback function for the indicated complex /
+   * session pair, that removes a collected session object from the session map.
    *
-   * @param {string} sessionId ID of the session that got reaped.
+   * **Note:** This does _not_ remove the session info from the carets part of
+   * the document: Even though the session has become idle from the perspective
+   * of this server, the session isn't necessarily totally idle / dead. For
+   * example, it might be the case that the client for the session happened to
+   * end up connecting to a different machine and is continuing to putter away
+   * at it.
+   *
+   * @param {string} sessionId ID of the session to remove.
+   * @returns {function} An appropriately-constructed function.
    */
-  async _sessionReaped(sessionId) {
-    // Pass through to the caret controller, since it might have a record of the
-    // session.
-    await this.caretControl._sessionReaped(sessionId);
+  _sessionReaper(sessionId) {
+    return () => {
+      this._sessions.delete(sessionId);
+      this.log.info('Reaped idle session:', sessionId);
+    };
   }
 }

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -88,6 +88,12 @@ export default class FileComplex extends BaseComplexMember {
     TString.nonEmpty(sessionId);
 
     // Ensure that the session ID doesn't correspond to a pre-existing session.
+    // **TODO:** This test suffers from a race condition, in that it's possible
+    // for some other machine to add a caret with this session ID after we
+    // determine that it's unused and before we actually store the first caret
+    // for the session. Instead, this method should arrange to actually perform
+    // an `appendChange()` from the snapshot which would conclusively establish
+    // the session as bona fide new.
     const caretSnapshot = await this.caretControl.getSnapshot();
     const already       = caretSnapshot.getOrNull(sessionId);
 


### PR DESCRIPTION
This PR rearranges the server-side session handling code so that it's better positioned to admit the possibility of looking up pre-existing sessions (though that lookup code isn't yet written[*]). This also includes a small tweak to session lifecycle management, to prevent sessions from getting removed prematurely. (It would have only started mattering once we run multiple servers, but I figured I might as well have fixed it when I noticed the problem.)

[*] because it requires trickier code, and I didn't want to roll that into this mostly-straightforward PR.