### PR TITLE
Work-in-progress on `api-client.ApiClient`.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -18,6 +18,12 @@ const UNKNOWN_CONNECTION_ID = 'id_unknown';
 
 /**
  * Connection with the server, via a websocket.
+ *
+ * **TODO:** This class is in the process of being replace by the combination of
+ * classes `ApiClientNew`, `BaseServerConnection`, and `WsServerConnection`.
+ * Once those are ready, call sites should be adjusted to use the new (but
+ * similar) API provided by `ApiClientNew`, this class should be removed, and
+ * then `ApiClientNew` can be renamed to be just `ApiClient`.
  */
 export default class ApiClient extends CommonBase {
   /**

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -19,8 +19,8 @@ const UNKNOWN_CONNECTION_ID = 'id_unknown';
 /**
  * Connection with the server, via a websocket.
  *
- * **TODO:** This class is in the process of being replace by the combination of
- * classes `ApiClientNew`, `BaseServerConnection`, and `WsServerConnection`.
+ * **TODO:** This class is in the process of being replaced by the combination
+ * of classes `ApiClientNew`, `BaseServerConnection`, and `WsServerConnection`.
  * Once those are ready, call sites should be adjusted to use the new (but
  * similar) API provided by `ApiClientNew`, this class should be removed, and
  * then `ApiClientNew` can be renamed to be just `ApiClient`.

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -448,7 +448,7 @@ export default class ApiClient extends CommonBase {
         return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
       }
       case WebSocket.CLOSING: {
-        return Promise.reject(this.connection_closing(this._connectionId));
+        return Promise.reject(ConnectionError.connection_closing(this._connectionId));
       }
     }
 

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -403,9 +403,6 @@ export default class ApiClient extends CommonBase {
   }
 
   /**
-   * Gets a proxy
-
-  /**
    * Initializes or resets the state having to do with an active connection. See
    * the constructor for documentation about these fields.
    */

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -1,0 +1,413 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BaseKey, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { Codec } from '@bayou/codec';
+import { TString } from '@bayou/typecheck';
+import { CommonBase, WebsocketCodes } from '@bayou/util-common';
+
+import BaseServerConnection from './BaseServerConnection';
+import TargetMap from './TargetMap';
+
+/**
+ * Connection with the server, via a websocket.
+ */
+export default class ApiClient extends CommonBase {
+  /**
+   * Constructs an instance, which uses the indicated connection handler to
+   * communicate with a server.
+   *
+   * @param {BaseServerConnection} connection Provider of the basic message
+   *   sending and receiving facilities. This also encapsulates all knowledge
+   *   of the network location of the far side of the connection (or, e.g.,
+   *   mocking of same).
+   * @param {Codec} codec Codec instance to use. In order to function properly,
+   *   its registry must include all of the encodable classes defined in
+   *   `@bayou/api-common` classes. See
+   *   {@link @bayou/api-common.TheModule.registerCodecs}.
+   */
+  constructor(connection, codec) {
+    super();
+
+    /**
+     * {BaseServerConnection} connection Provider of the basic message
+     * sending and receiving facilities.
+     */
+    this._connection = BaseServerConnection.check(connection);
+
+    /** {Codec} Codec instance to use. */
+    this._codec = Codec.check(codec);
+
+    /**
+     * {Int} Next message ID to use when sending a message. Initialized and
+     * reset in {@link #_resetConnection()}.
+     */
+    this._nextId = 0;
+
+    /**
+     * {object<Int,{resolve, reject}>} Map from message IDs to response
+     * callbacks. Each callback is an object that maps `resolve` and `reject` to
+     * functions that obey the usual promise contract for functions of those
+     * names. Initialized and reset in {@link #_resetConnection()}.
+     */
+    this._callbacks = null;
+
+    /**
+     * {TargetMap} Map of names to target proxies. See {@link
+     * TargetMap#constructor} for details about the argument.
+     */
+    this._targets = new TargetMap(this._send.bind(this));
+
+    /**
+     * {Map<string, Promise<Proxy>>} Map from target IDs to promises of their
+     * proxy, for each ID currently in the middle of being authorized. Used to
+     * avoid re-issuing authorization requests.
+     */
+    this._pendingAuths = new Map();
+
+    // Initialize the active connection fields (described above).
+    this._resetConnection();
+
+    Object.seal(this);
+  }
+
+  /**
+   * {string} The connection ID if known, or a reasonably suggestive string if
+   * not. This class automatically sets the ID when connections get made, so
+   * that clients of this class don't generally have to make an API call to find
+   * it out.
+   */
+  get connectionId() {
+    return this._connection.connectionId;
+  }
+
+  /**
+   * {Logger} The client-specific logger.
+   */
+  get log() {
+    return this._connection.log;
+  }
+
+  /**
+   * {Proxy} The object upon which meta-API calls can be made.
+   */
+  get meta() {
+    return this._targets.get('meta');
+  }
+
+  /**
+   * Performs a challenge-response authorization for a given key. When the
+   * returned promise resolves successfully, that means that the corresponding
+   * target (that is, `this.getTarget(key)`) can be accessed without further
+   * authorization.
+   *
+   * If `key.id` is already mapped as a target, it is returned directly, without
+   * further authorization. If it is in the middle of being authorized, the
+   * existing pending promise for the target is returned. (That is, this method
+   * is idempotent.)
+   *
+   * @param {BaseKey} key Key to authorize with.
+   * @returns {Promise<Proxy>} Promise which resolves to the proxy that
+   *   represents the foreign target which is controlled by `key`, once
+   *   authorization is complete.
+   */
+  authorizeTarget(key) {
+    BaseKey.check(key);
+
+    const id   = key.id;
+    const meta = this.meta;
+    let result;
+
+    result = this._targets.getOrNull(id);
+    if (result !== null) {
+      // The target is already authorized and bound. Return it.
+      return result;
+    }
+
+    result = this._pendingAuths.get(id);
+    if (result) {
+      // We have already initiated authorization on this target. Return the
+      // promise from the original initiation.
+      this.log.info('Already authing:', id);
+      return result;
+    }
+
+    // It's not yet bound as a target, and authorization isn't currently in
+    // progress.
+
+    result = (async () => {
+      try {
+        const challenge = await meta.makeChallenge(id);
+        const response  = key.challengeResponseFor(challenge);
+
+        this.log.event.gotChallenge(id, challenge);
+        await meta.authWithChallengeResponse(challenge, response);
+
+        // Successful auth.
+        this.log.event.authed(id);
+        this._pendingAuths.delete(id); // It's no longer pending.
+        return this._targets.add(id);
+      } catch (error) {
+        // Trouble along the way. Clean out the pending auth, and propagate the
+        // error.
+        this.log.event.authFailed(id);
+        this._pendingAuths.delete(id);
+        throw error;
+      }
+    })();
+
+    this._pendingAuths.set(id, result); // It's now pending.
+    return result;
+  }
+
+  /**
+   * Gets a proxy for the target with the given ID or which is controlled by the
+   * given key (or which was so controlled prior to authorizing it away). The
+   * target must already be known to this instance for this method to work
+   * (otherwise it is an error).
+   *
+   * @param {string|BaseKey} idOrKey ID or key for the target.
+   * @returns {Proxy} Proxy which locally represents the so-identified
+   *   server-side target.
+   */
+  getTarget(idOrKey) {
+    const id = (idOrKey instanceof BaseKey)
+      ? idOrKey.id
+      : TString.check(idOrKey);
+
+    return this._targets.get(id);
+  }
+
+  /**
+   * Opens the connection, if not already open. Once open, any pending messages
+   * will get sent to the server side. If the connection is already open (or in
+   * the process of opening), this does not re-open it; that is, the existing
+   * act of opening is allowed to continue.
+   *
+   * As an `async` method, this returns once the connection has been opened.
+   *
+   * @throws {ConnectionError} Indication of why the connection attempt failed.
+   */
+  async open() {
+    await this._connection.open();
+
+    this.log.event.opening();
+
+    const id = await this.meta.connectionId();
+
+    this.connectionId = id;
+    this.log.event.open();
+
+    // Test to make sure newly-proxied objects get returned as expected.
+    // **TODO:** Remove this once we have unit test coverage for this
+    // functionality.
+    /*
+    (async () => {
+      const counter = await this.meta.makeCounter();
+      this.log.info('Got counter:', counter);
+      const c0 = await counter.count();
+      const c1 = await counter.count();
+      const c2 = await counter.count();
+      this.log.info('Got counts:', c0, c1, c2);
+    })();
+    */
+  }
+
+  /**
+   * Handles a `close` event coming from a websocket. This logs the closure and
+   * terminates all active messages by rejecting their promises.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleClose(event) {
+    this.log.info('Closed:', event);
+
+    const code = WebsocketCodes.close(event.code);
+    const desc = event.reason ? `${code}: ${event.reason}` : code;
+    const error = ConnectionError.connection_closed(this._connectionId, desc);
+
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles an `error` event coming from a websocket. This behaves similarly
+   * to the `close` event.
+   *
+   * **Note:** Because errors in this case are typically due to transient
+   * connection issues (e.g. network went away) and not due to fundamental
+   * system issues, this is logged as `info` and not `error` (or `warn`).
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleError(event) {
+    this.log.info('Error:', event);
+
+    // **Note:** The error event does not have any particularly useful extra
+    // info, so -- alas -- there is nothing to get out of it for the
+    // `ConnectionError` description.
+    const error = ConnectionError.connection_error(this._connectionId);
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles a `message` event coming from a websocket. In this case, messages
+   * are expected to be the responses from previously-sent messages (e.g.
+   * method calls), encoded as JSON. The `id` of the response is used to look up
+   * the callback function in `this._callbacks`. That callback is then called in
+   * a separate turn.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleMessage(event) {
+    this.log.detail('Received raw data:', event.data);
+
+    const response = this._codec.decodeJson(event.data);
+
+    if (!(response instanceof Response)) {
+      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
+    }
+
+    const { id, result, error } = response;
+
+    const callback = this._callbacks[id];
+    if (callback) {
+      delete this._callbacks[id];
+      if (error) {
+        // **Note:** `error` is always an instance of `CodableError`.
+        this.log.detail(`Reject ${id}:`, error);
+        // What's going on here is that we use the information from the original
+        // error as the outer error payload, and include a `cause` that
+        // unambiguously indicates that the origin is remote. This arrangement
+        // means that clients can handle well-defined errors fairly
+        // transparently and straightforwardly (e.g. and notably, they don't
+        // have to "unwrap" the errors in the usual case), while still being
+        // able to ascertain the foreign origin of the errors when warranted.
+        const remoteCause = new CodableError('remote_error', this.connectionId);
+        const rejectReason = new CodableError(remoteCause, error.info);
+        callback.reject(rejectReason);
+      } else {
+        this.log.detail(`Resolve ${id}:`, result);
+        if (result instanceof Remote) {
+          // The result is a proxied object, not a regular value.
+          callback.resolve(this._targets.addOrGet(result.targetId));
+        } else {
+          callback.resolve(result);
+        }
+      }
+    } else {
+      // See above about `server_bug`.
+      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
+    }
+  }
+
+  /**
+   * Handles an `open` event coming from a websocket. In this case, it sends
+   * any pending messages (that were enqueued while the socket was still in the
+   * process of opening).
+   *
+   * @param {object} event_unused Event that caused this callback.
+   */
+  _handleOpen(event_unused) {
+    for (const msgJson of this._pendingMessages) {
+      this.log.detail('Sent from queue:', msgJson);
+      this._ws.send(msgJson);
+    }
+    this._pendingMessages = [];
+  }
+
+  /**
+   * Common code to handle both `error` and `close` events.
+   *
+   * @param {object} event_unused Event that caused this callback.
+   * @param {ConnectionError} error Reason for termination. "Error" is a bit of
+   *   a misnomer, as in many cases termination is a-okay.
+   */
+  _handleTermination(event_unused, error) {
+    // Reject the promises of any currently-pending messages.
+    for (const id in this._callbacks) {
+      this._callbacks[id].reject(error);
+    }
+
+    // Clear the state related to the websocket. It is safe to re-open the
+    // connection after this.
+    this._resetConnection();
+  }
+
+  /**
+   * Initializes or resets the state having to do with an active connection. See
+   * the constructor for documentation about these fields.
+   */
+  _resetConnection() {
+    this._nextId         = 0;
+    this._callbacks      = {};
+    this._targets.clear();
+    this._targets.add('meta'); // The one guaranteed target.
+
+    this.connectionId = null;
+  }
+
+  /**
+   * Sends the given call to the server.
+   *
+   * **Note:** This method is called via a `TargetHandler` instance, which is
+   * in turn called by a proxy object representing an object on the far side of
+   * the connection.
+   *
+   * @param {string} target Name of the target object.
+   * @param {Functor} payload The name of the method to call and the arguments
+   *   to call it with.
+   * @returns {Promise} Promise for the result (or error) of the call. In the
+   *   case of an error, the rejection reason will always be an instance of
+   *   `ConnectionError` (see which for details).
+   */
+  _send(target, payload) {
+    const wsState = (this._ws === null)
+      ? WebSocket.CLOSED
+      : this._ws.readyState;
+
+    // Handle the cases where socket shutdown is imminent or has already
+    // happened. We don't just `throw` directly here, so that clients can
+    // consistently handle errors via one of the promise chaining mechanisms.
+    switch (wsState) {
+      case WebSocket.CLOSED: {
+        // The detail string here differentiates this case from cases where the
+        // API message was already queued up or sent before the websocket became
+        // closed.
+        return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
+      }
+      case WebSocket.CLOSING: {
+        return Promise.reject(this.connection_closing(this._connectionId));
+      }
+    }
+
+    const id = this._nextId;
+    this._nextId++;
+
+    const msg     = new Message(id, target, payload);
+    const msgJson = this._codec.encodeJson(msg);
+
+    switch (wsState) {
+      case WebSocket.CONNECTING: {
+        // Not yet open. Need to queue it up.
+        this.log.detail('Queued:', msg);
+        this._pendingMessages.push(msgJson);
+        break;
+      }
+      case WebSocket.OPEN: {
+        this.log.detail('Sent:', msg);
+        this._ws.send(msgJson);
+        break;
+      }
+      default: {
+        // Whatever this state is, it's not documented as part of the websocket
+        // spec!
+        this.log.wtf('Weird state:', wsState);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      this._callbacks[id] = { resolve, reject };
+    });
+  }
+}

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -14,6 +14,9 @@ import TargetMap from './TargetMap';
  * API connection with a server. This is a layer on top of
  * {@link BaseServerConnection} which provides API semantics, not just sending
  * and receiving of (uninterpreted) data blobs.
+ *
+ * **TODO:** This class is an as-yet nonfunctional work-in-progress. See the
+ * header comment in {@link ApiClient} for more details.
  */
 export default class ApiClientNew extends CommonBase {
   /**

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -377,7 +377,7 @@ export default class ApiClient extends CommonBase {
         return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
       }
       case WebSocket.CLOSING: {
-        return Promise.reject(this.connection_closing(this._connectionId));
+        return Promise.reject(ConnectionError.connection_closing(this._connectionId));
       }
     }
 

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -222,7 +222,7 @@ export default class ApiClientNew extends CommonBase {
 
     const code = WebsocketCodes.close(event.code);
     const desc = event.reason ? `${code}: ${event.reason}` : code;
-    const error = ConnectionError.connection_closed(this._connectionId, desc);
+    const error = ConnectionError.connectionClosed(this._connectionId, desc);
 
     this._handleTermination(event, error);
   }
@@ -243,7 +243,7 @@ export default class ApiClientNew extends CommonBase {
     // **Note:** The error event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it for the
     // `ConnectionError` description.
-    const error = ConnectionError.connection_error(this._connectionId);
+    const error = ConnectionError.connectionError(this._connectionId);
     this._handleTermination(event, error);
   }
 
@@ -262,7 +262,7 @@ export default class ApiClientNew extends CommonBase {
     const response = this._codec.decodeJson(event.data);
 
     if (!(response instanceof Response)) {
-      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
+      throw ConnectionError.connectionNonsense(this._connectionId, 'Got strange response.');
     }
 
     const { id, result, error } = response;
@@ -280,7 +280,7 @@ export default class ApiClientNew extends CommonBase {
         // transparently and straightforwardly (e.g. and notably, they don't
         // have to "unwrap" the errors in the usual case), while still being
         // able to ascertain the foreign origin of the errors when warranted.
-        const remoteCause = new CodableError('remote_error', this.connectionId);
+        const remoteCause = CodableError.remoteError(this.connectionId);
         const rejectReason = new CodableError(remoteCause, error.info);
         callback.reject(rejectReason);
       } else {
@@ -294,7 +294,7 @@ export default class ApiClientNew extends CommonBase {
       }
     } else {
       // See above about `server_bug`.
-      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
+      throw ConnectionError.connectionNonsense(this._connectionId, `Orphan call for ID ${id}.`);
     }
   }
 

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -2,31 +2,45 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { EventSource } from '@bayou/prom-util';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
-import { CommonBase, Functor, WebsocketCodes } from '@bayou/util-common';
+import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 /** {string} Value used for an unknown connection ID. */
 const UNKNOWN_CONNECTION_ID = 'id_unknown';
-
-/** {string} Event name to use for messages (either sent or received). */
-const EVENT_MESSAGE = 'message';
 
 /** {Logger} Logger. */
 const log = new Logger('api-conn');
 
 /**
  * Base class which abstracts away details of a connection to a server. This
- * class provides a promise-chained sequence of events representing received
- * messages, along with an interface for queuing up / sending messages to the
- * far side of the connection.
+ * class provides a promise-chained sequence of events representing both
+ * enqueued and received messages, along with an interface for queuing up
+ * messages to send to the far side of the connection.
  *
  * **Note:** At this layer, messages are all strings. **TODO:** They should be
  * binary (arrays of bytes) instead.
  */
 export default class BaseServerConnection extends CommonBase {
+  /** {string} Event name to use for received messages. */
+  static get EVENT_receive() { return 'receive'; }
+
+  /** {string} Event name to use for messages to send. */
+  static get EVENT_send() { return 'send'; }
+
+  /** {string} Event name to use for the very first event emitted. */
+  static get EVENT_start() { return 'start'; }
+
+  /** {string} Connection state "closed" (no currenct connection). */
+  static get STATE_closed() { return 'closed'; }
+
+  /** {string} Connection state "opening" (in the process of becoming open). */
+  static get STATE_opening() { return 'opening'; }
+
+  /** {string} Connection state "open" (open and active). */
+  static get STATE_open() { return 'open'; }
+
   /**
    * Constructs an instance. Once constructed, it is valid to send messages
    * via the instance; should the connection not be fully established, any
@@ -37,29 +51,22 @@ export default class BaseServerConnection extends CommonBase {
     super();
 
     /**
-     * {string} Connection ID conveyed to us by the server. Reset in
-     * {@link #_resetConnection()}.
-     */
-    this._connectionId = UNKNOWN_CONNECTION_ID;
-
-    /**
      * {Logger} Logger which prefixes everything with the connection ID (if
      * available). Set in {@link #_updateLogger}, which is called whenever
      * {@link #_connectionId} is updated.
      */
     this._log = log;
 
-    /**
-     * {EventSource} Emitter used for the events representing messages received
-     * by this instance from the far side of the connection.
-     */
-    this._receivedSource = new EventSource();
+    /** {string} State of the connection. One of the `STATE_*` constants. */
+    this._state = BaseServerConnection.STATE_closed;
 
-    /**
-     * {EventSource} Emitter used for the events representing messages sent by
-     * this instance to the far side of the connection.
-     */
-    this._sentSource = new EventSource();
+    /** {string} Connection ID conveyed to us by the server. */
+    this._connectionId = UNKNOWN_CONNECTION_ID;
+
+    /** {EventSource} Emitter used for the events of this instance. */
+    this._events = new EventSource();
+
+    this._events.emit(new Functor(BaseServerConnection.EVENT_start));
   }
 
   /**
@@ -81,6 +88,14 @@ export default class BaseServerConnection extends CommonBase {
   }
 
   /**
+   * {ChainedEvent} The most recently emitted event from this instance. This
+   * is a `start` event before any "real" activity has occurred on an instance.
+   */
+  get currentEventNow() {
+    return this._events.currentEventNow;
+  }
+
+  /**
    * {Logger} The client-specific logger.
    */
   get log() {
@@ -88,256 +103,60 @@ export default class BaseServerConnection extends CommonBase {
   }
 
   /**
+   * {string} State of the connection. One of the static `STATE_*` constants
+   * defined by this class. It is up to subclasses to update this value.
+   */
+  get state() {
+    return this._state;
+  }
+
+  set state(state) {
+    switch (state) {
+      case BaseServerConnection.STATE_closed:
+      case BaseServerConnection.STATE_open:
+      case BaseServerConnection.STATE_opening: {
+        // Valid.
+        break;
+      }
+
+      default: {
+        throw Errors.badValue(state, String, 'connection state');
+      }
+    }
+
+    this._state = state;
+  }
+
+  /**
    * Queues up a message to send to the far side of the connection. If the
-   * connection is active, the message will in fact be sent shortly after this
-   * method completes.
+   * connection is active, the message will in fact be sent during the next
+   * chunk of event processing, as kicked off by {@link #sendAll}.
    *
    * @param {string} message Message to send.
    */
-  send(message) {
+  async enqueue(message) {
     TString.check(message);
-    this._sentSource.emit(new Functor(EVENT_MESSAGE, message));
+    this._events.emit(new Functor(BaseServerConnection.EVENT_send, message));
   }
 
   /**
-   * Opens the websocket. Once open, any pending messages will get sent to the
-   * server side. If the socket is already open (or in the process of opening),
-   * this does not re-open (that is, the existing open is allowed to continue).
+   * Indicates that a new message has been received. This is meant to be used by
+   * subclasses.
    *
-   * As an `async` method, this returns once the connection has been opened.
-   *
-   * @throws {ConnectionError} Indication of why the connection attempt failed.
+   * @param {string} message Message which was received.
    */
-  async open() {
-    // If `_ws` is `null` that means that the connection is not already open or
-    // in the process of opening.
-
-    if (this._connectionId !== UNKNOWN_CONNECTION_ID) {
-      // Already open.
-      return;
-    } else if (this._ws !== null) {
-      // In the middle of getting opened. Arguably this should do something a
-      // bit more efficient (instead of issuing a separate API call), but also
-      // this shouldn't ever happen, so it's not that big a deal.
-      this._log.info('open() called while in the middle of opening.');
-      await this.meta.ping();
-      return;
-    }
-
-    this._ws = new WebSocket(this._websocketUrl);
-    this._ws.onclose   = this._handleClose.bind(this);
-    this._ws.onerror   = this._handleError.bind(this);
-    this._ws.onmessage = this._handleMessage.bind(this);
-    this._ws.onopen    = this._handleOpen.bind(this);
-
-    this._updateLogger();
-    this._log.event.opening();
-
-    const id = await this.meta.connectionId();
-
-    this._connectionId = id;
-    this._updateLogger();
-    this._log.event.open();
+  async received(message) {
+    TString.check(message);
+    this._events.emit(new Functor(BaseServerConnection.EVENT_receive, message));
   }
 
   /**
-   * Handles a `close` event coming from a websocket. This logs the closure and
-   * terminates all active messages by rejecting their promises.
-   *
-   * @param {object} event Event that caused this callback.
+   * Sends all messages that have been enqueued by {@link #enqueue} that have
+   * not already been sent. If there is any sort of (non-recoverable) connection
+   * trouble, it will show up here as a thrown error.
    */
-  _handleClose(event) {
-    this._log.info('Closed:', event);
-
-    const code = WebsocketCodes.close(event.code);
-    const desc = event.reason ? `${code}: ${event.reason}` : code;
-    const error = ConnectionError.connection_closed(this._connectionId, desc);
-
-    this._handleTermination(event, error);
-  }
-
-  /**
-   * Handles an `error` event coming from a websocket. This behaves similarly
-   * to the `close` event.
-   *
-   * **Note:** Because errors in this case are typically due to transient
-   * connection issues (e.g. network went away) and not due to fundamental
-   * system issues, this is logged as `info` and not `error` (or `warn`).
-   *
-   * @param {object} event Event that caused this callback.
-   */
-  _handleError(event) {
-    this._log.info('Error:', event);
-
-    // **Note:** The error event does not have any particularly useful extra
-    // info, so -- alas -- there is nothing to get out of it for the
-    // `ConnectionError` description.
-    const error = ConnectionError.connection_error(this._connectionId);
-    this._handleTermination(event, error);
-  }
-
-  /**
-   * Handles a `message` event coming from a websocket. In this case, messages
-   * are expected to be the responses from previously-sent messages (e.g.
-   * method calls), encoded as JSON. The `id` of the response is used to look up
-   * the callback function in `this._callbacks`. That callback is then called in
-   * a separate turn.
-   *
-   * @param {object} event Event that caused this callback.
-   */
-  _handleMessage(event) {
-    this._log.detail('Received raw data:', event.data);
-
-    const response = this._codec.decodeJson(event.data);
-
-    if (!(response instanceof Response)) {
-      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
-    }
-
-    const { id, result, error } = response;
-
-    const callback = this._callbacks[id];
-    if (callback) {
-      delete this._callbacks[id];
-      if (error) {
-        // **Note:** `error` is always an instance of `CodableError`.
-        this._log.detail(`Reject ${id}:`, error);
-        // What's going on here is that we use the information from the original
-        // error as the outer error payload, and include a `cause` that
-        // unambiguously indicates that the origin is remote. This arrangement
-        // means that clients can handle well-defined errors fairly
-        // transparently and straightforwardly (e.g. and notably, they don't
-        // have to "unwrap" the errors in the usual case), while still being
-        // able to ascertain the foreign origin of the errors when warranted.
-        const remoteCause = new CodableError('remote_error', this.connectionId);
-        const rejectReason = new CodableError(remoteCause, error.info);
-        callback.reject(rejectReason);
-      } else {
-        this._log.detail(`Resolve ${id}:`, result);
-        if (result instanceof Remote) {
-          // The result is a proxied object, not a regular value.
-          callback.resolve(this._targets.addOrGet(result.targetId));
-        } else {
-          callback.resolve(result);
-        }
-      }
-    } else {
-      // See above about `server_bug`.
-      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
-    }
-  }
-
-  /**
-   * Handles an `open` event coming from a websocket. In this case, it sends
-   * any pending messages (that were enqueued while the socket was still in the
-   * process of opening).
-   *
-   * @param {object} event_unused Event that caused this callback.
-   */
-  _handleOpen(event_unused) {
-    for (const msgJson of this._pendingMessages) {
-      this._log.detail('Sent from queue:', msgJson);
-      this._ws.send(msgJson);
-    }
-    this._pendingMessages = [];
-  }
-
-  /**
-   * Common code to handle both `error` and `close` events.
-   *
-   * @param {object} event_unused Event that caused this callback.
-   * @param {ConnectionError} error Reason for termination. "Error" is a bit of
-   *   a misnomer, as in many cases termination is a-okay.
-   */
-  _handleTermination(event_unused, error) {
-    // Reject the promises of any currently-pending messages.
-    for (const id in this._callbacks) {
-      this._callbacks[id].reject(error);
-    }
-
-    // Clear the state related to the websocket. It is safe to re-open the
-    // connection after this.
-    this._resetConnection();
-  }
-
-  /**
-   * Initializes or resets the state having to do with an active connection. See
-   * the constructor for documentation about these fields.
-   */
-  _resetConnection() {
-    this._ws              = null;
-    this._connectionId    = UNKNOWN_CONNECTION_ID;
-    this._nextId          = 0;
-    this._callbacks       = {};
-    this._pendingMessages = [];
-    this._targets.clear();
-    this._targets.add('meta'); // The one guaranteed target.
-
-    this._updateLogger();
-  }
-
-  /**
-   * Sends the given call to the server.
-   *
-   * **Note:** This method is called via a `TargetHandler` instance, which is
-   * in turn called by a proxy object representing an object on the far side of
-   * the connection.
-   *
-   * @param {string} target Name of the target object.
-   * @param {Functor} payload The name of the method to call and the arguments
-   *   to call it with.
-   * @returns {Promise} Promise for the result (or error) of the call. In the
-   *   case of an error, the rejection reason will always be an instance of
-   *   `ConnectionError` (see which for details).
-   */
-  _send(target, payload) {
-    const wsState = (this._ws === null)
-      ? WebSocket.CLOSED
-      : this._ws.readyState;
-
-    // Handle the cases where socket shutdown is imminent or has already
-    // happened. We don't just `throw` directly here, so that clients can
-    // consistently handle errors via one of the promise chaining mechanisms.
-    switch (wsState) {
-      case WebSocket.CLOSED: {
-        // The detail string here differentiates this case from cases where the
-        // API message was already queued up or sent before the websocket became
-        // closed.
-        return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
-      }
-      case WebSocket.CLOSING: {
-        return Promise.reject(this.connection_closing(this._connectionId));
-      }
-    }
-
-    const id = this._nextId;
-    this._nextId++;
-
-    const msg     = new Message(id, target, payload);
-    const msgJson = this._codec.encodeJson(msg);
-
-    switch (wsState) {
-      case WebSocket.CONNECTING: {
-        // Not yet open. Need to queue it up.
-        this._log.detail('Queued:', msg);
-        this._pendingMessages.push(msgJson);
-        break;
-      }
-      case WebSocket.OPEN: {
-        this._log.detail('Sent:', msg);
-        this._ws.send(msgJson);
-        break;
-      }
-      default: {
-        // Whatever this state is, it's not documented as part of the websocket
-        // spec!
-        this._log.wtf('Weird state:', wsState);
-      }
-    }
-
-    return new Promise((resolve, reject) => {
-      this._callbacks[id] = { resolve, reject };
-    });
+  async sendAll() {
+    // TODO
   }
 
   /**

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -1,0 +1,353 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { EventSource } from '@bayou/prom-util';
+import { Logger } from '@bayou/see-all';
+import { TString } from '@bayou/typecheck';
+import { CommonBase, Functor, WebsocketCodes } from '@bayou/util-common';
+
+/** {string} Value used for an unknown connection ID. */
+const UNKNOWN_CONNECTION_ID = 'id_unknown';
+
+/** {string} Event name to use for messages (either sent or received). */
+const EVENT_MESSAGE = 'message';
+
+/** {Logger} Logger. */
+const log = new Logger('api-conn');
+
+/**
+ * Base class which abstracts away details of a connection to a server. This
+ * class provides a promise-chained sequence of events representing received
+ * messages, along with an interface for queuing up / sending messages to the
+ * far side of the connection.
+ *
+ * **Note:** At this layer, messages are all strings. **TODO:** They should be
+ * binary (arrays of bytes) instead.
+ */
+export default class BaseServerConnection extends CommonBase {
+  /**
+   * Constructs an instance. Once constructed, it is valid to send messages
+   * via the instance; should the connection not be fully established, any
+   * sent messages are queued up and will be sent in-order once the
+   * connection is ready.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {string} Connection ID conveyed to us by the server. Reset in
+     * {@link #_resetConnection()}.
+     */
+    this._connectionId = UNKNOWN_CONNECTION_ID;
+
+    /**
+     * {Logger} Logger which prefixes everything with the connection ID (if
+     * available). Set in {@link #_updateLogger}, which is called whenever
+     * {@link #_connectionId} is updated.
+     */
+    this._log = log;
+
+    /**
+     * {EventSource} Emitter used for the events representing messages received
+     * by this instance from the far side of the connection.
+     */
+    this._receivedSource = new EventSource();
+
+    /**
+     * {EventSource} Emitter used for the events representing messages sent by
+     * this instance to the far side of the connection.
+     */
+    this._sentSource = new EventSource();
+  }
+
+  /**
+   * {string} The connection ID if known, or a reasonably suggestive string if
+   * not. The client of this instance is responsible for setting this. If set
+   * to `null`, it will instead become aforementioned "reasonably suggestive"
+   * string.
+   */
+  get connectionId() {
+    return this._connectionId;
+  }
+
+  set connectionId(id) {
+    this._connectionId = (id === null)
+      ? UNKNOWN_CONNECTION_ID
+      : TString.nonEmpty(id);
+
+    this._updateLogger();
+  }
+
+  /**
+   * {Logger} The client-specific logger.
+   */
+  get log() {
+    return this._log;
+  }
+
+  /**
+   * Queues up a message to send to the far side of the connection. If the
+   * connection is active, the message will in fact be sent shortly after this
+   * method completes.
+   *
+   * @param {string} message Message to send.
+   */
+  send(message) {
+    TString.check(message);
+    this._sentSource.emit(new Functor(EVENT_MESSAGE, message));
+  }
+
+  /**
+   * Opens the websocket. Once open, any pending messages will get sent to the
+   * server side. If the socket is already open (or in the process of opening),
+   * this does not re-open (that is, the existing open is allowed to continue).
+   *
+   * As an `async` method, this returns once the connection has been opened.
+   *
+   * @throws {ConnectionError} Indication of why the connection attempt failed.
+   */
+  async open() {
+    // If `_ws` is `null` that means that the connection is not already open or
+    // in the process of opening.
+
+    if (this._connectionId !== UNKNOWN_CONNECTION_ID) {
+      // Already open.
+      return;
+    } else if (this._ws !== null) {
+      // In the middle of getting opened. Arguably this should do something a
+      // bit more efficient (instead of issuing a separate API call), but also
+      // this shouldn't ever happen, so it's not that big a deal.
+      this._log.info('open() called while in the middle of opening.');
+      await this.meta.ping();
+      return;
+    }
+
+    this._ws = new WebSocket(this._websocketUrl);
+    this._ws.onclose   = this._handleClose.bind(this);
+    this._ws.onerror   = this._handleError.bind(this);
+    this._ws.onmessage = this._handleMessage.bind(this);
+    this._ws.onopen    = this._handleOpen.bind(this);
+
+    this._updateLogger();
+    this._log.event.opening();
+
+    const id = await this.meta.connectionId();
+
+    this._connectionId = id;
+    this._updateLogger();
+    this._log.event.open();
+  }
+
+  /**
+   * Handles a `close` event coming from a websocket. This logs the closure and
+   * terminates all active messages by rejecting their promises.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleClose(event) {
+    this._log.info('Closed:', event);
+
+    const code = WebsocketCodes.close(event.code);
+    const desc = event.reason ? `${code}: ${event.reason}` : code;
+    const error = ConnectionError.connection_closed(this._connectionId, desc);
+
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles an `error` event coming from a websocket. This behaves similarly
+   * to the `close` event.
+   *
+   * **Note:** Because errors in this case are typically due to transient
+   * connection issues (e.g. network went away) and not due to fundamental
+   * system issues, this is logged as `info` and not `error` (or `warn`).
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleError(event) {
+    this._log.info('Error:', event);
+
+    // **Note:** The error event does not have any particularly useful extra
+    // info, so -- alas -- there is nothing to get out of it for the
+    // `ConnectionError` description.
+    const error = ConnectionError.connection_error(this._connectionId);
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles a `message` event coming from a websocket. In this case, messages
+   * are expected to be the responses from previously-sent messages (e.g.
+   * method calls), encoded as JSON. The `id` of the response is used to look up
+   * the callback function in `this._callbacks`. That callback is then called in
+   * a separate turn.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleMessage(event) {
+    this._log.detail('Received raw data:', event.data);
+
+    const response = this._codec.decodeJson(event.data);
+
+    if (!(response instanceof Response)) {
+      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
+    }
+
+    const { id, result, error } = response;
+
+    const callback = this._callbacks[id];
+    if (callback) {
+      delete this._callbacks[id];
+      if (error) {
+        // **Note:** `error` is always an instance of `CodableError`.
+        this._log.detail(`Reject ${id}:`, error);
+        // What's going on here is that we use the information from the original
+        // error as the outer error payload, and include a `cause` that
+        // unambiguously indicates that the origin is remote. This arrangement
+        // means that clients can handle well-defined errors fairly
+        // transparently and straightforwardly (e.g. and notably, they don't
+        // have to "unwrap" the errors in the usual case), while still being
+        // able to ascertain the foreign origin of the errors when warranted.
+        const remoteCause = new CodableError('remote_error', this.connectionId);
+        const rejectReason = new CodableError(remoteCause, error.info);
+        callback.reject(rejectReason);
+      } else {
+        this._log.detail(`Resolve ${id}:`, result);
+        if (result instanceof Remote) {
+          // The result is a proxied object, not a regular value.
+          callback.resolve(this._targets.addOrGet(result.targetId));
+        } else {
+          callback.resolve(result);
+        }
+      }
+    } else {
+      // See above about `server_bug`.
+      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
+    }
+  }
+
+  /**
+   * Handles an `open` event coming from a websocket. In this case, it sends
+   * any pending messages (that were enqueued while the socket was still in the
+   * process of opening).
+   *
+   * @param {object} event_unused Event that caused this callback.
+   */
+  _handleOpen(event_unused) {
+    for (const msgJson of this._pendingMessages) {
+      this._log.detail('Sent from queue:', msgJson);
+      this._ws.send(msgJson);
+    }
+    this._pendingMessages = [];
+  }
+
+  /**
+   * Common code to handle both `error` and `close` events.
+   *
+   * @param {object} event_unused Event that caused this callback.
+   * @param {ConnectionError} error Reason for termination. "Error" is a bit of
+   *   a misnomer, as in many cases termination is a-okay.
+   */
+  _handleTermination(event_unused, error) {
+    // Reject the promises of any currently-pending messages.
+    for (const id in this._callbacks) {
+      this._callbacks[id].reject(error);
+    }
+
+    // Clear the state related to the websocket. It is safe to re-open the
+    // connection after this.
+    this._resetConnection();
+  }
+
+  /**
+   * Initializes or resets the state having to do with an active connection. See
+   * the constructor for documentation about these fields.
+   */
+  _resetConnection() {
+    this._ws              = null;
+    this._connectionId    = UNKNOWN_CONNECTION_ID;
+    this._nextId          = 0;
+    this._callbacks       = {};
+    this._pendingMessages = [];
+    this._targets.clear();
+    this._targets.add('meta'); // The one guaranteed target.
+
+    this._updateLogger();
+  }
+
+  /**
+   * Sends the given call to the server.
+   *
+   * **Note:** This method is called via a `TargetHandler` instance, which is
+   * in turn called by a proxy object representing an object on the far side of
+   * the connection.
+   *
+   * @param {string} target Name of the target object.
+   * @param {Functor} payload The name of the method to call and the arguments
+   *   to call it with.
+   * @returns {Promise} Promise for the result (or error) of the call. In the
+   *   case of an error, the rejection reason will always be an instance of
+   *   `ConnectionError` (see which for details).
+   */
+  _send(target, payload) {
+    const wsState = (this._ws === null)
+      ? WebSocket.CLOSED
+      : this._ws.readyState;
+
+    // Handle the cases where socket shutdown is imminent or has already
+    // happened. We don't just `throw` directly here, so that clients can
+    // consistently handle errors via one of the promise chaining mechanisms.
+    switch (wsState) {
+      case WebSocket.CLOSED: {
+        // The detail string here differentiates this case from cases where the
+        // API message was already queued up or sent before the websocket became
+        // closed.
+        return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
+      }
+      case WebSocket.CLOSING: {
+        return Promise.reject(this.connection_closing(this._connectionId));
+      }
+    }
+
+    const id = this._nextId;
+    this._nextId++;
+
+    const msg     = new Message(id, target, payload);
+    const msgJson = this._codec.encodeJson(msg);
+
+    switch (wsState) {
+      case WebSocket.CONNECTING: {
+        // Not yet open. Need to queue it up.
+        this._log.detail('Queued:', msg);
+        this._pendingMessages.push(msgJson);
+        break;
+      }
+      case WebSocket.OPEN: {
+        this._log.detail('Sent:', msg);
+        this._ws.send(msgJson);
+        break;
+      }
+      default: {
+        // Whatever this state is, it's not documented as part of the websocket
+        // spec!
+        this._log.wtf('Weird state:', wsState);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      this._callbacks[id] = { resolve, reject };
+    });
+  }
+
+  /**
+   * Updates {@link #_log} based on {@link #_connectionId}.
+   */
+  _updateLogger() {
+    const id = (this._connectionId === UNKNOWN_CONNECTION_ID)
+      ? 'unknown'
+      : this._connectionId;
+
+    this._log = log.withAddedContext(id);
+  }
+}

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -60,7 +60,7 @@ export default class BaseServerConnection extends CommonBase {
     /** {string} State of the connection. One of the `STATE_*` constants. */
     this._state = BaseServerConnection.STATE_closed;
 
-    /** {string} Connection ID conveyed to us by the server. */
+    /** {string} Connection ID conveyed to us by the user of this instance. */
     this._connectionId = UNKNOWN_CONNECTION_ID;
 
     /** {EventSource} Emitter used for the events of this instance. */

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -170,7 +170,7 @@ export default class BaseServerConnection extends CommonBase {
   async sendAll() {
     // Call `_sendAll()` if not already in progress, or if in progress merely
     // wait for the return of that in-progress call.
-    return this._sendAllPiler.call();
+    await this._sendAllPiler.call();
   }
 
   /**
@@ -180,7 +180,7 @@ export default class BaseServerConnection extends CommonBase {
    * @abstract
    */
   async _impl_beReceiving() {
-    return this._mustOverride();
+    this._mustOverride();
   }
 
   /**
@@ -197,7 +197,7 @@ export default class BaseServerConnection extends CommonBase {
    * @param {string} message The message to send.
    */
   async _impl_sendMessage(message) {
-    return this._mustOverride(message);
+    this._mustOverride(message);
   }
 
   /**

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { EventSource, CallPiler } from '@bayou/prom-util';
+import { EventSource, CallPiler } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Functor } from '@bayou/util-common';

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -126,10 +126,12 @@ export default class BaseServerConnection extends CommonBase {
         return message;
       }
 
-      // There are no received messages that haven't yet been handled. Wait for
-      // one to show up on the event chain. But only then try to get to it
+      // There are no received messages that haven't yet been handled. Make sure
+      // the subclass is trying to receive, and then wait for one to show up on
+      // the event chain. Once an event shows up, loop back and try to get to it
       // synchronously via the code above, to avoid the possibility of returning
       // the same message twice.
+      await this._impl_beReceiving();
       await this._receiveHead.nextOf(BaseServerConnection.EVENT_receive);
     }
   }
@@ -166,6 +168,16 @@ export default class BaseServerConnection extends CommonBase {
     // Call `_sendAll()` if not already in progress, or if in progress merely
     // wait for the return of that in-progress call.
     return this._sendAllPiler.call();
+  }
+
+  /**
+   * Makes sure that the instance is in a position to receive messages from the
+   * far side of the connection.
+   *
+   * @abstract
+   */
+  async _impl_beReceiving() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -21,6 +21,9 @@ const log = new Logger('api-conn');
  *
  * **Note:** At this layer, messages are all strings. **TODO:** They should be
  * binary (arrays of bytes) instead.
+ *
+ * **TODO:** This class is an as-yet nonfunctional work-in-progress. See the
+ * header comment in {@link ApiClient} for more details.
  */
 export default class BaseServerConnection extends CommonBase {
   /** {string} Event name to use for received messages. */

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -5,7 +5,7 @@
 import { EventSource, CallPiler } from '@bayou/prom-util';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
-import { CommonBase, Errors, Functor } from '@bayou/util-common';
+import { CommonBase, Functor } from '@bayou/util-common';
 
 /** {string} Value used for an unknown connection ID. */
 const UNKNOWN_CONNECTION_ID = 'id_unknown';
@@ -31,15 +31,6 @@ export default class BaseServerConnection extends CommonBase {
 
   /** {string} Event name to use for the very first event emitted. */
   static get EVENT_start() { return 'start'; }
-
-  /** {string} Connection state "closed" (no currenct connection). */
-  static get STATE_closed() { return 'closed'; }
-
-  /** {string} Connection state "opening" (in the process of becoming open). */
-  static get STATE_opening() { return 'opening'; }
-
-  /** {string} Connection state "open" (open and active). */
-  static get STATE_open() { return 'open'; }
 
   /**
    * Constructs an instance. Once constructed, it is valid to send messages
@@ -117,31 +108,6 @@ export default class BaseServerConnection extends CommonBase {
    */
   get log() {
     return this._log;
-  }
-
-  /**
-   * {string} State of the connection. One of the static `STATE_*` constants
-   * defined by this class. It is up to subclasses to update this value.
-   */
-  get state() {
-    return this._state;
-  }
-
-  set state(state) {
-    switch (state) {
-      case BaseServerConnection.STATE_closed:
-      case BaseServerConnection.STATE_open:
-      case BaseServerConnection.STATE_opening: {
-        // Valid.
-        break;
-      }
-
-      default: {
-        throw Errors.badValue(state, String, 'connection state');
-      }
-    }
-
-    this._state = state;
   }
 
   /**

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Condition } from '@bayou/prom-util';
+import { Condition } from '@bayou/promise-util';
 import { WebsocketCodes } from '@bayou/util-common';
 
 import BaseServerConnection from './BaseServerConnection';

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -10,6 +10,9 @@ import BaseServerConnection from './BaseServerConnection';
 /**
  * Server connection handler which uses a websocket to communicate with a
  * server, using the standard URI endpoint `/api`.
+ *
+ * **TODO:** This class is an as-yet nonfunctional work-in-progress. See the
+ * header comment in {@link ApiClient} for more details.
  */
 export default class WsServerConnection extends BaseServerConnection {
   /**

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -50,6 +50,15 @@ export default class WsServerConnection extends BaseServerConnection {
   /**
    * Implementation as required by the superclass.
    *
+   * @abstract
+   */
+  async _impl_beReceiving() {
+    return this._ensureOpen();
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
    * @param {string} message The message to send.
    */
   async _impl_sendMessage(message) {

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -131,8 +131,7 @@ export default class WsServerConnection extends BaseServerConnection {
   }
 
   /**
-   * Handles a `close` event coming from a websocket. This logs the closure and
-   * terminates all active messages by rejecting their promises.
+   * Handles a `close` event coming from a websocket.
    *
    * @param {object} event Event that caused this callback.
    */
@@ -148,10 +147,6 @@ export default class WsServerConnection extends BaseServerConnection {
    * Handles an `error` event coming from a websocket. This behaves similarly
    * to the `close` event.
    *
-   * **Note:** Because errors in this case are typically due to transient
-   * connection issues (e.g. network went away) and not due to fundamental
-   * system issues, this is logged as `info` and not `error` (or `warn`).
-   *
    * @param {object} event Event that caused this callback.
    */
   _handleError(event) {
@@ -164,11 +159,7 @@ export default class WsServerConnection extends BaseServerConnection {
   }
 
   /**
-   * Handles a `message` event coming from a websocket. In this case, messages
-   * are expected to be the responses from previously-sent messages (e.g.
-   * method calls), encoded as JSON. The `id` of the response is used to look up
-   * the callback function in `this._callbacks`. That callback is then called in
-   * a separate turn.
+   * Handles a `message` event coming from a websocket.
    *
    * @param {object} event Event that caused this callback.
    */
@@ -178,9 +169,7 @@ export default class WsServerConnection extends BaseServerConnection {
   }
 
   /**
-   * Handles an `open` event coming from a websocket. In this case, it sends
-   * any pending messages (that were enqueued while the socket was still in the
-   * process of opening).
+   * Handles an `open` event coming from a websocket.
    *
    * @param {object} event Event that caused this callback.
    */

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -1,0 +1,320 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { WebsocketCodes } from '@bayou/util-common';
+
+import BaseServerConnection from './BaseServerConnection';
+
+/**
+ * Server connection handler which uses a websocket to communicate with a
+ * server, using the standard URI endpoint `/api`.
+ */
+export default class WsServerConnection extends BaseServerConnection {
+  /**
+   * Constructs an instance. This instance will connect to a websocket at the
+   * same domain as the given `url`, at the path `/api`. Once this constructor
+   * returns, it is safe to send messages on the instance; if the socket isn't
+   * yet ready for traffic, the messages will get enqueued and then later
+   * replayed in order once the socket becomes ready.
+   *
+   * @param {string} url The server origin, as an `http` or `https` URL.
+   */
+  constructor(url) {
+    super();
+
+    /** {string} Base URL for the server. */
+    this._baseUrl = WsServerConnection._getBaseUrl(url);
+
+    /** {string} URL to use when connecting a websocket. */
+    this._wsUrl = WsServerConnection._getWsUrl(this._baseUrl);
+
+    /**
+     * {WebSocket} Actual websocket instance. Set by `open()`. Reset in
+     * `_resetConnection()`.
+     */
+    this._ws = null;
+
+    // Initialize the active connection fields (described above).
+    this._resetConnection();
+
+    Object.seal(this);
+  }
+
+  /** {string} Base URL for the remote endpoint this client gets attached to. */
+  get baseUrl() {
+    return this._baseUrl;
+  }
+
+  /**
+   * Opens the websocket. Once open, any pending messages will get sent to the
+   * server side. If the socket is already open (or in the process of opening),
+   * this does not re-open (that is, the existing open is allowed to continue).
+   *
+   * @returns {boolean} `true` once the connection is open.
+   * @throws {ConnectionError} Indication of why the connection attempt failed.
+   */
+  async open() {
+    // If `_ws` is `null` that means that the connection is not already open or
+    // in the process of opening.
+
+    if (this._connectionId !== UNKNOWN_CONNECTION_ID) {
+      // Already open.
+      return true;
+    } else if (this._ws !== null) {
+      // In the middle of getting opened. Arguably this should do something a
+      // bit more efficient (instead of issuing a separate API call), but also
+      // this shouldn't ever happen, so it's not that big a deal.
+      this.log.info('open() called while in the middle of opening.');
+      await this.meta.ping();
+      return true;
+    }
+
+    this._ws = new WebSocket(this._websocketUrl);
+    this._ws.onclose   = this._handleClose.bind(this);
+    this._ws.onerror   = this._handleError.bind(this);
+    this._ws.onmessage = this._handleMessage.bind(this);
+    this._ws.onopen    = this._handleOpen.bind(this);
+
+    this._updateLogger();
+    this.log.event.opening();
+
+    const id = await this.meta.connectionId();
+
+    this._connectionId = id;
+    this._updateLogger();
+    this.log.event.open();
+
+    return true;
+  }
+
+  /**
+   * Handles a `close` event coming from a websocket. This logs the closure and
+   * terminates all active messages by rejecting their promises.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleClose(event) {
+    this.log.info('Closed:', event);
+
+    const code = WebsocketCodes.close(event.code);
+    const desc = event.reason ? `${code}: ${event.reason}` : code;
+    const error = ConnectionError.connection_closed(this._connectionId, desc);
+
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles an `error` event coming from a websocket. This behaves similarly
+   * to the `close` event.
+   *
+   * **Note:** Because errors in this case are typically due to transient
+   * connection issues (e.g. network went away) and not due to fundamental
+   * system issues, this is logged as `info` and not `error` (or `warn`).
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleError(event) {
+    this.log.info('Error:', event);
+
+    // **Note:** The error event does not have any particularly useful extra
+    // info, so -- alas -- there is nothing to get out of it for the
+    // `ConnectionError` description.
+    const error = ConnectionError.connection_error(this._connectionId);
+    this._handleTermination(event, error);
+  }
+
+  /**
+   * Handles a `message` event coming from a websocket. In this case, messages
+   * are expected to be the responses from previously-sent messages (e.g.
+   * method calls), encoded as JSON. The `id` of the response is used to look up
+   * the callback function in `this._callbacks`. That callback is then called in
+   * a separate turn.
+   *
+   * @param {object} event Event that caused this callback.
+   */
+  _handleMessage(event) {
+    this.log.detail('Received raw data:', event.data);
+
+    const response = this._codec.decodeJson(event.data);
+
+    if (!(response instanceof Response)) {
+      throw ConnectionError.connection_nonsense(this._connectionId, 'Got strange response.');
+    }
+
+    const { id, result, error } = response;
+
+    const callback = this._callbacks[id];
+    if (callback) {
+      delete this._callbacks[id];
+      if (error) {
+        // **Note:** `error` is always an instance of `CodableError`.
+        this.log.detail(`Reject ${id}:`, error);
+        // What's going on here is that we use the information from the original
+        // error as the outer error payload, and include a `cause` that
+        // unambiguously indicates that the origin is remote. This arrangement
+        // means that clients can handle well-defined errors fairly
+        // transparently and straightforwardly (e.g. and notably, they don't
+        // have to "unwrap" the errors in the usual case), while still being
+        // able to ascertain the foreign origin of the errors when warranted.
+        const remoteCause = new CodableError('remote_error', this.connectionId);
+        const rejectReason = new CodableError(remoteCause, error.info);
+        callback.reject(rejectReason);
+      } else {
+        this.log.detail(`Resolve ${id}:`, result);
+        if (result instanceof Remote) {
+          // The result is a proxied object, not a regular value.
+          callback.resolve(this._targets.addOrGet(result.targetId));
+        } else {
+          callback.resolve(result);
+        }
+      }
+    } else {
+      // See above about `server_bug`.
+      throw ConnectionError.connection_nonsense(this._connectionId, `Orphan call for ID ${id}.`);
+    }
+  }
+
+  /**
+   * Handles an `open` event coming from a websocket. In this case, it sends
+   * any pending messages (that were enqueued while the socket was still in the
+   * process of opening).
+   *
+   * @param {object} event_unused Event that caused this callback.
+   */
+  _handleOpen(event_unused) {
+    for (const msgJson of this._pendingMessages) {
+      this.log.detail('Sent from queue:', msgJson);
+      this._ws.send(msgJson);
+    }
+    this._pendingMessages = [];
+  }
+
+  /**
+   * Common code to handle both `error` and `close` events.
+   *
+   * @param {object} event_unused Event that caused this callback.
+   * @param {ConnectionError} error Reason for termination. "Error" is a bit of
+   *   a misnomer, as in many cases termination is a-okay.
+   */
+  _handleTermination(event_unused, error) {
+    // Reject the promises of any currently-pending messages.
+    for (const id in this._callbacks) {
+      this._callbacks[id].reject(error);
+    }
+
+    // Clear the state related to the websocket. It is safe to re-open the
+    // connection after this.
+    this._resetConnection();
+  }
+
+  /**
+   * Initializes or resets the state having to do with an active connection. See
+   * the constructor for documentation about these fields.
+   */
+  _resetConnection() {
+    this._ws              = null;
+    this._connectionId    = UNKNOWN_CONNECTION_ID;
+    this._nextId          = 0;
+    this._callbacks       = {};
+    this._pendingMessages = [];
+    this._targets.clear();
+    this._targets.add('meta'); // The one guaranteed target.
+
+    this._updateLogger();
+  }
+
+  /**
+   * Sends the given call to the server.
+   *
+   * **Note:** This method is called via a `TargetHandler` instance, which is
+   * in turn called by a proxy object representing an object on the far side of
+   * the connection.
+   *
+   * @param {string} target Name of the target object.
+   * @param {Functor} payload The name of the method to call and the arguments
+   *   to call it with.
+   * @returns {Promise} Promise for the result (or error) of the call. In the
+   *   case of an error, the rejection reason will always be an instance of
+   *   `ConnectionError` (see which for details).
+   */
+  _send(target, payload) {
+    const wsState = (this._ws === null)
+      ? WebSocket.CLOSED
+      : this._ws.readyState;
+
+    // Handle the cases where socket shutdown is imminent or has already
+    // happened. We don't just `throw` directly here, so that clients can
+    // consistently handle errors via one of the promise chaining mechanisms.
+    switch (wsState) {
+      case WebSocket.CLOSED: {
+        // The detail string here differentiates this case from cases where the
+        // API message was already queued up or sent before the websocket became
+        // closed.
+        return Promise.reject(ConnectionError.connection_closed(this._connectionId, 'Already closed.'));
+      }
+      case WebSocket.CLOSING: {
+        return Promise.reject(ConnectionError.connection_closing(this._connectionId));
+      }
+    }
+
+    const id = this._nextId;
+    this._nextId++;
+
+    const msg     = new Message(id, target, payload);
+    const msgJson = this._codec.encodeJson(msg);
+
+    switch (wsState) {
+      case WebSocket.CONNECTING: {
+        // Not yet open. Need to queue it up.
+        this.log.detail('Queued:', msg);
+        this._pendingMessages.push(msgJson);
+        break;
+      }
+      case WebSocket.OPEN: {
+        this.log.detail('Sent:', msg);
+        this._ws.send(msgJson);
+        break;
+      }
+      default: {
+        // Whatever this state is, it's not documented as part of the websocket
+        // spec!
+        this.log.wtf('Weird state:', wsState);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      this._callbacks[id] = { resolve, reject };
+    });
+  }
+
+  /**
+   * Gets the base URL for the given original URL.
+   *
+   * @param {string} origUrl The original URL.
+   * @returns {string} The corresponding base URL.
+   */
+  static _getBaseUrl(origUrl) {
+    return new URL(origUrl).origin;
+  }
+
+  /**
+   * Gets the websocket URL corresponding to the given base URL.
+   *
+   * @param {string} baseUrl The base URL.
+   * @returns {string} The corresponding websocket URL.
+   */
+  static _getWsUrl(baseUrl) {
+    const url = new URL(baseUrl);
+
+    // Convert the URL scheme to either `ws` or `wss`, corresponding to `http`
+    // or `https`.
+    url.protocol = url.protocol.replace(/^http/, 'ws');
+
+    // Drop the original path, and replace it with just `/api`.
+    url.pathname = '/api';
+
+    return url.href;
+  }
+}

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -56,7 +56,7 @@ export default class WsServerConnection extends BaseServerConnection {
    * @abstract
    */
   async _impl_beReceiving() {
-    return this._ensureOpen();
+    await this._ensureOpen();
   }
 
   /**

--- a/local-modules/@bayou/api-client/index.js
+++ b/local-modules/@bayou/api-client/index.js
@@ -3,5 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import ApiClient from './ApiClient';
+import ApiClientNew from './ApiClientNew';
+import BaseServerConnection from './BaseServerConnection';
+import WsServerConnection from './WsServerConnection';
 
-export { ApiClient };
+export { ApiClient, ApiClientNew, BaseServerConnection, WsServerConnection };

--- a/local-modules/@bayou/api-client/package.json
+++ b/local-modules/@bayou/api-client/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@bayou/api-common": "local",
+    "@bayou/prom-util": "local",
     "@bayou/see-all": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/api-client/package.json
+++ b/local-modules/@bayou/api-client/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@bayou/api-common": "local",
-    "@bayou/prom-util": "local",
+    "@bayou/promise-util": "local",
     "@bayou/see-all": "local",
     "@bayou/typecheck": "local",
     "@bayou/util-common": "local"


### PR DESCRIPTION
This PR is work-in-progress on splitting `ApiClient` into a few separate classes, with two aims:

* Make the class (now classes) easier to test.
* Make it possible to plug in different transport / socket implementations so that we're no longer stuck with just using `WebSocket` per se or something with _exactly_ its API.

What's missing as of this PR:

* Solid error recovery, including where the high-level class `ApiClientNew` has to figure out when its pending calls can't be expected to return and therefore needs to reissue them.
* Possibly: Global registry of pending calls (on the server side) to enable idempotency. (We need something like this eventually, but it's not yet clear to me how it will all shake out.)
* Bugfixes based on ad-hoc testing.
* Actual unit tests.