### PR TITLE
Two bits of API / session progress

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -351,7 +351,7 @@ export default class ApiClient extends CommonBase {
         // transparently and straightforwardly (e.g. and notably, they don't
         // have to "unwrap" the errors in the usual case), while still being
         // able to ascertain the foreign origin of the errors when warranted.
-        const remoteCause = new CodableError('remote_error', this.connectionId);
+        const remoteCause = CodableError.remoteError(this.connectionId);
         const rejectReason = new CodableError(remoteCause, error.info);
         callback.reject(rejectReason);
       } else {

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -293,7 +293,7 @@ export default class ApiClient extends CommonBase {
 
     const code = WebsocketCodes.close(event.code);
     const desc = event.reason ? `${code}: ${event.reason}` : code;
-    const error = ConnectionError.connection_closed(this._connectionId, desc);
+    const error = ConnectionError.connectionClosed(this._connectionId, desc);
 
     this._handleTermination(event, error);
   }
@@ -314,7 +314,7 @@ export default class ApiClient extends CommonBase {
     // **Note:** The error event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it for the
     // `ConnectionError` description.
-    const error = ConnectionError.connection_error(this._connectionId);
+    const error = ConnectionError.connectionError(this._connectionId);
     this._handleTermination(event, error);
   }
 
@@ -333,7 +333,7 @@ export default class ApiClient extends CommonBase {
     const response = this._codec.decodeJson(event.data);
 
     if (!(response instanceof Response)) {
-      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
+      throw ConnectionError.connectionNonsense(this._connectionId, 'Got strange response.');
     }
 
     const { id, result, error } = response;
@@ -365,7 +365,7 @@ export default class ApiClient extends CommonBase {
       }
     } else {
       // See above about `server_bug`.
-      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
+      throw ConnectionError.connectionNonsense(this._connectionId, `Orphan call for ID ${id}.`);
     }
   }
 
@@ -448,10 +448,10 @@ export default class ApiClient extends CommonBase {
         // The detail string here differentiates this case from cases where the
         // API message was already queued up or sent before the websocket became
         // closed.
-        return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
+        return Promise.reject(ConnectionError.connectionClosed(this._connectionId, 'Already closed.'));
       }
       case WebSocket.CLOSING: {
-        return Promise.reject(this.connection_closing(this._connectionId));
+        return Promise.reject(ConnectionError.connectionClosing(this._connectionId));
       }
     }
 

--- a/local-modules/@bayou/api-common/CodableError.js
+++ b/local-modules/@bayou/api-common/CodableError.js
@@ -19,6 +19,23 @@ export default class CodableError extends InfoError {
   }
 
   /**
+   * Constructs a "general" error (no particularly well-structured payload),
+   * meant to be a catch-all for when there's nothing better that can be thrown.
+   *
+   * @param {...*} args Arbitrary arguments. If the first argument is an
+   *   `Error`, it is treated as the error "cause."
+   * @returns {CodableError} An appropriately-constructed error.
+   */
+  static generalError(...args) {
+    if (args[0] instanceof Error) {
+      const [cause, ...rest] = args;
+      return new CodableError(cause, 'generalError', ...rest);
+    } else {
+      return new CodableError('generalError', ...args);
+    }
+  }
+
+  /**
    * Constructs an instance. Arguments are the same as for {@link InfoError}.
    *
    * **Note:** If a `cause` argument is given, the constructed instance will
@@ -79,14 +96,14 @@ export default class CodableError extends InfoError {
 
     if (error instanceof InfoError) {
       if (error.cause === null) {
-        return new CodableError(error.info);
+        return CodableError.generalError(error.info);
       } else {
-        return new CodableError(error.cause, error.info);
+        return CodableError.generalError(error.cause, error.info);
       }
     }
 
     // It's an `Error` outside of the control of this system. The best we can do
     // is re-encapsulate its `name` and `message`.
-    return new CodableError('general_error', error.name, error.message);
+    return CodableError.generalError(error.name, error.message);
   }
 }

--- a/local-modules/@bayou/api-common/CodableError.js
+++ b/local-modules/@bayou/api-common/CodableError.js
@@ -4,6 +4,7 @@
 
 import { inspect } from 'util';
 
+import { TString } from '@bayou/typecheck';
 import { InfoError } from '@bayou/util-common';
 
 /**
@@ -33,6 +34,21 @@ export default class CodableError extends InfoError {
     } else {
       return new CodableError('generalError', ...args);
     }
+  }
+
+  /**
+   * Constructs an error meant to be used as a "cause" to indicate that the
+   * linked error originated from the far side of a connection.
+   *
+   * **TODO:** Maybe this should be defined on `ConnectionError` instead?
+   *
+   * @param {String} connectionId ID of the connection from which the linked
+   *   error came.
+   * @returns {CodableError} An appropriately-constructed error.
+   */
+  static remoteError(connectionId) {
+    TString.nonEmpty(connectionId);
+    return new CodableError('remoteError', connectionId);
   }
 
   /**

--- a/local-modules/@bayou/api-common/ConnectionError.js
+++ b/local-modules/@bayou/api-common/ConnectionError.js
@@ -20,10 +20,10 @@ export default class ConnectionError extends InfoError {
    * @param {string} detail Human-oriented detail message about the problem.
    * @returns {ConnectionError} An appropriately-constructed error.
    */
