### PR TITLE
Rename (some cases of) "session" -> "caret," Part 1 of N.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -123,9 +123,9 @@ export default class AuthorAccess extends CommonBase {
 
     log.info(
       'Created new session.\n',
-      `  target:  ${targetId}\n`,
-      `  doc:     ${docId}\n`,
-      `  session: ${session.getSessionId()}`);
+      `  target: ${targetId}\n`,
+      `  doc:    ${docId}\n`,
+      `  caret:  ${session.getCaretId()}`);
 
     return targetId;
   }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -64,7 +64,7 @@ export default class RootAccess extends CommonBase {
       'Newly-authorized access.\n',
       `  author:  ${authorId}\n`,
       `  doc:     ${docId}\n`,
-      `  session: ${session.getSessionId()}\n`,
+      `  caret:   ${session.getCaretId()}\n`,
       `  key id:  ${key.printableId}\n`, // This is safe to log (not security-sensitive).
       `  key url: ${key.url}`);
 

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -66,7 +66,7 @@ export default class CaretTracker extends CommonBase {
     // Arrange for `_sessionProxy` to get set.
     (async () => {
       this._sessionProxy = await docSession.getSessionProxy();
-      this._caretId      = await this._sessionProxy.getSessionId();
+      this._caretId      = await this._sessionProxy.getCaretId();
       this._updating     = false;
 
       this._log.info(`Caret tracker ready; caret ID \`${this._caretId}\`.`);

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -2,9 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CaretId } from '@bayou/doc-common';
 import { RevisionNumber } from '@bayou/ot-common';
 import { Delay } from '@bayou/promise-util';
-import { TInt, TObject, TString } from '@bayou/typecheck';
+import { TInt, TObject } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import DocSession from './DocSession';
@@ -68,7 +69,7 @@ export default class CaretTracker extends CommonBase {
       this._sessionId    = await this._sessionProxy.getSessionId();
       this._updating     = false;
 
-      this._log.info(`Caret tracker ready; session ID \`${this._sessionId}\`.`);
+      this._log.info(`Caret tracker ready; caret ID \`${this._sessionId}\`.`);
 
       // Give the update loop a chance to send caret updates that happened
       // during initialization (if any).
@@ -77,21 +78,21 @@ export default class CaretTracker extends CommonBase {
   }
 
   /**
-   * Indicates whether the given caret session ID is the one controlled by this
-   * instance.
+   * Indicates whether the given caret ID identifies the caret controlled by
+   * this instance.
    *
    * **Note:** It is possible for this to return a false negative when the
    * session is in the process of being established (because we don't yet know
    * the ID we control).
    *
-   * @param {string} sessionId The caret session ID in question.
-   * @returns {boolean} `true` if `sessionId` is the ID that this instance
+   * @param {string} caretId The caret ID in question.
+   * @returns {boolean} `true` if `caretId` is the ID that this instance
    *   controls, or `false` if not.
    */
-  isControlledHere(sessionId) {
-    TString.check(sessionId);
+  isControlledHere(caretId) {
+    CaretId.check(caretId);
 
-    return (sessionId === this._sessionId);
+    return (caretId === this._sessionId);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -42,10 +42,10 @@ export default class CaretTracker extends CommonBase {
     this._sessionProxy = null;
 
     /**
-     * {string|null} The caret session ID that this instance controls, if known.
+     * {string|null} The ID of the caret that this instance controls, if known.
      * Becomes non-`null` during resolution of {@link #_sessionProxy}.
      */
-    this._sessionId = null;
+    this._caretId = null;
 
     /**
      * {boolean} Whether there is a caret update in progress. Starts out `true`
@@ -66,10 +66,10 @@ export default class CaretTracker extends CommonBase {
     // Arrange for `_sessionProxy` to get set.
     (async () => {
       this._sessionProxy = await docSession.getSessionProxy();
-      this._sessionId    = await this._sessionProxy.getSessionId();
+      this._caretId      = await this._sessionProxy.getSessionId();
       this._updating     = false;
 
-      this._log.info(`Caret tracker ready; caret ID \`${this._sessionId}\`.`);
+      this._log.info(`Caret tracker ready; caret ID \`${this._caretId}\`.`);
 
       // Give the update loop a chance to send caret updates that happened
       // during initialization (if any).
@@ -92,7 +92,7 @@ export default class CaretTracker extends CommonBase {
   isControlledHere(caretId) {
     CaretId.check(caretId);
 
-    return (caretId === this._sessionId);
+    return (caretId === this._caretId);
   }
 
   /**

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -165,6 +165,14 @@ export default class Caret extends CommonBase {
   }
 
   /**
+   * {string} ID of the caret. This uniquely identifies this caret within the
+   * context of a specific document.
+   */
+  get id() {
+    return this._id;
+  }
+
+  /**
    * {Int} The zero-based leading position of this caret / selection.
    */
   get index() {
@@ -192,14 +200,6 @@ export default class Caret extends CommonBase {
    */
   get revNum() {
     return this._fields.get('revNum');
-  }
-
-  /**
-   * {string} ID of the caret. This uniquely identifies this caret within the
-   * context of a specific document.
-   */
-  get id() {
-    return this._id;
   }
 
   /**

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -118,7 +118,7 @@ export default class Caret extends CommonBase {
 
     if (idOrBase instanceof Caret) {
       newFields = new Map(idOrBase._fields);
-      id = idOrBase.sessionId;
+      id = idOrBase.id;
     } else if (DEFAULT !== null) {
       newFields = new Map(DEFAULT._fields);
       id = CaretId.check(idOrBase);
@@ -150,7 +150,7 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {string|null} ID of the author responsible for this caret.
+   * {string} ID of the author responsible for this caret.
    */
   get authorId() {
     return this._fields.get('authorId');
@@ -195,17 +195,17 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {string} Opaque reference to be used with other APIs to get information
-   * about the author whose caret this is.
+   * {string} ID of the caret. This uniquely identifies this caret within the
+   * context of a specific document.
    */
-  get sessionId() {
+  get id() {
     return this._id;
   }
 
   /**
    * Composes the given `delta` on top of this instance, producing a new
    * instance. The operations in `delta` must all be `setField` ops for the same
-   * `sessionId` as this instance.
+   * `id` as this instance.
    *
    * @param {CaretDelta} delta Delta to apply.
    * @returns {Caret} Caret consisting of this instance's data as the base, with
@@ -220,8 +220,8 @@ export default class Caret extends CommonBase {
       const props = op.props;
       if (props.opName !== CaretOp.CODE_setField) {
         throw Errors.badUse(`Invalid operation name: ${props.opName}`);
-      } else if (props.sessionId !== this.sessionId) {
-        throw Errors.badUse('Mismatched session ID.');
+      } else if (props.sessionId !== this.id) {
+        throw Errors.badUse('Mismatched ID.');
       }
 
       fields[props.key] = props.value;
@@ -257,42 +257,42 @@ export default class Caret extends CommonBase {
    * method is called on.
    *
    * @param {Caret} newerCaret Caret to take the difference from. It must have
-   *   the same `sessionId` as this instance.
+   *   the same `id` as this instance.
    * @returns {CaretDelta} Delta which represents the difference between
    *   `newerCaret` and this instance.
    */
   diff(newerCaret) {
     Caret.check(newerCaret);
 
-    const sessionId = this.sessionId;
+    const id = this.id;
 
-    if (sessionId !== newerCaret.sessionId) {
-      throw Errors.badUse('Cannot `diff` carets with mismatched `sessionId`.');
+    if (id !== newerCaret.id) {
+      throw Errors.badUse('Cannot `diff` carets with mismatched `id`.');
     }
 
-    return this.diffFields(newerCaret, sessionId);
+    return this.diffFields(newerCaret, id);
   }
 
   /**
-   * Like `diff()`, except does _not_ check to see if the two instances'
-   * `sessionId`s match. That is, it only looks at the fields.
+   * Like `diff()`, except does _not_ check to see if the two instances' `id`s
+   * match. That is, it only looks at the fields.
    *
    * @param {Caret} newerCaret Caret to take the difference from.
-   * @param {string} sessionId Session ID to use for the ops in the result.
+   * @param {string} id ID to use for the ops in the result.
    * @returns {CaretDelta} Delta which represents the difference between
    *   `newerCaret` and this instance, _not_ including any difference in
-   *   `sessionId`, if any.
+   *   `id`, if any.
    */
-  diffFields(newerCaret, sessionId) {
+  diffFields(newerCaret, id) {
     Caret.check(newerCaret);
-    CaretId.check(sessionId);
+    CaretId.check(id);
 
     const fields = this._fields;
     const ops    = [];
 
     for (const [k, v] of newerCaret._fields) {
       if (!Caret._equalFields(v, fields.get(k))) {
-        ops.push(CaretOp.op_setField(sessionId, k, v));
+        ops.push(CaretOp.op_setField(id, k, v));
       }
     }
 

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -98,35 +98,35 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * Constructs an instance. Only the first argument (`sessionIdOrBase`) is
-   * required, and it is not necessary to specify all the fields in `fields`.
-   * Fields not listed are derived from the base caret (first argument) if
-   * specified as such, or from the default value {@link #DEFAULT} if the first
-   * argument is a session ID.
+   * Constructs an instance. Only the first argument (`idOrBase`) is required,
+   * and it is not necessary to specify all the fields in `fields`. Fields not
+   * listed are derived from the base caret (first argument) if specified as
+   * such, or from the default value {@link #DEFAULT} if the first argument is
+   * an ID.
    *
    * **Note:** {@link #DEFAULT} does not bind an `authorId`, which means that
    * that field must be specified when creating an instance "from scratch."
    *
-   * @param {string|Caret} sessionIdOrBase Session ID that identifies the caret,
-   *   or a base caret instance which provides the session and default values
-   *   for fields.
+   * @param {string|Caret} idOrBase Session ID that identifies the caret, or a
+   *   base caret instance which provides the session and default values for
+   *   fields.
    * @param {object} [fields = {}] Fields of the caret, as plain object mapping
    *   field names to values.
    */
-  constructor(sessionIdOrBase, fields = {}) {
+  constructor(idOrBase, fields = {}) {
     let sessionId;
     let newFields;
 
-    if (sessionIdOrBase instanceof Caret) {
-      newFields = new Map(sessionIdOrBase._fields);
-      sessionId = sessionIdOrBase.sessionId;
+    if (idOrBase instanceof Caret) {
+      newFields = new Map(idOrBase._fields);
+      sessionId = idOrBase.sessionId;
     } else if (DEFAULT !== null) {
       newFields = new Map(DEFAULT._fields);
-      sessionId = CaretId.check(sessionIdOrBase);
+      sessionId = CaretId.check(idOrBase);
     } else {
       // If we're here, it means that `DEFAULT` is currently being initialized.
       newFields = new Map();
-      sessionId = TString.check(sessionIdOrBase);
+      sessionId = TString.check(idOrBase);
     }
 
     TObject.plain(fields);

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -14,7 +14,7 @@ import CaretOp from './CaretOp';
  * {Map<string, function>} Map from each allowed caret field name to a type
  * checker predicate for same.
  *
- * **Note:** `sessionId` is not included, because that's separate from the
+ * **Note:** The caret's ID is not included, because that's separate from the
  * caret's "fields" per se.
  *
  * **Note:** We use the `bind(...)` form for method binding instead of an
@@ -48,8 +48,8 @@ let DEFAULT = null;
  *
  * **Note:** The use of the term "caret" in this and other classes, method
  * names, and the like, is meant to be a synecdochal metaphor for all
- * information about a session, including the human driving it. The caret per
- * se is merely the most blatant aspect of it.
+ * information about a session from the user's perspective, including the human
+ * driving it. The caret per se is merely the most blatant aspect of it.
  */
 export default class Caret extends CommonBase {
   /** {Caret} An instance with all default values. */
@@ -108,33 +108,32 @@ export default class Caret extends CommonBase {
    * that field must be specified when creating an instance "from scratch."
    *
    * @param {string|Caret} idOrBase Session ID that identifies the caret, or a
-   *   base caret instance which provides the session and default values for
-   *   fields.
+   *   base caret instance which provides the ID and default values for fields.
    * @param {object} [fields = {}] Fields of the caret, as plain object mapping
    *   field names to values.
    */
   constructor(idOrBase, fields = {}) {
-    let sessionId;
+    let id;
     let newFields;
 
     if (idOrBase instanceof Caret) {
       newFields = new Map(idOrBase._fields);
-      sessionId = idOrBase.sessionId;
+      id = idOrBase.sessionId;
     } else if (DEFAULT !== null) {
       newFields = new Map(DEFAULT._fields);
-      sessionId = CaretId.check(idOrBase);
+      id = CaretId.check(idOrBase);
     } else {
       // If we're here, it means that `DEFAULT` is currently being initialized.
       newFields = new Map();
-      sessionId = TString.check(idOrBase);
+      id = TString.check(idOrBase);
     }
 
     TObject.plain(fields);
 
     super();
 
-    /** {string} The session ID. */
-    this._sessionId = sessionId;
+    /** {string} The caret ID. */
+    this._id = id;
 
     /** {Map<string,*>} Map of all of the caret fields, from name to value. */
     this._fields = newFields;
@@ -173,7 +172,7 @@ export default class Caret extends CommonBase {
   }
 
   /**
-   * {Timestamp} The moment in time when this session was last active.
+   * {Timestamp} The moment in time when this caret was last active.
    */
   get lastActive() {
     return this._fields.get('lastActive');
@@ -200,7 +199,7 @@ export default class Caret extends CommonBase {
    * about the author whose caret this is.
    */
   get sessionId() {
-    return this._sessionId;
+    return this._id;
   }
 
   /**
@@ -243,7 +242,7 @@ export default class Caret extends CommonBase {
       fields[k] = v;
     }
 
-    return [this._sessionId, fields];
+    return [this._id, fields];
   }
 
   /**
@@ -314,7 +313,7 @@ export default class Caret extends CommonBase {
       return false;
     }
 
-    if (this._sessionId !== other._sessionId) {
+    if (this._id !== other._id) {
       return false;
     }
 

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -220,7 +220,7 @@ export default class Caret extends CommonBase {
       const props = op.props;
       if (props.opName !== CaretOp.CODE_setField) {
         throw Errors.badUse(`Invalid operation name: ${props.opName}`);
-      } else if (props.sessionId !== this.id) {
+      } else if (props.caretId !== this.id) {
         throw Errors.badUse('Mismatched ID.');
       }
 

--- a/local-modules/@bayou/doc-common/CaretDelta.js
+++ b/local-modules/@bayou/doc-common/CaretDelta.js
@@ -125,13 +125,13 @@ export default class CaretDelta extends BaseDelta {
 
       switch (opProps.opName) {
         case CaretOp.CODE_beginSession: {
-          const sessionId = opProps.caret.id;
+          const caretId = opProps.caret.id;
 
-          if (ids.has(sessionId)) {
+          if (ids.has(caretId)) {
             return false;
           }
 
-          ids.add(sessionId);
+          ids.add(caretId);
           break;
         }
 

--- a/local-modules/@bayou/doc-common/CaretDelta.js
+++ b/local-modules/@bayou/doc-common/CaretDelta.js
@@ -40,7 +40,7 @@ export default class CaretDelta extends BaseDelta {
         case CaretOp.CODE_beginSession: {
           // Clear out the session except for this op, because no earlier op
           // could possibly affect the result.
-          sessions.set(opProps.caret.sessionId, [op]);
+          sessions.set(opProps.caret.id, [op]);
           break;
         }
 
@@ -125,7 +125,7 @@ export default class CaretDelta extends BaseDelta {
 
       switch (opProps.opName) {
         case CaretOp.CODE_beginSession: {
-          const sessionId = opProps.caret.sessionId;
+          const sessionId = opProps.caret.id;
 
           if (ids.has(sessionId)) {
             return false;

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -43,29 +43,29 @@ export default class CaretOp extends BaseOp {
   /**
    * Constructs a new "end session" operation.
    *
-   * @param {string} sessionId ID of the session.
+   * @param {string} caretId ID of the caret which is to be removed.
    * @returns {CaretOp} The corresponding operation.
    */
-  static op_endSession(sessionId) {
-    CaretId.check(sessionId);
+  static op_endSession(caretId) {
+    CaretId.check(caretId);
 
-    return new CaretOp(CaretOp.CODE_endSession, sessionId);
+    return new CaretOp(CaretOp.CODE_endSession, caretId);
   }
 
   /**
    * Constructs a new "set caret field" operation.
    *
-   * @param {string} sessionId Session for the caret to update.
+   * @param {string} caretId ID of the caret to update.
    * @param {string} key Name of the field to update.
    * @param {*} value New value for the so-named field. Type restriction on this
    *   varies by name.
    * @returns {CaretOp} The corresponding operation.
    */
-  static op_setField(sessionId, key, value) {
-    CaretId.check(sessionId);
+  static op_setField(caretId, key, value) {
+    CaretId.check(caretId);
     Caret.checkField(key, value);
 
-    return new CaretOp(CaretOp.CODE_setField, sessionId, key, value);
+    return new CaretOp(CaretOp.CODE_setField, caretId, key, value);
   }
 
   /**
@@ -85,13 +85,13 @@ export default class CaretOp extends BaseOp {
       }
 
       case CaretOp.CODE_endSession: {
-        const [sessionId] = payload.args;
-        return Object.freeze({ opName, sessionId });
+        const [caretId] = payload.args;
+        return Object.freeze({ opName, caretId });
       }
 
       case CaretOp.CODE_setField: {
-        const [sessionId, key, value] = payload.args;
-        return Object.freeze({ opName, sessionId, key, value });
+        const [caretId, key, value] = payload.args;
+        return Object.freeze({ opName, caretId, key, value });
       }
 
       default: {

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -14,7 +14,7 @@ import CaretOp from './CaretOp';
 
 
 /**
- * Snapshot of information about all active sessions on a particular document.
+ * Snapshot of information about all active carets on a particular document.
  * Instances of this class are always frozen (immutable).
  *
  * When thought of in terms of a map, instances of this class can be taken to

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -44,7 +44,7 @@ export default class CaretSnapshot extends BaseSnapshot {
 
       switch (opProps.opName) {
         case CaretOp.CODE_beginSession: {
-          this._carets.set(opProps.caret.sessionId, op);
+          this._carets.set(opProps.caret.id, op);
           break;
         }
 
@@ -82,7 +82,7 @@ export default class CaretSnapshot extends BaseSnapshot {
   * entries() {
     for (const op of this.contents.ops) {
       const caret = op.props.caret;
-      yield [caret.sessionId, caret];
+      yield [caret.id, caret];
     }
   }
 
@@ -193,10 +193,10 @@ export default class CaretSnapshot extends BaseSnapshot {
   withCaret(caret) {
     Caret.check(caret);
 
-    const sessionId = caret.sessionId;
-    const op        = CaretOp.op_beginSession(caret);
+    const id = caret.id;
+    const op = CaretOp.op_beginSession(caret);
 
-    return op.equals(this._carets.get(sessionId))
+    return op.equals(this._carets.get(id))
       ? this
       : this.compose(new CaretChange(this.revNum, [op]));
   }
@@ -213,7 +213,7 @@ export default class CaretSnapshot extends BaseSnapshot {
    */
   withoutCaret(caret) {
     Caret.check(caret);
-    return this.withoutSession(caret.sessionId);
+    return this.withoutSession(caret.id);
   }
 
   /**

--- a/local-modules/@bayou/doc-common/PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/PropertySnapshot.js
@@ -11,7 +11,7 @@ import PropertyDelta from './PropertyDelta';
 import PropertyOp from './PropertyOp';
 
 /**
- * Snapshot of information about all active sessions on a particular document.
+ * Snapshot of information about all the properties of a particular document.
  * Instances of this class are always frozen (immutable).
  *
  * When thought of in terms of a map, instances of this class can be taken to

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -10,15 +10,15 @@ import { Caret, CaretDelta, CaretOp } from '@bayou/doc-common';
 /**
  * Convenient caret constructor, which takes positional parameters.
  *
- * @param {string} sessionId Session ID.
+ * @param {string} id Caret ID.
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
  * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaret(sessionId, index, length, color, authorId) {
-  return new Caret(sessionId, { index, length, color, authorId });
+function newCaret(id, index, length, color, authorId) {
+  return new Caret(id, { index, length, color, authorId });
 }
 
 const caret1 = newCaret('cr-11111', 1, 0,  '#111111', 'author-1');

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -41,42 +41,42 @@ describe('@bayou/doc-common/Caret', () => {
     });
 
     it('should update `authorId` given the appropriate op', () => {
-      const op     = CaretOp.op_setField(caret1.sessionId, 'authorId', 'boop');
+      const op     = CaretOp.op_setField(caret1.id, 'authorId', 'boop');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.authorId, 'boop');
     });
 
     it('should update `index` given the appropriate op', () => {
-      const op     = CaretOp.op_setField(caret1.sessionId, 'index', 99999);
+      const op     = CaretOp.op_setField(caret1.id, 'index', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.index, 99999);
     });
 
     it('should update `length` given the appropriate op', () => {
-      const op     = CaretOp.op_setField(caret1.sessionId, 'length', 99999);
+      const op     = CaretOp.op_setField(caret1.id, 'length', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.length, 99999);
     });
 
     it('should update `color` given the appropriate op', () => {
-      const op     = CaretOp.op_setField(caret1.sessionId, 'color', '#aabbcc');
+      const op     = CaretOp.op_setField(caret1.id, 'color', '#aabbcc');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.color, '#aabbcc');
     });
 
     it('should update `revNum` given the appropriate op', () => {
-      const op     = CaretOp.op_setField(caret1.sessionId, 'revNum', 12345);
+      const op     = CaretOp.op_setField(caret1.id, 'revNum', 12345);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.revNum, 12345);
     });
 
     it('should refuse to compose if given a non-matching session ID', () => {
-      const op = CaretOp.op_setField(caret2.sessionId, 'index', 55);
+      const op = CaretOp.op_setField(caret2.id, 'index', 55);
 
       assert.throws(() => { caret1.compose(new CaretDelta([op])); });
     });
@@ -96,7 +96,7 @@ describe('@bayou/doc-common/Caret', () => {
 
     it('should result in an `index` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_setField(older.sessionId, 'index', 99999);
+      const op      = CaretOp.op_setField(older.id, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
       const diffOps = older.diff(newer).ops;
 
@@ -119,9 +119,9 @@ describe('@bayou/doc-common/Caret', () => {
 
     it('should result in an `index` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_setField(older.sessionId, 'index', 99999);
+      const op      = CaretOp.op_setField(older.id, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
-      const diffOps = older.diffFields(newer, older.sessionId).ops;
+      const diffOps = older.diffFields(newer, older.id).ops;
 
       assert.strictEqual(diffOps.length, 1);
       assert.deepEqual(diffOps[0], op);
@@ -129,9 +129,9 @@ describe('@bayou/doc-common/Caret', () => {
 
     it('should result in a `length` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_setField(older.sessionId, 'length', 99999);
+      const op      = CaretOp.op_setField(older.id, 'length', 99999);
       const newer   = older.compose(new CaretDelta([op]));
-      const diffOps = older.diffFields(newer, older.sessionId).ops;
+      const diffOps = older.diffFields(newer, older.id).ops;
 
       assert.strictEqual(diffOps.length, 1);
       assert.deepEqual(diffOps[0], op);
@@ -139,9 +139,9 @@ describe('@bayou/doc-common/Caret', () => {
 
     it('should result in a `color` diff if that in fact changes', () => {
       const older   = caret1;
-      const op      = CaretOp.op_setField(older.sessionId, 'color', '#abcdef');
+      const op      = CaretOp.op_setField(older.id, 'color', '#abcdef');
       const newer   = older.compose(new CaretDelta([op]));
-      const diffOps = older.diffFields(newer, older.sessionId).ops;
+      const diffOps = older.diffFields(newer, older.id).ops;
 
       assert.strictEqual(diffOps.length, 1);
       assert.deepEqual(diffOps[0], op);
@@ -171,19 +171,19 @@ describe('@bayou/doc-common/Caret', () => {
       const c1 = caret1;
       let   c2, op;
 
-      op = CaretOp.op_setField(c1.sessionId, 'index', 99999);
+      op = CaretOp.op_setField(c1.id, 'index', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_setField(c1.sessionId, 'length', 99999);
+      op = CaretOp.op_setField(c1.id, 'length', 99999);
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_setField(c1.sessionId, 'color', '#999999');
+      op = CaretOp.op_setField(c1.id, 'color', '#999999');
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
 
-      op = CaretOp.op_setField(c1.sessionId, 'authorId', 'zagnut');
+      op = CaretOp.op_setField(c1.id, 'authorId', 'zagnut');
       c2 = c1.compose(new CaretDelta([op]));
       assert.isFalse(c1.equals(c2));
     });

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -106,8 +106,9 @@ describe('@bayou/doc-common/CaretId', () => {
 
     it('should return a different value every time (practically speaking)', () => {
       // This is well under the count at which we can statistically expect a
-      // collision to occur. (At about 6800, the chance of a collision is about
-      // 50%.)
+      // collision to always occur -- at about 6800, the chance of a collision
+      // is about 50% -- but collisions might still crop up in this test (they
+      // have in practice), we accept up to two.
       const COUNT = 1000;
 
       const all = new Set();
@@ -116,7 +117,7 @@ describe('@bayou/doc-common/CaretId', () => {
         all.add(CaretId.randomInstance());
       }
 
-      assert.strictEqual(all.size, COUNT);
+      assert.atLeast(all.size, COUNT - 2);
     });
   });
 });

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -107,8 +107,8 @@ describe('@bayou/doc-common/CaretId', () => {
     it('should return a different value every time (practically speaking)', () => {
       // This is well under the count at which we can statistically expect a
       // collision to always occur -- at about 6800, the chance of a collision
-      // is about 50% -- but collisions might still crop up in this test (they
-      // have in practice), we accept up to two.
+      // is about 50% -- but collisions might still legitimately crop up in this
+      // test (they have in practice), we accept up to two.
       const COUNT = 1000;
 
       const all = new Set();

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -117,7 +117,7 @@ describe('@bayou/doc-common/CaretId', () => {
         all.add(CaretId.randomInstance());
       }
 
-      assert.atLeast(all.size, COUNT - 2);
+      assert.isAtLeast(all.size, COUNT - 2);
     });
   });
 });

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -10,30 +10,30 @@ import { Caret, CaretChange, CaretDelta, CaretId, CaretOp, CaretSnapshot } from 
 /**
  * Convenient caret constructor, which takes positional parameters.
  *
- * @param {string} sessionId Session ID.
+ * @param {string} id Caret ID.
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
  * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaret(sessionId, index, length, color, authorId) {
-  return new Caret(sessionId, { index, length, color, authorId });
+function newCaret(id, index, length, color, authorId) {
+  return new Caret(id, { index, length, color, authorId });
 }
 
 /**
  * Convenient `op_beginSession` constructor, which takes positional parameters
  * for the caret fields.
  *
- * @param {string} sessionId Session ID.
+ * @param {string} id Caret ID.
  * @param {Int} index Start caret position.
  * @param {Int} length Selection length.
  * @param {string} color Highlight color.
  * @param {string} authorId Author ID.
  * @returns {Caret} Appropriately-constructed caret.
  */
-function newCaretOp(sessionId, index, length, color, authorId) {
-  return CaretOp.op_beginSession(newCaret(sessionId, index, length, color, authorId));
+function newCaretOp(id, index, length, color, authorId) {
+  return CaretOp.op_beginSession(newCaret(id, index, length, color, authorId));
 }
 
 const caret1 = newCaret('cr-11111', 1, 0,  '#111111', 'aa');
@@ -295,9 +295,9 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
         }
 
         const snap = new CaretSnapshot(1, ops);
-        for (const [sessionId, caret] of snap.entries()) {
-          assert.strictEqual(caret, expectMap.get(sessionId));
-          expectMap.delete(sessionId);
+        for (const [caretId, caret] of snap.entries()) {
+          assert.strictEqual(caret, expectMap.get(caretId));
+          expectMap.delete(caretId);
         }
 
         assert.strictEqual(expectMap.size, 0, 'All carets accounted for.');

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -116,12 +116,12 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       // Session ends aren't allowed.
       test([CaretOp.op_endSession('cr-xxxxx')]);
       test([op1, CaretOp.op_endSession('cr-xxxxx')]);
-      test([op1, CaretOp.op_endSession(caret1.sessionId)]);
+      test([op1, CaretOp.op_endSession(caret1.id)]);
 
       // Individual field sets aren't allowed.
       test([CaretOp.op_setField('cr-xxxxx', 'revNum', 1)]);
       test([op1, CaretOp.op_setField('cr-xxxxx', 'revNum', 1)]);
-      test([op1, CaretOp.op_setField(caret1.sessionId, 'revNum', 1)]);
+      test([op1, CaretOp.op_setField(caret1.id, 'revNum', 1)]);
 
       // Duplicates aren't allowed.
       test([op1, op1]);
@@ -210,7 +210,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     it('should remove a caret given the appropriate op', () => {
       const snap     = new CaretSnapshot(1, [op1, op2]);
       const expected = new CaretSnapshot(1, [op2]);
-      const result   = snap.compose(new CaretChange(1, [CaretOp.op_endSession(caret1.sessionId)]));
+      const result   = snap.compose(new CaretChange(1, [CaretOp.op_endSession(caret1.id)]));
 
       assert.isTrue(result.equals(expected));
     });
@@ -291,7 +291,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
         const expectMap = new Map();
         for (const op of ops) {
           const caret = op.props.caret;
-          expectMap.set(caret.sessionId, caret);
+          expectMap.set(caret.id, caret);
         }
 
         const snap = new CaretSnapshot(1, ops);
@@ -429,15 +429,15 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     it('should return the caret associated with an existing session', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
-      assert.strictEqual(snap.get(caret1.sessionId), caret1);
-      assert.strictEqual(snap.get(caret2.sessionId), caret2);
-      assert.strictEqual(snap.get(caret3.sessionId), caret3);
+      assert.strictEqual(snap.get(caret1.id), caret1);
+      assert.strictEqual(snap.get(caret2.id), caret2);
+      assert.strictEqual(snap.get(caret3.id), caret3);
     });
 
     it('should throw an error when given a session ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
-      assert.throws(() => { snap.get(caret2.sessionId); });
+      assert.throws(() => { snap.get(caret2.id); });
     });
 
     it('should throw an error if given an invalid session ID', () => {
@@ -453,15 +453,15 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     it('should return the caret associated with an existing session', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
-      assert.strictEqual(snap.getOrNull(caret1.sessionId), caret1);
-      assert.strictEqual(snap.getOrNull(caret2.sessionId), caret2);
-      assert.strictEqual(snap.getOrNull(caret3.sessionId), caret3);
+      assert.strictEqual(snap.getOrNull(caret1.id), caret1);
+      assert.strictEqual(snap.getOrNull(caret2.id), caret2);
+      assert.strictEqual(snap.getOrNull(caret3.id), caret3);
     });
 
     it('should return `null` when given a session ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
-      assert.isNull(snap.getOrNull(caret2.sessionId));
+      assert.isNull(snap.getOrNull(caret2.id));
     });
 
     it('should throw an error if given an invalid session ID', () => {
@@ -477,15 +477,15 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     it('should return `true` when given a session ID for an existing session', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
-      assert.isTrue(snap.has(caret1.sessionId));
-      assert.isTrue(snap.has(caret2.sessionId));
-      assert.isTrue(snap.has(caret3.sessionId));
+      assert.isTrue(snap.has(caret1.id));
+      assert.isTrue(snap.has(caret2.id));
+      assert.isTrue(snap.has(caret3.id));
     });
 
     it('should return `false` when given a session ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
-      assert.isFalse(snap.has(caret2.sessionId));
+      assert.isFalse(snap.has(caret2.id));
     });
 
     it('should throw an error if given an invalid session ID', () => {
@@ -638,7 +638,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       const snap     = new CaretSnapshot(1, [op1, op2]);
       const expected = new CaretSnapshot(1, [op2]);
 
-      assert.isTrue(snap.withoutSession(caret1.sessionId).equals(expected));
+      assert.isTrue(snap.withoutSession(caret1.id).equals(expected));
     });
   });
 });

--- a/local-modules/@bayou/doc-server/CaretColor.js
+++ b/local-modules/@bayou/doc-server/CaretColor.js
@@ -24,7 +24,7 @@ const INITIAL_CANDIDATES = 36; // That is, 10 degrees difference per candidate.
 const TOP_CANDIDATES = 8;
 
 /**
- * Selector of likely-distinctive caret highlight colors for sessions, based on
+ * Selector of likely-distinctive caret highlight colors for carets, based on
  * currently-used colors.
  *
  * The twist about this class is that it has to operate &mdash; and avoid

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -185,10 +185,10 @@ export default class CaretControl extends EphemeralControl {
   }
 
   /**
-   * Removes sessions out of the snapshot that haven't been active recently.
+   * Removes carets out of the snapshot that haven't been active recently.
    */
   async _removeIdleSessions() {
-    this.log.info('Checking for inactive sessions.');
+    this.log.info('Checking for inactive carets.');
 
     const snapshot = await this.getSnapshot();
 
@@ -209,7 +209,7 @@ export default class CaretControl extends EphemeralControl {
     }
 
     if (snapshot === newSnapshot) {
-      this.log.info('No inactive sessions.');
+      this.log.info('No inactive carets.');
       return;
     }
 
@@ -221,10 +221,10 @@ export default class CaretControl extends EphemeralControl {
       await this.update(change);
     } catch (e) {
       // Probably a timeout after losing too many races. Though it's
-      // log-worthy, it's not a showstopper. The sessions will ultimately get
+      // log-worthy, it's not a showstopper. The carets will ultimately get
       // cleaned up by another run of the idle timeout (either on this machine
       // or some other one).
-      this.log.warn('Error while removing idle sessions.', e);
+      this.log.warn('Error while removing idle carets.', e);
     }
   }
 

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -288,7 +288,7 @@ export default class DocSession extends CommonBase {
     const session = this._sessionId;
     const author  = this._authorId;
 
-    return `file ${file}; caret session ${session}; author ${author}`;
+    return `file ${file}; caret ${session}; author ${author}`;
   }
 
   /**
@@ -310,11 +310,11 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * Returns the caret session ID of this instance.
+   * Returns the caret ID of this instance.
    *
-   * @returns {string} The session ID.
+   * @returns {string} The caret ID.
    */
-  getSessionId() {
+  getCaretId() {
     return this._sessionId;
   }
 }

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -3,9 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Storage } from '@bayou/config-server';
-import { BodyChange, PropertyChange } from '@bayou/doc-common';
+import { BodyChange, CaretId, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
-import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import FileComplex from './FileComplex';
@@ -38,7 +37,7 @@ export default class DocSession extends CommonBase {
     this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
 
     /** {string} Caret ID. */
-    this._caretId = TString.nonEmpty(caretId);
+    this._caretId = CaretId.check(caretId);
 
     /** {BodyControl} The underlying body content controller. */
     this._bodyControl = fileComplex.bodyControl;

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -205,17 +205,17 @@ export default class CaretOverlay {
     } else {
       // We're not dragging so draw the remote author cursors and highlights.
 
-      // For each session…
-      for (const [sessionId, caret] of this._lastCaretSnapshot.entries()) {
+      // For each caret...
+      for (const [caretId, caret] of this._lastCaretSnapshot.entries()) {
         // Is this caret us? If so, don't draw anything. **TODO:** The caret
         // snapshot ideally wouldn't actually represent the caret controlled by
         // this editor. The code that pushes the snapshot into the store should
         // be updated accordingly.
-        if (this._editorComplex.docSession.caretTracker.isControlledHere(sessionId)) {
+        if (this._editorComplex.docSession.caretTracker.isControlledHere(caretId)) {
           continue;
         }
 
-        const avatarReference = this._useReferences.get(sessionId);
+        const avatarReference = this._useReferences.get(caretId);
 
         if (caret.length === 0) {
           // Length of zero means an insertion point instead of a selection

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -498,13 +498,13 @@ export default class CaretOverlay {
         }
 
         case CaretOp.CODE_endSession: {
-          this._removeAvatarFromDefs(props.sessionId);
+          this._removeAvatarFromDefs(props.caretId);
           updateDisplay = true;
           break;
         }
 
         case CaretOp.CODE_setField: {
-          const sessionId = props.sessionId;
+          const sessionId = props.caretId;
 
           if (sessionId === this._editorComplex.sessionId) {
             continue;

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -305,9 +305,9 @@ export default class CaretOverlay {
   _addAvatarToDefs(caret) {
     // The whole avatar is set in a group with a known id.
     const avatarGroup = this._document.createElementNS(SVG_NAMESPACE, 'g');
-    const sessionId = caret.sessionId;
+    const id          = caret.id;
 
-    avatarGroup.setAttribute('id', CaretOverlay.avatarNameForSessionId(sessionId));
+    avatarGroup.setAttribute('id', CaretOverlay.avatarNameForSessionId(id));
 
     // Add the circle that will hold the background color.
     const backgroundCircle = this._document.createElementNS(SVG_NAMESPACE, 'circle');
@@ -366,9 +366,9 @@ export default class CaretOverlay {
 
     this._svgDefs.appendChild(avatarGroup);
 
-    const useReferenceForAvatar = this._createUseElementForSessionAvatar(caret.sessionId);
+    const useReferenceForAvatar = this._createUseElementForSessionAvatar(caret.id);
 
-    this._useReferences.set(caret.sessionId, useReferenceForAvatar);
+    this._useReferences.set(caret.id, useReferenceForAvatar);
   }
 
   _avatarDefWithName(name) {
@@ -435,7 +435,7 @@ export default class CaretOverlay {
    * @param {Caret} caret Caret for the session.
    */
   _updateAvatarColor(caret) {
-    const avatarName = CaretOverlay.avatarNameForSessionId(caret.sessionId);
+    const avatarName = CaretOverlay.avatarNameForSessionId(caret.id);
     const avatar = this._avatarDefWithName(avatarName);
 
     if (avatar) {

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -504,14 +504,14 @@ export default class CaretOverlay {
         }
 
         case CaretOp.CODE_setField: {
-          const sessionId = props.caretId;
+          const caretId = props.caretId;
 
-          if (sessionId === this._editorComplex.sessionId) {
+          if (this._editorComplex.docSession.caretTracker.isControlledHere(caretId)) {
             continue;
           }
 
           if (props.key === 'color') {
-            const caret = newSnapshot.get(sessionId);
+            const caret = newSnapshot.get(caretId);
 
             this._updateAvatarColor(caret);
           }

--- a/local-modules/@bayou/doc-ui/CaretState.js
+++ b/local-modules/@bayou/doc-ui/CaretState.js
@@ -30,9 +30,9 @@ const REQUEST_DELAY_MSEC = 250;
 const ERROR_DELAY_MSEC = 5000;
 
 /**
- * Tracker of the state of carets for all sessions editing a given document.
- * It watches for changes observed from the session proxy and dispatches
- * actions to a redux data store to update the client caret model.
+ * Tracker of the state of all carets (active editing sessions) on a given
+ * document. It watches for changes observed from the session proxy and
+ * dispatches actions to a redux data store to update the client caret model.
  *
  * Other entities interested in caret changes (notably {@link CaretOverlay})
  * should look at the `carets` entry in {@link EditorComplex}'s store.

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -175,15 +175,6 @@ export default class EditorComplex extends CommonBase {
   }
 
   /**
-   * {string|null} The session ID of the current server session, or `null` if
-   * no session is currently active.
-   */
-  get sessionId() {
-    const docSession = this.docSession;
-    return (docSession === null) ? null : docSession.key.id;
-  }
-
-  /**
    * Hook this instance up to a new session.
    *
    * @param {SplitKey} sessionKey New session key to use.

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -14,8 +14,8 @@ import StorageId from './StorageId';
 import StoragePath from './StoragePath';
 
 /**
- * Snapshot of information about all active sessions on a particular document.
- * Instances of this class are always frozen (immutable).
+ * Snapshot of file contents. Instances of this class are always frozen
+ * (immutable).
  *
  * When thought of in terms of a map, instances of this class can be taken to
  * be maps from string keys to arbitrary data values.

--- a/local-modules/@bayou/ui-components/Avatars/index.js
+++ b/local-modules/@bayou/ui-components/Avatars/index.js
@@ -18,9 +18,9 @@ class Avatars extends React.Component {
     return (
       <div className={ styles['document-header__avatars'] }>
         {
-          [...this.props.sessions.entries()].map(([sessionId, caret]) => {
+          [...this.props.sessions.entries()].map(([caretId, caret]) => {
             return (
-              <div key={ sessionId } className={ styles['document-header__avatar'] }>
+              <div key={ caretId } className={ styles['document-header__avatar'] }>
                 <img src={ AVATAR_PLACEHOLDER_URL } />
                 <div
                   className={ styles['avatar-presence'] }

--- a/local-modules/@bayou/ui-components/Avatars/index.js
+++ b/local-modules/@bayou/ui-components/Avatars/index.js
@@ -18,7 +18,7 @@ class Avatars extends React.Component {
     return (
       <div className={ styles['document-header__avatars'] }>
         {
-          [...this.props.sessions.entries()].map(([caretId, caret]) => {
+          [...this.props.carets.entries()].map(([caretId, caret]) => {
             return (
               <div key={ caretId } className={ styles['document-header__avatar'] }>
                 <img src={ AVATAR_PLACEHOLDER_URL } />
@@ -39,7 +39,7 @@ class Avatars extends React.Component {
  * maps the redux store state to this component's properties.
  */
 Avatars.propTypes = {
-  sessions: PropTypes.object.isRequired,
+  carets: PropTypes.object.isRequired,
 };
 
 /**
@@ -51,7 +51,7 @@ Avatars.propTypes = {
  */
 const mapStateToProps = (state) => {
   return {
-    sessions: CaretState.caretSnapshot(state)
+    carets: CaretState.caretSnapshot(state)
   };
 };
 


### PR DESCRIPTION
This PR is the first in a series in which the term "session" is replaced with "caret," when the term is meant to refer specifically to the "caret sessions" as represented in the caret part of a file. This PR concentrated on the public API of the classes `Caret` and `CaretOp`, and worked its way out from there, with a few more tangential renames thrown in to harmonize with other code that was already being changed. Similarly, I took the opportunity to tighten up argument checking on caret IDs in a couple places, when I was changing an argument name to `caretId` and happened to notice that a check was lacking or lax.

As a minor note, one change that doesn't _quite_ fit the pattern as described above is that in `Caret` itself, the field `sessionId` got renamed to just be `id` instead of `caretId`. This matches the _larger_ pattern where a "thing with an ID" uses just `id` as the name within itself of its own ID.

This PR did _not_ change the document schema. But note that a subsequent PR will do so, because the op names in `CaretOp` will change to stop referring to `session`s.

**Bonus:** Fixed how `CaretId.randomInstance()` gets tested, such that it embodies a somewhat more nuanced understanding of statistics as it applies to randomness.