### PR TITLE
Rename "session" -> "caret" part 3 of N. 

### DIFF
--- a/local-modules/@bayou/deps-compiler/package.json
+++ b/local-modules/@bayou/deps-compiler/package.json
@@ -5,7 +5,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
-    "css-loader": "^0.28.11",
+    "css-loader": "^1.0.0",
     "html-loader": "^0.5.5",
     "less": "^3.0.4",
     "less-loader": "^4.1.0",

--- a/local-modules/@bayou/doc-common/CaretDelta.js
+++ b/local-modules/@bayou/doc-common/CaretDelta.js
@@ -13,7 +13,7 @@ import CaretOp from './CaretOp';
  * and `CaretSnapshot` to produce updated instances of those classes.
  *
  * **Note:** To be valid as a document delta, the set of operations must (a)
- * only consist of `beginSession` ops, and (b) not mention any given session ID
+ * only consist of `beginSession` ops, and (b) not mention any given caret ID
  * more than once.
  *
  * Instances of this class are immutable.
@@ -32,7 +32,7 @@ export default class CaretDelta extends BaseDelta {
     const carets = new Map();
 
     // Add / replace the ops, first from `this` and then from `other`, as a
-    // mapping from the session ID.
+    // mapping from the caret ID.
     for (const op of [...this.ops, ...other.ops]) {
       const opProps = op.props;
 
@@ -68,7 +68,7 @@ export default class CaretDelta extends BaseDelta {
             carets.set(caretId, [op]);
             handled = true;
           } else if (ops.length === 1) {
-            // We have a single-element array this session. It might be a
+            // We have a single-element array for this caret. It might be a
             // `beginSession` or an `endSession`, in which case we can do
             // something special.
             const op0Props = ops[0].props;

--- a/local-modules/@bayou/doc-common/CaretId.js
+++ b/local-modules/@bayou/doc-common/CaretId.js
@@ -8,8 +8,8 @@ import { Errors, Random, UtilityClass } from '@bayou/util-common';
 const CARET_ID_REGEX = /^cr-[0-9a-z]{5}$/;
 
 /**
- * Utility class for handling caret IDs (a/k/a session IDs). A caret ID is a
- * string that uniquely identifies an editing session within a given document.
+ * Utility class for handling caret IDs. A caret ID is a string that uniquely
+ * identifies an editing session within a given document.
  *
  * A valid ID consists of the prefix `cr-` followed by 5 lowercase alphanumeric
  * characters. (With an expected 5 bits of randomness in each character, that

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -30,8 +30,7 @@ export default class CaretOp extends BaseOp {
   /**
    * Constructs a new "begin session" operation.
    *
-   * @param {Caret} caret The initial caret for the new session (which includes
-   *   a session ID).
+   * @param {Caret} caret The initial caret for the new session.
    * @returns {CaretOp} The corresponding operation.
    */
   static op_beginSession(caret) {

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -206,33 +206,23 @@ export default class CaretSnapshot extends BaseSnapshot {
    * a caret with the indicated ID. If there is no such caret, this method
    * returns `this`.
    *
-   * @param {Caret} caret The caret whose ID should not be represented in the
-   *   result. Only the `id` of the caret is consulted; it doesn't matter if
-   *   other caret fields match.
+   * @param {string|Caret} idOrCaret The ID of the caret which should not be
+   *   represented in the result, or a {@link Caret} whose ID is used for the
+   *   check. (That is, if given a {@link Caret}, only the `id` is consulted; it
+   *   doesn't matter if other fields match.
    * @returns {CaretSnapshot} An appropriately-constructed instance.
    */
-  withoutCaret(caret) {
-    Caret.check(caret);
-    return this.withoutSession(caret.id);
-  }
+  withoutCaret(idOrCaret) {
+    const caretId = (typeof idOrCaret === 'string')
+      ? CaretId.check(idOrCaret)
+      : Caret.check(idOrCaret).id;
 
-  /**
-   * Constructs an instance just like this one, except without any caret which
-   * has the indicated ID. If there is no such caret in this instance, this
-   * method returns `this`.
-   *
-   * @param {string} caretId ID of the caret which should not be represented in
-   *   the result.
-   * @returns {CaretSnapshot} An appropriately-constructed instance.
-   */
-  withoutSession(caretId) {
-    // This type checks `caretId`, which is why it's not just run when we need
-    // to call `compose()`.
-    const op = CaretOp.op_endSession(caretId);
-
-    return this._carets.has(caretId)
-      ? this.compose(new CaretChange(this.revNum, [op]))
-      : this;
+    if (this._carets.has(caretId)) {
+      const op = CaretOp.op_endSession(caretId);
+      return this.compose(new CaretChange(this.revNum, [op]));
+    } else {
+      return this;
+    }
   }
 
   /**

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -75,7 +75,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.strictEqual(result.revNum, 12345);
     });
 
-    it('should refuse to compose if given a non-matching session ID', () => {
+    it('should refuse to compose if given a non-matching caret ID', () => {
       const op = CaretOp.op_setField(caret2.id, 'index', 55);
 
       assert.throws(() => { caret1.compose(new CaretDelta([op])); });
@@ -90,7 +90,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(result.ops, []);
     });
 
-    it('should refuse to diff if given a non-matching session ID', () => {
+    it('should refuse to diff if given a non-matching caret ID', () => {
       assert.throws(() => { caret1.diff(caret2); });
     });
 
@@ -113,7 +113,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(result.ops, []);
     });
 
-    it('should diff fields even if given a non-matching session ID', () => {
+    it('should diff fields even if given a non-matching caret ID', () => {
       assert.doesNotThrow(() => { caret1.diffFields(caret2, 'cr-florp'); });
     });
 
@@ -161,7 +161,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.isTrue(caret1.equals(same));
     });
 
-    it('should return `false` when session IDs differ', () => {
+    it('should return `false` when caret IDs differ', () => {
       const c1 = newCaret('cr-xxxxx', 1, 2, '#000011', 'some-author');
       const c2 = newCaret('cr-yyyyy', 1, 2, '#000011', 'some-author');
       assert.isFalse(c1.equals(c2));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -57,7 +57,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
       assert.throws(() => delta.compose(new MockDelta([]), true));
     });
 
-    it('should not include session ends when `wantDocument` is `true`', () => {
+    it('should not include `endSession` ops when `wantDocument` is `true`', () => {
       const op1    = CaretOp.op_beginSession(new Caret('cr-aaaaa', { authorId: 'xyz' }));
       const op2    = CaretOp.op_beginSession(new Caret('cr-bbbbb', { authorId: 'xyz' }));
       const op3    = CaretOp.op_beginSession(new Caret('cr-ccccc', { authorId: 'xyz' }));
@@ -70,7 +70,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
       assert.sameMembers(result.ops, [op1, op3]);
     });
 
-    describe('`endSession` preceded by anything for that session', () => {
+    describe('`endSession` preceded by anything for that caret', () => {
       it('should result in just the `endSession`', () => {
         const endOp = CaretOp.op_endSession('cr-sessi');
 

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -642,5 +642,21 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
         assert.isTrue(snap.withoutCaret(caret1.id).equals(expected));
       });
     });
+
+    describe('invalid argument', () => {
+      it('should reject invalid ID strings', () => {
+        const snap = new CaretSnapshot(1, [op1]);
+        assert.throws(() => snap.withoutCaret(''));
+        assert.throws(() => snap.withoutCaret('ZORCH_SPLAT'));
+      });
+
+      it('should reject arguments that are neither strings nor `Caret`s', () => {
+        const snap = new CaretSnapshot(1, [op1]);
+        assert.throws(() => snap.withoutCaret(undefined));
+        assert.throws(() => snap.withoutCaret(null));
+        assert.throws(() => snap.withoutCaret(123));
+        assert.throws(() => snap.withoutCaret([]));
+      });
+    });
   });
 });

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -426,7 +426,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('get()', () => {
-    it('should return the caret associated with an existing session', () => {
+    it('should return the caret associated with an existing ID', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.strictEqual(snap.get(caret1.id), caret1);
@@ -434,13 +434,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(snap.get(caret3.id), caret3);
     });
 
-    it('should throw an error when given a session ID that is not in the snapshot', () => {
+    it('should throw an error when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.throws(() => { snap.get(caret2.id); });
     });
 
-    it('should throw an error if given an invalid session ID', () => {
+    it('should throw an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.get(123); });
@@ -450,7 +450,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('getOrNull()', () => {
-    it('should return the caret associated with an existing session', () => {
+    it('should return the caret associated with an existing ID', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.strictEqual(snap.getOrNull(caret1.id), caret1);
@@ -458,13 +458,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(snap.getOrNull(caret3.id), caret3);
     });
 
-    it('should return `null` when given a session ID that is not in the snapshot', () => {
+    it('should return `null` when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.isNull(snap.getOrNull(caret2.id));
     });
 
-    it('should throw an error if given an invalid session ID', () => {
+    it('should throw an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.getOrNull(123); });
@@ -474,7 +474,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('has()', () => {
-    it('should return `true` when given a session ID for an existing session', () => {
+    it('should return `true` when given an ID for an existing caret', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.isTrue(snap.has(caret1.id));
@@ -482,13 +482,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(snap.has(caret3.id));
     });
 
-    it('should return `false` when given a session ID that is not in the snapshot', () => {
+    it('should return `false` when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.isFalse(snap.has(caret2.id));
     });
 
-    it('should throw an error if given an invalid session ID', () => {
+    it('should throw an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.has(123); });

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -604,41 +604,43 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('withoutCaret()', () => {
-    it('should return `this` if there is no matching session', () => {
-      const snap = new CaretSnapshot(1, [op1]);
+    describe('valid `Caret` argument', () => {
+      it('should return `this` if there is no matching caret', () => {
+        const snap = new CaretSnapshot(1, [op1]);
 
-      assert.strictEqual(snap.withoutCaret(caret2), snap);
-      assert.strictEqual(snap.withoutCaret(caret3), snap);
+        assert.strictEqual(snap.withoutCaret(caret2), snap);
+        assert.strictEqual(snap.withoutCaret(caret3), snap);
+      });
+
+      it('should return an appropriately-constructed instance if there is a matching caret', () => {
+        const snap     = new CaretSnapshot(1, [op1, op2]);
+        const expected = new CaretSnapshot(1, [op2]);
+
+        assert.isTrue(snap.withoutCaret(caret1).equals(expected));
+      });
+
+      it('should only pay attention to the ID of the given caret', () => {
+        const snap     = new CaretSnapshot(1, [op1, op2]);
+        const expected = new CaretSnapshot(1, [op2]);
+        const modCaret = new Caret(caret1, { revNum: 999999, index: 99 });
+
+        assert.isTrue(snap.withoutCaret(modCaret).equals(expected));
+      });
     });
 
-    it('should return an appropriately-constructed instance if there is a matching session', () => {
-      const snap     = new CaretSnapshot(1, [op1, op2]);
-      const expected = new CaretSnapshot(1, [op2]);
+    describe('valid ID argument', () => {
+      it('should return `this` if there is no matching caret', () => {
+        const snap = new CaretSnapshot(1, [op1]);
 
-      assert.isTrue(snap.withoutCaret(caret1).equals(expected));
-    });
+        assert.strictEqual(snap.withoutCaret('cr-not00'), snap);
+      });
 
-    it('should only pay attention to the session ID of the given caret', () => {
-      const snap     = new CaretSnapshot(1, [op1, op2]);
-      const expected = new CaretSnapshot(1, [op2]);
-      const modCaret = new Caret(caret1, { revNum: 999999, index: 99 });
+      it('should return an appropriately-constructed instance if there is a matching caret', () => {
+        const snap     = new CaretSnapshot(1, [op1, op2]);
+        const expected = new CaretSnapshot(1, [op2]);
 
-      assert.isTrue(snap.withoutCaret(modCaret).equals(expected));
-    });
-  });
-
-  describe('withoutSession()', () => {
-    it('should return `this` if there is no matching session', () => {
-      const snap = new CaretSnapshot(1, [op1]);
-
-      assert.strictEqual(snap.withoutSession('cr-not00'), snap);
-    });
-
-    it('should return an appropriately-constructed instance if there is a matching session', () => {
-      const snap     = new CaretSnapshot(1, [op1, op2]);
-      const expected = new CaretSnapshot(1, [op2]);
-
-      assert.isTrue(snap.withoutSession(caret1.id).equals(expected));
+        assert.isTrue(snap.withoutCaret(caret1.id).equals(expected));
+      });
     });
   });
 });

--- a/local-modules/@bayou/doc-server/CaretColor.js
+++ b/local-modules/@bayou/doc-server/CaretColor.js
@@ -43,7 +43,7 @@ export default class CaretColor extends UtilityClass {
    * @param {string} caretId ID of the nascent caret.
    * @param {array<string>} usedColors List of currently-used colors, in CSS
    *   hex form.
-   * @returns {string} Color to use for the session, in CSS hex form.
+   * @returns {string} Color to use for the caret, in CSS hex form.
    */
   static colorForCaret(caretId, usedColors) {
     TString.check(caretId); // We don't really need to care about caret ID syntax here.

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -12,7 +12,7 @@ import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
 
 /**
- * {Int} How long (in msec) that a session must be inactive before it gets
+ * {Int} How long (in msec) that a caret must be inactive before it gets
  * culled from the current caret snapshot.
  */
 const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
@@ -97,8 +97,8 @@ export default class CaretControl extends EphemeralControl {
     const lastActive = Timestamp.now();
     const caret      = new Caret(oldCaret, { revNum: docRevNum, lastActive, index, length });
 
-    // We always make a delta with a "begin session" op. Even though this change
-    // isn't always actually beginning a session, when ultimately applied via
+    // We always make a delta with a `beginSession` op. Even though this change
+    // isn't always actually adding a caret, when ultimately applied via
     // `update()` it will always turn into an appropriate new snapshot.
     return new CaretChange(
       snapshot.revNum + 1, [CaretOp.op_beginSession(caret)], lastActive);

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -203,7 +203,7 @@ export default class CaretControl extends EphemeralControl {
       if (minTime.compareTo(caret.lastActive) > 0) {
         // Too old!
         this.log.withAddedContext(caretId).info('Became inactive.');
-        newSnapshot = newSnapshot.withoutSession(caretId);
+        newSnapshot = newSnapshot.withoutCaret(caretId);
       }
     }
 

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -12,10 +12,10 @@ import Paths from './Paths';
 import SnapshotManager from './SnapshotManager';
 
 /**
- * {Int} How long (in msec) that a caret must be inactive before it gets
- * culled from the current caret snapshot.
+ * {Int} How long (in msec) that a caret must be inactive before it gets culled
+ * from the current caret snapshot.
  */
-const MAX_SESSION_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
+const MAX_CARET_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /**
  * Controller for the caret metadata of a particular document.
@@ -178,7 +178,7 @@ export default class CaretControl extends EphemeralControl {
       // "sneak past the gate" as it were, between the time that we decide to
       // run the idle check and the would-be later time that the `async`
       // {@link #_removeIdleCarets} method actually starts running.
-      this._nextIdleCheck = now + (MAX_SESSION_IDLE_MSEC / 4);
+      this._nextIdleCheck = now + (MAX_CARET_IDLE_MSEC / 4);
       this._removeIdleCarets();
     }
   }
@@ -196,7 +196,7 @@ export default class CaretControl extends EphemeralControl {
     // previous line.) Otherwise, we might produce a change with an out-of-order
     // timestamp.
     const now         = Timestamp.now();
-    const minTime     = now.addMsec(-MAX_SESSION_IDLE_MSEC);
+    const minTime     = now.addMsec(-MAX_CARET_IDLE_MSEC);
     let   newSnapshot = snapshot;
 
     for (const [caretId, caret] of snapshot.entries()) {

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -10,7 +10,7 @@ import { CommonBase } from '@bayou/util-common';
 import FileComplex from './FileComplex';
 
 /**
- * Server side representative for an editing session for a specific document,
+ * Server side representative of an editing session for a specific document,
  * author, and caret. Instances of this class are exposed across the API
  * boundary, and as such all public methods are available for client use.
  *


### PR DESCRIPTION
This PR is a follow-on to my previous two, and is more of the same. In this one I concentrated on `CaretSnapshot` as well as doing a pass of finding the plain word "session" throughout the codebase (mostly in docs / comments) and changing it to "caret" (along with associated rewordings) as made sense.

As of this PR, the main pending things that need renaming are the `CaretOp` operation names, but there may be a small handful of other stragglers.

**Bonus:** Update our `css-loader` dependency, because one of _its_ dependencies started issuing a warning during the build (and might be responsible for causing build failures).
