### PR TITLE
Carets have an associated author!

### DIFF
--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -21,7 +21,7 @@ import CaretOp from './CaretOp';
  * confuses the linter.
  */
 const CARET_FIELDS = new Map([
-  ['authorId',   TString.orNull.bind(TString)], // **TODO:** This shouldn't be optional.
+  ['authorId',   TString.check.bind(TString)],
   ['color',      ColorUtil.checkCss],
   ['index',      TInt.nonNegative],
   ['lastActive', Timestamp.check.bind(Timestamp)],
@@ -48,9 +48,10 @@ export default class Caret extends CommonBase {
   /** {Caret} An instance with all default values. */
   static get DEFAULT() {
     if (DEFAULT === null) {
+      // **Note:** There is no default for `authorId`, which is what makes it
+      // end up getting required when constructing a new instance from scratch.
       DEFAULT = new Caret('no_session',
         {
-          authorId:   null, // **TODO:** This shouldn't be optional.
           lastActive: Timestamp.now(),
           revNum:     0,
           index:      0,
@@ -93,8 +94,11 @@ export default class Caret extends CommonBase {
    * Constructs an instance. Only the first argument (`sessionIdOrBase`) is
    * required, and it is not necessary to specify all the fields in `fields`.
    * Fields not listed are derived from the base caret (first argument) if
-   * specified as such, or from the default value `Caret.DEFAULT` if the first
+   * specified as such, or from the default value {@link #DEFAULT} if the first
    * argument is a session ID.
+   *
+   * **Note:** {@link #DEFAULT} does not bind an `authorId`, which means that
+   * that field must be specified when creating an instance "from scratch."
    *
    * @param {string|Caret} sessionIdOrBase Session ID that identifies the caret,
    *   or a base caret instance which provides the session and default values
@@ -128,7 +132,7 @@ export default class Caret extends CommonBase {
       newFields.set(k, Caret.checkField(k, v));
     }
 
-    if (DEFAULT && (newFields.size !== DEFAULT._fields.size)) {
+    if (DEFAULT && (newFields.size !== CARET_FIELDS.size)) {
       throw Errors.badUse(`Missing field.`);
     }
 

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -21,7 +21,7 @@ import CaretOp from './CaretOp';
  * confuses the linter.
  */
 const CARET_FIELDS = new Map([
-  ['authorId',   TString.orNull.bind(TString)],
+  ['authorId',   TString.orNull.bind(TString)], // **TODO:** This shouldn't be optional.
   ['color',      ColorUtil.checkCss],
   ['index',      TInt.nonNegative],
   ['lastActive', Timestamp.check.bind(Timestamp)],
@@ -50,7 +50,7 @@ export default class Caret extends CommonBase {
     if (DEFAULT === null) {
       DEFAULT = new Caret('no_session',
         {
-          authorId:   null,
+          authorId:   null, // **TODO:** This shouldn't be optional.
           lastActive: Timestamp.now(),
           revNum:     0,
           index:      0,

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -21,11 +21,11 @@ import CaretOp from './CaretOp';
  * confuses the linter.
  */
 const CARET_FIELDS = new Map([
-  ['lastActive', Timestamp.check.bind(Timestamp)],
-  ['revNum',     RevisionNumber.check],
+  ['color',      ColorUtil.checkCss],
   ['index',      TInt.nonNegative],
+  ['lastActive', Timestamp.check.bind(Timestamp)],
   ['length',     TInt.nonNegative],
-  ['color',      ColorUtil.checkCss]
+  ['revNum',     RevisionNumber.check]
 ]);
 
 /**

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -21,6 +21,7 @@ import CaretOp from './CaretOp';
  * confuses the linter.
  */
 const CARET_FIELDS = new Map([
+  ['authorId',   TString.orNull.bind(TString)],
   ['color',      ColorUtil.checkCss],
   ['index',      TInt.nonNegative],
   ['lastActive', Timestamp.check.bind(Timestamp)],
@@ -49,6 +50,7 @@ export default class Caret extends CommonBase {
     if (DEFAULT === null) {
       DEFAULT = new Caret('no_session',
         {
+          authorId:   null,
           lastActive: Timestamp.now(),
           revNum:     0,
           index:      0,
@@ -131,6 +133,13 @@ export default class Caret extends CommonBase {
     }
 
     Object.freeze(this);
+  }
+
+  /**
+   * {string|null} ID of the author responsible for this caret.
+   */
+  get authorId() {
+    return this._fields.get('authorId');
   }
 
   /**

--- a/local-modules/@bayou/doc-common/TheModule.js
+++ b/local-modules/@bayou/doc-common/TheModule.js
@@ -36,7 +36,7 @@ export default class TheModule extends UtilityClass {
    * or two, so that it isn't mistaken for a month.)
    */
   static get SCHEMA_VERSION() {
-    return '2018-002';
+    return '2018-003';
   }
 
   /**

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -14,15 +14,16 @@ import { Caret, CaretDelta, CaretOp } from '@bayou/doc-common';
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
+ * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaret(sessionId, index, length, color) {
-  return new Caret(sessionId, { index, length, color });
+function newCaret(sessionId, index, length, color, authorId) {
+  return new Caret(sessionId, { index, length, color, authorId });
 }
 
-const caret1 = newCaret('session-1', 1, 0,  '#111111');
-const caret2 = newCaret('session-2', 2, 6,  '#222222');
-const caret3 = newCaret('session-3', 3, 99, '#333333');
+const caret1 = newCaret('session-1', 1, 0,  '#111111', 'author-1');
+const caret2 = newCaret('session-2', 2, 6,  '#222222', 'author-2');
+const caret3 = newCaret('session-3', 3, 99, '#333333', 'third-author');
 
 describe('@bayou/doc-common/Caret', () => {
   describe('compose()', () => {
@@ -161,8 +162,8 @@ describe('@bayou/doc-common/Caret', () => {
     });
 
     it('should return `false` when session IDs differ', () => {
-      const c1 = newCaret('x', 1, 2, '#000011');
-      const c2 = newCaret('y', 1, 2, '#000011');
+      const c1 = newCaret('x', 1, 2, '#000011', 'some-author');
+      const c2 = newCaret('y', 1, 2, '#000011', 'some-author');
       assert.isFalse(c1.equals(c2));
     });
 
@@ -181,10 +182,14 @@ describe('@bayou/doc-common/Caret', () => {
       op = CaretOp.op_setField(c1.sessionId, 'color', '#999999');
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
+
+      op = CaretOp.op_setField(c1.sessionId, 'authorId', 'zagnut');
+      c2 = c1.compose(new CaretDelta([op]));
+      assert.isFalse(c1.equals(c2));
     });
 
     it('should return `false` when passed a non-caret', () => {
-      const caret = newCaret('x', 1, 2, '#000011');
+      const caret = newCaret('x', 1, 2, '#000011', 'blorp');
 
       assert.isFalse(caret.equals(undefined));
       assert.isFalse(caret.equals(null));

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -39,6 +39,13 @@ describe('@bayou/doc-common/Caret', () => {
       test(caret3);
     });
 
+    it('should update `authorId` given the appropriate op', () => {
+      const op     = CaretOp.op_setField(caret1.sessionId, 'authorId', 'boop');
+      const result = caret1.compose(new CaretDelta([op]));
+
+      assert.strictEqual(result.authorId, 'boop');
+    });
+
     it('should update `index` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.sessionId, 'index', 99999);
       const result = caret1.compose(new CaretDelta([op]));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -58,9 +58,9 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     it('should not include session ends when `wantDocument` is `true`', () => {
-      const op1    = CaretOp.op_beginSession(new Caret('aaa'));
-      const op2    = CaretOp.op_beginSession(new Caret('bbb'));
-      const op3    = CaretOp.op_beginSession(new Caret('ccc'));
+      const op1    = CaretOp.op_beginSession(new Caret('aaa', { authorId: 'xyz' }));
+      const op2    = CaretOp.op_beginSession(new Caret('bbb', { authorId: 'xyz' }));
+      const op3    = CaretOp.op_beginSession(new Caret('ccc', { authorId: 'xyz' }));
       const op4    = CaretOp.op_endSession('bbb');
       const op5    = CaretOp.op_endSession('ddd');
       const d1     = new CaretDelta([op1, op2]);
@@ -93,7 +93,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
         );
 
         test(
-          [CaretOp.op_beginSession(new Caret('session1'))],
+          [CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' }))],
           [endOp],
           [endOp]
         );
@@ -130,7 +130,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
         );
 
         test(
-          [CaretOp.op_beginSession(new Caret('session1')), endOp],
+          [CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' })), endOp],
           [setOp],
           [endOp]
         );
@@ -139,9 +139,9 @@ describe('@bayou/doc-common/CaretDelta', () => {
 
     describe('`setField` after `beginSession`', () => {
       it('should result in a modified `beginSession`', () => {
-        const beginOp  = CaretOp.op_beginSession(new Caret('session1'));
+        const beginOp  = CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' }));
         const setOp    = CaretOp.op_setField('session1', 'revNum', 123);
-        const resultOp = CaretOp.op_beginSession(new Caret('session1', { revNum: 123 }));
+        const resultOp = CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz', revNum: 123 }));
 
         test(
           [beginOp, setOp],

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -14,10 +14,11 @@ import { Caret, CaretChange, CaretDelta, CaretOp, CaretSnapshot } from '@bayou/d
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
+ * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaret(sessionId, index, length, color) {
-  return new Caret(sessionId, { index, length, color });
+function newCaret(sessionId, index, length, color, authorId) {
+  return new Caret(sessionId, { index, length, color, authorId });
 }
 
 /**
@@ -28,15 +29,16 @@ function newCaret(sessionId, index, length, color) {
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
+ * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaretOp(sessionId, index, length, color) {
-  return CaretOp.op_beginSession(newCaret(sessionId, index, length, color));
+function newCaretOp(sessionId, index, length, color, authorId) {
+  return CaretOp.op_beginSession(newCaret(sessionId, index, length, color, authorId));
 }
 
-const caret1 = newCaret('session_1', 1, 0,  '#111111');
-const caret2 = newCaret('session_2', 2, 6,  '#222222');
-const caret3 = newCaret('session_3', 3, 99, '#333333');
+const caret1 = newCaret('session_1', 1, 0,  '#111111', 'aa');
+const caret2 = newCaret('session_2', 2, 6,  '#222222', 'bb');
+const caret3 = newCaret('session_3', 3, 99, '#333333', 'cc');
 
 const op1 = CaretOp.op_beginSession(caret1);
 const op2 = CaretOp.op_beginSession(caret2);
@@ -195,8 +197,8 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     it('should update a pre-existing caret given an appropriate op', () => {
-      const c1       = newCaretOp('foo', 1, 2, '#333333');
-      const c2       = newCaretOp('foo', 3, 2, '#333333');
+      const c1       = newCaretOp('foo', 1, 2, '#333333', 'dd');
+      const c2       = newCaretOp('foo', 3, 2, '#333333', 'dd');
       const snap     = new CaretSnapshot(1, [op1, c1]);
       const expected = new CaretSnapshot(1, [op1, c2]);
       const op       = CaretOp.op_setField('foo', 'index', 3);
@@ -258,9 +260,9 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     it('should result in a caret update if that in fact happens', () => {
-      const c1     = newCaretOp('florp', 1, 3, '#444444');
-      const c2     = newCaretOp('florp', 2, 4, '#555555');
-      const c3     = newCaretOp('florp', 3, 5, '#666666');
+      const c1     = newCaretOp('florp', 1, 3, '#444444', 'ff');
+      const c2     = newCaretOp('florp', 2, 4, '#555555', 'gg');
+      const c3     = newCaretOp('florp', 3, 5, '#666666', 'hh');
       const snap1  = new CaretSnapshot(1, [c1]);
       const snap2  = new CaretSnapshot(1, [c2]);
       const result = snap1.diff(snap2);
@@ -345,10 +347,10 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     it('should return `true` when equal carets are not also `===`', () => {
-      const c1a = newCaretOp('florp', 2, 3, '#444444');
-      const c1b = newCaretOp('florp', 2, 3, '#444444');
-      const c2a = newCaretOp('like',  3, 0, '#dbdbdb');
-      const c2b = newCaretOp('like',  3, 0, '#dbdbdb');
+      const c1a = newCaretOp('florp', 2, 3, '#444444', 'ab');
+      const c1b = newCaretOp('florp', 2, 3, '#444444', 'ab');
+      const c2a = newCaretOp('like',  3, 0, '#dbdbdb', 'cd');
+      const c2b = newCaretOp('like',  3, 0, '#dbdbdb', 'cd');
 
       const snap1 = new CaretSnapshot(1, [c1a, c2a]);
       const snap2 = new CaretSnapshot(1, [c1b, c2b]);

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -198,6 +198,11 @@ export default class DocSession extends CommonBase {
         await this._caretControl.changeForNewSession(this._sessionId, this._authorId);
 
       this._caretControl.log.warn(`Got update for session \`${this._sessionId}\` before caret was set up.`);
+
+      // **TODO:** This should possibly have the same kind of race-loss-retry
+      // logic as seen elsewhere in the codebase. However, for now -- and
+      // perhaps forever -- this is probably fine, because this whole situation
+      // isn't ever supposed to happen anyway.
       await this._caretControl.update(newSessionChange);
     }
 


### PR DESCRIPTION
This PR adds an essential piece of info to `Caret` objects, namely the identity of the author who is manipulating the caret in question. In addition, this information is used productively to simplify things in a couple places and to add the new (but currently unused) method `FileComplex.findExistingSession()` (which is the method I'd alluded to in the previous PR).