### PR TITLE
Allow new objects to get added to a connection dynamically.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -254,6 +254,7 @@ export default class ApiClient extends CommonBase {
     // Test to make sure newly-proxied objects get returned as expected.
     // **TODO:** Remove this once we have unit test coverage for this
     // functionality.
+    /*
     (async () => {
       const counter = await this.meta.makeCounter();
       this._log.info('Got counter:', counter);
@@ -262,6 +263,7 @@ export default class ApiClient extends CommonBase {
       const c2 = await counter.count();
       this._log.info('Got counts:', c0, c1, c2);
     })();
+    */
 
     return true;
   }

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -251,6 +251,18 @@ export default class ApiClient extends CommonBase {
     this._updateLogger();
     this._log.event.open();
 
+    // Test to make sure newly-proxied objects get returned as expected.
+    // **TODO:** Remove this once we have unit test coverage for this
+    // functionality.
+    (async () => {
+      const counter = await this.meta.makeCounter();
+      this._log.info('Got counter:', counter);
+      const c0 = await counter.count();
+      const c1 = await counter.count();
+      const c2 = await counter.count();
+      this._log.info('Got counts:', c0, c1, c2);
+    })();
+
     return true;
   }
 

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BaseKey, CodableError, ConnectionError, Message, Response } from '@bayou/api-common';
+import { BaseKey, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
@@ -197,8 +197,8 @@ export default class ApiClient extends CommonBase {
   /**
    * Gets a proxy for the target with the given ID or which is controlled by the
    * given key (or which was so controlled prior to authorizing it away). The
-   * target must already have been authorized for this method to work (otherwise
-   * it is an error); use `authorizeTarget()` to perform authorization.
+   * target must already be known to this instance for this method to work
+   * (otherwise it is an error).
    *
    * @param {string|BaseKey} idOrKey ID or key for the target.
    * @returns {Proxy} Proxy which locally represents the so-identified
@@ -342,7 +342,12 @@ export default class ApiClient extends CommonBase {
         callback.reject(rejectReason);
       } else {
         this._log.detail(`Resolve ${id}:`, result);
-        callback.resolve(result);
+        if (result instanceof Remote) {
+          // The result is a proxied object, not a regular value.
+          callback.resolve(this._targets.addOrGet(result.targetId));
+        } else {
+          callback.resolve(result);
+        }
       }
     } else {
       // See above about `server_bug`.
@@ -384,8 +389,11 @@ export default class ApiClient extends CommonBase {
   }
 
   /**
-   * Init or reset the state having to do with an active connection. See the
-   * constructor for documentation about these fields.
+   * Gets a proxy
+
+  /**
+   * Initializes or resets the state having to do with an active connection. See
+   * the constructor for documentation about these fields.
    */
   _resetConnection() {
     this._ws              = null;

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -58,6 +58,19 @@ export default class TargetMap extends CommonBase {
   }
 
   /**
+   * Adds the target as if by {@link #add} if not already bound, or returns the
+   * pre-existing binding as if by {@link #get}.
+   *
+   * @param {string} id Target ID.
+   * @returns {Proxy} The corresponding proxy.
+   */
+  addOrGet(id) {
+    const already = this.getOrNull(id);
+
+    return (already === null) ? this.add(id) : already;
+  }
+
+  /**
    * Clears out the targets of this instance.
    */
   clear() {

--- a/local-modules/@bayou/api-common/Remote.js
+++ b/local-modules/@bayou/api-common/Remote.js
@@ -1,0 +1,43 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CommonBase } from '@bayou/util-common';
+
+import TargetId from './TargetId';
+
+/**
+ * Encodable representation of an object that is proxied over a connection.
+ * Instances of this class are what get encoded instead of encoding a
+ * {@link ProxiedObject} (or its target).
+ */
+export default class Remote extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} targetId ID which represents the object, specifically with
+   *   respect to the connection over which this instance is being used.
+   */
+  constructor(targetId) {
+    super();
+
+    /** {string} ID of the represented object. */
+    this._targetId = TargetId.check(targetId);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Gets reconstruction arguments for this instance.
+   *
+   * @returns {array<*>} Reconstruction arguments.
+   */
+  deconstruct() {
+    return [this._targetId];
+  }
+
+  /** {string} ID of the represented object. */
+  get targetId() {
+    return this._targetId;
+  }
+}

--- a/local-modules/@bayou/api-common/TheModule.js
+++ b/local-modules/@bayou/api-common/TheModule.js
@@ -8,6 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 import CodableError from './CodableError';
 import Message from './Message';
 import Response from './Response';
+import Remote from './Remote';
 import SplitKey from './SplitKey';
 
 /**
@@ -24,6 +25,7 @@ export default class TheModule extends UtilityClass {
 
     registry.registerClass(CodableError);
     registry.registerClass(Message);
+    registry.registerClass(Remote);
     registry.registerClass(Response);
     registry.registerClass(SplitKey);
   }

--- a/local-modules/@bayou/api-common/index.js
+++ b/local-modules/@bayou/api-common/index.js
@@ -8,6 +8,7 @@ import BearerToken from './BearerToken';
 import CodableError from './CodableError';
 import ConnectionError from './ConnectionError';
 import Message from './Message';
+import Remote from './Remote';
 import Response from './Response';
 import SplitKey from './SplitKey';
 import TargetId from './TargetId';
@@ -19,6 +20,7 @@ export {
   CodableError,
   ConnectionError,
   Message,
+  Remote,
   Response,
   SplitKey,
   TargetId

--- a/local-modules/@bayou/api-common/tests/test_Remote.js
+++ b/local-modules/@bayou/api-common/tests/test_Remote.js
@@ -1,0 +1,71 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { Remote } from '@bayou/api-common';
+
+/** {array<object>} Valid values for `targetId`. */
+const VALID_IDS = [
+  'a',
+  '1',
+  'abc',
+  'florp-like',
+  'foo.bar',
+  'something_else'
+];
+
+/** {array<object>} Invalid values for `targetId`. */
+const INVALID_IDS = [
+  null,
+  undefined,
+  true,
+  123,
+  [],
+  ['x'],
+  { a: 'b' },
+  new Map(),
+  '',
+  '#',
+  'foo!'
+];
+
+describe('@bayou/api-common/Remote', () => {
+  describe('constructor()', () => {
+    it('should accept valid IDs', () => {
+      for (const id of VALID_IDS) {
+        assert.doesNotThrow(() => new Remote(id), id);
+      }
+    });
+
+    it('should reject invalid values for `targetId`', () => {
+      for (const id of INVALID_IDS) {
+        assert.throws(() => new Remote(id), /badValue/, inspect(id));
+      }
+    });
+  });
+
+  describe('.targetId', () => {
+    it('should be the same as the `targetID` passed to the constructor', () => {
+      for (const id of VALID_IDS) {
+        const r = new Remote(id);
+        assert.strictEqual(r.targetId, id);
+      }
+    });
+  });
+
+  describe('deconstruct()', () => {
+    it('should be a single-element array with the same contents as the `targetId` passed to the constructor', () => {
+      for (const id of VALID_IDS) {
+        const r   = new Remote(id);
+        const dec = r.deconstruct();
+        assert.isArray(dec);
+        assert.lengthOf(dec, 1);
+        assert.strictEqual(dec[0], id, id);
+      }
+    });
+  });
+});

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ConnectionError, Message, Response } from '@bayou/api-common';
+import { ProxiedObject } from '@bayou/api-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
@@ -166,10 +167,16 @@ export default class Connection extends CommonBase {
 
   /**
    * Helper for `handleJsonMessage()` which actually performs the method call
-   * requested by the given message. Because `undefined` is not used on the API,
-   * a top-level `undefined` result (which, e.g., is what is returned from a
-   * method that just falls through to the end or `return`s without specifying
-   * a value) is replaced by `null`.
+   * requested by the given message.
+   *
+   * Because `undefined` is not used across the API boundary, a top-level
+   * `undefined` result (which, notably, is what is returned from a method that
+   * just falls through to the end or `return`s without specifying a value) is
+   * replaced by `null`.
+   *
+   * In addition, if the result is an instance of {@link ProxiedObject}, it
+   * is replaced with a {@link Remote} which can represent it across the API
+   * boundary.
    *
    * @param {Message} msg Parsed message.
    * @returns {*} Whatever the called method returns, except `null` replacing
@@ -179,7 +186,19 @@ export default class Connection extends CommonBase {
     const target = await this._getTarget(msg.targetId);
     const result = await target.call(msg.payload);
 
-    return (result === undefined) ? null : result;
+    if (result === undefined) {
+      // See method header comment.
+      return null;
+    } else if (result instanceof ProxiedObject) {
+      // The result isn't a regular encodable value. Instead, it will end up
+      // proxied across the connection. This is achieved by encoding it as a
+      // `Remote`, which the far side of the connection will convert into a
+      // proxy on its side. **TODO:** This conversion shouldn't just be limited
+      // to direct return values.
+      return this._context.getRemoteFor(result);
+    } else {
+      return result;
+    }
   }
 
   /**

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -50,9 +50,6 @@ export default class Connection extends CommonBase {
      */
     this._connectionId = Random.shortLabel('conn');
 
-    /** {Int} Count of messages received. Used for liveness logging. */
-    this._messageCount = 0;
-
     /** {Codec} The codec to use. */
     this._codec = context.codec;
 

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -222,7 +222,7 @@ export default class Context extends CommonBase {
     const obj     = proxiedObject.target;
     const already = this._remoteMap.get(obj);
 
-    if (already !== null) {
+    if (already !== undefined) {
       return already;
     }
 

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -48,8 +48,14 @@ export default class Context extends CommonBase {
      */
     this._tokenAuth = (tokenAuth === null) ? null : TokenAuthorizer.check(tokenAuth);
 
-    /** {Map<string, Target>} The underlying map. */
+    /** {Map<string, Target>} The underlying map from IDs to targets. */
     this._map = new Map();
+
+    /**
+     * {Map<object, string>} Reverse map from target objects (the things wrapped
+     * by instances of {@link Target} to their corresponding IDs.
+     */
+    this._reverseMap = new Map();
 
     /**
      * {Int} Msec timestamp indicating the most recent time that idle cleanup
@@ -71,22 +77,32 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Adds a {@link Target} to this instance's map of same. The given `target`
-   * must not have an ID that is already represented in the map.
+   * Adds a {@link Target} to this instance's map of same, and also adds the
+   * reverse map from the target's wrapped object to the ID. The given `target`
+   * must not have an ID that is already represented in the map. In addition,
+   * the object wrapped by `target` must not already be bound to another ID.
+   * (That is, for any given instance of this class, there is a one-to-one
+   * mapping between IDs and target objects.)
    *
    * @param {Target} target Target to add.
-   * @throws {Error} Thrown if `target.id` is already represented in the target
-   *   map.
+   * @throws {Error} Thrown if either `target.id` or `target.target` is already
+   *   represented in the target map.
    */
   addTarget(target) {
     Target.check(target);
-    const id = target.id;
+    const id  = target.id;
+    const obj = target.target;
 
     if (this._getOrNull(id) !== null) {
-      throw this._targetError(id, 'Duplicate target');
+      throw this._targetError(id, 'Duplicate target ID');
+    }
+
+    if (this._reverseMap.has(obj)) {
+      throw this._targetError(id, 'Duplicate target object');
     }
 
     this._map.set(id, target);
+    this._reverseMap.set(obj, id);
   }
 
   /**
@@ -287,9 +303,10 @@ export default class Context extends CommonBase {
    * checks, erring on the side of _keeping_ a "stale" target.
    */
   _idleCleanupIfNecessary() {
-    const now       = Date.now();
-    const idleLimit = now - IDLE_TIME_MSEC;
-    const map       = this._map;
+    const now        = Date.now();
+    const idleLimit  = now - IDLE_TIME_MSEC;
+    const map        = this._map;
+    const reverseMap = this._reverseMap;
 
     if (now < (this._lastIdleCleanup + (IDLE_TIME_MSEC / 4))) {
       // Cleaning already happened recently.
@@ -303,10 +320,11 @@ export default class Context extends CommonBase {
     // Note: The ECMAScript spec guarantees that it is safe to delete keys from
     // a map while iterating over it. See
     // <https://tc39.github.io/ecma262/#sec-runtime-semantics-forin-div-ofheadevaluation-tdznames-expr-iterationkind>.
-    for (const [key, value] of map) {
-      if (value.wasIdleAsOf(idleLimit)) {
-        log.event.idleCleanupRemoved(key);
-        map.delete(key);
+    for (const [id, target] of map) {
+      if (target.wasIdleAsOf(idleLimit)) {
+        log.event.idleCleanupRemoved(id);
+        map.delete(id);
+        reverseMap.delete(target.target);
       }
     }
 

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -85,13 +85,13 @@ export default class Context extends CommonBase {
    * mapping between IDs and target objects.)
    *
    * @param {Target} target Target to add.
-   * @throws {Error} Thrown if either `target.id` or `target.target` is already
-   *   represented in the target map.
+   * @throws {Error} Thrown if either `target.id` or `target.directObject` is
+   *   already represented in the target map.
    */
   addTarget(target) {
     Target.check(target);
     const id  = target.id;
-    const obj = target.target;
+    const obj = target.directObject;
 
     if (this._getOrNull(id) !== null) {
       throw this._targetError(id, 'Duplicate target ID');
@@ -324,7 +324,7 @@ export default class Context extends CommonBase {
       if (target.wasIdleAsOf(idleLimit)) {
         log.event.idleCleanupRemoved(id);
         map.delete(id);
-        reverseMap.delete(target.target);
+        reverseMap.delete(target.directObject);
       }
     }
 

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -6,6 +6,8 @@ import { TString } from '@bayou/typecheck';
 import { Delay } from '@bayou/promise-util';
 import { Errors } from '@bayou/util-common';
 
+import ProxiedObject from './ProxiedObject';
+
 /** {Int} How long an unanswered challenge remains active for, in msec. */
 const CHALLENGE_TIMEOUT_MSEC = 5 * 60 * 1000; // Five minutes.
 
@@ -139,5 +141,28 @@ export default class MetaHandler {
    */
   ping() {
     return true;
+  }
+
+  /**
+   * Makes a new counter, which is kept on the server and returned to the client
+   * as a proxied object. The method `count()` on the result returns the next
+   * number in sequence, starting with `0`.
+   *
+   * **TODO:** This method only exists for ad-hoc testing of the API mechanism
+   * and should be removed once we have real tests.
+   *
+   * @returns {ProxiedObject} A new counter.
+   */
+  makeCounter() {
+    let value = -1;
+
+    const result = {
+      count() {
+        value++;
+        return value;
+      }
+    };
+
+    return new ProxiedObject(result);
   }
 }

--- a/local-modules/@bayou/api-server/ProxiedObject.js
+++ b/local-modules/@bayou/api-server/ProxiedObject.js
@@ -1,0 +1,50 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TObject } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
+
+/**
+ * Wrapper for an object which is to be proxied over an API connection.
+ * Instances of this class can be returned by methods of other proxied objects
+ * to indicate that those return values should be proxied rather than returned
+ * as encoded values. When a {@link Connection} encounters one of these as a
+ * return value, it automatically registers its {@link #target} as a target in
+ * the connection's associated context if not already present. If the target
+ * _is_ already present, then the pre-existing target is used. In either case,
+ * the response message sent to the client indicates that the result is a
+ * proxied object and not a regular encoded value.
+ */
+export default class ProxiedObject extends CommonBase {
+  /**
+   * Constructs an instance which wraps the given object.
+   *
+   * @param {object} target Object to provide access to.
+   */
+  constructor(target) {
+    super();
+
+    /** {object} The target object. */
+    this._target = TObject.check(target);
+
+    Object.freeze(this);
+  }
+
+  /** {object} The underlying target object. */
+  get target() {
+    return this._target;
+  }
+
+  /**
+   * Gets reconstruction arguments for this instance. Instances of this class
+   * aren't typically registered as encodable on an API connection. However,
+   * {@link CommonBase} uses this method when available when supplying output
+   * for `inspect()`, which is why this is implemented here.
+   *
+   * @returns {array<*>} Reconstruction arguments.
+   */
+  deconstruct() {
+    return [this._target];
+  }
+}

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseKey, TargetId } from '@bayou/api-common';
-import { TObject, TString } from '@bayou/typecheck';
+import { TObject } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 import Schema from './Schema';

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -41,8 +41,7 @@ export default class Target extends CommonBase {
     this._key = (idOrKey instanceof BaseKey) ? idOrKey : null;
 
     /** {string} The target ID. */
-    this._id = TargetId.check(
-      (this._key === null) ? TString.check(idOrKey) : this._key.id);
+    this._id = TargetId.check((this._key === null) ? idOrKey : this._key.id);
 
     /**
      * {object} The object which this instance represents, wraps, and generally

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -65,6 +65,16 @@ export default class Target extends CommonBase {
     Object.seal(this);
   }
 
+  /**
+  * {object} The object which this instance represents, wraps, and generally
+  * provides access to. Accessing this property indicates that this instance is
+  * _not_ currently idle.
+  */
+  get directObject() {
+    this.refresh();
+    return this._directObject;
+  }
+
   /** {string} The target ID. */
   get id() {
     return this._id;
@@ -78,24 +88,14 @@ export default class Target extends CommonBase {
     return this._key;
   }
 
-  /** {Schema} The schema of {@link #target}. */
+  /** {Schema} The schema of {@link #directObject}. */
   get schema() {
     return this._schema;
   }
 
   /**
-  * {object} The object which this instance represents, wraps, and generally
-  * provides access to. Accessing this property indicates that this instance is
-  * _not_ currently idle.
-  */
-  get target() {
-    this.refresh();
-    return this._directObject;
-  }
-
-  /**
-   * Synchronously performs a method call on the {@link #target}, returning the
-   * result or (directly) throwing an error.
+   * Synchronously performs a method call on the {@link #directObject},
+   * returning the result or (directly) throwing an error.
    *
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
@@ -125,9 +125,9 @@ export default class Target extends CommonBase {
 
   /**
    * "Refreshes" this instance in terms of access time. This is no different
-   * than just saying `this.target` (and ignoring the result). It exists as an
-   * explicitly different method so as to provide a solid way to convey intent
-   * at call sites.
+   * than just saying `this.directObject` (and ignoring the result). It exists
+   * as an explicitly different method so as to provide a solid way to convey
+   * intent at call sites.
    */
   refresh() {
     if (this._lastAccess !== EVERGREEN) {

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -6,6 +6,7 @@ import Connection from './Connection';
 import Context from './Context';
 import PostConnection from './PostConnection';
 import ProxiedObject from './ProxiedObject';
+import Schema from './Schema';
 import Target from './Target';
 import TokenAuthorizer from './TokenAuthorizer';
 import TokenMint from './TokenMint';
@@ -16,6 +17,7 @@ export {
   Context,
   PostConnection,
   ProxiedObject,
+  Schema,
   Target,
   TokenAuthorizer,
   TokenMint,

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -5,6 +5,7 @@
 import Connection from './Connection';
 import Context from './Context';
 import PostConnection from './PostConnection';
+import ProxiedObject from './ProxiedObject';
 import Target from './Target';
 import TokenAuthorizer from './TokenAuthorizer';
 import TokenMint from './TokenMint';
@@ -14,6 +15,7 @@ export {
   Connection,
   Context,
   PostConnection,
+  ProxiedObject,
   Target,
   TokenAuthorizer,
   TokenMint,

--- a/local-modules/@bayou/api-server/tests/test_ProxiedObject.js
+++ b/local-modules/@bayou/api-server/tests/test_ProxiedObject.js
@@ -1,0 +1,64 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { BearerToken } from '@bayou/api-common';
+import { ProxiedObject } from '@bayou/api-server';
+
+/** {array<object>} Valid values for `target`. */
+const VALID_TARGETS = [
+  new Map(),
+  new BearerToken('foo', 'bar'), // Picked as an arbitrary non-system class.
+  { florp() { return 'like'; } }
+];
+
+/** {array<object>} Invalid values for `target`. */
+const INVALID_TARGETS = [
+  null,
+  undefined,
+  true,
+  123,
+  'florp'
+];
+
+describe('@bayou/api-server/ProxiedObject', () => {
+  describe('constructor()', () => {
+    it('should accept arbitrary objects', () => {
+      for (const t of VALID_TARGETS) {
+        assert.doesNotThrow(() => new ProxiedObject(t), inspect(t));
+      }
+    });
+
+    it('should accept reject non-objects', () => {
+      for (const t of INVALID_TARGETS) {
+        assert.throws(() => new ProxiedObject(t), /badValue/, inspect(t));
+      }
+    });
+  });
+
+  describe('.target', () => {
+    it('should be the same as the `target` passed to the constructor', () => {
+      for (const t of VALID_TARGETS) {
+        const str = inspect(t);
+        const po  = new ProxiedObject(t);
+        assert.strictEqual(po.target, t, str);
+      }
+    });
+  });
+
+  describe('deconstruct()', () => {
+    it('should be a single-element array with the same contents as the `target` passed to the constructor', () => {
+      for (const t of VALID_TARGETS) {
+        const str = inspect(t);
+        const po  = new ProxiedObject(t);
+        const dec = po.deconstruct();
+        assert.lengthOf(dec, 1);
+        assert.strictEqual(dec[0], t, str);
+      }
+    });
+  });
+});

--- a/local-modules/@bayou/api-server/tests/test_ProxiedObject.js
+++ b/local-modules/@bayou/api-server/tests/test_ProxiedObject.js
@@ -33,7 +33,7 @@ describe('@bayou/api-server/ProxiedObject', () => {
       }
     });
 
-    it('should accept reject non-objects', () => {
+    it('should reject non-objects', () => {
       for (const t of INVALID_TARGETS) {
         assert.throws(() => new ProxiedObject(t), /badValue/, inspect(t));
       }
@@ -56,6 +56,7 @@ describe('@bayou/api-server/ProxiedObject', () => {
         const str = inspect(t);
         const po  = new ProxiedObject(t);
         const dec = po.deconstruct();
+        assert.isArray(dec);
         assert.lengthOf(dec, 1);
         assert.strictEqual(dec[0], t, str);
       }

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -1,0 +1,162 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+import { inspect } from 'util';
+
+import { BearerToken } from '@bayou/api-common';
+import { Schema, Target } from '@bayou/api-server';
+import { Functor } from '@bayou/util-common';
+
+/** {array<object>} Valid values for `directObject`. */
+const VALID_DIRECTS = [
+  new Map(),
+  new BearerToken('foo', 'bar'), // Picked as an arbitrary non-system class.
+  { florp() { return 'like'; } },
+  {}
+];
+
+/** {array<object>} Invalid values for `directObject`. */
+const INVALID_DIRECTS = [
+  null,
+  undefined,
+  true,
+  123,
+  'florp'
+];
+
+describe('@bayou/api-server/Target', () => {
+  describe('constructor()', () => {
+    it('should accept a key as the first argument', () => {
+      assert.doesNotThrow(() => new Target(new BearerToken('x', 'y'), {}));
+    });
+
+    it('should accept a valid ID string as the first argument', () => {
+      assert.doesNotThrow(() => new Target('x', {}));
+    });
+
+    it('should reject a non-key object as the first argument', () => {
+      assert.throws(() => new Target(new Set('bad'), {}), /badValue/);
+    });
+
+    it('should reject an invalid ID string as the first argument', () => {
+      assert.throws(() => new Target('***bad***', {}), /badValue/);
+    });
+
+    it('should accept arbitrary objects as the second argument', () => {
+      for (const d of VALID_DIRECTS) {
+        assert.doesNotThrow(() => new Target('x', d), inspect(d));
+      }
+    });
+
+    it('should reject non-objects as the second argument', () => {
+      for (const d of INVALID_DIRECTS) {
+        assert.throws(() => new Target('x', d), /badValue/, inspect(d));
+      }
+    });
+
+    it('should accept a `Schema` as the third argument', () => {
+      const schema = new Schema({});
+      assert.doesNotThrow(() => new Target('x', {}, schema));
+    });
+  });
+
+  describe('.directObject', () => {
+    it('should be the same as the `directObject` passed to the constructor', () => {
+      for (const obj of VALID_DIRECTS) {
+        const str = inspect(obj);
+        const t   = new Target('x', obj);
+        assert.strictEqual(t.directObject, obj, str);
+      }
+    });
+  });
+
+  describe('.id', () => {
+    it('should be the same as a string `idOrKey` passed to the constructor', () => {
+      const id = 'some-id';
+      const t  = new Target(id, {});
+      assert.strictEqual(t.id, id);
+    });
+
+    it('should be the same as the key\'s `id` when a key is passed as `idOrKey` to the constructor', () => {
+      const id  = 'some-key-id';
+      const key = new BearerToken(id, 'this-is-secret');
+      const t   = new Target(key, {});
+      assert.strictEqual(t.id, id);
+    });
+  });
+
+  describe('.directObject', () => {
+    it('should be the same as the `schema` passed to the constructor', () => {
+      const schema = new Schema({});
+      const t      = new Target('x', {}, schema);
+
+      assert.strictEqual(t.schema, schema);
+    });
+  });
+
+  describe('.key', () => {
+    it('should be the same as a key `idOrKey` passed to the constructor', () => {
+      const id  = 'some-key-id';
+      const key = new BearerToken(id, 'this-is-secret');
+      const t  = new Target(key, {});
+      assert.strictEqual(t.key, key);
+    });
+
+    it('should be `null` when a string is passed as `idOrKey` to the constructor', () => {
+      const id  = 'some-id';
+      const t   = new Target(id, {});
+      assert.isNull(t.key);
+    });
+  });
+
+  describe('call()', () => {
+    it('should call through to the `directObject`', () => {
+      const obj = {
+        florp(x, y) {
+          return `<${x} ${y}>`;
+        }
+      };
+
+      const t      = new Target('x', obj);
+      const result = t.call(new Functor('florp', 'hey', 'buddy'));
+
+      assert.strictEqual(result, '<hey buddy>');
+    });
+
+    it('should be transparent with respect to thrown errors', () => {
+      const err = new Error('eek!');
+      const obj = {
+        blort() {
+          throw err;
+        }
+      };
+
+      const t = new Target('x', obj);
+      try {
+        t.call(new Functor('blort'));
+        assert.fail('Expected to throw.');
+      } catch (e) {
+        // Done this way instead of `assert.throws` so as to be able to do a
+        // strict equality check.
+        assert.strictEqual(e, err);
+      }
+    });
+  });
+
+  describe('withoutKey()', () => {
+    it('should be the same as the original except with `null` for `key`', () => {
+      const id   = 'some-key-id';
+      const key  = new BearerToken(id, 'this-is-secret');
+      const orig = new Target(key, {});
+      const wk   = orig.withoutKey();
+
+      assert.strictEqual(wk.directObject, orig.directObject);
+      assert.strictEqual(wk.id, orig.id);
+      assert.strictEqual(wk.schema, orig.schema);
+      assert.isNull(wk.key);
+    });
+  });
+});

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -70,8 +70,15 @@ describe('@bayou/doc-common/BodyDelta', () => {
       // caught actual build problems.
 
       // The check doesn't really know that it got a bona fide implementation of
-      // `quill-delta`, just that it's an instance of a class named `Delta`.
-      class Delta { /* empty */ }
+      // `quill-delta`, just that it's an instance of a class named `Delta`. We
+      // define `forEach()` because that's the method that gets used to induce
+      // an error which helps produce an informative message.
+      class Delta {
+        forEach(func) {
+          func('x');
+        }
+      }
+
       const wrongDelta = new Delta();
 
       wrongDelta.ops = [];

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.2
+version = 1.1.3


### PR DESCRIPTION
This PR touches a decent handful of code but all with the aim of adding a straightforward bit of functionality to the API layer: Specifically, it makes it so that it's possible to return objects from API methods which are themselves objects which get proxied on the same connection. The direct use case for this is to be able to have an API method defined on an author token which returns a `DocSession` object, which can then be used more directly (and in the same manner as the status quo). Further down the line, we can use this same functionality to decompose `DocSession` into better chunks (instead of using the `subsystem_methodName` pattern that's currently employed).

This PR _only_ introduces the new API mechanism. It does not change any of the higher-level implementation to use this mechanism. Those changes will be made in later PRs.

I added a bunch of unit tests for the lowest layer classes that are involved in this PR, but the API modules still need way better test coverage in general. (I left in the one ad-hoc test I wrote for the new stuff, but commented out. This is to make my life ever so slightly easier in the very-short term.)

**Note:** As of this PR, the new facilities are only available when directly returning values from API methods. Ideally, though, it will be possible to (a) embed newly-proxied objects within other objects, where those other objects are returned via the usual value-encoding mechanism, and (b) _pass_ proxied objects from the client to the server, either for asynchronous callback or so that those same objects could be passed back to the client and "survive" the round trip with identity intact. Those abilities, though, aren't strictly necessary for the current effort and would be a lot more work, so they're off the table for now.

