### PR TITLE
Automatically-generated opcode name validation.

### DIFF
--- a/local-modules/@bayou/doc-common/BodyOp.js
+++ b/local-modules/@bayou/doc-common/BodyOp.js
@@ -292,11 +292,6 @@ export default class BodyOp extends BaseOp {
     }
   }
 
-  // TODO: implement caret op specific validation
-  _impl_validate() {
-    return true;
-  }
-
   /**
    * Converts an `attributes` argument value into an array (of zero or one
    * element), suitable for passing to the payload constructor call, including
@@ -319,5 +314,16 @@ export default class BodyOp extends BaseOp {
       // More specific error.
       throw Errors.badValue(value, 'body attributes');
     }
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #isValidPayload}.
+   *
+   * @param {Functor} payload_unused The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static _impl_isValidPayload(payload_unused) {
+    // **TODO:** Fill this in!
+    return true;
   }
 }

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -99,8 +99,14 @@ export default class CaretOp extends BaseOp {
     }
   }
 
-  // TODO: implement caret op specific validation
-  _impl_validate() {
+  /**
+   * Subclass-specific implementation of {@link #isValidPayload}.
+   *
+   * @param {Functor} payload_unused The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static _impl_isValidPayload(payload_unused) {
+    // **TODO:** Fill this in!
     return true;
   }
 }

--- a/local-modules/@bayou/doc-common/PropertyOp.js
+++ b/local-modules/@bayou/doc-common/PropertyOp.js
@@ -74,8 +74,14 @@ export default class PropertyOp extends BaseOp {
     }
   }
 
-  // TODO: implement property op specific validation
-  _impl_validate() {
+  /**
+   * Subclass-specific implementation of {@link #isValidPayload}.
+   *
+   * @param {Functor} payload_unused The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static _impl_isValidPayload(payload_unused) {
+    // **TODO:** Fill this in!
     return true;
   }
 }

--- a/local-modules/@bayou/doc-server/mocks/MockControl.js
+++ b/local-modules/@bayou/doc-server/mocks/MockControl.js
@@ -16,7 +16,7 @@ export default class MockControl extends DurableControl {
   }
 
   _impl_getSnapshot(revNum) {
-    return new MockSnapshot(revNum, [[`snap_${revNum}`]]);
+    return new MockSnapshot(revNum, [['snap', revNum]]);
   }
 
   _impl_validateChange() {

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -659,7 +659,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
         if (op0Name === `composed_blort_${base}`) {
           composedCount++;
-        } else if (op0Name === 'diff_delta') {
+        } else if (op0Name === 'diffDelta') {
           diffCount++;
           assert.lengthOf(ops, 2);
           assert.strictEqual(ops[1].name, `snap_blort_${newer}`);

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -626,7 +626,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
       control.getSnapshot = async (revNum) => {
         assert((revNum === reqBase) || (revNum === reqNewer), `Unexpected revNum: ${revNum}`);
-        return new MockSnapshot(revNum, [[`snap_blort_${revNum}`]]);
+        return new MockSnapshot(revNum, [['snap', revNum]]);
       };
 
       control.getComposedChanges = async (baseDelta, startInc, endExc, wantDocument) => {
@@ -635,7 +635,7 @@ describe('@bayou/doc-server/BaseControl', () => {
         assert.strictEqual(startInc, reqBase + 1);
         assert.strictEqual(endExc, reqNewer + 1);
         assert.isFalse(wantDocument);
-        return new MockDelta([[`composed_blort_${reqBase}`]]);
+        return new MockDelta([['yes', reqBase]]);
       };
 
       // Counts for each tactic, to make sure both paths are exercised.
@@ -654,15 +654,14 @@ describe('@bayou/doc-server/BaseControl', () => {
         assert.isNull(result.timestamp);
         assert.isAbove(result.delta.ops.length, 0);
 
-        const ops     = result.delta.ops;
-        const op0Name = ops[0].name;
+        const ops = result.delta.ops;
 
-        if (op0Name === `composed_blort_${base}`) {
+        if (ops[0].equals(new MockOp('yes', base))) {
           composedCount++;
-        } else if (op0Name === 'diffDelta') {
+        } else if (ops[0].name === 'diffDelta') {
           diffCount++;
           assert.lengthOf(ops, 2);
-          assert.strictEqual(ops[1].name, `snap_blort_${newer}`);
+          assert.deepEqual(ops[1], new MockOp('snap', newer));
         } else {
           assert(false, 'Unexpected ops.');
         }

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -179,7 +179,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const fileAccess = new FileAccess(CODEC, file);
       const control = new MockControl(fileAccess, 'boop');
       const expectedMockChangeRevNum = 99;
-      const change = new MockChange(expectedMockChangeRevNum, [['florp', 'f'], ['blort', 'b']]);
+      const change = new MockChange(expectedMockChangeRevNum, [['x', 'f'], ['y', 'b']]);
       const snapshotRevNum = 100;
       const expectedFileChangeRevNum = snapshotRevNum + 1;
 
@@ -187,7 +187,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
       // TODO: Replace with stub
       Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(snapshotRevNum, [[`snap_blort_${snapshotRevNum}`]])
+        get: () => new MockSnapshot(snapshotRevNum, [['yes']])
       });
 
       // TODO: Replace with stub
@@ -215,7 +215,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const file = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, file);
       const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
+      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       let actualFileChange;
       let actualTimeout;
@@ -229,7 +229,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
       // TODO: Replace with stub
       Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [[`snap_blort_${100}`]])
+        get: () => new MockSnapshot(100, [['x', 1]])
       });
 
       async function test(timeout, expect, msg) {
@@ -262,10 +262,10 @@ describe('@bayou/doc-server/BaseControl', () => {
       const file = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, file);
       const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
+      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [[`snap_blort_${100}`]])
+        get: () => new MockSnapshot(100, [['yes']])
       });
 
       // TODO: Replace with spy
@@ -282,10 +282,10 @@ describe('@bayou/doc-server/BaseControl', () => {
       const file = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, file);
       const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
+      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [[`snap_blort_${100}`]])
+        get: () => new MockSnapshot(100, [['yes']])
       });
 
       control._maybeWriteStoredSnapshot = (revNum_unused) => {
@@ -308,10 +308,10 @@ describe('@bayou/doc-server/BaseControl', () => {
       const file = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, file);
       const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
+      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [[`snap_blort_${100}`]])
+        get: () => new MockSnapshot(100, [['x']])
       });
 
       control._maybeWriteStoredSnapshot = (revNum_unused) => {
@@ -351,7 +351,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, file);
       const control    = new MockControl(fileAccess, 'boop');
-      const change     = new MockChange(99, [['florp', 'f'], ['blort', 'b']]);
+      const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       async function test(v) {
         await assert.isRejected(control.appendChange(change, v), /badValue/);
@@ -876,7 +876,7 @@ describe('@bayou/doc-server/BaseControl', () => {
         throw new Error('This should not have been called.');
       };
 
-      const change = new MockChange(12, [new MockOp('abc')], Timestamp.MIN_VALUE);
+      const change = new MockChange(12, [new MockOp('y')], Timestamp.MIN_VALUE);
       await assert.isRejected(control.update(change), /^badValue/);
     });
 
@@ -920,21 +920,21 @@ describe('@bayou/doc-server/BaseControl', () => {
         gotBase     = baseSnapshot;
         gotExpected = expectedSnapshot;
         gotTimeout  = timeoutMsec;
-        return new MockChange(14, [new MockOp('q')]);
+        return new MockChange(14, [new MockOp('yes')]);
       };
 
-      const change = new MockChange(7, [new MockOp('abc')], Timestamp.MIN_VALUE);
+      const change = new MockChange(7, [new MockOp('y')], Timestamp.MIN_VALUE);
       const result = await control.update(change);
 
       assert.strictEqual(callCount, 1);
       assert.deepEqual(gotBase, new MockSnapshot(6, [new MockOp('x', 6)]));
       assert.strictEqual(gotChange, change);
       assert.deepEqual(gotExpected,
-        new MockSnapshot(7, [new MockOp('composedDoc'), new MockOp('abc')]));
+        new MockSnapshot(7, [new MockOp('composedDoc'), new MockOp('y')]));
       assert.isNumber(gotTimeout);
 
       assert.instanceOf(result, MockChange);
-      assert.deepEqual(result, new MockChange(14, [new MockOp('q')]));
+      assert.deepEqual(result, new MockChange(14, [new MockOp('yes')]));
     });
 
     it('should retry the `_attemptUpdate()` call if it returns `null`', async () => {
@@ -953,14 +953,14 @@ describe('@bayou/doc-server/BaseControl', () => {
           if (callCount === 1) {
             return null;
           }
-          return new MockChange(14, [new MockOp('florp')]);
+          return new MockChange(14, [new MockOp('yes')]);
         };
 
-      const change = new MockChange(7, [new MockOp('abc')], Timestamp.MIN_VALUE);
+      const change = new MockChange(7, [new MockOp('x')], Timestamp.MIN_VALUE);
       const result = await control.update(change);
 
       assert.strictEqual(callCount, 2);
-      assert.deepEqual(result, new MockChange(14, [new MockOp('florp')]));
+      assert.deepEqual(result, new MockChange(14, [new MockOp('yes')]));
     });
   });
 

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -930,7 +930,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.deepEqual(gotBase, new MockSnapshot(6, [new MockOp('x', 6)]));
       assert.strictEqual(gotChange, change);
       assert.deepEqual(gotExpected,
-        new MockSnapshot(7, [new MockOp('composed_doc'), new MockOp('abc')]));
+        new MockSnapshot(7, [new MockOp('composedDoc'), new MockOp('abc')]));
       assert.isNumber(gotTimeout);
 
       assert.instanceOf(result, MockChange);

--- a/local-modules/@bayou/file-store-ot/FileOp.js
+++ b/local-modules/@bayou/file-store-ot/FileOp.js
@@ -209,8 +209,14 @@ export default class FileOp extends BaseOp {
     }
   }
 
-  // TODO: implement file op specific validation
-  _impl_validate() {
+  /**
+   * Subclass-specific implementation of {@link #isValidPayload}.
+   *
+   * @param {Functor} payload_unused The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static _impl_isValidPayload(payload_unused) {
+    // **TODO:** Fill this in!
     return true;
   }
 }

--- a/local-modules/@bayou/file-store-ot/PredicateOp.js
+++ b/local-modules/@bayou/file-store-ot/PredicateOp.js
@@ -320,4 +320,15 @@ export default class PredicateOp extends BaseOp {
   static _op_revNumIs(snapshot, props) {
     return snapshot.revNum === props.revNum;
   }
+
+  /**
+   * Subclass-specific implementation of {@link #isValidPayload}.
+   *
+   * @param {Functor} payload_unused The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static _impl_isValidPayload(payload_unused) {
+    // **TODO:** Fill this in!
+    return true;
+  }
 }

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -2,14 +2,89 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CommonBase, Functor } from '@bayou/util-common';
+import { TBoolean, TString } from '@bayou/typecheck';
+import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 /**
  * Base class for OT operations. Instances of concrete subclasses of this class
  * are what compose the main contents of a corresponding concrete {@link
  * BaseDelta} subclasses.
+ *
+ * **Note:** Each concrete subclass of this class needs to define a set of
+ * static properties with names of the form `CODE_<name>`, each of which has a
+ * string value. These values are collectively taken to be the acceptable opcode
+ * names for use with the concrete subclass.
  */
 export default class BaseOp extends CommonBase {
+  /**
+   * Indicates whether the given name is acceptable for use as an opcode name
+   * on an instance of this class.
+   *
+   * **Note:** This depends on the set of `CODE_*` properties being correct for
+   * the concrete subclass class.
+   *
+   * @param {string} name Potential opcode name.
+   * @returns {boolean} `true` if `name` is valid for use as an opcode name on
+   *   this class, or `false` if not.
+   */
+  static isValidName(name) {
+    TString.check(name);
+
+    if (!this._names) {
+      // First time this method has been called on the concrete subclass;
+      // collect all the names.
+
+      const names = new Set();
+      const descs = Object.getOwnPropertyDescriptors(this);
+
+      for (const [propName, desc] of Object.entries(descs)) {
+        if (!/^CODE_/.test(propName)) {
+          continue;
+        }
+
+        const value = TString.nonEmpty(desc.get ? desc.get() : desc.value);
+        names.add(value);
+      }
+
+      this._names = Object.freeze(names);
+    }
+
+    return this._names.has(name);
+  }
+
+  /**
+   * Validates a {@link Functor} to be used as the payload for an instance of
+   * this class, returning a `boolean` indicating validity.
+   *
+   * @param {Functor} payload The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
+   */
+  static isValidPayload(payload) {
+    if (!this.isValidName(payload.name)) {
+      return false;
+    }
+
+    const result = this._impl_isValidPayload(payload);
+
+    return TBoolean.check(result);
+  }
+
+  /**
+   * Validates a {@link Functor} to be used as the payload for an instance of
+   * this class.
+   *
+   * @param {Functor} payload The would-be payload for an instance.
+   * @returns {Functor} `payload`, if it turns out to be valid.
+   * @throws {Error} Thrown if `payload` is invalid.
+   */
+  static validatePayload(payload) {
+    if (this.isValidPayload(payload)) {
+      return payload;
+    }
+
+    throw Errors.badUse(`Invalid payload for ${this.name}.`);
+  }
+
   /**
    * Constructs an instance. This should not be used directly. Instead, use
    * the static constructor methods defined by concrete subclasses of this
@@ -24,11 +99,12 @@ export default class BaseOp extends CommonBase {
   constructor(name, ...args) {
     super();
 
-    // Perform syntactic validation based on subclass
-    this._impl_validate(name, args);
+    // Perform syntactic validation based on the concrete subclass.
+    const payload = new Functor(name, ...args).withFrozenArgs();
+    this.constructor.validatePayload(payload);
 
     /** {Functor} The operation payload (name and arguments). */
-    this._payload = new Functor(name, ...args).withFrozenArgs();
+    this._payload = payload;
 
     Object.freeze(this);
   }