-  static connection_closed(connectionId, detail) {
+  static connectionClosed(connectionId, detail) {
     TString.check(connectionId);
     TString.check(detail);
-    return new ConnectionError('connection_closed', connectionId, detail);
+    return new ConnectionError('connectionClosed', connectionId, detail);
   }
 
   /**
@@ -34,9 +34,9 @@ export default class ConnectionError extends InfoError {
    * @param {string} connectionId Connection ID string.
    * @returns {ConnectionError} An appropriately-constructed error.
    */
-  static connection_closing(connectionId) {
+  static connectionClosing(connectionId) {
     TString.check(connectionId);
-    return new ConnectionError('connection_closing', connectionId);
+    return new ConnectionError('connectionClosing', connectionId);
   }
 
   /**
@@ -46,9 +46,9 @@ export default class ConnectionError extends InfoError {
    * @param {string} connectionId Connection ID string.
    * @returns {ConnectionError} An appropriately-constructed error.
    */
-  static connection_error(connectionId) {
+  static connectionError(connectionId) {
     TString.check(connectionId);
-    return new ConnectionError('connection_error', connectionId);
+    return new ConnectionError('connectionError', connectionId);
   }
 
   /**
@@ -60,10 +60,10 @@ export default class ConnectionError extends InfoError {
    * @param {string} detail Human-oriented detail message about the problem.
    * @returns {ConnectionError} An appropriately-constructed error.
    */
-  static connection_nonsense(connectionId, detail) {
+  static connectionNonsense(connectionId, detail) {
     TString.check(connectionId);
     TString.check(detail);
-    return new ConnectionError('connection_nonsense', connectionId, detail);
+    return new ConnectionError('connectionNonsense', connectionId, detail);
   }
 
   /**

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt } from '@bayou/typecheck';
+import { TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Functor } from '@bayou/util-common';
 
 import TargetId from './TargetId';
@@ -16,8 +16,8 @@ export default class Message extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} id Message ID, used to match requests and responses. Must be
-   *   a non-negative integer.
+   * @param {Int|string} id Message ID, used to match requests and responses.
+   *   Must be a non-negative integer or a string of at least eight characters.
    * @param {string} targetId ID of the target object to send to.
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
@@ -25,8 +25,10 @@ export default class Message extends CommonBase {
   constructor(id, targetId, payload) {
     super();
 
-    /** {Int} Message ID. */
-    this._id = TInt.nonNegative(id);
+    /** {Int|string} Message ID. */
+    this._id = ((typeof id) === 'number')
+      ? TInt.nonNegative(id)
+      : TString.minLen(id, 8);
 
     /** {string} ID of the target object. */
     this._targetId = TargetId.check(targetId);
@@ -49,7 +51,7 @@ export default class Message extends CommonBase {
     return [this._id, this._targetId, this._payload];
   }
 
-  /** {Int} Message ID. */
+  /** {Int|string} Message ID. */
   get id() {
     return this._id;
   }

--- a/local-modules/@bayou/api-common/Response.js
+++ b/local-modules/@bayou/api-common/Response.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TInt, TObject } from '@bayou/typecheck';
+import { TInt, TObject, TString } from '@bayou/typecheck';
 import { CommonBase, ErrorUtil, Errors, InfoError } from '@bayou/util-common';
 
 import CodableError from './CodableError';
@@ -19,8 +19,8 @@ export default class Response extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {Int} id Message ID, used to match requests and responses. Must be
-   *   a non-negative integer.
+   * @param {Int|string} id Message ID, used to match requests and responses.
+   *   Must be a non-negative integer or a string of at least eight characters.
    * @param {*} result Non-error result. Must be `null` if `error` is non-`null`
    *   (but note that `null` is a valid non-error result).
    * @param {Error|null} [error = null] Error response, or `null` if there is no
@@ -35,8 +35,10 @@ export default class Response extends CommonBase {
       throw Errors.badUse('`result` and `error` cannot both be non-`null`.');
     }
 
-    /** {Int} Message ID. */
-    this._id = TInt.nonNegative(id);
+    /** {Int|string} Message ID. */
+    this._id = ((typeof id) === 'number')
+      ? TInt.nonNegative(id)
+      : TString.minLen(id, 8);
 
     /**
      * {*} Non-error result, if any. Always `null` if this is an error

--- a/local-modules/@bayou/api-common/Response.js
+++ b/local-modules/@bayou/api-common/Response.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TInt, TObject } from '@bayou/typecheck';
-import { CommonBase, ErrorUtil, Errors, Functor, InfoError } from '@bayou/util-common';
+import { CommonBase, ErrorUtil, Errors, InfoError } from '@bayou/util-common';
 
 import CodableError from './CodableError';
 
@@ -131,7 +131,7 @@ export default class Response extends CommonBase {
       return new CodableError(error.info);
     } else {
       // Adopt the message. Lose the rest of the info.
-      return new CodableError(new Functor('general_error', error.message));
+      return CodableError.generalError(error.message);
     }
   }
 }

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -18,8 +18,15 @@ describe('@bayou/api-common/Message', () => {
       assert.doesNotThrow(() => new Message(37, 'target', VALID_FUNCTOR));
     });
 
-    it('rejects `id`s which are not non-negative integers', () => {
-      assert.throws(() => new Message('this better not work!', 'foo', VALID_FUNCTOR));
+    it('accepts string `id`s of appropriate length', () => {
+      assert.doesNotThrow(() => new Message('12345678', 'target', VALID_FUNCTOR));
+      assert.doesNotThrow(() => new Message('abcdefghijklmnop', 'target', VALID_FUNCTOR));
+    });
+
+    it('rejects `id`s which are not non-negative integers or appropriate-length strings', () => {
+      assert.throws(() => new Message('', 'foo', VALID_FUNCTOR));
+      assert.throws(() => new Message('nope', 'foo', VALID_FUNCTOR));
+      assert.throws(() => new Message('nopenop', 'foo', VALID_FUNCTOR));
       assert.throws(() => new Message(3.7, 'target', VALID_FUNCTOR));
       assert.throws(() => new Message(true, 'target', VALID_FUNCTOR));
       assert.throws(() => new Message(null, 'target', VALID_FUNCTOR));
@@ -69,9 +76,11 @@ describe('@bayou/api-common/Message', () => {
 
   describe('.id', () => {
     it('is the constructed `id`', () => {
-      const msg = new Message(1234, 'target', VALID_FUNCTOR);
+      const msg1 = new Message(1234, 'target', VALID_FUNCTOR);
+      const msg2 = new Message('xyzxyzxyz', 'target', VALID_FUNCTOR);
 
-      assert.strictEqual(msg.id, 1234);
+      assert.strictEqual(msg1.id, 1234);
+      assert.strictEqual(msg2.id, 'xyzxyzxyz');
     });
   });
 

--- a/local-modules/@bayou/api-common/tests/test_Response.js
+++ b/local-modules/@bayou/api-common/tests/test_Response.js
@@ -25,7 +25,16 @@ describe('@bayou/api-common/Response', () => {
       test(12345);
     });
 
-    it('rejects `id`s which are not non-negative integers', () => {
+    it('accepts string `id`s of appropriate length', () => {
+      function test(id) {
+        assert.doesNotThrow(() => new Response(id, 'x'), /badValue/);
+      }
+
+      test('12345678');
+      test('abcdefghijklmnopqrstuvwxyz');
+    });
+
+    it('rejects `id`s which are not non-negative integers or appropriate-length strings', () => {
       function test(id) {
         assert.throws(() => new Response(id, 'x'), /badValue/);
       }
@@ -34,9 +43,12 @@ describe('@bayou/api-common/Response', () => {
       test(0.5);
       test(NaN);
 
+      test('');
+      test('1');
+      test('1234567');
+
       test(undefined);
       test(null);
-      test('123');
       test([]);
     });
 

--- a/local-modules/@bayou/api-common/tests/test_Response.js
+++ b/local-modules/@bayou/api-common/tests/test_Response.js
@@ -101,7 +101,7 @@ describe('@bayou/api-common/Response', () => {
 
     it('is a `CodableError` with the message in the payload when the constructed `error` was not an `InfoError`', () => {
       const e      = new Error('Yikes!');
-      const expect = new CodableError('general_error', 'Yikes!');
+      const expect = CodableError.generalError('Yikes!');
       const r      = new Response(1, null, e);
 
       assert.instanceOf(r.error, CodableError);

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -213,14 +213,14 @@ export default class Connection extends CommonBase {
     try {
       msg = this._codec.decodeJson(msg);
     } catch (error) {
-      return ConnectionError.connection_nonsense(this._connectionId, error.message);
+      return ConnectionError.connectionNonsense(this._connectionId, error.message);
     }
 
     if (msg instanceof Message) {
       return msg;
     }
 
-    return ConnectionError.connection_nonsense(
+    return ConnectionError.connectionNonsense(
       this._connectionId, 'Did not receive `Message` object.');
   }
 
@@ -241,7 +241,7 @@ export default class Connection extends CommonBase {
     const context = this._context;
 
     if (context === null) {
-      throw ConnectionError.connection_closed(this._connectionId, 'Connection closed.');
+      throw ConnectionError.connectionClosed(this._connectionId, 'Connection closed.');
     }
 
     return context.getAuthorizedTarget(idOrToken);


### PR DESCRIPTION
This PR addresses two issues I noticed while working on my other (longer) change, which I thought were worth pulling out and getting in sooner:

* There were a handful of places which used `snake_case` error names instead of `camelCase`, which were missed when we switched to consistently using `camelCase`. Fixed!

* When connection and session lifetimes get untangled, it will no longer be the case that a simple sequence number will suffice to unambiguously identify a message (e.g. for handling idempotency). To that end, I changed the `id` field in `Message` and `Response` to now be able to be an arbitrary string in addition to a non-negative integer.