### PR TITLE
New `DocSession` constructor arguments in support of new-style sessions.

### DIFF
--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -37,7 +37,7 @@ export default class DocSession extends CommonBase {
    *   `key` is being used). If being used and `null`, a new caret will be
    *   created for this session.
    */
-  constructor(key, authorToken, documentId, caretId) {
+  constructor(key, authorToken = null, documentId = null, caretId = null) {
     super();
 
     /**

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -136,6 +136,31 @@ export default class DocSession extends CommonBase {
     return this._apiClient;
   }
 
+  /**
+   * {string|null} Token which identifies the author (user) under whose
+   * authority the session is run. `null` if {@link #_key} is being used.
+   */
+  get authorToken() {
+    return this._authorToken;
+  }
+
+  /**
+   * {string|null} ID of the document to be edited in this session. `null` if
+   * {@link #_key} is being used.
+   */
+  get documentId() {
+    return this._documentId;
+  }
+
+  /**
+   * {string|null} ID of the caret to be controlled in this session. `null` if
+   * {@link #_key} is being used _or_ if a new caret needs to be created for
+   * this instance.
+   */
+  get caretId() {
+    return this._caretId;
+  }
+
   /** {CaretTracker} Caret tracker for this session. */
   get caretTracker() {
     if (this._caretTracker === null) {

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -69,6 +69,9 @@ export default class DocSession extends CommonBase {
       // **Note:** This clause can't possibly be run yet, because of the call to
       // `BaseKey.check()` above (which guarantees that `_key` is non-`null`).
       // That will change once the new session code is more fleshed out.
+      // **TODO:** Consider performing more validation of these strings. If
+      // they're problematic, we'll _eventually_ get errors back from the
+      // server, but maybe it's better to know sooner.
       this._authorToken = TString.check(authorToken);
       this._documentId = TString.check(documentId);
       this._caretId = TString.orNull(caretId);

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -6,6 +6,7 @@ import { ApiClient } from '@bayou/api-client';
 import { BaseKey } from '@bayou/api-common';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { Logger } from '@bayou/see-all';
+import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import CaretTracker from './CaretTracker';
@@ -24,8 +25,19 @@ export default class DocSession extends CommonBase {
    * @param {BaseKey} key Key that identifies the session and grants access to
    *   it. **Note:** A session is specifically tied to a specific caret, which
    *   is associated with a single document and a specific author.
+   * @param {string|null} [authorToken = null] Token which identifies the author
+   *   (user) under whose authority the session is run. This is only used if it
+   *   is non-`null` _and_ `key` is `null`. **TODO:** This argument is ignored
+   *   for now but will ultimately replace `key`.
+   * @param {string|null} [documentId = null] ID of the document to be edited in
+   *   this session. Only used if `authorToken` is being used (not if `key` is
+   *   being used).
+   * @param {string|null} [caretId = null] ID of a pre-existing caret to control
+   *   with this instance. Only used if `authorToken` is being used (not if
+   *   `key` is being used). If being used and `null`, a new caret will be
+   *   created for this session.
    */
-  constructor(key) {
+  constructor(key, authorToken, documentId, caretId) {
     super();
 
     /**
@@ -33,6 +45,34 @@ export default class DocSession extends CommonBase {
      * to it.
      */
     this._key = BaseKey.check(key);
+
+    /**
+     * {string|null} Token which identifies the author (user) under whose
+     * authority the session is run. `null` if {@link #_key} is being used.
+     */
+    this._authorToken = null;
+
+    /**
+     * {string|null} ID of the document to be edited in this session. `null` if
+     * {@link #_key} is being used.
+     */
+    this._documentId = null;
+
+    /**
+     * {string|null} ID of the caret to be controlled in this session. `null` if
+     * {@link #_key} is being used _or_ if a new caret needs to be created for
+     * this instance.
+     */
+    this._caretId = null;
+
+    if (this._key === null) {
+      // **Note:** This clause can't possibly be run yet, because of the call to
+      // `BaseKey.check()` above (which guarantees that `_key` is non-`null`).
+      // That will change once the new session code is more fleshed out.
+      this._authorToken = TString.check(authorToken);
+      this._documentId = TString.check(documentId);
+      this._caretId = TString.orNull(caretId);
+    }
 
     /** {Logger} Logger specific to this document's ID. */
     this._log = log.withAddedContext(key.id);


### PR DESCRIPTION
This PR leaves things a little messy, but _necessarily_ messy as we ramp up new-style sessions while still leaving the old-style session management code intact. The only thing going on in this PR is adding new arguments to the `DocSession` constructor for the new style. Nothing is yet passing these. Later PRs will flesh things out on either side (passing valid data in, and actually using it)… but gotta start somewhere!