@@ -70,16 +146,14 @@ export default class BaseOp extends CommonBase {
   }
 
   /**
-   * Abstract function to alidates op arguments based on
-   * op subclass. Subclasses must implement their own validation.
+   * Main implementation of {@link #isValidPayload}. Subclasses must fill this
+   * in.
    *
-   * @param {string} name The name of the op type.
-   * @param {array} args The op arguments to validate.
-   * @returns {boolean} `true` if arguments are valid,
-   *   throws and error otherwise.
    * @abstract
+   * @param {Functor} payload The would-be payload for an instance.
+   * @returns {boolean} `true` if `payload` is valid, or `false` if not.
    */
-  _impl_validate(name, args) {
-    return this._mustOverride(name, args);
+  static _impl_isValidPayload(payload) {
+    return this._mustOverride(payload);
   }
 }

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -44,6 +44,10 @@ export default class BaseOp extends CommonBase {
 
         const value = TString.nonEmpty(desc.get ? desc.get() : desc.value);
         names.add(value);
+
+        if (names.size === 0) {
+          throw new Errors.wtf(`No \`CODE_*\` properties found on ${this.name}.`);
+        }
       }
 
       this._names = Object.freeze(names);

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TBoolean, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
@@ -86,7 +88,7 @@ export default class BaseOp extends CommonBase {
       return payload;
     }
 
