### PR TITLE
Treat otherwise-uncaught errors the same as "too many API errors."

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -242,6 +242,19 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
+   * Handler for all `error` events (errors that were uncaught by other handlers
+   * and which would by default just cause the state machine to die). In this
+   * case, we make it turn into an "unrecoverable" error, which is the same as
+   * what happens when the instance receives too many API errors.
+   *
+   * @param {Error} error The error.
+   */
+  _handle_any_error(error) {
+    this._log.error('Unexpected error in handler', error);
+    this.s_unrecoverableError();
+  }
+
+  /**
    * In any state, handles event `apiError`. This is a "normal" occurrence if
    * the error has to do with the network connection (e.g. the network drops),
    * but is considered unusual (and error-worthy) if it happens for some other

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.5
+version = 1.1.6


### PR DESCRIPTION
This resolves the tension of "make bugs blatant" vs. "provide good user experience" on the latter side. Specifically, right now we don't do as much explicit catching of server connection problems as we should, and this makes `BodyClient` a bit too fragile. This PR is the "blunt instrument" approach and not meant to preclude later finer-grained tweakage.