### PR TITLE
Add some `api-*` tests.

### DIFF
--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -18,11 +18,14 @@ export default class TargetMap extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {function} sendMessage Function to call to send a message. This is
-   *   bound to the private `_send()` method on an instance of
-   *   {@link ApiClient}. (This arrangement is done, instead of making a public
-   *   `send()` method on {@link ApiClient}, so as to make it clear that the
-   *   right way to send messages is via the exposed proxies.)
+   * @param {function} sendMessage Function to call to send a message. It is
+   *   called with two arguments, `targetId` (a string) and `payload` (a
+   *   functor). This is typically bound to the private `_send()` method on an
+   *   instance of {@link ApiClient}. (This arrangement is done, instead of
+   *   making a public `send()` method on {@link ApiClient}, so as to make it
+   *   clear that the right way to send messages is via the exposed proxies.
+   *   This arrangement also makes it possible to test this class in isolation
+   *   from the higher layer.)
    */
   constructor(sendMessage) {
     super();

--- a/local-modules/@bayou/api-client/tests/test_TargetHandler.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetHandler.js
@@ -9,7 +9,7 @@ import { Functor } from '@bayou/util-common';
 
 import TargetHandler from '@bayou/api-client/TargetHandler';
 
-describe('@bayou/api-common/TargetHandler', () => {
+describe('@bayou/api-client/TargetHandler', () => {
   describe('makeProxy()', () => {
     it('should make a proxy that wraps an appropriately-contructed instance of this class', () => {
       let gotTargetId;

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -1,0 +1,79 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Functor } from '@bayou/util-common';
+
+import TargetMap from '@bayou/api-client/TargetMap';
+
+/**
+ * Class which has a {@link #sendMessage} that when invoked remembers the
+ * arguments it was called with, for later testing.
+ */
+class MessageCollector {
+  constructor() {
+    this.messages = [];
+  }
+
+  get sendMessage() {
+    return (targetId, payload, ...rest) => {
+      this.messages.push({ targetId, payload, rest });
+    };
+  }
+}
+
+describe('@bayou/api-client/TargetMap', () => {
+  describe('constructor', () => {
+    it('should accept a valid callable function argument', () => {
+      const func = () => { /*empty*/ };
+      assert.doesNotThrow(() => new TargetMap(func));
+    });
+
+    it('should reject invalid arguments', () => {
+      function test(value) {
+        assert.throws(() => new TargetMap(value), /badValue/);
+      }
+
+      // Classes defined with `class ...` aren't callable.
+      test(class { /* empty*/ });
+
+      // Various non-functions.
+      test(null);
+      test(undefined);
+      test(true);
+      test('blort');
+      test([1, 2, 3]);
+      test(new Map());
+    });
+  });
+
+  describe('add()', () => {
+    it('should add a previously-unbound ID', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('xyz'));
+
+      // **Note:** The proxy that we should be getting here is almost completely
+      // transparent. This means that attempts to `inspect()` it, `instanceof`
+      // it, etc., will result in the proxy being called upon to do those
+      // things. So, the best that we can do is just call through it and see if
+      // we get the expected behavior coming out the other end.
+      const proxy = tm.add('xyz');
+      proxy.florp(10);
+
+      const got = mc.messages;
+
+      assert.lengthOf(got, 1);
+
+      const msg = got[0];
+
+      assert.strictEqual(msg.targetId, 'xyz');
+      assert.deepEqual(msg.payload, new Functor('florp', 10));
+      assert.deepEqual(msg.rest, []);
+    });
+  });
+});

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -113,6 +113,18 @@ describe('@bayou/api-client/TargetMap', () => {
       assert.isNotNull(tm.getOrNull('xyz')); // Base assumption.
       assert.throws(() => tm.add('xyz'), /badUse/);
     });
+
+    it('should refuse to add the same ID twice when originally added with `addOrGet()`', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('xyz')); // Base assumption.
+
+      tm.addOrGet('xyz');
+
+      assert.isNotNull(tm.getOrNull('xyz')); // Base assumption.
+      assert.throws(() => tm.add('xyz'), /badUse/);
+    });
   });
 
   describe('addOrGet()', () => {
@@ -140,6 +152,38 @@ describe('@bayou/api-client/TargetMap', () => {
       const proxy2 = tm.addOrGet('pdq');
 
       assert.isTrue(proxy1 === proxy2);
+    });
+
+    it('should return the same proxy when given the same ID as a previous `add()`', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('pdq')); // Base assumption.
+
+      const proxy1 = tm.add('pdq');
+
+      assert.isNotNull(tm.getOrNull('pdq')); // Base assumption.
+
+      const proxy2 = tm.addOrGet('pdq');
+
+      assert.isTrue(proxy1 === proxy2);
+    });
+  });
+
+  describe('clear()', () => {
+    it('should remove all targets', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      tm.add('foo');
+      tm.add('bar');
+      tm.add('baz');
+
+      tm.clear();
+
+      assert.isNull(tm.getOrNull('foo'));
+      assert.isNull(tm.getOrNull('bar'));
+      assert.isNull(tm.getOrNull('baz'));
     });
   });
 });

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -114,4 +114,32 @@ describe('@bayou/api-client/TargetMap', () => {
       assert.throws(() => tm.add('xyz'), /badUse/);
     });
   });
