### PR TITLE
Preserve the selection across socket reconnections.

### DIFF
--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.4
+version = 1.1.5


### PR DESCRIPTION
Small PR; this turned out to be an easy tactical fix, though note the long comment in the code with a caveat / suggestion for possible improvement.

Anyhoo, when the editor goes through a disconnect / reconnect, it now makes a reasonable attempt to preserve the selection (caret).