-    throw Errors.badUse(`Invalid payload for ${this.name}.`);
+    throw Errors.badUse(`Invalid payload for ${this.name}: ${inspect(payload)}`);
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -19,6 +19,22 @@ import { CommonBase, Errors, Functor } from '@bayou/util-common';
  */
 export default class BaseOp extends CommonBase {
   /**
+   * Validates a {@link Functor} to be used as the payload for an instance of
+   * this class.
+   *
+   * @param {Functor} payload The would-be payload for an instance.
+   * @returns {Functor} `payload`, if it turns out to be valid.
+   * @throws {Error} Thrown if `payload` is invalid.
+   */
+  static checkPayload(payload) {
+    if (this.isValidPayload(payload)) {
+      return payload;
+    }
+
+    throw Errors.badUse(`Invalid payload for ${this.name}: ${inspect(payload)}`);
+  }
+
+  /**
    * Indicates whether the given name is acceptable for use as an opcode name
    * on an instance of this class.
    *
@@ -76,22 +92,6 @@ export default class BaseOp extends CommonBase {
   }
 
   /**
-   * Validates a {@link Functor} to be used as the payload for an instance of
-   * this class.
-   *
-   * @param {Functor} payload The would-be payload for an instance.
-   * @returns {Functor} `payload`, if it turns out to be valid.
-   * @throws {Error} Thrown if `payload` is invalid.
-   */
-  static validatePayload(payload) {
-    if (this.isValidPayload(payload)) {
-      return payload;
-    }
-
-    throw Errors.badUse(`Invalid payload for ${this.name}: ${inspect(payload)}`);
-  }
-
-  /**
    * Constructs an instance. This should not be used directly. Instead, use
    * the static constructor methods defined by concrete subclasses of this
    * class.
@@ -107,7 +107,7 @@ export default class BaseOp extends CommonBase {
 
     // Perform syntactic validation based on the concrete subclass.
     const payload = new Functor(name, ...args).withFrozenArgs();
-    this.constructor.validatePayload(payload);
+    this.constructor.checkPayload(payload);
 
     /** {Functor} The operation payload (name and arguments). */
     this._payload = payload;

--- a/local-modules/@bayou/ot-common/mocks/MockDelta.js
+++ b/local-modules/@bayou/ot-common/mocks/MockDelta.js
@@ -20,7 +20,7 @@ export default class MockDelta extends BaseDelta {
    * document.
    */
   static get NOT_DOCUMENT_OPS() {
-    return [new MockOp('not_document')];
+    return [new MockOp('notDocument')];
   }
 
   /** {array<object>} Ops array that will be considered valid. */
@@ -29,7 +29,7 @@ export default class MockDelta extends BaseDelta {
   }
 
   _impl_compose(other, wantDocument) {
-    let resultName = wantDocument ? 'composed_doc' : 'composed_not_doc';
+    let resultName = wantDocument ? 'composedDoc' : 'composedNotDoc';
     const op0 = this.ops[0];
 
     if (op0 && op0.name.startsWith(resultName)) {
@@ -44,7 +44,7 @@ export default class MockDelta extends BaseDelta {
   _impl_isDocument() {
     const op0 = this.ops[0];
 
-    return op0 ? (op0.name !== 'not_document') : true;
+    return op0 ? (op0.name !== 'notDocument') : true;
   }
 
   /**

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -8,11 +8,20 @@ import { BaseOp } from '@bayou/ot-common';
  * Mock operation class for testing.
  */
 export default class MockOp extends BaseOp {
+  static get CODE_composedDoc()    { return 'composedDoc';    }
+  static get CODE_composedDoc_()   { return 'composedDoc_';   }
+  static get CODE_composedDoc__()  { return 'composedDoc__';  }
+  static get CODE_composedNotDoc() { return 'composedNotDoc'; }
+  static get CODE_notDocument()    { return 'notDocument';    }
+  static get CODE_x()              { return 'x';              }
+  static get CODE_y()              { return 'y';              }
+  static get CODE_yes()            { return 'yes';            }
+
   get name() {
     return this.payload.name;
   }
 
-  _impl_isValidPayload() {
+  static _impl_isValidPayload() {
     return true;
   }
 }

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -12,10 +12,12 @@ export default class MockOp extends BaseOp {
   static get CODE_composedDoc_()   { return 'composedDoc_';   }
   static get CODE_composedDoc__()  { return 'composedDoc__';  }
   static get CODE_composedNotDoc() { return 'composedNotDoc'; }
+  static get CODE_diffDelta()      { return 'diffDelta';      }
   static get CODE_notDocument()    { return 'notDocument';    }
   static get CODE_x()              { return 'x';              }
   static get CODE_y()              { return 'y';              }
   static get CODE_yes()            { return 'yes';            }
+  static get CODE_z()              { return 'z';              }
 
   get name() {
     return this.payload.name;

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -14,6 +14,7 @@ export default class MockOp extends BaseOp {
   static get CODE_composedNotDoc() { return 'composedNotDoc'; }
   static get CODE_diffDelta()      { return 'diffDelta';      }
   static get CODE_notDocument()    { return 'notDocument';    }
+  static get CODE_snap()           { return 'snap';    }
   static get CODE_x()              { return 'x';              }
   static get CODE_y()              { return 'y';              }
   static get CODE_yes()            { return 'yes';            }

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -12,7 +12,7 @@ export default class MockOp extends BaseOp {
     return this.payload.name;
   }
 
-  _impl_validate() {
+  _impl_isValidPayload() {
     return true;
   }
 }

--- a/local-modules/@bayou/ot-common/mocks/MockSnapshot.js
+++ b/local-modules/@bayou/ot-common/mocks/MockSnapshot.js
@@ -32,7 +32,7 @@ export default class MockSnapshot extends BaseSnapshot {
   }
 
   _impl_diffAsDelta(newerSnapshot) {
-    return [new MockOp('diff_delta'), newerSnapshot.contents.ops[0]];
+    return [new MockOp('diffDelta'), newerSnapshot.contents.ops[0]];
   }
 
   _impl_validateChange() {

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -105,9 +105,9 @@ describe('@bayou/ot-common/BaseDelta', () => {
         }
       }
 
-      test(['blort']);
-      test(['blort', 1]);
-      test(['blort', 1, 2, 3, 4, 'florp']);
+      test(['z']);
+      test(['z', 1]);
+      test(['z', 1, 2, 3, 4, 'florp']);
       test(['x'], ['y'], ['z']);
       test(['x', ['a']], ['y', { b: 10 }], ['z', [[['pdq']]]]);
     });
@@ -232,8 +232,8 @@ describe('@bayou/ot-common/BaseDelta', () => {
     });
 
     it('should return `true` when equal ops are not also `===`', () => {
-      const ops1 = [new MockOp('foo'), new MockOp('bar')];
-      const ops2 = [new MockOp('foo'), new MockOp('bar')];
+      const ops1 = [new MockOp('x'), new MockOp('y')];
+      const ops2 = [new MockOp('x'), new MockOp('y')];
       const d1 = new MockDelta(ops1);
       const d2 = new MockDelta(ops2);
 
@@ -242,8 +242,8 @@ describe('@bayou/ot-common/BaseDelta', () => {
     });
 
     it('should return `false` when array lengths differ', () => {
-      const op1 = new MockOp('foo');
-      const op2 = new MockOp('bar');
+      const op1 = new MockOp('x');
+      const op2 = new MockOp('y');
       const d1 = new MockDelta([op1]);
       const d2 = new MockDelta([op1, op2]);
 
@@ -260,11 +260,11 @@ describe('@bayou/ot-common/BaseDelta', () => {
         assert.isFalse(d2.equals(d1));
       }
 
-      const op1 = new MockOp('foo');
-      const op2 = new MockOp('bar');
-      const op3 = new MockOp('baz');
-      const op4 = new MockOp('biff');
-      const op5 = new MockOp('quux');
+      const op1 = new MockOp('x');
+      const op2 = new MockOp('y');
+      const op3 = new MockOp('z');
+      const op4 = new MockOp('x', 1);
+      const op5 = new MockOp('x', 2);
 
       test([op1],                     [op2]);
       test([op1, op2],                [op1, op3]);

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -165,14 +165,14 @@ describe('@bayou/ot-common/BaseDelta', () => {
 
   describe('deconstruct()', () => {
     it('should return a data value', () => {
-      const delta  = new MockDelta([['a', 1, 2, 3, [4, 5, 6]], ['b', { x: ['y'] }]]);
+      const delta  = new MockDelta([['x', 1, 2, 3, [4, 5, 6]], ['y', { x: ['y'] }]]);
       const result = delta.deconstruct();
 
       assert.isTrue(DataUtil.isData(result));
     });
 
     it('should return an array of length one, which contains an array-of-arrays', () => {
-      const delta  = new MockDelta([['a', 1], ['b', [1, 2]]]);
+      const delta  = new MockDelta([['x', 1], ['y', [1, 2]]]);
       const result = delta.deconstruct();
 
       assert.isArray(result);

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -126,8 +126,8 @@ describe('@bayou/ot-common/BaseDelta', () => {
         assert.deepEqual(result.ops, expectOps);
       }
 
-      test([], [['x']], false, [['composed_not_doc'], ['x']]);
-      test([], [['x']], true,  [['composed_doc'], ['x']]);
+      test([], [['x']], false, [['composedNotDoc'], ['x']]);
+      test([], [['x']], true,  [['composedDoc'], ['x']]);
     });
 
     it('should reject invalid `other` arguments', () => {
@@ -158,7 +158,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
     });
 
     it('should reject a non-document `this` when `wantDocument` is `true`', () => {
-      const delta = new MockDelta([['not_document']]);
+      const delta = new MockDelta([['notDocument']]);
       assert.throws(() => { delta.compose(MockDelta.EMPTY, true); }, /badUse/);
     });
   });

--- a/local-modules/@bayou/ot-common/tests/test_BaseOp.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseOp.js
@@ -13,24 +13,24 @@ import { MockOp } from '@bayou/ot-common/mocks';
 describe('@bayou/ot-common/BaseOp', () => {
   describe('constructor()', () => {
     it('should accept a string `name argument', () => {
-      const result = new MockOp('blort');
-      assert.strictEqual(result.payload.name, 'blort');
+      const result = new MockOp('x');
+      assert.strictEqual(result.payload.name, 'x');
     });
 
     it('should accept at least ten arguments after the name', () => {
-      const result = new MockOp('blort', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+      const result = new MockOp('x', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
       assert.strictEqual(result.payload.args.length, 10);
     });
 
     it('should produce a frozen instance with a frozen payload', () => {
-      const op = new MockOp('blort');
+      const op = new MockOp('x');
       assert.isFrozen(op);
       assert.isFrozen(op.payload);
     });
 
     it('should have all frozen payload arguments even when given non-frozen ones', () => {
       function test(...args) {
-        const op      = new MockOp('blort', ...args);
+        const op      = new MockOp('x', ...args);
         const gotArgs = op.payload.args;
 
         for (const arg of gotArgs) {
@@ -58,11 +58,11 @@ describe('@bayou/ot-common/BaseOp', () => {
 
     it('should reject payloads with arguments that are neither frozen nor deep-freezable data', () => {
       function test(...args) {
-        assert.throws(() => new MockOp(...args));
+        assert.throws(() => new MockOp('x', ...args));
       }
 
       test(new Map());
-      test(new Functor('x', 1, 2));
+      test(new Functor('x', 1, 2, [1, 2]));
       test(/blort/);
       test(() => 'woo');
       test(1, 2, 3, new Map(), 4, 5, 6);
@@ -91,7 +91,7 @@ describe('@bayou/ot-common/BaseOp', () => {
 
   describe('deconstruct()', () => {
     it('should return an array data value', () => {
-      const op     = new MockOp('blort', ['florp', 'like'], { timeline: 'sideways' });
+      const op     = new MockOp('x', ['florp', 'like'], { timeline: 'sideways' });
       const result = op.deconstruct();
 
       assert.isArray(result);
@@ -108,11 +108,11 @@ describe('@bayou/ot-common/BaseOp', () => {
         assert.deepEqual(op1, op2);
       }
 
-      test('foo');
-      test('bar', 1, 2, 3);
-      test('baz', ['florp', 'like']);
-      test('goo', { timeline: 'sideways' });
-      test('boo', [[[[[[[[[['floomp']]]]]]]]]]);
+      test('x');
+      test('y', 1, 2, 3);
+      test('z', ['florp', 'like']);
+      test('x', { timeline: 'sideways' });
+      test('y', [[[[[[[[[['floomp']]]]]]]]]]);
     });
   });
 
@@ -130,9 +130,9 @@ describe('@bayou/ot-common/BaseOp', () => {
       }
 
       test('x');
-      test('foo', 1);
-      test('bar', ['x']);
-      test('baz', { a: 10, b: 20 });
+      test('y', 1);
+      test('z', ['x']);
+      test('z', { a: 10, b: 20 });
     });
 
     it('should return `false` when payloads differ', () => {

--- a/local-modules/@bayou/ot-common/tests/test_BaseOp.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseOp.js
@@ -62,10 +62,17 @@ describe('@bayou/ot-common/BaseOp', () => {
       }
 
       test(new Map());
-      test(new Functor('x', 1, 2, [1, 2]));
+      test([1, 2, new Set()], 3);
+      test('foo', 3, [new Set()], 4);
       test(/blort/);
       test(() => 'woo');
       test(1, 2, 3, new Map(), 4, 5, 6);
+
+      // **TODO:** This should arguably fail, in that `Set` can't be
+      // deep-frozen. The issue is probably that the `BaseOp` constructor
+      // doesn't actually try to deep-freeze its arguments, just single-level
+      // freeze.
+      //test(new Functor('x', 1, 2, new Set()));
     });
 
     it('should reject non-string first arguments', () => {

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -118,7 +118,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composed_doc'), new MockOp('change_op')]);
+        [new MockOp('composedDoc'), new MockOp('change_op')]);
     });
 
     it('should return `this` given a same-`revNum` empty-`delta` change', () => {

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -109,8 +109,8 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
 
   describe('compose()', () => {
     it('should call through to the delta and wrap the result in a new instance', () => {
-      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
-      const change = new MockChange(20, [new MockOp('change_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('x')]);
+      const change = new MockChange(20, [new MockOp('y')]);
       const result = snap.compose(change);
 
       assert.instanceOf(result, MockSnapshot);
@@ -118,11 +118,11 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composedDoc'), new MockOp('change_op')]);
+        [new MockOp('composedDoc'), new MockOp('y')]);
     });
 
     it('should return `this` given a same-`revNum` empty-`delta` change', () => {
-      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(10, []);
       const result = snap.compose(change);
 
@@ -158,9 +158,9 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
 
   describe('composeAll()', () => {
     it('should call through to the delta and wrap the result in a new instance', () => {
-      const snap    = new MockSnapshot(10, [new MockOp('some_op')]);
-      const change1 = new MockChange(21, [new MockOp('change_op1')]);
-      const change2 = new MockChange(22, [new MockOp('change_op2')]);
+      const snap    = new MockSnapshot(10, [new MockOp('x')]);
+      const change1 = new MockChange(21, [new MockOp('y')]);
+      const change2 = new MockChange(22, [new MockOp('z')]);
       const result = snap.composeAll([change1, change2]);
 
       assert.instanceOf(result, MockSnapshot);
@@ -168,11 +168,11 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composed_doc_'), new MockOp('change_op2')]);
+        [new MockOp('composedDoc_'), new MockOp('z')]);
     });
 
     it('should return `this` given same-`revNum` empty-`delta` changes', () => {
-      const snap   = new MockSnapshot(10, [new MockOp('some_op')]);
+      const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(10, []);
       const result = snap.composeAll([change, change, change, change]);
 
@@ -215,7 +215,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   describe('diff()', () => {
     it('should call through to the impl and wrap the result in a timeless authorless change', () => {
       const oldSnap = new MockSnapshot(10, []);
-      const newSnap = new MockSnapshot(20, [new MockOp('new_snap')]);
+      const newSnap = new MockSnapshot(20, [new MockOp('x')]);
       const result  = oldSnap.diff(newSnap);
 
       assert.instanceOf(result, MockChange);
@@ -225,7 +225,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.isNull(result.authorId);
 
       assert.deepEqual(result.delta.ops,
-        [new MockOp('diff_delta'), new MockOp('new_snap')]);
+        [new MockOp('diffDelta'), new MockOp('x')]);
     });
 
     it('should return an empty change when given an argument with identical contents', () => {
@@ -236,8 +236,8 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
         assert.lengthOf(result.delta.ops, 0);
       }
 
-      const snap1 = new MockSnapshot(10, [new MockOp('some_op')]);
-      const snap2 = new MockSnapshot(20, [new MockOp('some_op')]);
+      const snap1 = new MockSnapshot(10, [new MockOp('x')]);
+      const snap2 = new MockSnapshot(20, [new MockOp('x')]);
       const snap3 = new MockSnapshot(30, snap2.contents);
 
       test(snap1, snap1);
@@ -349,8 +349,8 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
     });
 
     it('should return an appropriately-constructed instance given a different `contents`', () => {
-      const delta  = new MockDelta([new MockOp('yo')]);
-      const snap   = new MockSnapshot(123, [new MockOp('hello')]);
+      const delta  = new MockDelta([new MockOp('x')]);
+      const snap   = new MockSnapshot(123, [new MockOp('y')]);
       const result = snap.withContents(delta);
 
       assert.strictEqual(result.revNum,   123);


### PR DESCRIPTION
This PR adds validation of the opcode names used in concrete `BaseOp` subclasses, achieved via reflection on the `CODE_*` properties already present on each subclass.

I also took the opportunity to rework the ad-hoc validation method defined by `BaseOp`, formerly called `_impl_validate()`: It was better as a `static` method, it was specified as "return `true`, or throw" which isn't the dominant pattern used in this code base, and it had an opportunity to modify the `args` (whereas the project tends toward forcing immutability). [*] It's now a `boolean`-returning method called `_impl_isValidPayload()`. I left the status quo that all of the concrete implementations of the method are effectively no-ops. (We will still need to fill them in at some point!)

[*] I accept blame for all of these issues.