+
+  describe('addOrGet()', () => {
+    it('should add a previously-unbound ID', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('pdq')); // Base assumption.
+
+      const proxy = tm.addOrGet('pdq');
+
+      checkProxy(proxy, mc, 'pdq');
+    });
+
+    it('should return the same proxy when given the same ID twice', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('pdq')); // Base assumption.
+
+      const proxy1 = tm.addOrGet('pdq');
+
+      assert.isNotNull(tm.getOrNull('pdq')); // Base assumption.
+
+      const proxy2 = tm.addOrGet('pdq');
+
+      assert.isTrue(proxy1 === proxy2);
+    });
+  });
 });

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -55,7 +55,7 @@ describe('@bayou/api-client/TargetMap', () => {
       const mc = new MessageCollector();
       const tm = new TargetMap(mc.sendMessage);
 
-      assert.isNull(tm.getOrNull('xyz'));
+      assert.isNull(tm.getOrNull('xyz')); // Base assumption.
 
       // **Note:** The proxy that we should be getting here is almost completely
       // transparent. This means that attempts to `inspect()` it, `instanceof`
@@ -74,6 +74,18 @@ describe('@bayou/api-client/TargetMap', () => {
       assert.strictEqual(msg.targetId, 'xyz');
       assert.deepEqual(msg.payload, new Functor('florp', 10));
       assert.deepEqual(msg.rest, []);
+    });
+
+    it('should refuse to add the same ID twice', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('xyz')); // Base assumption.
+
+      tm.add('xyz');
+
+      assert.isNotNull(tm.getOrNull('xyz')); // Base assumption.
+      assert.throws(() => tm.add('xyz'), /badUse/);
     });
   });
 });

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -186,4 +186,70 @@ describe('@bayou/api-client/TargetMap', () => {
       assert.isNull(tm.getOrNull('baz'));
     });
   });
+
+  describe('get()', () => {
+    it('should find a target added with `add()`', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('zorch')); // Base assumption.
+      const added = tm.add('zorch');
+
+      const got = tm.get('zorch');
+      assert.isTrue(got === added);
+
+      checkProxy(got, mc, 'zorch');
+    });
+
+    it('should find a target added with `addOrGet()`', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('zorch')); // Base assumption.
+      const added = tm.addOrGet('zorch');
+
+      const got = tm.get('zorch');
+      assert.isTrue(got === added);
+
+      checkProxy(got, mc, 'zorch');
+    });
+
+    it('should throw given an unbound ID', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.throws(() => tm.get('zorch'), /badUse/);
+    });
+  });
+
+  describe('getOrNull()', () => {
+    it('should find a target added with `add()`', () => {
+      const mc    = new MessageCollector();
+      const tm    = new TargetMap(mc.sendMessage);
+      const added = tm.add('splort');
+      const got   = tm.getOrNull('splort');
+
+      assert.isTrue(got === added);
+
+      checkProxy(got, mc, 'splort');
+    });
+
+    it('should find a target added with `addOrGet()`', () => {
+      const mc    = new MessageCollector();
+      const tm    = new TargetMap(mc.sendMessage);
+      const added = tm.addOrGet('splort');
+      const got   = tm.getOrNull('splort');
+
+      assert.isTrue(got === added);
+
+      checkProxy(got, mc, 'splort');
+    });
+
+    it('should return `null` given an unbound ID', () => {
+      const mc = new MessageCollector();
+      const tm = new TargetMap(mc.sendMessage);
+
+      assert.isNull(tm.getOrNull('splort'));
+    });
+  });
 });

