### PR TITLE
Rename "session" -> "caret" part 2 of N.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -56,7 +56,7 @@ export default class AuthorAccess extends CommonBase {
    * instance's author.
    *
    * **TODO:** Context binding ought to happen at a different layer of the
-   * system. See comment about this in {@link #makeSession} for more details.
+   * system. See comment about this in {@link #makeNewSession} for more details.
    *
    * @param {string} docId ID of the document which the session is for.
    * @param {string} caretId ID of the caret.

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -106,7 +106,7 @@ export default class AuthorAccess extends CommonBase {
    * @returns {string} Target ID within the API context which refers to the
    *   session. This is _not_ the same as the `sessionId`.
    */
-  async makeSession(docId) {
+  async makeNewSession(docId) {
     // We only check the document ID syntax here, because we can count on the
     // call to `getFileComplex()` to do a full validity check as part of its
     // work.

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -107,8 +107,8 @@ export default class Caret extends CommonBase {
    * **Note:** {@link #DEFAULT} does not bind an `authorId`, which means that
    * that field must be specified when creating an instance "from scratch."
    *
-   * @param {string|Caret} idOrBase Session ID that identifies the caret, or a
-   *   base caret instance which provides the ID and default values for fields.
+   * @param {string|Caret} idOrBase Caret ID, or a base caret instance which
+   *   provides the ID and default values for fields.
    * @param {object} [fields = {}] Fields of the caret, as plain object mapping
    *   field names to values.
    */

--- a/local-modules/@bayou/doc-common/CaretId.js
+++ b/local-modules/@bayou/doc-common/CaretId.js
@@ -43,6 +43,20 @@ export default class CaretId extends UtilityClass {
   }
 
   /**
+   * Gets the non-boilerplate "payload" of the given ID. That is, the result is
+   * the ID without its distincitve prefix.
+   *
+   * @param {string} id Caret ID string.
+   * @returns {string} The "payload" portion of `id`.
+   */
+  static payloadFromId(id) {
+    CaretId.check(id);
+
+    // Strip everything up to and including the first dash (`-`).
+    return id.replace(/^[^-]+-/, '');
+  }
+
+  /**
    * Constructs and returns a random caret ID string.
    *
    * @returns {string} A randomly-generated caret ID string.

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -96,6 +96,25 @@ describe('@bayou/doc-common/CaretId', () => {
     });
   });
 
+  describe('payloadFromId()', () => {
+    it('should return the payload from a valid id', () => {
+      assert.strictEqual('fooba', CaretId.payloadFromId('cr-fooba'));
+      assert.strictEqual('0zor0', CaretId.payloadFromId('cr-0zor0'));
+    });
+
+    it('should reject invalid ID strings', () => {
+      for (const s of INVALID_STRINGS) {
+        assert.throws(() => CaretId.payloadFromId(s), /badValue/, s);
+      }
+    });
+
+    it('should reject non-strings', () => {
+      for (const v of NON_STRINGS) {
+        assert.throws(() => CaretId.payloadFromId(v), /badValue/, v);
+      }
+    });
+  });
+
   describe('randomInstance()', () => {
     it('should return values for which `isInstance()` is `true`', () => {
       for (let i = 0; i < 10; i++) {

--- a/local-modules/@bayou/doc-server/CaretColor.js
+++ b/local-modules/@bayou/doc-server/CaretColor.js
@@ -37,15 +37,15 @@ const TOP_CANDIDATES = 8;
  */
 export default class CaretColor extends UtilityClass {
   /**
-   * Given a session ID and a set of existing colors, returns the color to use
-   * for a new session with that ID.
+   * Given a caret ID and a set of existing colors, returns the color to use
+   * for a new caret with that ID.
    *
    * @param {string} caretId ID of the nascent caret.
    * @param {array<string>} usedColors List of currently-used colors, in CSS
    *   hex form.
    * @returns {string} Color to use for the session, in CSS hex form.
    */
-  static colorForSession(caretId, usedColors) {
+  static colorForCaret(caretId, usedColors) {
     TString.check(caretId); // We don't really need to care about caret ID syntax here.
 
     const seed = StringUtil.hash32(caretId);

--- a/local-modules/@bayou/doc-server/CaretColor.js
+++ b/local-modules/@bayou/doc-server/CaretColor.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TString } from '@bayou/typecheck';
 import { ColorUtil, StringUtil, UtilityClass } from '@bayou/util-common';
 
 /**
@@ -32,20 +33,22 @@ const TOP_CANDIDATES = 8;
  * synchronously coordinate with instances of this class running on different
  * servers. The tactic that we implement to achive this is to start with the
  * top N choices for "most distinctly different color" and pick one of them
- * pseudo-randomly based on the (guaranteed unique) session ID as the seed.
+ * pseudo-randomly based on the (guaranteed unique) caret ID as the seed.
  */
 export default class CaretColor extends UtilityClass {
   /**
    * Given a session ID and a set of existing colors, returns the color to use
    * for a new session with that ID.
    *
-   * @param {string} sessionId ID of the nascent session.
+   * @param {string} caretId ID of the nascent caret.
    * @param {array<string>} usedColors List of currently-used colors, in CSS
    *   hex form.
    * @returns {string} Color to use for the session, in CSS hex form.
    */
-  static colorForSession(sessionId, usedColors) {
-    const seed = StringUtil.hash32(sessionId);
+  static colorForSession(caretId, usedColors) {
+    TString.check(caretId); // We don't really need to care about caret ID syntax here.
+
+    const seed = StringUtil.hash32(caretId);
 
     if (usedColors.length === 0) {
       // No other colors to avoid. Just reduce the seed to a hue directly.

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -263,6 +263,6 @@ export default class CaretControl extends EphemeralControl {
       usedColors.push(caret.color);
     }
 
-    return CaretColor.colorForSession(caretId, usedColors);
+    return CaretColor.colorForCaret(caretId, usedColors);
   }
 }

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Caret, CaretChange, CaretOp, CaretSnapshot } from '@bayou/doc-common';
+import { Caret, CaretChange, CaretId, CaretOp, CaretSnapshot } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import { TInt, TString } from '@bayou/typecheck';
 
@@ -46,23 +46,23 @@ export default class CaretControl extends EphemeralControl {
   }
 
   /**
-   * Constructs a {@link CaretChange} instance which introduces a new session.
+   * Constructs a {@link CaretChange} instance which introduces a new caret.
    *
-   * @param {string} sessionId ID of the session being introduced.
-   * @param {string} authorId ID of the author which controls the session.
+   * @param {string} caretId ID of the caret being introduced.
+   * @param {string} authorId ID of the author which controls the caret.
    * @returns {CaretChange} A change instance which represents the above
    *   information, along with anything else needed to be properly applied.
    */
-  async changeForNewSession(sessionId, authorId) {
-    TString.check(sessionId);
+  async changeForNewCaret(caretId, authorId) {
+    CaretId.check(caretId);
     TString.check(authorId);
 
     // Construct the new/updated caret.
 
     const snapshot   = await this.getSnapshot();
     const lastActive = Timestamp.now();
-    const color      = CaretControl._pickSessionColor(sessionId, snapshot);
-    const caret      = new Caret(sessionId, { authorId, color, lastActive });
+    const color      = CaretControl._pickSessionColor(caretId, snapshot);
+    const caret      = new Caret(caretId, { authorId, color, lastActive });
 
     return new CaretChange(
       snapshot.revNum + 1,

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -75,8 +75,7 @@ export default class CaretControl extends EphemeralControl {
    * caret, as indicated by the given individual arguments, along with
    * additional information as needed.
    *
-   * @param {string} sessionId ID of the session from which this information
-   *   comes.
+   * @param {string} caretId ID of the caret to update.
    * @param {Int} docRevNum The _document_ revision number that this information
    *   is with respect to.
    * @param {Int} index Caret position (if no selection per se) or starting
@@ -85,8 +84,8 @@ export default class CaretControl extends EphemeralControl {
    * @returns {CaretChange} A change instance which represents the above
    *   information, along with anything else needed to be properly applied.
    */
-  async changeForUpdate(sessionId, docRevNum, index, length = 0) {
-    TString.check(sessionId);
+  async changeForUpdate(caretId, docRevNum, index, length = 0) {
+    CaretId.check(caretId);
     RevisionNumber.check(docRevNum);
     TInt.nonNegative(index);
     TInt.nonNegative(length);
@@ -94,7 +93,7 @@ export default class CaretControl extends EphemeralControl {
     // Construct the updated caret.
 
     const snapshot   = await this.getSnapshot();
-    const oldCaret   = snapshot.get(sessionId);
+    const oldCaret   = snapshot.get(caretId);
     const lastActive = Timestamp.now();
     const caret      = new Caret(oldCaret, { revNum: docRevNum, lastActive, index, length });
 

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -10,12 +10,12 @@ import { CommonBase } from '@bayou/util-common';
 import FileComplex from './FileComplex';
 
 /**
- * Server side representative for a session for a specific author and document.
- * Instances of this class are exposed across the API boundary, and as such
- * all public methods are available for client use.
+ * Server side representative for an editing session for a specific document,
+ * author, and caret. Instances of this class are exposed across the API
+ * boundary, and as such all public methods are available for client use.
  *
  * For document access methods, this passes non-mutating methods through to the
- * underlying `BodyControl` while implicitly adding an author argument to
+ * underlying {@link BodyControl} while implicitly adding an author argument to
  * methods that modify the document.
  */
 export default class DocSession extends CommonBase {

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -187,13 +187,14 @@ export default class DocSession extends CommonBase {
     const snapshot = await this._caretControl.getSnapshot();
 
     if (snapshot.getOrNull(this._caretId) === null) {
-      // The session isn't actually represented in the caret snapshot. This is
+      // The caret isn't actually represented in the caret snapshot. This is
       // unexpected -- the code which sets up a session is supposed to ensure
-      // that the session is represented before the client ever has a chance to
-      // send an update -- but we can recover. Note the issue, and store a new
-      // caret first before issuing the update.
+      // that the associated caret is represented in the file before the client
+      // ever has a chance to send an update -- but we can recover: We note the
+      // issue as a warning, and store a new caret first, before applying the
+      // update.
       const newSessionChange =
-        await this._caretControl.changeForNewSession(this._caretId, this._authorId);
+        await this._caretControl.changeForNewCaret(this._caretId, this._authorId);
 
       this._caretControl.log.warn(`Got update for caret \`${this._caretId}\` before it was set up.`);
 

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -5,7 +5,7 @@
 import weak from 'weak';
 
 import { Storage } from '@bayou/config-server';
-import { TString } from '@bayou/typecheck';
+import { CaretId } from '@bayou/doc-common';
 import { Errors } from '@bayou/util-common';
 
 import BaseComplexMember from './BaseComplexMember';
@@ -45,7 +45,7 @@ export default class FileComplex extends BaseComplexMember {
     this._bootstrap = new FileBootstrap(this._fileAccess);
 
     /**
-     * {Map<string, Weak<DocSession>>} Map from session IDs to corresponding
+     * {Map<string, Weak<DocSession>>} Map from caret IDs to corresponding
      * weak-reference-wrapped {@link DocSession} instances. The weak reference
      * is made because we don't want a session's presence in the map to keep it
      * from getting GC'ed. And we _need_ the map here, so that we can find
@@ -81,25 +81,25 @@ export default class FileComplex extends BaseComplexMember {
   }
 
   /**
-   * Finds and returns a pre-existing session for this instance. More
-   * specifically, the session has to exist in the caret part of the file, but
-   * there doesn't have to already be a {@link DocSession} object in this
-   * process which represents it.
+   * Finds and returns a session to control a pre-existing caret on the document
+   * managed by this instance. More specifically, the caret has to exist in the
+   * caret part of the file, but there doesn't have to already be a
+   * {@link DocSession} object in this process which represents it.
    *
-   * @param {string} authorId ID for the author.
-   * @param {string} sessionId ID for the session.
-   * @returns {DocSession} A session object representing the so-identified
-   *   session.
+   * @param {string} authorId ID of the author.
+   * @param {string} caretId ID of the caret.
+   * @returns {DocSession} A session object to control the indicated
+   *   pre-existing caret.
    */
-  async findExistingSession(authorId, sessionId) {
+  async findExistingSession(authorId, caretId) {
     // **Note:** We only need to validate syntax, because if we actually find
     // the session, we can match the author ID and (if it does match) know that
     // the author really exists and is valid.
     Storage.dataStore.checkAuthorIdSyntax(authorId);
 
-    TString.nonEmpty(sessionId);
+    CaretId.check(caretId);
 
-    const foundWeak = this._sessions.get(sessionId);
+    const foundWeak = this._sessions.get(caretId);
     if ((foundWeak !== undefined) && !weak.isDead(foundWeak)) {
       const foundSession = weak.get(foundWeak);
       if (foundSession instanceof DocSession) {
@@ -108,7 +108,7 @@ export default class FileComplex extends BaseComplexMember {
           // ...and the author ID matches. Bingo!
           return foundSession;
         } else {
-          throw Errors.badUse(`Wrong author ID for session: author ID \`${authorId}\`; session ID \`${sessionId}\``);
+          throw Errors.badUse(`Wrong author ID for caret: author \`${authorId}\`; caret \`${caretId}\``);
         }
       }
     }
@@ -118,19 +118,19 @@ export default class FileComplex extends BaseComplexMember {
     // author matches, we create and return the corresponding object.
 
     const caretSnapshot = await this.caretControl.getSnapshot();
-    const foundCaret    = caretSnapshot.get(sessionId); // This throws if the session isn't found.
+    const foundCaret    = caretSnapshot.get(caretId); // This throws if the caret isn't found.
 
     if (foundCaret.authorId !== authorId) {
-      throw Errors.badUse(`Wrong author ID for session: author ID \`${authorId}\`; session ID \`${sessionId}\``);
+      throw Errors.badUse(`Wrong author ID for session: author \`${authorId}\`; caret \`${caretId}\``);
     }
 
-    return this._activateSession(authorId, sessionId);
+    return this._activateSession(authorId, caretId);
   }
 
   /**
-   * Makes a new author-associated session for this instance. The resulting
-   * session's ID is guaranteed to be unique for the document represented by
-   * this instance.
+   * Makes and returns a new session for the document controlled by this
+   * instance, which allows the indicated author to control a newly-instantiated
+   * caret.
    *
    * @param {string} authorId ID for the author.
    * @returns {DocSession} A newly-constructed session.
@@ -147,18 +147,18 @@ export default class FileComplex extends BaseComplexMember {
       }
 
       const caretSnapshot = await this.caretControl.getSnapshot();
-      const sessionId     = caretSnapshot.randomUnusedId();
+      const caretId       = caretSnapshot.randomUnusedId();
 
       // Establish the new session, as a change from the instantaneously-latest
       // carets.
 
       const newSessionChange =
-        await this.caretControl.changeForNewSession(sessionId, authorId);
+        await this.caretControl.changeForNewSession(caretId, authorId);
       const appendResult = await this.caretControl.appendChange(newSessionChange);
 
       if (appendResult) {
         // There was no append race, or we won it.
-        return this._activateSession(authorId, sessionId);
+        return this._activateSession(authorId, caretId);
       }
 
       // We lost an append race, but the session introduction might still be
@@ -170,42 +170,44 @@ export default class FileComplex extends BaseComplexMember {
    * Helper for {@link #makeNewSession} and {@link #findExistingSession}, which
    * does the final setup of a new {@link DocSession} instance.
    *
-   * @param {string} authorId ID for the author.
-   * @param {string} sessionId ID for the session.
+   * @param {string} authorId ID of the author.
+   * @param {string} caretId ID of the caret.
    * @returns {DocSession} A newly-constructed session.
    */
-  _activateSession(authorId, sessionId) {
-    const result = new DocSession(this, authorId, sessionId);
-    const reaper = this._sessionReaper(sessionId);
+  _activateSession(authorId, caretId) {
+    const result = new DocSession(this, authorId, caretId);
+    const reaper = this._sessionReaper(caretId);
 
-    this._sessions.set(sessionId, weak(result, reaper));
+    this._sessions.set(caretId, weak(result, reaper));
 
     this.log.info(
-      `Session ${sessionId} now active.\n`,
+      `Session now active.\n`,
       `  file:    ${this.file.id}\n`,
-      `  author:  ${authorId}\n`);
+      `  author:  ${authorId}\n`,
+      `  caret:   ${caretId}`);
 
     return result;
   }
 
   /**
-   * Returns a weak reference callback function for the indicated complex /
-   * session pair, that removes a collected session object from the session map.
+   * Returns a weak reference callback function which reaps the
+   * {@link DocSession} associated with the indicate caret.
    *
-   * **Note:** This does _not_ remove the session info from the carets part of
+   * **Note:** This does _not_ remove the caret info from the carets part of
    * the document: Even though the session has become idle from the perspective
-   * of this server, the session isn't necessarily totally idle / dead. For
+   * of this server, the caret isn't necessarily totally idle / dead. For
    * example, it might be the case that the client for the session happened to
    * end up connecting to a different machine and is continuing to putter away
    * at it.
    *
-   * @param {string} sessionId ID of the session to remove.
+   * @param {string} caretId ID of the caret whose associated session is to be
+   *   removed.
    * @returns {function} An appropriately-constructed function.
    */
-  _sessionReaper(sessionId) {
+  _sessionReaper(caretId) {
     return () => {
-      this._sessions.delete(sessionId);
-      this.log.info('Reaped idle session:', sessionId);
+      this._sessions.delete(caretId);
+      this.log.info('Reaped idle session:', caretId);
     };
   }
 }

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -146,15 +146,13 @@ export default class FileComplex extends BaseComplexMember {
         throw Errors.timedOut(timeoutTime);
       }
 
-      const caretSnapshot = await this.caretControl.getSnapshot();
-      const caretId       = caretSnapshot.randomUnusedId();
+      // Establish a new caret in the document, by creating and appending a
+      // change from the instantaneously-latest carets.
 
-      // Establish the new session, as a change from the instantaneously-latest
-      // carets.
-
-      const newSessionChange =
-        await this.caretControl.changeForNewSession(caretId, authorId);
-      const appendResult = await this.caretControl.appendChange(newSessionChange);
+      const caretSnapshot  = await this.caretControl.getSnapshot();
+      const caretId        = caretSnapshot.randomUnusedId();
+      const newCaretChange = await this.caretControl.changeForNewCaret(caretId, authorId);
+      const appendResult   = await this.caretControl.appendChange(newCaretChange);
 
       if (appendResult) {
         // There was no append race, or we won it.

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -207,7 +207,7 @@ export default class FileComplex extends BaseComplexMember {
   _sessionReaper(caretId) {
     return () => {
       this._sessions.delete(caretId);
-      this.log.info('Reaped idle session:', caretId);
+      this.log.info(`Reaped idle session; caret ${caretId}.`);
     };
   }
 }

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { DragState } from '@bayou/data-model-client';
-import { CaretOp, CaretSnapshot } from '@bayou/doc-common';
+import { CaretId, CaretOp, CaretSnapshot } from '@bayou/doc-common';
 import { Delay } from '@bayou/promise-util';
 import { QuillEvents, QuillGeometry, QuillUtil } from '@bayou/quill-util';
 import { TObject } from '@bayou/typecheck';
@@ -536,6 +536,7 @@ export default class CaretOverlay {
    *   for this caret.
    */
   static _domIdFromCaretId(caretId) {
-    return `avatar-${caretId}`;
+    const rawId = CaretId.payloadFromId(caretId);
+    return `avatar-${rawId}`;
   }
 }

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -63,11 +63,11 @@ export default class CaretOverlay {
      *   <defs>
      *     [reusuable elements such as clip paths, avatars, gradients, etc]
      *   </defs>
-     *   [caret/selection drawing commands for session A]
+     *   [caret/selection drawing commands for caret A]
      *   <use href="#avatarA" />
-     *   [caret/selection drawing commands for session B]
+     *   [caret/selection drawing commands for caret B]
      *   <use href="#avatarB" />
-     *   [caret/selection drawing commands for session N]
+     *   [caret/selection drawing commands for caret N]
      *   <use href="#avatarN" />
      * </svg>
      * ```
@@ -76,7 +76,7 @@ export default class CaretOverlay {
 
     /**
      * {SVGDefsElement} The `<defs>` element within `_svgOverlay`. This holds
-     * reusable definitions such as clip paths, gradients, session avatars, etc.
+     * reusable definitions such as clip paths, gradients, caret avatars, etc.
      * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
      */
     this._svgDefs = this._addInitialSvgDefs();
@@ -97,10 +97,10 @@ export default class CaretOverlay {
     this._useReferences = new Map();
 
     /**
-     * {Int|null} While a drag session is in progress this property
+     * {Int|null} While a drag action is in progress this property
      * indicates where in the Quill document the cursor currently is.
      * This lets the drawing code know where to put the drop coach mark.
-     * When there is no drag session this property is `null`.
+     * When there is no drag action this property is `null`.
      */
     this._dragIndex = null;
 
@@ -297,7 +297,7 @@ export default class CaretOverlay {
   }
 
   /**
-   * Constructs an avatar image for the session and adds it to the `<defs>`
+   * Constructs an avatar image for the caret and adds it to the `<defs>`
    * section of the SVG.
    *
    * @param {Caret} caret The caret for which we're adding an avatar def.
@@ -307,7 +307,7 @@ export default class CaretOverlay {
     const avatarGroup = this._document.createElementNS(SVG_NAMESPACE, 'g');
     const id          = caret.id;
 
-    avatarGroup.setAttribute('id', CaretOverlay.avatarNameForSessionId(id));
+    avatarGroup.setAttribute('id', CaretOverlay._domIdFromCaretId(id));
 
     // Add the circle that will hold the background color.
     const backgroundCircle = this._document.createElementNS(SVG_NAMESPACE, 'circle');
@@ -382,12 +382,12 @@ export default class CaretOverlay {
   }
 
   /**
-   * Removes a session avatar from the `<defs>` section of the SVG.
+   * Removes a caret avatar from the `<defs>` section of the SVG.
    *
    * @param {string} sessionId The session whose avatar is being removed.
    */
   _removeAvatarFromDefs(sessionId) {
-    const avatarName = CaretOverlay.avatarNameForSessionId(sessionId);
+    const avatarName = CaretOverlay._domIdFromCaretId(sessionId);
     const avatar = this._avatarDefWithName(avatarName);
 
     if (avatar) {
@@ -406,7 +406,7 @@ export default class CaretOverlay {
    * @returns {SVGUseElement} A reference to the session's avatar definition.
    */
   _createUseElementForSessionAvatar(sessionId) {
-    const avatarName = CaretOverlay.avatarNameForSessionId(sessionId);
+    const avatarName = CaretOverlay._domIdFromCaretId(sessionId);
     const useElement = this._document.createElementNS(SVG_NAMESPACE, 'use');
 
     useElement.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `#${avatarName}`);
@@ -417,25 +417,13 @@ export default class CaretOverlay {
   }
 
   /**
-   * Takes a session id as input and returns a DOM id to use to reference the
-   * avatar for that session in the `<defs>` section of the SVG.
-   *
-   * @param {string} sessionId The if for the session being referenced.
-   * @returns {string} The DOM id to use when referencing the avatar definition
-   *   for this session.
-   */
-  static avatarNameForSessionId(sessionId) {
-    return `avatar-${sessionId}`;
-  }
-
-  /**
-   * Finds the avatar for a given session in the `<defs>` section of the SVG and
+   * Finds the avatar for a given caret in the `<defs>` section of the SVG and
    * updates all of its thematic color values to the given new color.
    *
-   * @param {Caret} caret Caret for the session.
+   * @param {Caret} caret Caret in question.
    */
   _updateAvatarColor(caret) {
-    const avatarName = CaretOverlay.avatarNameForSessionId(caret.id);
+    const avatarName = CaretOverlay._domIdFromCaretId(caret.id);
     const avatar = this._avatarDefWithName(avatarName);
 
     if (avatar) {
@@ -454,7 +442,7 @@ export default class CaretOverlay {
    */
   _updateAvatarChildColors(root, color) {
     // Predefined elements in the `<defs>` section of the SVG that adopt the
-    // thematic color for a given session are tagged with the class
+    // thematic color for a given caret are tagged with the class
     // `avatar-theme-color`. Items in that class will have their `fill` colors
     // changed to the provided value.
     if (root.classList.contains('avatar-theme-color')) {
@@ -537,5 +525,17 @@ export default class CaretOverlay {
 
     this._dragIndex = dragIndex;
     this._updateDisplay();
+  }
+
+  /**
+   * Takes a caret ID as input and returns a DOM ID to use to reference the
+   * avatar for that caret in the `<defs>` section of the SVG.
+   *
+   * @param {string} caretId The ID for the caret being referenced.
+   * @returns {string} The DOM ID to use when referencing the avatar definition
+   *   for this caret.
+   */
+  static _domIdFromCaretId(caretId) {
+    return `avatar-${caretId}`;
   }
 }

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -88,9 +88,9 @@ export default class CaretOverlay {
     this._lastCaretSnapshot = CaretSnapshot.EMPTY;
 
     /**
-     * {Map<string, SVGUseElement>} Map of session id to the `<use>` elements
+     * {Map<string, SVGUseElement>} Map from caret ID to the `<use>` elements
      * for each avatar. By pre-allocating them and storing one for each
-     * session we can avoid te cost of redrawing the user avatar each update
+     * caret we can avoid the cost of redrawing the user avatar each update
      * and can instead just translate the x/y position of this `<use>`
      * reference.
      */
@@ -384,29 +384,29 @@ export default class CaretOverlay {
   /**
    * Removes a caret avatar from the `<defs>` section of the SVG.
    *
-   * @param {string} sessionId The session whose avatar is being removed.
+   * @param {string} caretId ID of the caret whose avatar is being removed.
    */
-  _removeAvatarFromDefs(sessionId) {
-    const avatarName = CaretOverlay._domIdFromCaretId(sessionId);
+  _removeAvatarFromDefs(caretId) {
+    const avatarName = CaretOverlay._domIdFromCaretId(caretId);
     const avatar = this._avatarDefWithName(avatarName);
 
     if (avatar) {
       this._svgDefs.removeChild(avatar);
     }
 
-    this._useReferences.delete(sessionId);
+    this._useReferences.delete(caretId);
   }
 
   /**
-   * Prepares an SVG `<use>` element to use-by-reference a session avatar stored
+   * Prepares an SVG `<use>` element to use-by-reference a caret avatar stored
    * in the `<defs>` section of the layer.
    * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
    *
-   * @param {string} sessionId The id for the session being referenced.
-   * @returns {SVGUseElement} A reference to the session's avatar definition.
+   * @param {string} caretId The ID of the caret.
+   * @returns {SVGUseElement} A reference to the caret's avatar definition.
    */
-  _createUseElementForSessionAvatar(sessionId) {
-    const avatarName = CaretOverlay._domIdFromCaretId(sessionId);
+  _createUseElementForSessionAvatar(caretId) {
+    const avatarName = CaretOverlay._domIdFromCaretId(caretId);
     const useElement = this._document.createElementNS(SVG_NAMESPACE, 'use');
 
     useElement.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `#${avatarName}`);


### PR DESCRIPTION
This is a follow-on to my previous PR, and is more of the same. In this one I tackled pretty much every place where I found `sessionId`, _except_ for the class `CaretSnapshot`, which deserves a PR of its own. Beyond that, there still remain a number of references to `session` in method and operation names, which will need to be addressed.