### PR TITLE
Testing and couple tweaks mostly in `api-common`.

### DIFF
--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -151,6 +151,10 @@ describe('@bayou/api-client/TargetMap', () => {
 
       const proxy2 = tm.addOrGet('pdq');
 
+      // `===` directly here and not `assert.strictEqual()` because in the
+      // failure case we might otherwise end up calling through to the
+      // (probable) proxy, which would probably _not_ provide any useful info
+      // and very well might throw, thus obscuring the actual problem.
       assert.isTrue(proxy1 === proxy2);
     });
 
@@ -166,6 +170,7 @@ describe('@bayou/api-client/TargetMap', () => {
 
       const proxy2 = tm.addOrGet('pdq');
 
+      // See above in re `===` vs. `assert.strictEqual()`.
       assert.isTrue(proxy1 === proxy2);
     });
   });

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -87,11 +87,6 @@ export default class BaseKey extends CommonBase {
     return new URL(this._url).origin;
   }
 
-  /** {string} URL at which the resource may be accessed, or `*`. */
-  get url() {
-    return this._url;
-  }
-
   /** {string} Key / resource identifier. */
   get id() {
     return this._id;
@@ -104,6 +99,11 @@ export default class BaseKey extends CommonBase {
    */
   get safeString() {
     return TString.check(this._impl_safeString());
+  }
+
+  /** {string} URL at which the resource may be accessed, or `*`. */
+  get url() {
+    return this._url;
   }
 
   /**
@@ -121,19 +121,6 @@ export default class BaseKey extends CommonBase {
     TString.minLen(challenge, 16);
     const response = this._impl_challengeResponseFor(challenge);
     return TString.minLen(response, 16);
-  }
-
-  /**
-   * Main implementation of `challengeResponseFor()`. By default this throws
-   * an error ("not implemented"). Subclasses wishing to support challenges
-   * must override this to do something else.
-   *
-   * @param {string} challenge The challenge. It is guaranteed to be a string of
-   *   at least 16 characters.
-   * @returns {string} The challenge response.
-   */
-  _impl_challengeResponseFor(challenge) {
-    return this._mustOverride(challenge);
   }
 
   /**
@@ -170,6 +157,19 @@ export default class BaseKey extends CommonBase {
 
     TString.minLen(challenge, 16);
     return { challenge, response };
+  }
+
+  /**
+   * Main implementation of `challengeResponseFor()`. By default this throws
+   * an error ("not implemented"). Subclasses wishing to support challenges
+   * must override this to do something else.
+   *
+   * @param {string} challenge The challenge. It is guaranteed to be a string of
+   *   at least 16 characters.
+   * @returns {string} The challenge response.
+   */
+  _impl_challengeResponseFor(challenge) {
+    return this._mustOverride(challenge);
   }
 
   /**

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -137,9 +137,13 @@ export default class BaseKey extends CommonBase {
   }
 
   /**
-   * Custom inspector function, as called by `util.inspect()`. This
-   * implementation redacts the contents so as to prevent inadvertent logging of
-   * the secret values.
+   * Custom inspector function, as called by `util.inspect()`, which returns a
+   * string that identifies the class and includes just the URL and ID
+   * properties. The main point of this implementation is to make it so that
+   * subclasses can define additional properties which are security-sensitive
+   * without worrying about those properties ending up in the `inspect()`
+   * output. (That is, subclasses don't have to override this method in order to
+   * ensure good security hygiene with respect to stringification.)
    *
    * @param {Int} depth_unused Current inspection depth.
    * @param {object} opts Inspection options.

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -99,15 +99,6 @@ export default class BaseKey extends CommonBase {
 
   /**
    * {string} Printable and security-safe (i.e. redacted if necessary) form of
-   * the token. This includes an "ASCII ellipsis" (`...`) if to indicate
-   * redaction.
-   */
-  get printableId() {
-    return this._impl_printableId();
-  }
-
-  /**
-   * {string} Printable and security-safe (i.e. redacted if necessary) form of
    * the token. This will include an "ASCII ellipsis" (`...`) if needed, to
    * indicate redaction.
    */
@@ -192,18 +183,6 @@ export default class BaseKey extends CommonBase {
    */
   _impl_randomChallengeString() {
     return this._mustOverride();
-  }
-
-  /**
-   * Gets the printable form of the ID. This defaults to the same as `.id`,
-   * but subclasses can override this if they want to produce something
-   * different. If the form has any redaction, it should use `...` (an ASCII
-   * ellipsis) to indicate that fact.
-   *
-   * @returns {string} The printable form of the ID.
-   */
-  _impl_printableId() {
-    return this.id;
   }
 
   /**

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -25,8 +25,6 @@ import TargetId from './TargetId';
  *   unguessable.
  *
  * In addition, subclasses can include additional information.
- *
- *
  */
 export default class BaseKey extends CommonBase {
   /**

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -160,10 +160,10 @@ export default class BaseKey extends CommonBase {
   }
 
   /**
-   * Main implementation of `challengeResponseFor()`. By default this throws
-   * an error ("not implemented"). Subclasses wishing to support challenges
-   * must override this to do something else.
+   * Main implementation of `challengeResponseFor()`. Subclasses wishing to
+   * support challenges must override this.
    *
+   * @abstract
    * @param {string} challenge The challenge. It is guaranteed to be a string of
    *   at least 16 characters.
    * @returns {string} The challenge response.
@@ -174,9 +174,8 @@ export default class BaseKey extends CommonBase {
 
   /**
    * Creates and returns a random challenge string. The returned string must be
-   * at least 16 characters long but may be longer. By default this throws an
-   * error ("not implemented"). Subclasses wishing to support challenges must
-   * override this to do something else.
+   * at least 16 characters long but may be longer. Subclasses wishing to
+   * support challenges must override this.
    *
    * @abstract
    * @returns {string} A random challenge string.

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -20,12 +20,13 @@ import TargetId from './TargetId';
  * Instances of this (base) class hold two pieces of information:
  *
  * * A URL at which the resource is available.
- * * The ID of the resource.
+ * * The ID of the resource. **Note:** The ID is _not_ meant to require secrecy
+ *   in order for the system to be secure. That is, IDs are not required to be
+ *   unguessable.
  *
  * In addition, subclasses can include additional information.
  *
- * **Note:** The resource ID is _not_ meant to require secrecy in order for
- * the system to be secure. That is, IDs are not required to be unguessable.
+ *
  */
 export default class BaseKey extends CommonBase {
   /**
@@ -149,7 +150,7 @@ export default class BaseKey extends CommonBase {
 
     return (opts.depth < 0)
       ? `${name} {...}`
-      : `${name} { ${this._url} ${this.printableId} }`;
+      : `${name} { ${this._url} ${this.id} }`;
   }
 
   /**

--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -107,6 +107,15 @@ export default class BaseKey extends CommonBase {
   }
 
   /**
+   * {string} Printable and security-safe (i.e. redacted if necessary) form of
+   * the token. This will include an "ASCII ellipsis" (`...`) if needed, to
+   * indicate redaction.
+   */
+  get safeString() {
+    return TString.check(this._impl_safeString());
+  }
+
+  /**
    * Gets a challenge response. This is used as a tactic for two sides of a
    * connection to authenticate each other without ever having to provide a
    * shared secret directly over a connection.
@@ -178,6 +187,7 @@ export default class BaseKey extends CommonBase {
    * error ("not implemented"). Subclasses wishing to support challenges must
    * override this to do something else.
    *
+   * @abstract
    * @returns {string} A random challenge string.
    */
   _impl_randomChallengeString() {
@@ -194,5 +204,16 @@ export default class BaseKey extends CommonBase {
    */
   _impl_printableId() {
     return this.id;
+  }
+
+  /**
+   * Main implementation of {@link #safeString}. Subclasses must provide an
+   * implementation of this.
+   *
+   * @abstract
+   * @returns {string} The redacted string form of this instance.
+   */
+  _impl_safeString() {
+    return this._mustOverride();
   }
 }

--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -91,4 +91,13 @@ export default class BearerToken extends BaseKey {
   _impl_printableId() {
     return `${this.id}-...`;
   }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @returns {string} The safe string form of this instance.
+   */
+  _impl_safeString() {
+    return `${this.id}-...`;
+  }
 }

--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -83,16 +83,6 @@ export default class BearerToken extends BaseKey {
   }
 
   /**
-   * Gets the printable form of the ID. This class adds an "ASCII ellipsis" to
-   * the ID, to make it clear that the ID is a redaction of the full token.
-   *
-   * @returns {string} The printable form of the ID.
-   */
-  _impl_printableId() {
-    return `${this.id}-...`;
-  }
-
-  /**
    * Implementation as required by the superclass.
    *
    * @returns {string} The safe string form of this instance.

--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -85,6 +85,17 @@ export default class BearerToken extends BaseKey {
   /**
    * Implementation as required by the superclass.
    *
+   * @returns {string} The secret to use for challenges, as a hex string.
+   */
+  _impl_challengeSecret() {
+    const buf = Buffer.from(this._secretToken, 'utf-8');
+
+    return buf.toString('hex');
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
    * @returns {string} The safe string form of this instance.
    */
   _impl_safeString() {

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -49,19 +49,6 @@ export default class Message extends CommonBase {
     return [this._id, this._targetId, this._payload];
   }
 
-  /**
-   * Converts this instance to a form suitable for logging.
-   *
-   * @returns {object} Log-appropriate form.
-   */
-  toLog() {
-    return {
-      id:       this._id,
-      targetId: this._targetId,
-      payload:  this._payload
-    };
-  }
-
   /** {Int} Message ID. */
   get id() {
     return this._id;

--- a/local-modules/@bayou/api-common/SplitKey.js
+++ b/local-modules/@bayou/api-common/SplitKey.js
@@ -117,4 +117,13 @@ export default class SplitKey extends BaseKey {
   _impl_randomChallengeString() {
     return Random.hexByteString(8);
   }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @returns {string} The safe string form of this instance.
+   */
+  _impl_safeString() {
+    return `${this.id}-...`;
+  }
 }

--- a/local-modules/@bayou/api-common/SplitKey.js
+++ b/local-modules/@bayou/api-common/SplitKey.js
@@ -2,10 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-// **Note:** Babel's browser polyfill includes a Node-compatible `crypto`
-// module, which is why this is possible to import regardless of environment.
-import crypto from 'crypto';
-
 import { TString } from '@bayou/typecheck';
 import { Random } from '@bayou/util-common';
 
@@ -90,32 +86,12 @@ export default class SplitKey extends BaseKey {
   }
 
   /**
-   * Main implementation of `challengeResponseFor()`, as defined by the
-   * superclass.
+   * Implementation as required by the superclass.
    *
-   * @param {string} challenge The challenge.
-   * @returns {string} The challenge response.
+   * @returns {string} The secret to use for challenges.
    */
-  _impl_challengeResponseFor(challenge) {
-    TString.hexBytes(challenge, 8, 8);
-
-    const hash = crypto.createHash('sha256');
-
-    hash.update(Buffer.from(challenge, 'hex'));
-    hash.update(Buffer.from(this._secret, 'hex'));
-
-    return hash.digest('hex');
-  }
-
-  /**
-   * Creates and returns a random challenge string, as defined by the
-   * superclass. In this case, the result is always an eight byte long hex
-   * string (lower case).
-   *
-   * @returns {string} A random challenge string.
-   */
-  _impl_randomChallengeString() {
-    return Random.hexByteString(8);
+  _impl_challengeSecret() {
+    return this._secret;
   }
 
   /**

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -17,8 +17,8 @@ const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,64}$/;
  * programatically-generated IDs (e.g. for specific files).
  *
  * Syntactically, a target ID must be a string of consisting of ASCII-range
- * alphanumerics, underscore (`_`), or dash (`-`), which is no longer than 64
- * characters.
+ * alphanumerics, underscore (`_`), dash (`-`), or period (`.`), which is at
+ * least one and no longer than 64 characters.
  */
 export default class TargetId extends UtilityClass {
   /**

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -6,25 +6,8 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseKey } from '@bayou/api-common';
-import { Random } from '@bayou/util-common';
 
 const VALID_ID = '12345678';
-
-class FakeKey extends BaseKey {
-  _impl_randomChallengeString() {
-    return Random.hexByteString(16);
-  }
-
-  _impl_challengeResponseFor(challenge) {
-    const bytes = Buffer.from(challenge, 'hex');
-
-    for (let i = 0; i < bytes.length; i++) {
-      bytes[i] ^= 0x0e;
-    }
-
-    return bytes.toString('hex');
-  }
-}
 
 describe('@bayou/api-common/BaseKey', () => {
   describe('redactString()', () => {
@@ -201,6 +184,12 @@ describe('@bayou/api-common/BaseKey', () => {
 
   describe('makeChallengePair()', () => {
     it('returns a challenge/response pair in an object', () => {
+      class FakeKey extends BaseKey {
+        _impl_challengeSecret() {
+          return '0123456789abcdef';
+        }
+      }
+
       const key  = new FakeKey('*', VALID_ID);
       const pair = key.makeChallengePair();
 

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -157,6 +157,21 @@ describe('@bayou/api-common/BaseKey', () => {
 
       assert.isString(key.toString());
     });
+
+    it('returns a string that contains the URL and the ID', () => {
+      function test(url, id) {
+        const key    = new BaseKey(url, id);
+        const result = key.toString();
+
+        assert.isTrue(result.indexOf(url) >= 0, url);
+        assert.isTrue(result.indexOf(id) >= 0, id);
+      }
+
+      test('*', 'x');
+      test('*', '123-florp');
+      test('http://milk.com/', 'a');
+      test('https://milk.com/florp', 'like');
+    });
   });
 
   describe('makeChallengePair()', () => {
@@ -165,8 +180,9 @@ describe('@bayou/api-common/BaseKey', () => {
       const pair = key.makeChallengePair();
 
       assert.isObject(pair);
-      assert.property(pair, 'challenge');
-      assert.property(pair, 'response');
+      assert.hasAllKeys(pair, ['challenge', 'response']);
+      assert.isString(pair.challenge);
+      assert.isString(pair.response);
     });
   });
 });

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -28,7 +28,7 @@ class FakeKey extends BaseKey {
 
 describe('@bayou/api-common/BaseKey', () => {
   describe('redactString()', () => {
-    it('should fully redact strings of length 11 or shorter', () => {
+    it('fully redacts strings of length 11 or shorter', () => {
       const FULL_STRING   = '1234567890x';
       const EXPECT_STRING = '...';
 
@@ -37,7 +37,7 @@ describe('@bayou/api-common/BaseKey', () => {
       }
     });
 
-    it('should drop all but the first 8 characters of strings of length 12 through 23', () => {
+    it('drops all but the first 8 characters of strings of length 12 through 23', () => {
       const FULL_STRING   = '1234567890abcdefghijklm';
       const EXPECT_STRING = '12345678...';
 
@@ -46,7 +46,7 @@ describe('@bayou/api-common/BaseKey', () => {
       }
     });
 
-    it('should drop all but the first 16 characters of strings of length 24 or greater', () => {
+    it('drops all but the first 16 characters of strings of length 24 or greater', () => {
       const FULL_STRING   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyz';
       const EXPECT_STRING = 'ABCDEFGHIJKLMNOP...';
 
@@ -57,11 +57,11 @@ describe('@bayou/api-common/BaseKey', () => {
   });
 
   describe('constructor', () => {
-    it('should accept `*` as the URL', () => {
+    it('accepts `*` as the URL', () => {
       assert.doesNotThrow(() => new BaseKey('*', VALID_ID));
     });
 
-    it('should accept an absoulute URL', () => {
+    it('accepts an absoulute URL', () => {
       assert.doesNotThrow(() => new BaseKey('http://foo.com/', VALID_ID));
       assert.doesNotThrow(() => new BaseKey('https://foo.com/', VALID_ID));
       assert.doesNotThrow(() => new BaseKey('https://bar.org/x', VALID_ID));
@@ -69,17 +69,32 @@ describe('@bayou/api-common/BaseKey', () => {
       assert.doesNotThrow(() => new BaseKey('https://bar.org/x/a%20b', VALID_ID));
     });
 
-    it('should throw an error given a URL with auth', () => {
-      assert.throws(() => new BaseKey('http://foo@example.com/', VALID_ID));
-      assert.throws(() => new BaseKey('http://foo:blort@example.com/', VALID_ID));
+    it('rejects a non-absolute URL', () => {
+      function test(value) {
+        assert.throws(() => new BaseKey(value, VALID_ID));
+      }
+
+      test('http://foo@example.com/');
+      test('http://foo:blort@example.com/');
+      test('https://example.com/?a');
+      test('https://example.com/?a=10');
+      test('https://example.com/x?a');
+      test('https://example.com/florp?a=10');
+      test('https://example.com/bip/bop/?a');
+      test('https://example.com/florp/like/?a=10');
+      test('https://example.com/#');
+      test('https://example.com/#hashie');
+      test('https://example.com/a#hashie');
+      test('https://example.com/a/#hashie');
+      test('https://example.com/a/nother/#hashie');
     });
 
-    it('should throw an error given an invalid absolute URL', () => {
+    it('rejects an invalid absolute URL', () => {
       assert.throws(() => new BaseKey('http:foo.com/', VALID_ID));
       assert.throws(() => new BaseKey('https://blort.com', VALID_ID)); // Needs a final slash.
     });
 
-    it('should throw an error given an invalid ID', () => {
+    it('rejects an invalid ID', () => {
       assert.throws(() => new BaseKey('http://foo.com/', ''), /badValue/);
       assert.throws(() => new BaseKey('http://foo.com/', '!'), /badValue/);
       assert.throws(() => new BaseKey('http://foo.com/', null), /badValue/);
@@ -88,7 +103,7 @@ describe('@bayou/api-common/BaseKey', () => {
   });
 
   describe('.url', () => {
-    it('should return the URL passed to the constructor', () => {
+    it('is the URL passed to the constructor', () => {
       function test(url) {
         assert.strictEqual(new BaseKey(url, VALID_ID).url, url, url);
       }
@@ -100,11 +115,11 @@ describe('@bayou/api-common/BaseKey', () => {
   });
 
   describe('.baseUrl', () => {
-    it('should throw an error for URL `*`', () => {
+    it('throws if `.url` is `*`', () => {
       assert.throws(() => new BaseKey('*', VALID_ID).baseUrl);
     });
 
-    it('should return the base URL of the originally-passed URL', () => {
+    it('is the base URL of the originally-passed URL', () => {
       // This uses a regex to chop up the URL. The actual implementation uses
       // the URL class. To the extent that they differ, the regex is probably
       // wrong.
@@ -124,16 +139,11 @@ describe('@bayou/api-common/BaseKey', () => {
       test('https://x.y:37/');
       test('https://x.y:123/b');
       test('https://x.y.z/aa/bb/cc/');
-
-      test('https://example.com/?what=does&this=mean');
-      test('https://example.com/foo/bar?what=does&this=mean');
-      test('https://example.com/#hashie');
-      test('https://example.com/foo/bar#hashie');
     });
   });
 
   describe('.id', () => {
-    it('should return the ID passed to the constructor', () => {
+    it('is the ID passed to the constructor', () => {
       const id  = 'this_is_an_id';
       const key = new BaseKey('*', id);
 
@@ -151,9 +161,10 @@ describe('@bayou/api-common/BaseKey', () => {
 
   describe('makeChallengePair()', () => {
     it('returns a challenge/response pair in an object', () => {
-      const key = new FakeKey('*', VALID_ID);
+      const key  = new FakeKey('*', VALID_ID);
       const pair = key.makeChallengePair();
 
+      assert.isObject(pair);
       assert.property(pair, 'challenge');
       assert.property(pair, 'response');
     });

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -57,6 +57,18 @@ describe('@bayou/api-common/BaseKey', () => {
   });
 
   describe('constructor', () => {
+    it('should accept `*` as the URL', () => {
+      assert.doesNotThrow(() => new BaseKey('*', VALID_ID));
+    });
+
+    it('should accept an absoulute URL', () => {
+      assert.doesNotThrow(() => new BaseKey('http://foo.com/', VALID_ID));
+      assert.doesNotThrow(() => new BaseKey('https://foo.com/', VALID_ID));
+      assert.doesNotThrow(() => new BaseKey('https://bar.org/x', VALID_ID));
+      assert.doesNotThrow(() => new BaseKey('https://bar.org/x/', VALID_ID));
+      assert.doesNotThrow(() => new BaseKey('https://bar.org/x/a%20b', VALID_ID));
+    });
+
     it('should throw an error given a URL with auth', () => {
       assert.throws(() => new BaseKey('http://foo@example.com/', VALID_ID));
       assert.throws(() => new BaseKey('http://foo:blort@example.com/', VALID_ID));
@@ -65,6 +77,13 @@ describe('@bayou/api-common/BaseKey', () => {
     it('should throw an error given an invalid absolute URL', () => {
       assert.throws(() => new BaseKey('http:foo.com/', VALID_ID));
       assert.throws(() => new BaseKey('https://blort.com', VALID_ID)); // Needs a final slash.
+    });
+
+    it('should throw an error given an invalid ID', () => {
+      assert.throws(() => new BaseKey('http://foo.com/', ''), /badValue/);
+      assert.throws(() => new BaseKey('http://foo.com/', '!'), /badValue/);
+      assert.throws(() => new BaseKey('http://foo.com/', null), /badValue/);
+      assert.throws(() => new BaseKey('http://foo.com/', 123), /badValue/);
     });
   });
 

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BaseKey } from '@bayou/api-common';
+import { TString } from '@bayou/typecheck';
 
 const VALID_ID = '12345678';
 
@@ -197,6 +198,8 @@ describe('@bayou/api-common/BaseKey', () => {
       assert.hasAllKeys(pair, ['challenge', 'response']);
       assert.isString(pair.challenge);
       assert.isString(pair.response);
+      assert.doesNotThrow(() => TString.hexBytes(pair.challenge, 8, 8));
+      assert.doesNotThrow(() => TString.hexBytes(pair.response, 32, 32));
     });
   });
 });

--- a/local-modules/@bayou/api-common/tests/test_BaseKey.js
+++ b/local-modules/@bayou/api-common/tests/test_BaseKey.js
@@ -151,6 +151,31 @@ describe('@bayou/api-common/BaseKey', () => {
     });
   });
 
+  describe('.safeString', () => {
+    it('calls through to the `_impl`', () => {
+      class SomeKey extends BaseKey {
+        _impl_safeString() {
+          return 'hello!';
+        }
+      }
+
+      const result = new SomeKey('*', VALID_ID).safeString;
+      assert.strictEqual(result, 'hello!');
+    });
+
+    it('rejects an invalid subclass implementation', () => {
+      class SomeKey extends BaseKey {
+        _impl_safeString() {
+          return 123; // Supposed to be a string.
+        }
+      }
+
+      const key = new SomeKey('*', VALID_ID);
+
+      assert.throws(() => key.safeString, /badValue/);
+    });
+  });
+
   describe('toString()', () => {
     it('returns a string', () => {
       const key = new BaseKey('*', VALID_ID);

--- a/local-modules/@bayou/api-common/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-common/tests/test_BearerToken.js
@@ -16,12 +16,28 @@ describe('@bayou/api-common/BearerToken', () => {
     });
   });
 
+  describe('.id', () => {
+    it('is the `id` passed to the constructor', () => {
+      const token = new BearerToken('some-id', 'some-secret');
+
+      assert.strictEqual(token.id, 'some-id');
+    });
+  });
+
   describe('.secretToken', () => {
     it('is the `secretToken` passed to the constructor', () => {
       const secret = 'florp';
       const token = new BearerToken('x', secret);
 
       assert.strictEqual(token.secretToken, secret);
+    });
+  });
+
+  describe('.url', () => {
+    it('is always `*`', () => {
+      const token = new BearerToken('some-id', 'some-secret');
+
+      assert.strictEqual(token.url, '*');
     });
   });
 

--- a/local-modules/@bayou/api-common/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-common/tests/test_BearerToken.js
@@ -9,16 +9,15 @@ import { BearerToken } from '@bayou/api-common';
 
 describe('@bayou/api-common/BearerToken', () => {
   describe('constructor()', () => {
-    it('should return a frozen instance of the class', () => {
+    it('returns a frozen instance', () => {
       const token = new BearerToken('x', 'y');
 
-      assert.instanceOf(token, BearerToken);
       assert.isFrozen(token);
     });
   });
 
   describe('.secretToken', () => {
-    it('should return the token provided to the constructor', () => {
+    it('is the `secretToken` passed to the constructor', () => {
       const secret = 'florp';
       const token = new BearerToken('x', secret);
 
@@ -27,33 +26,33 @@ describe('@bayou/api-common/BearerToken', () => {
   });
 
   describe('sameToken()', () => {
-    it('should return `false` when passed `null`', () => {
+    it('returns `false` when passed `null`', () => {
       const token = new BearerToken('x', 'y');
 
       assert.isFalse(token.sameToken(null));
     });
 
-    it('should return `false` when passed `undefined`', () => {
+    it('returns `false` when passed `undefined`', () => {
       const token = new BearerToken('x', 'y');
 
       assert.isFalse(token.sameToken(undefined));
     });
 
-    it('should return `false` when passed a token with a different secret key', () => {
+    it('returns `false` when passed a token with a different `secretToken`', () => {
       const token = new BearerToken('x', 'y');
       const other = new BearerToken('x', 'z');
 
       assert.isFalse(token.sameToken(other));
     });
 
-    it('should return `false` when passed a token with a different ID', () => {
+    it('returns `false` when passed a token with a different `id`', () => {
       const token = new BearerToken('x', 'y');
       const other = new BearerToken('z', 'y');
 
       assert.isFalse(token.sameToken(other));
     });
 
-    it('should return `true` when passed a token with the same ID and secret key', () => {
+    it('returns `true` when passed an identically-constructed token', () => {
       const token = new BearerToken('x', 'y');
       const other = new BearerToken('x', 'y');
 
@@ -62,7 +61,7 @@ describe('@bayou/api-common/BearerToken', () => {
   });
 
   describe('sameArrays()', () => {
-    it('should return `false` given arrays that are different lengths', () => {
+    it('returns `false` given arrays of different length', () => {
       const token1 = new BearerToken('a', '1');
       const token2 = new BearerToken('b', '2');
       const token3 = new BearerToken('c', '3');
@@ -74,7 +73,7 @@ describe('@bayou/api-common/BearerToken', () => {
       assert.isFalse(BearerToken.sameArrays(array1, array2));
     });
 
-    it('should throw an error if given arrays that contain things other than `BearerToken`s', () => {
+    it('throws when given arrays that contain things other than `BearerToken`s', () => {
       const token = new BearerToken('a', '1');
 
       const array1 = [token, 'a'];
@@ -83,7 +82,7 @@ describe('@bayou/api-common/BearerToken', () => {
       assert.throws(() => BearerToken.sameArrays(array1, array2));
     });
 
-    it('should return `true` given identically-constructed arrays of `BearerToken`s', () => {
+    it('returns `true` given identically-constructed arrays of `BearerToken`s', () => {
       const token1 = new BearerToken('a', '1');
       const token2 = new BearerToken('b', '2');
       const token3 = new BearerToken('c', '3');

--- a/local-modules/@bayou/api-common/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-common/tests/test_BearerToken.js
@@ -24,6 +24,14 @@ describe('@bayou/api-common/BearerToken', () => {
     });
   });
 
+  describe('.safeString', () => {
+    it('is the `id` with the expected suffix', () => {
+      const token = new BearerToken('foo', 'bar');
+
+      assert.strictEqual(token.safeString, 'foo-...');
+    });
+  });
+
   describe('.secretToken', () => {
     it('is the `secretToken` passed to the constructor', () => {
       const secret = 'florp';

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -90,4 +90,28 @@ describe('@bayou/api-common/Message', () => {
       assert.strictEqual(msg.targetId, 'target-yep');
     });
   });
+
+  describe('withTargetId()', () => {
+    it('returns an instance with a replaced `targetId`', () => {
+      const msg    = new Message(123, 'target-first', VALID_FUNCTOR);
+      const result = msg.withTargetId('target-second');
+
+      assert.strictEqual(result.targetId, 'target-second');
+      assert.strictEqual(result.id, 123);
+      assert.strictEqual(result.payload, VALID_FUNCTOR);
+    });
+
+    it('rejects an invalid `targetId`', () => {
+      const msg = new Message(123, 'target-first', VALID_FUNCTOR);
+
+      function test(tid) {
+        assert.throws(() => msg.withTargetId(tid), /badValue/);
+      }
+
+      test(null);
+      test(123);
+      test('');
+      test('&');
+    });
+  });
 });

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -13,12 +13,12 @@ const VALID_FUNCTOR = new Functor('blort', 37, 914);
 
 describe('@bayou/api-common/Message', () => {
   describe('constructor()', () => {
-    it('should accept non-negative integer ids', () => {
+    it('accepts non-negative integer `id`s', () => {
       assert.doesNotThrow(() => new Message(0, 'target', VALID_FUNCTOR));
       assert.doesNotThrow(() => new Message(37, 'target', VALID_FUNCTOR));
     });
 
-    it('should reject ids which are not non-negative integers', () => {
+    it('rejects `id`s which are not non-negative integers', () => {
       assert.throws(() => new Message('this better not work!', 'foo', VALID_FUNCTOR));
       assert.throws(() => new Message(3.7, 'target', VALID_FUNCTOR));
       assert.throws(() => new Message(true, 'target', VALID_FUNCTOR));
@@ -27,14 +27,23 @@ describe('@bayou/api-common/Message', () => {
       assert.throws(() => new Message(-1, 'target', VALID_FUNCTOR));
     });
 
-    it('should accept non-empty target strings', () => {
+    it('accepts valid ID strings for `targetId`', () => {
       assert.doesNotThrow(() => new Message(0, 'a', VALID_FUNCTOR));
       assert.doesNotThrow(() => new Message(0, 'A', VALID_FUNCTOR));
       assert.doesNotThrow(() => new Message(0, '_', VALID_FUNCTOR));
+      assert.doesNotThrow(() => new Message(0, '-', VALID_FUNCTOR));
+      assert.doesNotThrow(() => new Message(0, '.', VALID_FUNCTOR));
       assert.doesNotThrow(() => new Message(0, 'fooBar', VALID_FUNCTOR));
+      assert.doesNotThrow(() => new Message(0, 'x-y.z_pdq', VALID_FUNCTOR));
     });
 
-    it('should reject targets that are not non-empty strings', () => {
+    it('rejects strings which aren\'t in the propert syntax for `targetId`', () => {
+      assert.throws(() => new Message(37, '', VALID_FUNCTOR));
+      assert.throws(() => new Message(37, '/', VALID_FUNCTOR));
+      assert.throws(() => new Message(37, '%zorch*', VALID_FUNCTOR));
+    });
+
+    it('rejects non-strings for `targetId`', () => {
       assert.throws(() => new Message(37, 37, VALID_FUNCTOR));
       assert.throws(() => new Message(37, false, VALID_FUNCTOR));
       assert.throws(() => new Message(37, null, VALID_FUNCTOR));
@@ -42,24 +51,24 @@ describe('@bayou/api-common/Message', () => {
       assert.throws(() => new Message(37, '', VALID_FUNCTOR));
     });
 
-    it('should accept a functor for the payload', () => {
+    it('accepts a functor for `payload`', () => {
       assert.doesNotThrow(() => new Message(0, 'target', VALID_FUNCTOR));
     });
 
-    it('should reject a payload that is not a functor', () => {
+    it('rejects a non-functor `payload`', () => {
       assert.throws(() => new Message(0, 'target', null));
       assert.throws(() => new Message(0, 'target', 'blort'));
       assert.throws(() => new Message(0, 'target', { name: 'x', args: [] }));
     });
 
-    it('should return a frozen object', () => {
+    it('returns a frozen object', () => {
       const message = new Message(0, 'target', VALID_FUNCTOR);
       assert.isFrozen(message);
     });
   });
 
   describe('.id', () => {
-    it('should return the constructed message id', () => {
+    it('is the constructed `id`', () => {
       const msg = new Message(1234, 'target', VALID_FUNCTOR);
 
       assert.strictEqual(msg.id, 1234);
@@ -67,7 +76,7 @@ describe('@bayou/api-common/Message', () => {
   });
 
   describe('.payload', () => {
-    it('should return the constructed payload', () => {
+    it('is the constructed `payload`', () => {
       const msg = new Message(123, 'target', VALID_FUNCTOR);
 
       assert.strictEqual(msg.payload, VALID_FUNCTOR);
@@ -75,7 +84,7 @@ describe('@bayou/api-common/Message', () => {
   });
 
   describe('.targetId', () => {
-    it('should return the constructed target ID', () => {
+    it('is the constructed `targetId`', () => {
       const msg = new Message(123, 'target-yep', VALID_FUNCTOR);
 
       assert.strictEqual(msg.targetId, 'target-yep');

--- a/local-modules/@bayou/api-common/tests/test_Response.js
+++ b/local-modules/@bayou/api-common/tests/test_Response.js
@@ -1,0 +1,157 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { CodableError, Response } from '@bayou/api-common';
+import { InfoError } from '@bayou/util-common';
+
+describe('@bayou/api-common/Response', () => {
+  describe('constructor()', () => {
+    it('returns a frozen object', () => {
+      const r = new Response(0, 'x');
+      assert.isFrozen(r);
+    });
+
+    it('accepts non-negative integer `id`s', () => {
+      function test(id) {
+        assert.doesNotThrow(() => new Response(id, 'x'), /badValue/);
+      }
+
+      test(0);
+      test(1);
+      test(12345);
+    });
+
+    it('rejects `id`s which are not non-negative integers', () => {
+      function test(id) {
+        assert.throws(() => new Response(id, 'x'), /badValue/);
+      }
+
+      test(-1);
+      test(0.5);
+      test(NaN);
+
+      test(undefined);
+      test(null);
+      test('123');
+      test([]);
+    });
+
+    it('accepts a variety of `result`s', () => {
+      function test(r) {
+        assert.doesNotThrow(() => new Response(1, r));
+      }
+
+      test(undefined);
+      test(null);
+      test(true);
+      test(123);
+      test('florp');
+      test([]);
+      test([1, 'x', [2.5]]);
+      test({ a: 'a', b: ['c', 'd', 'e'] });
+    });
+
+    it('accepts `null` and `Error`s for the `error`', () => {
+      function test(e) {
+        assert.doesNotThrow(() => new Response(1, null, e));
+      }
+
+      test(null);
+      test(new Error('Oy!'));
+      test(new InfoError('yow'));
+      test(new CodableError('eeek'));
+    });
+
+    it('rejects non-`null` non-`Error`s for the `error`', () => {
+      function test(e) {
+        assert.throws(() => new Response(1, null, e), /badValue/);
+      }
+
+      test(true);
+      test(9.14);
+      test('blort');
+      test([]);
+      test(new Map());
+    });
+
+    it('will not construct an instance with non-`null` `result` and `error`', () => {
+      assert.throws(() => new Response(1, 'x', new Error('eep')), /badUse/);
+    });
+  });
+
+  describe('.error', () => {
+    it('is the constructed `error` when it was a `CodableError`', () => {
+      const e = new CodableError('zorch', 1, 2, 3);
+      const r = new Response(1, null, e);
+
+      assert.strictEqual(r.error, e);
+    });
+
+    it('is a `CodableError` with matching payload when the constructed `error` was an `InfoError`', () => {
+      const e = new InfoError('blorp', 'what', 'is', 'happening', 'here?');
+      const r = new Response(1, null, e);
+
+      assert.instanceOf(r.error, CodableError);
+      assert.strictEqual(r.error.info, e.info);
+    });
+
+    it('is a `CodableError` with the message in the payload when the constructed `error` was not an `InfoError`', () => {
+      const e      = new Error('Yikes!');
+      const expect = new CodableError('general_error', 'Yikes!');
+      const r      = new Response(1, null, e);
+
+      assert.instanceOf(r.error, CodableError);
+      assert.deepEqual(r.error.info, expect.info);
+    });
+  });
+
+  describe('.id', () => {
+    it('is the constructed `id`', () => {
+      const r = new Response(1234, 'x');
+
+      assert.strictEqual(r.id, 1234);
+    });
+  });
+
+  describe('.originalError', () => {
+    it('is the constructed `error`', () => {
+      function test(e) {
+        const r = new Response(1, null, e);
+        assert.strictEqual(r.originalError, e);
+      }
+
+      test(null);
+      test(new Error('Oy!'));
+      test(new InfoError('yow'));
+      test(new CodableError('eeek'));
+    });
+  });
+
+  describe('.result', () => {
+    it('is the constructed `result`', () => {
+      const r = new Response(1, 'florp');
+
+      assert.strictEqual(r.result, 'florp');
+    });
+  });
+
+  describe('.deconstruct', () => {
+    it('is a two-element array when there is no `error`', () => {
+      const r = new Response(1, 'florp');
+      const got = r.deconstruct();
+
+      assert.deepEqual(got, [1, 'florp']);
+    });
+
+    it('is a three-element array with `null` middle element when there is an `error`', () => {
+      const r = new Response(1, null, new Error('oy'));
+      const got = r.deconstruct();
+
+      assert.deepEqual(got, [1, null, r.error]);
+    });
+  });
+});

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -18,11 +18,18 @@ describe('@bayou/api-common/TargetId', () => {
       test('z');
       test('AZ');
       test('0123456789');
+      test('.');
+      test('-');
+      test('_');
       test('-x-y-');
       test('_X_Y_');
+      test('.x.Y.');
 
       for (let len = 10; len <= 64; len++) {
         test('x'.repeat(len));
+        test(`-${'x'.repeat(len - 2)}-`);
+        test(`_${'Y'.repeat(len - 2)}_`);
+        test(`.${'0'.repeat(len - 2)}.`);
       }
     });
 

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -127,7 +127,7 @@ export default class ApiLog extends CommonBase {
 
     if (this._tokenAuth.isToken(targetId)) {
       const token = this._tokenAuth.tokenFromString(targetId);
-      msg = msg.withTargetId(token.printableId);
+      msg = msg.withTargetId(token.safeString);
     }
 
     // **TODO:** This will ultimately need to do more redaction.

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -371,7 +371,7 @@ export default class Context extends CommonBase {
   _targetError(idOrToken, msg = 'Unknown target') {
     const tokenAuth = this._tokenAuth;
     const idToReport = ((tokenAuth !== null) && tokenAuth.isToken(idOrToken))
-      ? tokenAuth.tokenFromString(idOrToken).printableId
+      ? tokenAuth.tokenFromString(idOrToken).safeString
       : idOrToken;
 
     return Errors.badUse(`${msg}: ${idToReport}`);

--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -161,7 +161,7 @@ export default class TokenMint extends CommonBase {
     const already = this._allTokens.get(token.id);
 
     if (already !== undefined) {
-      throw Errors.badUse(`Duplicate token: ${token.printableId}`);
+      throw Errors.badUse(`Duplicate token: ${token.safeString}`);
     }
 
     this._allTokens.set(token.id, { info, token });

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -65,7 +65,7 @@ export default class RootAccess extends CommonBase {
       `  author:  ${authorId}\n`,
       `  doc:     ${docId}\n`,
       `  caret:   ${session.getCaretId()}\n`,
-      `  key id:  ${key.printableId}\n`, // This is safe to log (not security-sensitive).
+      `  key id:  ${key.safeString}\n`, // This is safe to log (not security-sensitive).
       `  key url: ${key.url}`);
 
     return key;

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -28,7 +28,7 @@ export default class VarInfo extends CommonBase {
   async get() {
     // **Note:** The "printable" form of a bearer token is redacted, such that
     // the secret portion is not represented.
-    const tokenIds = Auth.rootTokens.map(t => t.printableId);
+    const tokenIds = Auth.rootTokens.map(t => t.safeString);
 
     return {
       pid:        process.pid,

--- a/local-modules/@bayou/typecheck/TString.js
+++ b/local-modules/@bayou/typecheck/TString.js
@@ -158,8 +158,9 @@ export default class TString extends UtilityClass {
     try {
       url = new URL(TString.nonEmpty(value));
     } catch (e) {
-      // Throw a higher-fidelity error.
-      throw Errors.badValue(value, String, 'absolute URL syntax');
+      // Set up `url` so that the test below will cause us to throw the proper
+      // error.
+      url = {};
     }
 
     // **Note:** Though `new URL()` is lenient with respect to parsing, if it

--- a/local-modules/@bayou/typecheck/TString.js
+++ b/local-modules/@bayou/typecheck/TString.js
@@ -146,8 +146,8 @@ export default class TString extends UtilityClass {
 
   /**
    * Checks a value which must be a syntactically valid absolute URL with a path
-   * (which can just be `/`) and without auth info. (Auth info consists of a
-   * username and optional password before the host name.)
+   * (which can just be `/`) and without either auth info or a query. (Auth info
+   * consists of a username and optional password before the host name.)
    *
    * @param {*} value Value to check.
    * @returns {string} `value`.
@@ -162,14 +162,14 @@ export default class TString extends UtilityClass {
     }
 
     // Some versions of `URL` will parse a missing origin into the literal
-    // string `null`, hence the third check here. The last check ensures that
+    // string `null`, hence the extra check there. The last check ensures that
     // the original `value` is well-formed; while `new URL()` is somewhat
     // lenient, the `href` it produces is guaranteed to be well-formed, and so
     // the `===` comparison transitively ensures that the original `value` is
     // also well-formed.
     if (!(   url.host
-          && url.origin
-          && (url.origin !== 'null')
+          && (url.origin && (url.origin !== 'null'))
+          && (url.search === '')
           && (url.href === value))) {
       throw Errors.badValue(value, String, 'absolute URL syntax');
     }

--- a/local-modules/@bayou/typecheck/TString.js
+++ b/local-modules/@bayou/typecheck/TString.js
@@ -162,22 +162,13 @@ export default class TString extends UtilityClass {
       throw Errors.badValue(value, String, 'absolute URL syntax');
     }
 
-    // Some versions of `URL` will parse a missing origin into the literal
-    // string `null`, hence the extra check there. The last check ensures that
-    // the original `value` is well-formed; while `new URL()` is somewhat
-    // lenient, the `href` it produces is guaranteed to be well-formed, and so
-    // the `===` comparison transitively ensures that the original `value` is
-    // also well-formed.
-    if (!(   url.host
-          && (url.origin && (url.origin !== 'null'))
-          && (url.search === '')
-          && (url.hash === '')
-          && (url.href === value))) {
+    // **Note:** Though `new URL()` is lenient with respect to parsing, if it
+    // _does_ parse successfully, `origin` and `pathname` will always be
+    // well-formed, and if they combine to form the originally given value, we
+    // know the original doesn't have any of the verboten parts (nor a missing
+    // path).
+    if (value !== `${url.origin}${url.pathname}`) {
       throw Errors.badValue(value, String, 'absolute URL syntax');
-    }
-
-    if (url.username || url.password) {
-      throw Errors.badValue(value, String, 'absolute URL syntax, without auth');
     }
 
     return value;

--- a/local-modules/@bayou/typecheck/TString.js
+++ b/local-modules/@bayou/typecheck/TString.js
@@ -146,8 +146,9 @@ export default class TString extends UtilityClass {
 
   /**
    * Checks a value which must be a syntactically valid absolute URL with a path
-   * (which can just be `/`) and without either auth info or a query. (Auth info
-   * consists of a username and optional password before the host name.)
+   * (which can just be `/`) and without any of auth info, a query, or a hash.
+   * (Auth info  consists of a username and optional password before the host
+   * name.)
    *
    * @param {*} value Value to check.
    * @returns {string} `value`.
@@ -170,6 +171,7 @@ export default class TString extends UtilityClass {
     if (!(   url.host
           && (url.origin && (url.origin !== 'null'))
           && (url.search === '')
+          && (url.hash === '')
           && (url.href === value))) {
       throw Errors.badValue(value, String, 'absolute URL syntax');
     }

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -439,10 +439,16 @@ describe('@bayou/typecheck/TString', () => {
         assert.throws(() => TString.urlOrigin(value), /badValue/, inspect(value));
       }
 
-      test('http://foo.bar/');
+      test('http://foo.bar/'); // Shouldn't end with a slash.
       test('http://foo.bar/x');
       test('https://foo@bar.com');
       test('https://florp:like@example.com');
+      test('http://foo.bar/?a=10');
+      test('http://foo.bar/x?a=10');
+      test('http://foo.bar/x/?a=10');
+      test('http://foo.bar/#123');
+      test('http://foo.bar/baz#123');
+      test('http://foo.bar/baz/#123');
     });
 
     it('should throw if value is not a URL string at all', () => {

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -384,7 +384,7 @@ describe('@bayou/typecheck/TString', () => {
       test('https://bar.baz.co/biff/boo');
     });
 
-    it('should throw if value is not a URL string at all', () => {
+    it('should throw if the value is not a URL string at all', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -400,7 +400,7 @@ describe('@bayou/typecheck/TString', () => {
       test(null);
     });
 
-    it('should throw if value has auth info', () => {
+    it('should throw if the value has auth info', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -409,7 +409,7 @@ describe('@bayou/typecheck/TString', () => {
       test('http://user:pass@example.com/');
     });
 
-    it('should throw if value has a query', () => {
+    it('should throw if the value has a query', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -418,6 +418,16 @@ describe('@bayou/typecheck/TString', () => {
       test('https://milk.com/?x=1&y=2');
       test('http://milk.com/bcd?e=10');
       test('http://milk.com/bcd/efgh?i=123&jkl=234');
+    });
+
+    it('should throw if the value has a hash', () => {
+      function test(value) {
+        assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
+      }
+
+      test('https://milk.com/#florp');
+      test('http://milk.com/bcd#florp');
+      test('http://milk.com/bcd/efgh#florp');
     });
   });
 

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -385,27 +385,39 @@ describe('@bayou/typecheck/TString', () => {
     });
 
     it('should throw if value is not a URL string at all', () => {
-      assert.throws(() => TString.urlAbsolute('this better not work!'));
-      assert.throws(() => TString.urlAbsolute('/home/users/fnord'));
-      assert.throws(() => TString.urlAbsolute('http:example.com'));
-      assert.throws(() => TString.urlAbsolute('http:example.com/foo'));
-      assert.throws(() => TString.urlAbsolute('http:/example.com'));
-      assert.throws(() => TString.urlAbsolute('http://example.com')); // Needs final slash.
-      assert.throws(() => TString.urlAbsolute(5.1));
-      assert.throws(() => TString.urlAbsolute(undefined));
-      assert.throws(() => TString.urlAbsolute(null));
+      function test(value) {
+        assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
+      }
+
+      test('this better not work!');
+      test('/home/users/fnord');
+      test('http:example.com');
+      test('http:example.com/foo');
+      test('http:/example.com');
+      test('http://example.com'); // Needs final slash.
+      test(5.1);
+      test(undefined);
+      test(null);
     });
 
     it('should throw if value has auth info', () => {
-      assert.throws(() => TString.urlAbsolute('http://user@example.com/'));
-      assert.throws(() => TString.urlAbsolute('http://user:pass@example.com/'));
+      function test(value) {
+        assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
+      }
+
+      test('http://user@example.com/');
+      test('http://user:pass@example.com/');
     });
 
     it('should throw if value has a query', () => {
-      assert.throws(() => TString.urlAbsolute('https://milk.com/?a=10'));
-      assert.throws(() => TString.urlAbsolute('https://milk.com/?x=1&y=2'));
-      assert.throws(() => TString.urlAbsolute('http://milk.com/bcd?e=10'));
-      assert.throws(() => TString.urlAbsolute('http://milk.com/bcd/efgh?i=123&jkl=234'));
+      function test(value) {
+        assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
+      }
+
+      test('https://milk.com/?a=10');
+      test('https://milk.com/?x=1&y=2');
+      test('http://milk.com/bcd?e=10');
+      test('http://milk.com/bcd/efgh?i=123&jkl=234');
     });
   });
 
@@ -423,21 +435,29 @@ describe('@bayou/typecheck/TString', () => {
     });
 
     it('should throw if value is not an origin-only URL', () => {
-      assert.throws(() => TString.urlOrigin('http://foo.bar/'));
-      assert.throws(() => TString.urlOrigin('http://foo.bar/x'));
-      assert.throws(() => TString.urlOrigin('https://foo@bar.com'));
-      assert.throws(() => TString.urlOrigin('https://florp:like@example.com'));
+      function test(value) {
+        assert.throws(() => TString.urlOrigin(value), /badValue/, inspect(value));
+      }
+
+      test('http://foo.bar/');
+      test('http://foo.bar/x');
+      test('https://foo@bar.com');
+      test('https://florp:like@example.com');
     });
 
     it('should throw if value is not a URL string at all', () => {
-      assert.throws(() => TString.urlOrigin('this better not work!'));
-      assert.throws(() => TString.urlOrigin('/home/users/fnord'));
-      assert.throws(() => TString.urlOrigin('http:example.com'));
-      assert.throws(() => TString.urlOrigin('http:example.com/foo'));
-      assert.throws(() => TString.urlOrigin('http:/example.com'));
-      assert.throws(() => TString.urlOrigin(5.1));
-      assert.throws(() => TString.urlOrigin(undefined));
-      assert.throws(() => TString.urlOrigin(null));
+      function test(value) {
+        assert.throws(() => TString.urlOrigin(value), /badValue/, inspect(value));
+      }
+
+      test('this better not work!');
+      test('/home/users/fnord');
+      test('http:example.com');
+      test('http:example.com/foo');
+      test('http:/example.com');
+      test(5.1);
+      test(undefined);
+      test(null);
     });
   });
 });

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -376,13 +376,13 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('urlAbsolute()', () => {
-    it('should return the provided value if it is an absolute URL string', () => {
+    it('should return the given value if it is an absolute URL string', () => {
       const value = 'https://www.example.com/';
 
       assert.strictEqual(TString.urlAbsolute(value), value);
     });
 
-    it('should throw an Error if value is not a URL string at all', () => {
+    it('should throw if value is not a URL string at all', () => {
       assert.throws(() => TString.urlAbsolute('this better not work!'));
       assert.throws(() => TString.urlAbsolute('/home/users/fnord'));
       assert.throws(() => TString.urlAbsolute('http:example.com'));
@@ -394,14 +394,21 @@ describe('@bayou/typecheck/TString', () => {
       assert.throws(() => TString.urlAbsolute(null));
     });
 
-    it('should throw an Error if value has auth info', () => {
+    it('should throw if value has auth info', () => {
       assert.throws(() => TString.urlAbsolute('http://user@example.com/'));
       assert.throws(() => TString.urlAbsolute('http://user:pass@example.com/'));
+    });
+
+    it('should throw if value has a query', () => {
+      assert.throws(() => TString.urlAbsolute('https://milk.com/?a=10'));
+      assert.throws(() => TString.urlAbsolute('https://milk.com/?x=1&y=2'));
+      assert.throws(() => TString.urlAbsolute('http://milk.com/bcd?e=10'));
+      assert.throws(() => TString.urlAbsolute('http://milk.com/bcd/efgh?i=123&jkl=234'));
     });
   });
 
   describe('urlOrigin()', () => {
-    it('should return the provided value if it is an origin-only URL', () => {
+    it('should return the given value if it is an origin-only URL', () => {
       let which = 0;
       function test(value) {
         which++;
@@ -413,14 +420,14 @@ describe('@bayou/typecheck/TString', () => {
       test('http://florp.co.uk:123');
     });
 
-    it('should throw an Error if value is not an origin-only URL', () => {
+    it('should throw if value is not an origin-only URL', () => {
       assert.throws(() => TString.urlOrigin('http://foo.bar/'));
       assert.throws(() => TString.urlOrigin('http://foo.bar/x'));
       assert.throws(() => TString.urlOrigin('https://foo@bar.com'));
       assert.throws(() => TString.urlOrigin('https://florp:like@example.com'));
     });
 
-    it('should throw an Error if value is not a URL string at all', () => {
+    it('should throw if value is not a URL string at all', () => {
       assert.throws(() => TString.urlOrigin('this better not work!'));
       assert.throws(() => TString.urlOrigin('/home/users/fnord'));
       assert.throws(() => TString.urlOrigin('http:example.com'));

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -25,13 +25,13 @@ const NON_STRING_CASES = [
 
 describe('@bayou/typecheck/TString', () => {
   describe('check(value)', () => {
-    it('should return the provided value when passed a string', () => {
+    it('should return the given string value', () => {
       const value = 'this better work!';
 
       assert.strictEqual(TString.check(value), value);
     });
 
-    it('should throw an Error when passed anything other than a string', () => {
+    it('should throw when passed anything other than a string', () => {
       assert.throws(() => TString.check(54));
       assert.throws(() => TString.check(true));
       assert.throws(() => TString.check([]));
@@ -48,7 +48,7 @@ describe('@bayou/typecheck/TString', () => {
       assert.doesNotThrow(() => TString.check(value, /^([a-f0-9]{2})+$/));
     });
 
-    it('should throw an Error when a string fails to match the provided regex', () => {
+    it('should throw when a string fails to match the provided regex', () => {
       const value = 'this better not work!';
 
       assert.throws(() => TString.check(value, /^([a-f0-9]{2})+$/));
@@ -62,7 +62,7 @@ describe('@bayou/typecheck/TString', () => {
       assert.strictEqual(TString.hexBytes(value), value);
     });
 
-    it('should throw an Error when anything other than a string of hex bytes is provided', () => {
+    it('should throw when anything other than a string of hex bytes is provided', () => {
       const value = 'this better not work!';
 
       assert.throws(() => TString.hexBytes(value));
@@ -108,13 +108,13 @@ describe('@bayou/typecheck/TString', () => {
       assert.strictEqual(TString.hexBytes(value, 3, 11), value);
     });
 
-    it('should throw an Error if the number of bytes is less than the minimum', () => {
+    it('should throw if the number of bytes is less than the minimum', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 32, 64));
     });
 
-    it('should throw an Error if the number of bytes is greater than the minimum', () => {
+    it('should throw if the number of bytes is greater than the minimum', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 4, 8));
@@ -346,27 +346,23 @@ describe('@bayou/typecheck/TString', () => {
       assert.strictEqual(TString.nonEmpty(value), value);
     });
 
-    it('should throw an Error if value is a string of length 0', () => {
-      const value = '';
-
-      assert.throws(() => TString.nonEmpty(value));
+    it('should throw if value is a string of length 0', () => {
+      assert.throws(() => TString.nonEmpty(''));
     });
   });
 
   describe('orNull()', () => {
-    it('should return the provided value if it is a string', () => {
+    it('should return the given string value', () => {
       const value = 'This better work!';
 
       assert.strictEqual(TString.orNull(value), value);
     });
 
-    it('should return the provided value if it is null', () => {
-      const value = null;
-
-      assert.strictEqual(TString.orNull(value), value);
+    it('should return `null` given `null`', () => {
+      assert.strictEqual(TString.orNull(null), null);
     });
 
-    it('should throw an Error if value is not a string and is not null', () => {
+    it('should throw if value is neither a string nor `null`', () => {
       assert.throws(() => TString.orNull(undefined));
       assert.throws(() => TString.orNull(5.1));
       assert.throws(() => TString.orNull([]));
@@ -377,9 +373,15 @@ describe('@bayou/typecheck/TString', () => {
 
   describe('urlAbsolute()', () => {
     it('should return the given value if it is an absolute URL string', () => {
-      const value = 'https://www.example.com/';
+      function test(value) {
+        assert.strictEqual(TString.urlAbsolute(value), value, value);
+      }
 
-      assert.strictEqual(TString.urlAbsolute(value), value);
+      test('https://www.example.com/');
+      test('http://foo.com/');
+      test('https://bar.baz.co/florp');
+      test('https://bar.baz.co/florp/');
+      test('https://bar.baz.co/biff/boo');
     });
 
     it('should throw if value is not a URL string at all', () => {

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -25,13 +25,13 @@ const NON_STRING_CASES = [
 
 describe('@bayou/typecheck/TString', () => {
   describe('check(value)', () => {
-    it('should return the given string value', () => {
+    it('accepts strings', () => {
       const value = 'this better work!';
 
       assert.strictEqual(TString.check(value), value);
     });
 
-    it('should throw when passed anything other than a string', () => {
+    it('rejects anything other than a string', () => {
       assert.throws(() => TString.check(54));
       assert.throws(() => TString.check(true));
       assert.throws(() => TString.check([]));
@@ -42,13 +42,13 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('check(value, regex)', () => {
-    it('should allow a string when it matches the provided regex', () => {
+    it('accepts a string which matches the given regex', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.doesNotThrow(() => TString.check(value, /^([a-f0-9]{2})+$/));
     });
 
-    it('should throw when a string fails to match the provided regex', () => {
+    it('rejects a non-matching string', () => {
       const value = 'this better not work!';
 
       assert.throws(() => TString.check(value, /^([a-f0-9]{2})+$/));
@@ -56,13 +56,13 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('hexBytes(value)', () => {
-    it('should return the provided value if it is a string of hex bytes', () => {
+    it('accepts a string of hex bytes', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value), value);
     });
 
-    it('should throw when anything other than a string of hex bytes is provided', () => {
+    it('rejects a string of non-hex', () => {
       const value = 'this better not work!';
 
       assert.throws(() => TString.hexBytes(value));
@@ -70,19 +70,19 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('hexBytes(value, minBytes)', () => {
-    it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
+    it('accepts a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value, 11), value);
     });
 
-    it('should return the provided value if it is a string of hex bytes greater than the required minimum length', () => {
+    it('accepts a string of hex bytes greater than the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value, 3), value);
     });
 
-    it('should throw an Error if the number of bytes is less than the minimum', () => {
+    it('rejects too-short strings', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 128));
@@ -90,31 +90,31 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('hexBytes(value, minBytes, maxBytes)', () => {
-    it('should return the provided value if it is a string of hex bytes of the required minimum length', () => {
+    it('accepts a string of hex bytes of the required minimum length', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value, 11, 128), value);
     });
 
-    it('should return the provided value if it is a string of hex bytes within the required length range', () => {
+    it('accepts a string of hex bytes within the required length range', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value, 3, 128), value);
     });
 
-    it('should return the provided value if it is a string of hex bytes equal to the maximum length', () => {
+    it('accepts a string of hex bytes equal to the maximum length', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.strictEqual(TString.hexBytes(value, 3, 11), value);
     });
 
-    it('should throw if the number of bytes is less than the minimum', () => {
+    it('rejects too-short strings', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 32, 64));
     });
 
-    it('should throw if the number of bytes is greater than the minimum', () => {
+    it('rejects too-long strings', () => {
       const value = 'deadbeef7584930215cafe';
 
       assert.throws(() => TString.hexBytes(value, 4, 8));
@@ -340,10 +340,14 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('nonEmpty()', () => {
-    it('should return the provided value if it is a string with length >= 1', () => {
-      const value = 'This better work!';
+    it('accepts strings of length `1` or longer', () => {
+      function test(value) {
+        assert.strictEqual(TString.nonEmpty(value), value);
+      }
 
-      assert.strictEqual(TString.nonEmpty(value), value);
+      test('x');
+      test('xy');
+      test('This better work!');
     });
 
     it('should throw if value is a string of length 0', () => {
@@ -352,17 +356,17 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('orNull()', () => {
-    it('should return the given string value', () => {
+    it('accepts strings', () => {
       const value = 'This better work!';
 
       assert.strictEqual(TString.orNull(value), value);
     });
 
-    it('should return `null` given `null`', () => {
+    it('accepts `null`', () => {
       assert.strictEqual(TString.orNull(null), null);
     });
 
-    it('should throw if value is neither a string nor `null`', () => {
+    it('rejects non-`null` non-strings', () => {
       assert.throws(() => TString.orNull(undefined));
       assert.throws(() => TString.orNull(5.1));
       assert.throws(() => TString.orNull([]));
@@ -372,7 +376,7 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('urlAbsolute()', () => {
-    it('should return the given value if it is an absolute URL string', () => {
+    it('accepts absolute URLs', () => {
       function test(value) {
         assert.strictEqual(TString.urlAbsolute(value), value, value);
       }
@@ -384,23 +388,31 @@ describe('@bayou/typecheck/TString', () => {
       test('https://bar.baz.co/biff/boo');
     });
 
-    it('should throw if the value is not a URL string at all', () => {
+    it('rejects non-absolute URLs', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
 
-      test('this better not work!');
       test('/home/users/fnord');
       test('http:example.com');
       test('http:example.com/foo');
       test('http:/example.com');
       test('http://example.com'); // Needs final slash.
+    });
+
+    it('rejects non-URLs', () => {
+      function test(value) {
+        assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
+      }
+
+      test('');
+      test('this better not work!');
       test(5.1);
       test(undefined);
       test(null);
     });
 
-    it('should throw if the value has auth info', () => {
+    it('rejects URLs with auth info', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -409,7 +421,7 @@ describe('@bayou/typecheck/TString', () => {
       test('http://user:pass@example.com/');
     });
 
-    it('should throw if the value has a query', () => {
+    it('rejects URLs with a query', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -420,7 +432,7 @@ describe('@bayou/typecheck/TString', () => {
       test('http://milk.com/bcd/efgh?i=123&jkl=234');
     });
 
-    it('should throw if the value has a hash', () => {
+    it('rejects URLs with a hash', () => {
       function test(value) {
         assert.throws(() => TString.urlAbsolute(value), /badValue/, inspect(value));
       }
@@ -432,7 +444,7 @@ describe('@bayou/typecheck/TString', () => {
   });
 
   describe('urlOrigin()', () => {
-    it('should return the given value if it is an origin-only URL', () => {
+    it('accepts origin-only URLs', () => {
       let which = 0;
       function test(value) {
         which++;
@@ -444,7 +456,7 @@ describe('@bayou/typecheck/TString', () => {
       test('http://florp.co.uk:123');
     });
 
-    it('should throw if value is not an origin-only URL', () => {
+    it('rejects URLs that are not origin-only', () => {
       function test(value) {
         assert.throws(() => TString.urlOrigin(value), /badValue/, inspect(value));
       }
@@ -461,7 +473,7 @@ describe('@bayou/typecheck/TString', () => {
       test('http://foo.bar/baz/#123');
     });
 
-    it('should throw if value is not a URL string at all', () => {
+    it('rejects non-URLs', () => {
       function test(value) {
         assert.throws(() => TString.urlOrigin(value), /badValue/, inspect(value));
       }


### PR DESCRIPTION
This PR is another one which concentrates on rounding out the tests of the API code, this one mostly touching `api-common`. In addition, I ended up making a couple tweaks to the implementation:

* Reworked `BaseKey.printableId` as `BaseKey.safeString`. The former name came from a time when the `id` could possibly contain a secret value.
* Pulled most of the challenge-response code from `SplitKey` into `BaseKey`. `SplitKey` is going to go away once the new session stuff is in place end-to-end, but I didn't want to lose the possibility of supporting challenge-response, which is a good security pattern.
* Removed a bit of dead code in `Message`.

**Bonus:** I ended up discovering that the contract for `TString.urlAbsolute()` was looser than I expected, so I tightened it up, and then went ahead and cleaned up the `TString` test cases in general. And in the end I realized I could simplify the implementation a bit, so I did that.