--- a/local-modules/@bayou/api-server/TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/TokenAuthorizer.js
@@ -54,6 +54,8 @@ export default class TokenAuthorizer extends CommonBase {
   async targetFromToken(token) {
     if (typeof token === 'string') {
       token = this.tokenFromString(token);
+    } else {
+      BearerToken.check(token);
     }
 
     const result = await this._impl_targetFromToken(token);

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -88,15 +88,6 @@ describe('@bayou/api-server/Target', () => {
     });
   });
 
-  describe('.directObject', () => {
-    it('should be the same as the `schema` passed to the constructor', () => {
-      const schema = new Schema({});
-      const t      = new Target('x', {}, schema);
-
-      assert.strictEqual(t.schema, schema);
-    });
-  });
-
   describe('.key', () => {
     it('should be the same as a key `idOrKey` passed to the constructor', () => {
       const id  = 'some-key-id';
@@ -109,6 +100,15 @@ describe('@bayou/api-server/Target', () => {
       const id  = 'some-id';
       const t   = new Target(id, {});
       assert.isNull(t.key);
+    });
+  });
+
+  describe('.schema', () => {
+    it('should be the same as the `schema` passed to the constructor', () => {
+      const schema = new Schema({});
+      const t      = new Target('x', {}, schema);
+
+      assert.strictEqual(t.schema, schema);
     });
   });
 

--- a/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
@@ -1,0 +1,32 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { TokenAuthorizer } from '@bayou/api-server';
+
+describe('@bayou/api-server/TokenAuthorizer', () => {
+  describe('.nonTokenPrefix', () => {
+    it('should call through to the `_impl`', () => {
+      class Authie extends TokenAuthorizer {
+        get _impl_nonTokenPrefix() {
+          return 'foomp';
+        }
+      }
+
+      assert.strictEqual(new Authie().nonTokenPrefix, 'foomp');
+    });
+
+    it('should reject a bad subclass implementation', () => {
+      class Authie extends TokenAuthorizer {
+        get _impl_nonTokenPrefix() {
+          return ['not just a string'];
+        }
+      }
+
+      assert.throws(() => new Authie().nonTokenPrefix, /badValue/);
+    });
+  });
+});

--- a/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
@@ -5,6 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
+import { BearerToken } from '@bayou/api-common';
 import { TokenAuthorizer } from '@bayou/api-server';
 
 describe('@bayou/api-server/TokenAuthorizer', () => {
@@ -60,12 +61,91 @@ describe('@bayou/api-server/TokenAuthorizer', () => {
 
     it('should reject a bad subclass implementation', () => {
       class Authie extends TokenAuthorizer {
-        get _impl_nonTokenPrefix() {
-          return ['not just a string'];
+        _impl_isToken(value_unused) {
+          return 'this is not a boolean';
         }
       }
 
-      assert.throws(() => new Authie().nonTokenPrefix, /badValue/);
+      assert.throws(() => new Authie().isToken('x'), /badValue/);
+    });
+  });
+
+  describe('targetFromToken()', () => {
+    it('should call through to the `_impl` given a `BearerToken`', async () => {
+      class Authie extends TokenAuthorizer {
+        async _impl_targetFromToken(value) {
+          return { got: value };
+        }
+      }
+
+      const au     = new Authie();
+      const token  = new BearerToken('x', 'y');
+      const result = await au.targetFromToken(token);
+
+      assert.deepEqual(result, { got: token });
+    });
+
+    it('should convert a string to a `BearerToken` then through to the `_impl`', async () => {
+      class Authie extends TokenAuthorizer {
+        async _impl_targetFromToken(value) {
+          return { got: value };
+        }
+
+        _impl_tokenFromString(value) {
+          return new BearerToken(value, value);
+        }
+
+        _impl_isToken(value_unused) {
+          return true;
+        }
+      }
+
+      const au     = new Authie();
+      const result = await au.targetFromToken('yes');
+
+      assert.deepEqual(result, { got: new BearerToken('yes', 'yes') });
+    });
+
+    it('should reject a non-string non-`BearerToken` argument without calling through to the `_impl`', async () => {
+      class Authie extends TokenAuthorizer {
+        _impl_targetFromToken(value_unused) {
+          throw new Error('Should not have been called.');
+        }
+      }
+
+      const au = new Authie();
+
+      await assert.isRejected(au.targetFromToken(undefined), /badValue/);
+      await assert.isRejected(au.targetFromToken(null), /badValue/);
+      await assert.isRejected(au.targetFromToken(true), /badValue/);
+      await assert.isRejected(au.targetFromToken(914), /badValue/);
+      await assert.isRejected(au.targetFromToken(['foo']), /badValue/);
+    });
+
+    it('should accept `null` from the `_impl`', async () => {
+      class Authie extends TokenAuthorizer {
+        async _impl_targetFromToken(value_unused) {
+          return null;
+        }
+      }
+
+      const au     = new Authie();
+      const result = await au.targetFromToken(new BearerToken('x', 'y'));
+
+      assert.isNull(result);
+    });
+
+    it('should reject a bad subclass implementation', () => {
+      class Authie extends TokenAuthorizer {
+        _impl_targetFromToken(value_unused) {
+          // Supposed to be an object or `null`.
+          return 123;
+        }
+      }
+
+      const token = new BearerToken('x', 'y');
+
+      assert.isRejected(new Authie().targetFromToken(token), /badValue/);
     });
   });
 });

--- a/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_TokenAuthorizer.js
@@ -29,4 +29,43 @@ describe('@bayou/api-server/TokenAuthorizer', () => {
       assert.throws(() => new Authie().nonTokenPrefix, /badValue/);
     });
   });
+
+  describe('isToken()', () => {
+    it('should call through to the `_impl` given a string', () => {
+      class Authie extends TokenAuthorizer {
+        _impl_isToken(value) {
+          return value.startsWith('token-');
+        }
+      }
+
+      const au = new Authie();
+
+      assert.isTrue(au.isToken('token-yes'));
+      assert.isFalse(au.isToken('not-a-token'));
+    });
+
+    it('should reject a non-string without calling through to the `_impl`', () => {
+      class Authie extends TokenAuthorizer {
+        _impl_isToken(value_unused) {
+          throw new Error('Should not have been called.');
+        }
+      }
+
+      const au = new Authie();
+
+      assert.throws(() => au.isToken(null), /badValue/);
+      assert.throws(() => au.isToken(123), /badValue/);
+      assert.throws(() => au.isToken(['x']), /badValue/);
+    });
+
+    it('should reject a bad subclass implementation', () => {
+      class Authie extends TokenAuthorizer {
+        get _impl_nonTokenPrefix() {
+          return ['not just a string'];
+        }
+      }
+
+      assert.throws(() => new Authie().nonTokenPrefix, /badValue/);
+    });
+  });
 });

