### PR TITLE
Tweak the old session code, to allow for some session continuation across websocket connections.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -434,11 +434,11 @@ export default class ApiClient extends CommonBase {
    * @param {string} target Name of the target object.
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
-   * @returns {Promise} Promise for the result (or error) of the call. In the
-   *   case of an error, the rejection reason will always be an instance of
-   *   `ConnectionError` (see which for details).
+   * @returns {*} Result or error returned by the remote call. In the case of an
+   *   error, the rejection reason will always be an instance of
+   *  {@link ConnectionError} (see which for details).
    */
-  _send(target, payload) {
+  async _send(target, payload) {
     const wsState = (this._ws === null)
       ? WebSocket.CLOSED
       : this._ws.readyState;

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -174,7 +174,7 @@ export default class ApiClient extends CommonBase {
     if (result) {
       // We have already initiated authorization on this target. Return the
       // promise from the original initiation.
-      this._log.info('Already authing:', id);
+      this._log.event.concurrentAuth(id);
       return result;
     }
 
@@ -243,9 +243,8 @@ export default class ApiClient extends CommonBase {
       return true;
     } else if (this._ws !== null) {
       // In the middle of getting opened. Arguably this should do something a
-      // bit more efficient (instead of issuing a separate API call), but also
-      // this shouldn't ever happen, so it's not that big a deal.
-      this._log.info('open() called while in the middle of opening.');
+      // bit more efficient (instead of issuing a separate API call).
+      this._log.event.concurrentOpen();
       await this.meta.ping();
       return true;
     }

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -89,7 +89,13 @@ export default class ApiClient extends CommonBase {
     this._pendingMessages = null;
 
     /**
-     * {TargetMap} Map of names to target proxies. See {@link
+     * {Map<string, BaseKey>} Map of IDs to keys, for keys which have been
+     * added via {@link #authorizeTarget}.
+     */
+    this._keys = new Map();
+
+    /**
+     * {TargetMap} Map of names/IDs to target proxies. See {@link
      * TargetMap#constructor} for details about the argument.
      */
     this._targets = new TargetMap(this._send.bind(this));
@@ -174,6 +180,8 @@ export default class ApiClient extends CommonBase {
 
     // It's not yet bound as a target, and authorization isn't currently in
     // progress.
+
+    this._keys.set(id, key);
 
     result = (async () => {
       try {
@@ -431,7 +439,7 @@ export default class ApiClient extends CommonBase {
    * in turn called by a proxy object representing an object on the far side of
    * the connection.
    *
-   * @param {string} target Name of the target object.
+   * @param {string} target Name/ID of the target object.
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
    * @returns {*} Result or error returned by the remote call. In the case of an
@@ -455,6 +463,24 @@ export default class ApiClient extends CommonBase {
       }
       case WebSocket.CLOSING: {
         return Promise.reject(ConnectionError.connectionClosing(this._connectionId));
+      }
+    }
+
+    if (this._targets.getOrNull(target) === null) {
+      // `target` isn't in the map of same. It's probably the case that it
+      // represents a key that was authed in an earlier since-closed websocket
+      // connection.
+      const key = this._keys.get(target);
+      if (key === undefined) {
+        // Nope! Totally unknown ID. Most likely indicates a bug in a higher
+        // layer of the system.
+        return Promise.reject(ConnectionError.unknownTargetId(this._connectionId, target));
+      } else {
+        // Yep! We found the original key. Reauthorize it and then let the call
+        // proceed.
+        this._log.event.reauthorizing(target);
+        await this.authorizeTarget(key);
+        this._log.event.reauthed(target);
       }
     }
 

--- a/local-modules/@bayou/api-common/ConnectionError.js
+++ b/local-modules/@bayou/api-common/ConnectionError.js
@@ -67,6 +67,20 @@ export default class ConnectionError extends InfoError {
   }
 
   /**
+   * Constructs an error indicating that the _local_ side of the API received a
+   * target ID that it didn't already know about.
+   *
+   * @param {string} connectionId Connection ID string.
+   * @param {string} targetId ID of the target in question.
+   * @returns {ConnectionError} An appropriately-constructed error.
+   */
+  static unknownTargetId(connectionId, targetId) {
+    TString.check(connectionId);
+    TString.check(targetId);
+    return new ConnectionError('unknownTargetId', connectionId, targetId);
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {...*} args Constructor arguments, as described by `InfoError`.

--- a/local-modules/@bayou/api-common/ConnectionError.js
+++ b/local-modules/@bayou/api-common/ConnectionError.js
@@ -79,13 +79,4 @@ export default class ConnectionError extends InfoError {
     TString.check(targetId);
     return new ConnectionError('unknownTargetId', connectionId, targetId);
   }
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {...*} args Constructor arguments, as described by `InfoError`.
-   */
-  constructor(...args) {
-    super(...args);
-  }
 }

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -19,7 +19,7 @@ const log = new Logger('api');
  * {Int} The amount of time in msec a target must be idle and unaccessed before
  * it is considered sufficiently idle to warrant automated cleanup.
  */
-const IDLE_TIME_MSEC = 20 * 60 * 1000; // Twenty minutes.
+const IDLE_TIME_MSEC = 4 * 60 * 60 * 1000; // Four hours.
 
 /**
  * Binding context for an API server or session therein. Instances of this class

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -21,9 +21,7 @@ export default class WsConnection extends Connection {
   constructor(ws, req, context) {
     super(context);
 
-    // **TODO:** Remove this once we're a bit more sure about what to expect.
-    this._log.info(`Websocket host: ${req.headers.host}`);
-    this._log.info(`Websocket origin: ${req.headers.origin}`);
+    this._log.event.websocketOrigin(req.headers.origin);
 
     /** {WebSocket} The websocket for the client connection. */
     this._ws = ws;
@@ -53,7 +51,7 @@ export default class WsConnection extends Connection {
    * @param {object} error The error event.
    */
   _handleError(error) {
-    this._log.info('Error:', error);
+    this._log.event.websocketError(error);
     this.close();
   }
 

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -25,21 +25,28 @@ const ERROR_WINDOW_MSEC = 3 * 60 * 1000; // Three minutes.
 const ERROR_MAX_PER_MINUTE = 2.25;
 
 /**
- * How long to wait (in msec) after receiving a local change (to allow time for
- * other changes to get coalesced) before pushing a change up to the server.
+ * {Int} How long to wait (in msec) after receiving a local change (to allow
+ * time for other changes to get coalesced) before pushing a change up to the
+ * server.
  */
 const PUSH_DELAY_MSEC = 1000;
 
 /**
- * How long to wait (in msec) after receiving a server change (to allow time for
- * other changes to get coalesced) before requesting additional changes from
- * the server.
+ * {Int} How long to wait (in msec) after receiving a server change (to allow
+ * time for other changes to get coalesced) before requesting additional changes
+ * from the server.
  */
 const PULL_DELAY_MSEC = 1000;
 
 /**
- * How long to wait (in msec) after detecting an error, before attempting to
- * restart.
+ * {Int} How long to wait (in msec) after detecting the first error in the error
+ * window, before attempting to restart.
+ */
+const FIRST_RESTART_DELAY_MSEC = 1000; // One second.
+
+/**
+ * {Int} How long to wait (in msec) after detecting an error after the first,
+ * before attempting to restart.
  */
 const RESTART_DELAY_MSEC = 5 * 1000; // Five seconds.
 
@@ -270,7 +277,10 @@ export default class BodyClient extends StateMachine {
     // be handled differently than a clean start from scratch.
 
     (async () => {
-      await Delay.resolve(RESTART_DELAY_MSEC);
+      const delayMsec = (this._errorStamps.length === 1)
+        ? FIRST_RESTART_DELAY_MSEC
+        : RESTART_DELAY_MSEC;
+      await Delay.resolve(delayMsec);
       this.start();
     })();
 

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -41,7 +41,7 @@ const PULL_DELAY_MSEC = 1000;
  * How long to wait (in msec) after detecting an error, before attempting to
  * restart.
  */
-const RESTART_DELAY_MSEC = 10000;
+const RESTART_DELAY_MSEC = 5 * 1000; // Five seconds.
 
 /**
  * Tag used to identify this module as the source of a Quill event or action.

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -334,7 +334,7 @@ export default class BodyClient extends StateMachine {
     // won't become open synchronously, the API client code allows us to start
     // sending messages over it immediately. (They'll just get queued up as
     // necessary.)
-    this._docSession.apiClient.open();
+    await this._docSession.apiClient.open();
 
     // Perform a challenge-response to authorize access to the document.
     try {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.3
+version = 1.1.4


### PR DESCRIPTION
This PR is meant as a stop-gap to enable document editing sessions to extend in length across multiple websocket connections. This is done as a short-term tactic to make for a better experience while the session rework continues apace.

To be clear, about half of this PR is throwaway work just to address the situation in the old session code. The other half is mostly going to be useful going forward, with maybe just a bit of the usual innocuous churn.

**Bonus:** Cleaned up some log messages.