### PR TITLE
 Carets are a kind of session, but stop conflating the connection with the caret.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -103,8 +103,8 @@ export default class AuthorAccess extends CommonBase {
    *
    * @param {string} docId ID of the document which the resulting bound object
    *   allows access to.
-   * @returns {string} ID within the API context which refers to the
-   *   newly-created session.
+   * @returns {string} Target ID within the API context which refers to the
+   *   session. This is _not_ the same as the `sessionId`.
    */
   async makeSession(docId) {
     // We only check the document ID syntax here, because we can count on the
@@ -114,18 +114,20 @@ export default class AuthorAccess extends CommonBase {
 
     const sessionId   = this._context.randomId();
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
+    const targetId    = this._context.randomId();
 
     // **Note:** This call includes data store back-end validation of the author
     // ID.
     const session = await fileComplex.makeNewSession(this._authorId, sessionId);
 
-    this._context.addTarget(new Target(sessionId, session));
+    this._context.addTarget(new Target(targetId, session));
 
     log.info(
       'Created new session.\n',
-      `  doc:        ${docId}\n`,
-      `  session id: ${sessionId}`);
+      `  target:  ${targetId}\n`,
+      `  doc:     ${docId}\n`,
+      `  session: ${sessionId}`);
 
-    return sessionId;
+    return targetId;
   }
 }

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -112,13 +112,12 @@ export default class AuthorAccess extends CommonBase {
     // work.
     Storage.dataStore.checkDocumentIdSyntax(docId);
 
-    const sessionId   = this._context.randomId();
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
     const targetId    = this._context.randomId();
 
     // **Note:** This call includes data store back-end validation of the author
     // ID.
-    const session = await fileComplex.makeNewSession(this._authorId, sessionId);
+    const session = await fileComplex.makeNewSession(this._authorId);
 
     this._context.addTarget(new Target(targetId, session));
 
@@ -126,7 +125,7 @@ export default class AuthorAccess extends CommonBase {
       'Created new session.\n',
       `  target:  ${targetId}\n`,
       `  doc:     ${docId}\n`,
-      `  session: ${sessionId}`);
+      `  session: ${session.getSessionId()}`);
 
     return targetId;
   }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -55,15 +55,16 @@ export default class RootAccess extends CommonBase {
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 
     const url       = `${Network.baseUrl}/api`;
-    const sessionId = this._context.randomSplitKeyId();
-    const session   = await fileComplex.makeNewSession(authorId, sessionId);
-    const key       = new SplitKey(url, sessionId);
+    const targetId = this._context.randomSplitKeyId();
+    const session   = await fileComplex.makeNewSession(authorId);
+    const key       = new SplitKey(url, targetId);
     this._context.addTarget(new Target(key, session));
 
     log.info(
       'Newly-authorized access.\n',
       `  author:  ${authorId}\n`,
       `  doc:     ${docId}\n`,
+      `  session: ${session.getSessionId()}\n`,
       `  key id:  ${key.printableId}\n`, // This is safe to log (not security-sensitive).
       `  key url: ${key.url}`);
 

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -22,8 +22,8 @@ export default class DocSession extends CommonBase {
    * Constructs an instance.
    *
    * @param {BaseKey} key Key that identifies the session and grants access to
-   *   it. **Note:** A session is specifically tied to a single author and a
-   *   single document.
+   *   it. **Note:** A session is specifically tied to a specific caret, which
+   *   is associated with a single document and a specific author.
    */
   constructor(key) {
     super();

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -7,6 +7,7 @@ import { TInt, TObject, TString } from '@bayou/typecheck';
 import { ColorUtil, CommonBase, Errors } from '@bayou/util-common';
 
 import CaretDelta from './CaretDelta';
+import CaretId from './CaretId';
 import CaretOp from './CaretOp';
 
 /**
@@ -30,6 +31,12 @@ const CARET_FIELDS = new Map([
 ]);
 
 /**
+ * {string} Special value for the ID which is only allowed for the default
+ * caret.
+ */
+const DEFAULT_ID = '<no_id>';
+
+/**
  * {Caret|null} An instance with all default values. Initialized in the static
  * method of the same name.
  */
@@ -50,7 +57,7 @@ export default class Caret extends CommonBase {
     if (DEFAULT === null) {
       // **Note:** There is no default for `authorId`, which is what makes it
       // end up getting required when constructing a new instance from scratch.
-      DEFAULT = new Caret('no_session',
+      DEFAULT = new Caret(DEFAULT_ID,
         {
           lastActive: Timestamp.now(),
           revNum:     0,
@@ -113,10 +120,13 @@ export default class Caret extends CommonBase {
     if (sessionIdOrBase instanceof Caret) {
       newFields = new Map(sessionIdOrBase._fields);
       sessionId = sessionIdOrBase.sessionId;
+    } else if (DEFAULT !== null) {
+      newFields = new Map(DEFAULT._fields);
+      sessionId = CaretId.check(sessionIdOrBase);
     } else {
-      newFields = DEFAULT ? new Map(DEFAULT._fields) : new Map();
-      // **TODO:** This should require the ID to pass `CaretId.check()`.
-      sessionId = TString.nonEmpty(sessionIdOrBase);
+      // If we're here, it means that `DEFAULT` is currently being initialized.
+      newFields = new Map();
+      sessionId = TString.check(sessionIdOrBase);
     }
 
     TObject.plain(fields);

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -286,7 +286,7 @@ export default class Caret extends CommonBase {
    */
   diffFields(newerCaret, sessionId) {
     Caret.check(newerCaret);
-    TString.nonEmpty(sessionId);
+    CaretId.check(sessionId);
 
     const fields = this._fields;
     const ops    = [];

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -115,6 +115,7 @@ export default class Caret extends CommonBase {
       sessionId = sessionIdOrBase.sessionId;
     } else {
       newFields = DEFAULT ? new Map(DEFAULT._fields) : new Map();
+      // **TODO:** This should require the ID to pass `CaretId.check()`.
       sessionId = TString.nonEmpty(sessionIdOrBase);
     }
 

--- a/local-modules/@bayou/doc-common/CaretId.js
+++ b/local-modules/@bayou/doc-common/CaretId.js
@@ -1,0 +1,52 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Errors, Random, UtilityClass } from '@bayou/util-common';
+
+/** {RexExp} Expression which matches caret IDs. */
+const CARET_ID_REGEX = /^cr-[0-9a-z]{10}$/;
+
+/**
+ * Utility class for handling caret IDs (a/k/a session IDs). A caret ID is a
+ * string that uniquely identifies an editing session within a given document.
+ *
+ * A valid ID consists of the prefix `cr-` followed by 10 lowercase alphanumeric
+ * characters.
+ */
+export default class CaretId extends UtilityClass {
+  /**
+   * Validates that the given value is a valid caret ID string. Throws an
+   * error if not.
+   *
+   * @param {*} value Value to check.
+   * @returns {string} `value` if it is in fact a valid caret ID string.
+   */
+  static check(value) {
+    if (CaretId.isInstance(value)) {
+      return value;
+    }
+
+    throw Errors.badValue(value, CaretId);
+  }
+
+  /**
+   * Indicates whether the given value is a valid caret ID string.
+   *
+   * @param {*} value Value in question.
+   * @returns {boolean} `true` if `value` is indeed a valid caret ID string,
+   *   or `false` if not.
+   */
+  static isInstance(value) {
+    return (typeof value === 'string') && CARET_ID_REGEX.test(value);
+  }
+
+  /**
+   * Constructs and returns a random caret ID string.
+   *
+   * @returns {string} A randomly-generated caret ID string.
+   */
+  static randomInstance() {
+    return Random.idString('cr', 10);
+  }
+}

--- a/local-modules/@bayou/doc-common/CaretId.js
+++ b/local-modules/@bayou/doc-common/CaretId.js
@@ -5,14 +5,15 @@
 import { Errors, Random, UtilityClass } from '@bayou/util-common';
 
 /** {RexExp} Expression which matches caret IDs. */
-const CARET_ID_REGEX = /^cr-[0-9a-z]{10}$/;
+const CARET_ID_REGEX = /^cr-[0-9a-z]{5}$/;
 
 /**
  * Utility class for handling caret IDs (a/k/a session IDs). A caret ID is a
  * string that uniquely identifies an editing session within a given document.
  *
- * A valid ID consists of the prefix `cr-` followed by 10 lowercase alphanumeric
- * characters.
+ * A valid ID consists of the prefix `cr-` followed by 5 lowercase alphanumeric
+ * characters. (With an expected 5 bits of randomness in each character, that
+ * allows for about 33 million simultaneous carets on any given document.)
  */
 export default class CaretId extends UtilityClass {
   /**
@@ -47,6 +48,6 @@ export default class CaretId extends UtilityClass {
    * @returns {string} A randomly-generated caret ID string.
    */
   static randomInstance() {
-    return Random.idString('cr', 10);
+    return Random.idString('cr', 5);
   }
 }

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -3,10 +3,10 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseOp } from '@bayou/ot-common';
-import { TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import Caret from './Caret';
+import CaretId from './CaretId';
 
 /**
  * Operation which can be applied to a `Caret` or `CaretSnapshot`.
@@ -47,7 +47,7 @@ export default class CaretOp extends BaseOp {
    * @returns {CaretOp} The corresponding operation.
    */
   static op_endSession(sessionId) {
-    TString.nonEmpty(sessionId);
+    CaretId.check(sessionId);
 
     return new CaretOp(CaretOp.CODE_endSession, sessionId);
   }
@@ -62,7 +62,7 @@ export default class CaretOp extends BaseOp {
    * @returns {CaretOp} The corresponding operation.
    */
   static op_setField(sessionId, key, value) {
-    TString.nonEmpty(sessionId);
+    CaretId.check(sessionId);
     Caret.checkField(key, value);
 
     return new CaretOp(CaretOp.CODE_setField, sessionId, key, value);

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -9,6 +9,7 @@ import { Errors } from '@bayou/util-common';
 import Caret from './Caret';
 import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
+import CaretId from './CaretId';
 import CaretOp from './CaretOp';
 
 
@@ -162,6 +163,22 @@ export default class CaretSnapshot extends BaseSnapshot {
    */
   has(sessionId) {
     return this.getOrNull(sessionId) !== null;
+  }
+
+  /**
+   * Returns a randomly-generated ID which is guaranteed not to be used by any
+   * caret in this instance.
+   *
+   * @returns {string} Available session ID.
+   */
+  randomUnusedId() {
+    // Loop in case we get _very_ unlucky.
+    for (;;) {
+      const result = CaretId.randomInstance();
+      if (!this.has(result)) {
+        return result;
+      }
+    }
   }
 
   /**

--- a/local-modules/@bayou/doc-common/index.js
+++ b/local-modules/@bayou/doc-common/index.js
@@ -10,6 +10,7 @@ import BodySnapshot from './BodySnapshot';
 import Caret from './Caret';
 import CaretChange from './CaretChange';
 import CaretDelta from './CaretDelta';
+import CaretId from './CaretId';
 import CaretOp from './CaretOp';
 import CaretSnapshot from './CaretSnapshot';
 import Property from './Property';
@@ -28,6 +29,7 @@ export {
   Caret,
   CaretChange,
   CaretDelta,
+  CaretId,
   CaretOp,
   CaretSnapshot,
   Property,

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -107,14 +107,14 @@ describe('@bayou/doc-common/Caret', () => {
 
   describe('diffFields()', () => {
     it('should produce an empty diff when passed itself', () => {
-      const result = caret1.diffFields(caret1, 'florp');
+      const result = caret1.diffFields(caret1, 'cr-florp');
 
       assert.instanceOf(result, CaretDelta);
       assert.deepEqual(result.ops, []);
     });
 
     it('should diff fields even if given a non-matching session ID', () => {
-      assert.doesNotThrow(() => { caret1.diffFields(caret2, 'florp'); });
+      assert.doesNotThrow(() => { caret1.diffFields(caret2, 'cr-florp'); });
     });
 
     it('should result in an `index` diff if that in fact changes', () => {

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -21,9 +21,9 @@ function newCaret(sessionId, index, length, color, authorId) {
   return new Caret(sessionId, { index, length, color, authorId });
 }
 
-const caret1 = newCaret('session-1', 1, 0,  '#111111', 'author-1');
-const caret2 = newCaret('session-2', 2, 6,  '#222222', 'author-2');
-const caret3 = newCaret('session-3', 3, 99, '#333333', 'third-author');
+const caret1 = newCaret('cr-11111', 1, 0,  '#111111', 'author-1');
+const caret2 = newCaret('cr-22222', 2, 6,  '#222222', 'author-2');
+const caret3 = newCaret('cr-33333', 3, 99, '#333333', 'third-author');
 
 describe('@bayou/doc-common/Caret', () => {
   describe('compose()', () => {
@@ -162,8 +162,8 @@ describe('@bayou/doc-common/Caret', () => {
     });
 
     it('should return `false` when session IDs differ', () => {
-      const c1 = newCaret('x', 1, 2, '#000011', 'some-author');
-      const c2 = newCaret('y', 1, 2, '#000011', 'some-author');
+      const c1 = newCaret('cr-xxxxx', 1, 2, '#000011', 'some-author');
+      const c2 = newCaret('cr-yyyyy', 1, 2, '#000011', 'some-author');
       assert.isFalse(c1.equals(c2));
     });
 
@@ -189,7 +189,7 @@ describe('@bayou/doc-common/Caret', () => {
     });
 
     it('should return `false` when passed a non-caret', () => {
-      const caret = newCaret('x', 1, 2, '#000011', 'blorp');
+      const caret = newCaret('cr-florp', 1, 2, '#000011', 'blorp');
 
       assert.isFalse(caret.equals(undefined));
       assert.isFalse(caret.equals(null));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -58,11 +58,11 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     it('should not include session ends when `wantDocument` is `true`', () => {
-      const op1    = CaretOp.op_beginSession(new Caret('aaa', { authorId: 'xyz' }));
-      const op2    = CaretOp.op_beginSession(new Caret('bbb', { authorId: 'xyz' }));
-      const op3    = CaretOp.op_beginSession(new Caret('ccc', { authorId: 'xyz' }));
-      const op4    = CaretOp.op_endSession('bbb');
-      const op5    = CaretOp.op_endSession('ddd');
+      const op1    = CaretOp.op_beginSession(new Caret('cr-aaaaa', { authorId: 'xyz' }));
+      const op2    = CaretOp.op_beginSession(new Caret('cr-bbbbb', { authorId: 'xyz' }));
+      const op3    = CaretOp.op_beginSession(new Caret('cr-ccccc', { authorId: 'xyz' }));
+      const op4    = CaretOp.op_endSession('cr-bbbbb');
+      const op5    = CaretOp.op_endSession('cr-ddddd');
       const d1     = new CaretDelta([op1, op2]);
       const d2     = new CaretDelta([op3, op4, op5]);
       const result = d1.compose(d2, true);
@@ -72,7 +72,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
 
     describe('`endSession` preceded by anything for that session', () => {
       it('should result in just the `endSession`', () => {
-        const endOp = CaretOp.op_endSession('session1');
+        const endOp = CaretOp.op_endSession('cr-sessi');
 
         test(
           [endOp],
@@ -93,13 +93,13 @@ describe('@bayou/doc-common/CaretDelta', () => {
         );
 
         test(
-          [CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' }))],
+          [CaretOp.op_beginSession(new Caret('cr-sessi', { authorId: 'xyz' }))],
           [endOp],
           [endOp]
         );
 
         test(
-          [CaretOp.op_setField('session1', 'revNum', 5)],
+          [CaretOp.op_setField('cr-sessi', 'revNum', 5)],
           [endOp],
           [endOp]
         );
@@ -108,8 +108,8 @@ describe('@bayou/doc-common/CaretDelta', () => {
 
     describe('`setField` after `endSession`', () => {
       it('should result in just the `endSession`', () => {
-        const endOp = CaretOp.op_endSession('session1');
-        const setOp = CaretOp.op_setField('session1', 'revNum', 123);
+        const endOp = CaretOp.op_endSession('cr-sess1');
+        const setOp = CaretOp.op_setField('cr-sess1', 'revNum', 123);
 
         test(
           [endOp, setOp],
@@ -130,7 +130,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
         );
 
         test(
-          [CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' })), endOp],
+          [CaretOp.op_beginSession(new Caret('cr-sess1', { authorId: 'xyz' })), endOp],
           [setOp],
           [endOp]
         );
@@ -139,9 +139,9 @@ describe('@bayou/doc-common/CaretDelta', () => {
 
     describe('`setField` after `beginSession`', () => {
       it('should result in a modified `beginSession`', () => {
-        const beginOp  = CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz' }));
-        const setOp    = CaretOp.op_setField('session1', 'revNum', 123);
-        const resultOp = CaretOp.op_beginSession(new Caret('session1', { authorId: 'xyz', revNum: 123 }));
+        const beginOp  = CaretOp.op_beginSession(new Caret('cr-sess1', { authorId: 'xyz' }));
+        const setOp    = CaretOp.op_setField('cr-sess1', 'revNum', 123);
+        const resultOp = CaretOp.op_beginSession(new Caret('cr-sess1', { authorId: 'xyz', revNum: 123 }));
 
         test(
           [beginOp, setOp],
@@ -162,7 +162,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
         );
 
         test(
-          [beginOp, CaretOp.op_setField('session1', 'revNum', 9999)],
+          [beginOp, CaretOp.op_setField('cr-sess1', 'revNum', 9999)],
           [setOp],
           [resultOp]
         );
@@ -171,8 +171,8 @@ describe('@bayou/doc-common/CaretDelta', () => {
 
     describe('`setField` after `setField`', () => {
       it('should drop earlier sets for the same field', () => {
-        const setOp1 = CaretOp.op_setField('session1', 'revNum', 123);
-        const setOp2 = CaretOp.op_setField('session1', 'revNum', 999);
+        const setOp1 = CaretOp.op_setField('cr-sess1', 'revNum', 123);
+        const setOp2 = CaretOp.op_setField('cr-sess1', 'revNum', 999);
 
         test(
           [setOp1, setOp2],

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -1,0 +1,113 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { CaretId } from '@bayou/doc-common';
+
+/** {array<string>} Example valid ID strings. */
+const VALID_IDS = [
+  'cr-1234567890',
+  'cr-abcdefghij',
+  'cr-klmnopqrst',
+  'cr-uvwxyz0123'
+];
+
+/** {array<string>} Example invalid ID strings. */
+const INVALID_STRINGS = [
+  '',
+  'c',
+  'cr',
+  'cr-',
+  'cr-1',
+  'cr-12',
+  'cr-123',
+  'cr-1234',
+  'cr-12345',
+  'cr-123456',
+  'cr-1234567',
+  'cr-12345678',
+  'cr-123456789',
+  'cr-1234567890x',
+  'cr-1234567890xy',
+  'cr-ABCDEFGHIJ',
+  'cr-abc#defghi',
+  'cr-abcde-fghi',
+  'xy-1234567890',
+  'cr+1234567890'
+];
+
+/** {array<*>} Example non-strings. */
+const NON_STRINGS = [
+  undefined,
+  null,
+  false,
+  true,
+  123,
+  ['x'],
+  { a: 914 }
+];
+
+describe('@bayou/doc-common/CaretId', () => {
+  describe('check()', () => {
+    it('should accept valid ID strings', () => {
+      for (const s of VALID_IDS) {
+        assert.strictEqual(CaretId.check(s), s, s);
+      }
+    });
+
+    it('should reject invalid ID strings', () => {
+      for (const s of INVALID_STRINGS) {
+        assert.throws(() => CaretId.check(s), /badValue/, s);
+      }
+    });
+
+    it('should reject non-strings', () => {
+      for (const v of NON_STRINGS) {
+        assert.throws(() => CaretId.check(v), /badValue/, v);
+      }
+    });
+  });
+
+  describe('isInstance()', () => {
+    it('should return `true` for valid ID strings', () => {
+      for (const s of VALID_IDS) {
+        assert.isTrue(CaretId.isInstance(s), s);
+      }
+    });
+
+    it('should return `false` for invalid ID strings', () => {
+      for (const s of INVALID_STRINGS) {
+        assert.isFalse(CaretId.isInstance(s), s);
+      }
+    });
+
+    it('should return `false` for non-strings', () => {
+      for (const v of NON_STRINGS) {
+        assert.isFalse(CaretId.isInstance(v), v);
+      }
+    });
+  });
+
+  describe('randomInstance()', () => {
+    it('should return values for which `isInstance()` is `true`', () => {
+      for (let i = 0; i < 10; i++) {
+        const id = CaretId.randomInstance();
+        assert.isTrue(CaretId.isInstance(id), id);
+      }
+    });
+
+    it('should return a different value every time (practically speaking)', () => {
+      const all   = new Set();
+      const COUNT = 1000;
+
+      for (let i = 0; i < COUNT; i++) {
+        all.add(CaretId.randomInstance());
+      }
+
+      assert.strictEqual(all.size, COUNT);
+    });
+  });
+});

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -9,10 +9,14 @@ import { CaretId } from '@bayou/doc-common';
 
 /** {array<string>} Example valid ID strings. */
 const VALID_IDS = [
-  'cr-1234567890',
-  'cr-abcdefghij',
-  'cr-klmnopqrst',
-  'cr-uvwxyz0123'
+  'cr-12345',
+  'cr-67890',
+  'cr-abcde',
+  'cr-fghij',
+  'cr-klmno',
+  'cr-pqrst',
+  'cr-uvwxy',
+  'cr-z0123'
 ];
 
 /** {array<string>} Example invalid ID strings. */
@@ -25,18 +29,19 @@ const INVALID_STRINGS = [
   'cr-12',
   'cr-123',
   'cr-1234',
-  'cr-12345',
   'cr-123456',
   'cr-1234567',
   'cr-12345678',
   'cr-123456789',
+  'cr-1234567890',
   'cr-1234567890x',
   'cr-1234567890xy',
-  'cr-ABCDEFGHIJ',
-  'cr-abc#defghi',
-  'cr-abcde-fghi',
-  'xy-1234567890',
-  'cr+1234567890'
+  'cr-ABCDE',
+  'cr-FGHIJ',
+  'cr-abc#d',
+  'cr-ab-cd',
+  'xy-12345',
+  'cr+12345'
 ];
 
 /** {array<*>} Example non-strings. */
@@ -100,8 +105,12 @@ describe('@bayou/doc-common/CaretId', () => {
     });
 
     it('should return a different value every time (practically speaking)', () => {
-      const all   = new Set();
+      // This is well under the count at which we can statistically expect a
+      // collision to occur. (At about 6800, the chance of a collision is about
+      // 50%.)
       const COUNT = 1000;
+
+      const all = new Set();
 
       for (let i = 0; i < COUNT; i++) {
         all.add(CaretId.randomInstance());

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -631,7 +631,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     it('should return `this` if there is no matching session', () => {
       const snap = new CaretSnapshot(1, [op1]);
 
-      assert.strictEqual(snap.withoutSession('blort_is_not_a_session'), snap);
+      assert.strictEqual(snap.withoutSession('cr-not00'), snap);
     });
 
     it('should return an appropriately-constructed instance if there is a matching session', () => {

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -36,9 +36,9 @@ function newCaretOp(sessionId, index, length, color, authorId) {
   return CaretOp.op_beginSession(newCaret(sessionId, index, length, color, authorId));
 }
 
-const caret1 = newCaret('session_1', 1, 0,  '#111111', 'aa');
-const caret2 = newCaret('session_2', 2, 6,  '#222222', 'bb');
-const caret3 = newCaret('session_3', 3, 99, '#333333', 'cc');
+const caret1 = newCaret('cr-11111', 1, 0,  '#111111', 'aa');
+const caret2 = newCaret('cr-22222', 2, 6,  '#222222', 'bb');
+const caret3 = newCaret('cr-33333', 3, 99, '#333333', 'cc');
 
 const op1 = CaretOp.op_beginSession(caret1);
 const op2 = CaretOp.op_beginSession(caret2);
@@ -102,8 +102,8 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test([1]);
       test(['florp', op1]);
       test([op1, 'florp', op2]);
-      test([CaretOp.op_endSession('x')]); // Session ends aren't allowed.
-      test([CaretOp.op_setField('x', 'revNum', 1)]); // Individual field sets aren't allowed.
+      test([CaretOp.op_endSession('cr-xxxxx')]); // Session ends aren't allowed.
+      test([CaretOp.op_setField('cr-xxxxx', 'revNum', 1)]); // Individual field sets aren't allowed.
       test([op1, op1]); // Duplicates aren't allowed.
     });
 
@@ -114,13 +114,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       }
 
       // Session ends aren't allowed.
-      test([CaretOp.op_endSession('x')]);
-      test([op1, CaretOp.op_endSession('x')]);
+      test([CaretOp.op_endSession('cr-xxxxx')]);
+      test([op1, CaretOp.op_endSession('cr-xxxxx')]);
       test([op1, CaretOp.op_endSession(caret1.sessionId)]);
 
       // Individual field sets aren't allowed.
-      test([CaretOp.op_setField('x', 'revNum', 1)]);
-      test([op1, CaretOp.op_setField('x', 'revNum', 1)]);
+      test([CaretOp.op_setField('cr-xxxxx', 'revNum', 1)]);
+      test([op1, CaretOp.op_setField('cr-xxxxx', 'revNum', 1)]);
       test([op1, CaretOp.op_setField(caret1.sessionId, 'revNum', 1)]);
 
       // Duplicates aren't allowed.
@@ -191,17 +191,17 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
 
     it('should refuse to update a nonexistent caret', () => {
       const snap   = new CaretSnapshot(1, [op1]);
-      const change = new CaretChange(1, [CaretOp.op_setField('florp', 'index', 1)]);
+      const change = new CaretChange(1, [CaretOp.op_setField('cr-florp', 'index', 1)]);
 
       assert.throws(() => { snap.compose(change); });
     });
 
     it('should update a pre-existing caret given an appropriate op', () => {
-      const c1       = newCaretOp('foo', 1, 2, '#333333', 'dd');
-      const c2       = newCaretOp('foo', 3, 2, '#333333', 'dd');
+      const c1       = newCaretOp('cr-foooo', 1, 2, '#333333', 'dd');
+      const c2       = newCaretOp('cr-foooo', 3, 2, '#333333', 'dd');
       const snap     = new CaretSnapshot(1, [op1, c1]);
       const expected = new CaretSnapshot(1, [op1, c2]);
-      const op       = CaretOp.op_setField('foo', 'index', 3);
+      const op       = CaretOp.op_setField('cr-foooo', 'index', 3);
       const result   = snap.compose(new CaretChange(1, [op]));
 
       assert.isTrue(result.equals(expected));
@@ -260,9 +260,9 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     it('should result in a caret update if that in fact happens', () => {
-      const c1     = newCaretOp('florp', 1, 3, '#444444', 'ff');
-      const c2     = newCaretOp('florp', 2, 4, '#555555', 'gg');
-      const c3     = newCaretOp('florp', 3, 5, '#666666', 'hh');
+      const c1     = newCaretOp('cr-florp', 1, 3, '#444444', 'ff');
+      const c2     = newCaretOp('cr-florp', 2, 4, '#555555', 'gg');
+      const c3     = newCaretOp('cr-florp', 3, 5, '#666666', 'hh');
       const snap1  = new CaretSnapshot(1, [c1]);
       const snap2  = new CaretSnapshot(1, [c2]);
       const result = snap1.diff(snap2);
@@ -347,10 +347,10 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     it('should return `true` when equal carets are not also `===`', () => {
-      const c1a = newCaretOp('florp', 2, 3, '#444444', 'ab');
-      const c1b = newCaretOp('florp', 2, 3, '#444444', 'ab');
-      const c2a = newCaretOp('like',  3, 0, '#dbdbdb', 'cd');
-      const c2b = newCaretOp('like',  3, 0, '#dbdbdb', 'cd');
+      const c1a = newCaretOp('cr-florp', 2, 3, '#444444', 'ab');
+      const c1b = newCaretOp('cr-florp', 2, 3, '#444444', 'ab');
+      const c2a = newCaretOp('cr-like0',  3, 0, '#dbdbdb', 'cd');
+      const c2b = newCaretOp('cr-like0',  3, 0, '#dbdbdb', 'cd');
 
       const snap1 = new CaretSnapshot(1, [c1a, c2a]);
       const snap2 = new CaretSnapshot(1, [c1b, c2b]);

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -26,8 +26,7 @@ export default class DocSession extends CommonBase {
    * @param {fileComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
-   * @param {string} sessionId Session ID for this instance, which is expected
-   *   to be guaranteed unique by whatever service it is that generates it.
+   * @param {string} sessionId Caret session ID for this instance.
    */
   constructor(fileComplex, authorId, sessionId) {
     super();
@@ -289,7 +288,7 @@ export default class DocSession extends CommonBase {
     const session = this._sessionId;
     const author  = this._authorId;
 
-    return `file ${file}; session ${session}; author ${author}`;
+    return `file ${file}; caret session ${session}; author ${author}`;
   }
 
   /**
@@ -311,7 +310,7 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * Returns the session ID of this instance.
+   * Returns the caret session ID of this instance.
    *
    * @returns {string} The session ID.
    */

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -128,24 +128,18 @@ export default class FileComplex extends BaseComplexMember {
   }
 
   /**
-   * Makes a new author-associated session for this instance.
+   * Makes a new author-associated session for this instance. The resulting
+   * session's ID is guaranteed to be unique for the document represented by
+   * this instance.
    *
    * @param {string} authorId ID for the author.
-   * @param {string|null} [sessionId = null] ID for the session, or `null` to
-   *   let the system pick a random available ID. **TODO:** This argument should
-   *   be removed; all callers should let the snapshot pick an unused ID.
    * @returns {DocSession} A newly-constructed session.
    */
-  async makeNewSession(authorId, sessionId = null) {
+  async makeNewSession(authorId) {
     const timeoutTime = Date.now() + MAKE_SESSION_TIMEOUT_MSEC;
-    const pickId      = (sessionId === null);
 
     // This validates the ID with the back end.
     await Storage.dataStore.checkExistingAuthorId(authorId);
-
-    if (!pickId) {
-      TString.nonEmpty(sessionId);
-    }
 
     for (;;) {
       if (Date.now() >= timeoutTime) {
@@ -153,18 +147,7 @@ export default class FileComplex extends BaseComplexMember {
       }
 
       const caretSnapshot = await this.caretControl.getSnapshot();
-
-      if (pickId) {
-        sessionId = caretSnapshot.randomUnusedId();
-      } else {
-        // The caller specified an ID, so ensure that it doesn't correspond to a
-        // pre-existing session.
-        const already = caretSnapshot.getOrNull(sessionId);
-
-        if (already !== null) {
-          throw Errors.badUse(`Attempt to create session with already-used ID: \`${sessionId}\``);
-        }
-      }
+      const sessionId     = caretSnapshot.randomUnusedId();
 
       // Establish the new session, as a change from the instantaneously-latest
       // carets.
@@ -175,14 +158,12 @@ export default class FileComplex extends BaseComplexMember {
 
       if (appendResult) {
         // There was no append race, or we won it.
-        break;
+        return this._activateSession(authorId, sessionId);
       }
 
       // We lost an append race, but the session introduction might still be
       // valid, so loop and try again (until timeout).
     }
-
-    return this._activateSession(authorId, sessionId);
   }
 
   /**

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -207,8 +207,11 @@ export default class CaretOverlay {
 
       // For each session…
       for (const [sessionId, caret] of this._lastCaretSnapshot.entries()) {
-        // Is this caret us? If so, don't draw anything.
-        if (sessionId === this._editorComplex.sessionId) {
+        // Is this caret us? If so, don't draw anything. **TODO:** The caret
+        // snapshot ideally wouldn't actually represent the caret controlled by
+        // this editor. The code that pushes the snapshot into the store should
+        // be updated accordingly.
+        if (this._editorComplex.docSession.caretTracker.isControlledHere(sessionId)) {
           continue;
         }
 

--- a/local-modules/@bayou/util-common/Random.js
+++ b/local-modules/@bayou/util-common/Random.js
@@ -6,12 +6,12 @@
 // module, which is why this is possible to import regardless of environment.
 import crypto from 'crypto';
 
-import { TInt } from '@bayou/typecheck';
+import { TInt, TString } from '@bayou/typecheck';
 import { UtilityClass } from '@bayou/util-core';
 
 /**
  * Character set used for ID strings. This is intended to be the set of 32 most
- * visually and audibly unambiguous alphanumerics.
+ * visually and audibly unambiguous lowercase alphanumerics.
  */
 const ID_CHARS = 'abcdefghjkmnpqrstuwxyz0123456789';
 
@@ -52,20 +52,37 @@ export default class Random extends UtilityClass {
   }
 
   /**
+   * Constructs an ID-ish string with the indicated tag prefix along with a dash
+   * (`-`), and the given number of characters after the prefix.
+   *
+   * @param {string} prefix The prefix.
+   * @param {Int} length The number of characters in the non-prefix portion of
+   *   the ID.
+   * @returns {string} The constructed random ID string.
+   */
+  static idString(prefix, length) {
+    TString.nonEmpty(prefix);
+    TInt.min(length, 1);
+
+    const result = [`${prefix}-`];
+
+    for (let i = 0; i < length; i++) {
+      result.push(ID_CHARS[Random.byte() % ID_CHARS.length]);
+    }
+
+    return result.join('');
+  }
+
+  /**
    * Constructs a short label string with the indicated tag prefix. These are
-   * _typically_ but not _guaranteed_ to be unique and are intended to aid in
-   * disambiguating logs (and not for anything deeper).
+   * _typically_ but not _guaranteed_ or _necessarily expected_ to be unique.
+   * Instead, these are are intended to aid in disambiguating logs (and not for
+   * anything deeper).
    *
    * @param {string} prefix The prefix.
    * @returns {string} The constructed random ID string.
    */
   static shortLabel(prefix) {
-    let result = `${prefix}-`;
-
-    for (let i = 0; i < 8; i++) {
-      result += ID_CHARS[Random.byte() % ID_CHARS.length];
-    }
-
-    return result;
+    return Random.idString(prefix, 8);
   }
 }

--- a/local-modules/@bayou/util-common/tests/test_Random.js
+++ b/local-modules/@bayou/util-common/tests/test_Random.js
@@ -35,6 +35,57 @@ describe('@bayou/util-common/Random', () => {
     });
   });
 
+  describe('idString()', () => {
+    it('should reject a non-string prefix', () => {
+      assert.throws(() => Random.idString(true, 10));
+    });
+
+    it('should reject an empty prefix', () => {
+      assert.throws(() => Random.idString('', 10));
+    });
+
+    it('should reject a non-number length', () => {
+      assert.throws(() => Random.idString('x', 'foo'));
+    });
+
+    it('should reject a non-integer length', () => {
+      assert.throws(() => Random.idString('x', 12.34));
+    });
+
+    it('should reject a non-positive length', () => {
+      assert.throws(() => Random.idString('x', 0));
+      assert.throws(() => Random.idString('x', -1));
+    });
+
+    it('should return a string that starts with the indicated prefix', () => {
+      function test(p) {
+        const result = Random.idString(p, 4);
+        assert.isTrue(result.startsWith(`${p}-`));
+      }
+
+      test('a');
+      test('foo');
+      test('123456');
+    });
+
+    it('should return a string with the expected number and kind of characters after the prefix', () => {
+      function test(l) {
+        const result = Random.idString('x', l);
+        assert.lengthOf(result, l + 2);
+
+        const suffix = result.match(/-(.*)$/)[1];
+        assert.lengthOf(suffix, l);
+
+        assert.isTrue(/^[0-9a-z]+$/.test(suffix));
+      }
+
+      test(1);
+      test(2);
+      test(3);
+      test(50);
+    });
+  });
+
   describe('shortLabel()', () => {
     it('should return a probably-random string of the form "[prefix]-[8 * base32ish random character]"', () => {
       const label1A = Random.shortLabel('A');

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.0
+version = 1.1.1


### PR DESCRIPTION
This PR makes a bunch of progress disentangling the concept of "session as network connection" from "session as user manipulating a caret." The most noticeable change is that these two things now use different IDs, and for the caret IDs, these are now more strictly checked.

One major thing left to do — in a follow-on PR — is to rename things which are currently called `session` or `sessionId` to `caret` or `caretId`, if in fact they are meant to refer to carets. I didn't want to do that in this PR because I thought it would distract from the main semantic content.

This PR bumps the product version, because of the earlier change to `Caret` (last PR). I should've bumped it then.