--- a/local-modules/@bayou/testing-common/BaseReporter.js
+++ b/local-modules/@bayou/testing-common/BaseReporter.js
@@ -55,7 +55,12 @@ export default class BaseReporter extends CommonBase {
 
     runner.on('suite end', () => {
       this._suiteDepth--;
-      this._impl_suiteEnd();
+
+      // Don't make an `_impl_suiteEnd()` call for the anonymous top-level
+      // suite.
+      if (this._suiteDepth !== 0) {
+        this._impl_suiteEnd();
+      }
     });
 
     runner.on('pending', (test) => {

--- a/local-modules/@bayou/testing-common/BaseReporter.js
+++ b/local-modules/@bayou/testing-common/BaseReporter.js
@@ -55,12 +55,7 @@ export default class BaseReporter extends CommonBase {
 
     runner.on('suite end', () => {
       this._suiteDepth--;
-
-      if (this._suiteDepth === 0) {
-        this._impl_allDone();
-      } else {
-        this._impl_suiteEnd();
-      }
+      this._impl_suiteEnd();
     });
 
     runner.on('pending', (test) => {
@@ -74,6 +69,24 @@ export default class BaseReporter extends CommonBase {
     runner.on('fail', (test, error) => {
       this._testResult(test, 'fail', error);
     });
+  }
+
+  /**
+   * Standard Mocha reporter method. This always gets called when testing is
+   * complete. By way of contrast, if there are no tests run (e.g. because the
+   * specified filter matches no tests), then the runner emits no events, and so
+   * nothing else on this class will get called.
+   *
+   * @param {int} failures The number of test failures.
+   * @param {function|undefined} fn Optional function to call with `failures` as
+   *   an argument.
+   */
+  done(failures, fn) {
+    this._impl_allDone();
+
+    if (fn) {
+      fn(failures);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds unit tests for `TargetMap` and `TokenAuthorizer`, and fixes a couple of minor issues with pre-existing tests (wrong name, wrong module). And — yay! — testing revealed one (admittedly minor) bug which is now fixed.

**Bonus:** Worked around the (arguable) bug in Mocha in which it never emits top-level suite start/end events if you manage to not specify any tests (which is what happens if you pass a filter to the test runner which doesn't match any tests). This would cause the client tester to hang waiting for an `allDone` event which would never get emitted.