### PR TITLE
An increment of session rework.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -205,6 +205,25 @@ export default class ApiClient extends CommonBase {
   }
 
   /**
+   * Gets a proxy for the target with the given ID or which is controlled by the
+   * given key. This will create the proxy if it did not previously exist. This
+   * method does _not_ check to see if the far side of the connection knows
+   * about the so-identified target (or if it does, whether it allows access to
+   * it without further authorization).
+   *
+   * @param {string|BaseKey} idOrKey ID or key for the target.
+   * @returns {Proxy} Proxy which locally represents the so-identified
+   *   server-side target.
+   */
+  getProxy(idOrKey) {
+    const id = (idOrKey instanceof BaseKey)
+      ? idOrKey.id
+      : TString.check(idOrKey);
+
+    return this._targets.addOrGet(id);
+  }
+
+  /**
    * Opens the websocket. Once open, any pending messages will get sent to the
    * server side. If the socket is already open (or in the process of opening),
    * this does not re-open (that is, the existing open is allowed to continue).

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -113,11 +113,6 @@ export default class ApiClient extends CommonBase {
     Object.seal(this);
   }
 
-  /** {string} Base URL for the remote endpoint this client gets attached to. */
-  get baseUrl() {
-    return this._baseUrl;
-  }
-
   /**
    * {string} The connection ID if known, or a reasonably suggestive string if
    * not. This class automatically sets the ID when connections get made, so

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -33,17 +33,17 @@ export default class ApiClient extends CommonBase {
    * socket isn't yet ready for traffic, the messages will get enqueued and then
    * replayed in order once the socket becomes ready.
    *
-   * @param {string} url The server origin, as an `http` or `https` URL.
+   * @param {string} serverUrl The server origin, as an `http` or `https` URL.
    * @param {Codec} codec Codec instance to use. In order to function properly,
    *   its registry must include all of the encodable classes defined in
    *   `@bayou/api-common` classes. See
    *   {@link @bayou/api-common.TheModule.registerCodecs}.
    */
-  constructor(url, codec) {
+  constructor(serverUrl, codec) {
     super();
 
     /** {string} Base URL for the server. */
-    this._baseUrl = ApiClient._getBaseUrl(url);
+    this._baseUrl = ApiClient._getBaseUrl(serverUrl);
 
     /** {Codec} Codec instance to use. */
     this._codec = Codec.check(codec);

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -141,8 +141,7 @@ export default class ApiClient extends CommonBase {
   /**
    * Performs a challenge-response authorization for a given key. When the
    * returned promise resolves successfully, that means that the corresponding
-   * target (that is, `this.getTarget(key)`) can be accessed without further
-   * authorization.
+   * target can be accessed without further authorization.
    *
    * If `key.id` is already mapped as a target, it is returned directly, without
    * further authorization. If it is in the middle of being authorized, the
@@ -203,24 +202,6 @@ export default class ApiClient extends CommonBase {
 
     this._pendingAuths.set(id, result); // It's now pending.
     return result;
-  }
-
-  /**
-   * Gets a proxy for the target with the given ID or which is controlled by the
-   * given key (or which was so controlled prior to authorizing it away). The
-   * target must already be known to this instance for this method to work
-   * (otherwise it is an error).
-   *
-   * @param {string|BaseKey} idOrKey ID or key for the target.
-   * @returns {Proxy} Proxy which locally represents the so-identified
-   *   server-side target.
-   */
-  getTarget(idOrKey) {
-    const id = (idOrKey instanceof BaseKey)
-      ? idOrKey.id
-      : TString.check(idOrKey);
-
-    return this._targets.get(id);
   }
 
   /**

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -4,6 +4,7 @@
 
 import { BaseKey, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
+import { TString } from '@bayou/typecheck';
 import { CommonBase, WebsocketCodes } from '@bayou/util-common';
 
 import BaseServerConnection from './BaseServerConnection';
@@ -157,6 +158,25 @@ export default class ApiClientNew extends CommonBase {
 
     this._pendingAuths.set(id, result); // It's now pending.
     return result;
+  }
+
+  /**
+   * Gets a proxy for the target with the given ID or which is controlled by the
+   * given key. This will create the proxy if it did not previously exist. This
+   * method does _not_ check to see if the far side of the connection knows
+   * about the so-identified target (or if it does, whether it allows access to
+   * it without further authorization).
+   *
+   * @param {string|BaseKey} idOrKey ID or key for the target.
+   * @returns {Proxy} Proxy which locally represents the so-identified
+   *   server-side target.
+   */
+  getProxy(idOrKey) {
+    const id = (idOrKey instanceof BaseKey)
+      ? idOrKey.id
+      : TString.check(idOrKey);
+
+    return this._targets.addOrGet(id);
   }
 
   /**

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -4,7 +4,6 @@
 
 import { BaseKey, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
-import { TString } from '@bayou/typecheck';
 import { CommonBase, WebsocketCodes } from '@bayou/util-common';
 
 import BaseServerConnection from './BaseServerConnection';
@@ -99,8 +98,7 @@ export default class ApiClientNew extends CommonBase {
   /**
    * Performs a challenge-response authorization for a given key. When the
    * returned promise resolves successfully, that means that the corresponding
-   * target (that is, `this.getTarget(key)`) can be accessed without further
-   * authorization.
+   * target can be accessed without further authorization.
    *
    * If `key.id` is already mapped as a target, it is returned directly, without
    * further authorization. If it is in the middle of being authorized, the
@@ -159,24 +157,6 @@ export default class ApiClientNew extends CommonBase {
 
     this._pendingAuths.set(id, result); // It's now pending.
     return result;
-  }
-
-  /**
-   * Gets a proxy for the target with the given ID or which is controlled by the
-   * given key (or which was so controlled prior to authorizing it away). The
-   * target must already be known to this instance for this method to work
-   * (otherwise it is an error).
-   *
-   * @param {string|BaseKey} idOrKey ID or key for the target.
-   * @returns {Proxy} Proxy which locally represents the so-identified
-   *   server-side target.
-   */
-  getTarget(idOrKey) {
-    const id = (idOrKey instanceof BaseKey)
-      ? idOrKey.id
-      : TString.check(idOrKey);
-
-    return this._targets.get(id);
   }
 
   /**

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -9,10 +9,13 @@ import { CommonBase, Errors } from '@bayou/util-common';
 import TargetHandler from './TargetHandler';
 
 /**
- * Map of the various targets being provided by a connection. Items present in
- * this map are assumed to be _uncontrolled_ targets, that is, without an
- * auth requirements (or, to the extent that auth requirements were ever
- * present, that they have already been fulfilled).
+ * Map of the various targets being provided over a connection. Items present in
+ * this map are assumed to be _uncontrolled_ targets, that is, either (a) with
+ * implied auth (e.g. a bearer token), or (b) without any auth requirements
+ * (including, to the extent that auth requirements were ever present, that they
+ * have already been fulfilled). This assumption only comes into play by virtue
+ * of the fact that the _other_ side of the connection will balk if there turn
+ * out to be auth requirements on targets that get referenced.
  */
 export default class TargetMap extends CommonBase {
   /**

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -45,11 +45,6 @@ export default class WsServerConnection extends BaseServerConnection {
     Object.seal(this);
   }
 
-  /** {string} Base URL for the remote endpoint this client gets attached to. */
-  get baseUrl() {
-    return this._baseUrl;
-  }
-
   /**
    * Implementation as required by the superclass.
    *

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -22,13 +22,13 @@ export default class WsServerConnection extends BaseServerConnection {
    * yet ready for traffic, the messages will get enqueued and then later
    * replayed in-order once the socket becomes ready.
    *
-   * @param {string} url The server origin, as an `http` or `https` URL.
+   * @param {string} serverUrl The server origin, as an `http` or `https` URL.
    */
-  constructor(url) {
+  constructor(serverUrl) {
     super();
 
     /** {string} Base URL for the server. */
-    this._baseUrl = WsServerConnection._getBaseUrl(url);
+    this._baseUrl = WsServerConnection._getBaseUrl(serverUrl);
 
     /** {string} URL to use when connecting a websocket. */
     this._wsUrl = WsServerConnection._getWsUrl(this._baseUrl);

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -138,14 +138,6 @@ export default class DocSession extends CommonBase {
     return this._caretTracker;
   }
 
-  /**
-   * {BaseKey|null} The session key, or `null` if {@link #sessionInfo} is being
-   * used.
-   */
-  get key() {
-    return this._key;
-  }
-
   /** {PropertyClient} Property accessor this session. */
   get propertyClient() {
     if (this._propertyClient === null) {
@@ -157,7 +149,7 @@ export default class DocSession extends CommonBase {
 
   /**
    * {SessionInfo|null} Information which identifies and authorizes the session,
-   * or `null` if {@link #key} is being used.
+   * or `null` if this instance was constructed with a `SplitKey`.
    */
   get sessionInfo() {
     return this._sessionInfo;

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -111,18 +111,17 @@ export default class DocSession extends CommonBase {
    * @returns {ApiClient} API client interface.
    */
   get apiClient() {
-    // **TODO:** Allow `sessionInfo`!
-    if (this._sessionInfo !== null) {
-      throw Errors.wtf('Cannot use `sessionInfo`... yet!');
-    }
+    const url = (this._sessionInfo !== null)
+      ? this._sessionInfo.serverUrl
+      : this._key.url;
 
     if (this._apiClient === null) {
-      this._log.detail('Opening API client...');
-      this._apiClient = new ApiClient(this._key.url, appCommon_TheModule.fullCodec);
+      this._log.event.opening(url);
+      this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
 
       (async () => {
         await this._apiClient.open();
-        this._log.detail('API client open.');
+        this._log.event.opened(url);
       })();
     }
 

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -42,7 +42,7 @@ export default class DocSession extends CommonBase {
 
     // **TODO:** Remove this when the extra arguments are removed.
     if (keyOrInfo === null) {
-      keyOrInfo = new SessionInfo('http://localhost:8080', authorToken, documentId, caretId);
+      keyOrInfo = new SessionInfo('http://localhost:8080/api', authorToken, documentId, caretId);
     }
 
     /**

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -14,8 +14,8 @@ export default class SessionInfo extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {string} serverUrl Origin-only URL of the server to connect to in
-   *   order to use the session.
+   * @param {string} serverUrl URL of the server to connect to in order to use
+   *   the session.
    * @param {string} authorToken Token which identifies the author (user) under
    *   whose authority the session is to be run.
    * @param {string} documentId ID of the document to be edited in the session.
@@ -30,11 +30,8 @@ export default class SessionInfo extends CommonBase {
     // they're problematic, we'll _eventually_ get errors back from the server,
     // but arguably it's better to know sooner.
 
-    /**
-     * {string} Origin-only URL of the server to connect to in order to use the
-     * session.
-     */
-    this._serverUrl = TString.urlOrigin(serverUrl);
+    /** {string} URL of the server to connect to in order to use the session. */
+    this._serverUrl = TString.urlAbsolute(serverUrl);
 
     /**
      * {string} Token which identifies the author (user) under whose authority

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -7,25 +7,25 @@ import { describe, it } from 'mocha';
 
 import { SessionInfo } from '@bayou/doc-common';
 
-/** {string} Handy origin-only URL. */
-const ORIGIN_URL = 'https://example.com';
+/** {string} Handy valid server URL. */
+const SERVER_URL = 'https://example.com:1234/the/path';
 
 describe('@bayou/doc-common/SessionInfo', () => {
   describe('constructor()', () => {
     it('should accept four strings', () => {
       // **TODO:** Will have to be updated when validation is improved. Likewise
       // throughout the file.
-      const result = new SessionInfo(ORIGIN_URL, 'one', 'two', 'three');
+      const result = new SessionInfo(SERVER_URL, 'one', 'two', 'three');
       assert.isFrozen(result);
     });
 
     it('should accept three strings', () => {
-      const result = new SessionInfo(ORIGIN_URL, 'one', 'two');
+      const result = new SessionInfo(SERVER_URL, 'one', 'two');
       assert.isFrozen(result);
     });
 
     it('should accept three strings and `null`', () => {
-      const result = new SessionInfo(ORIGIN_URL, 'one', 'two', null);
+      const result = new SessionInfo(SERVER_URL, 'one', 'two', null);
       assert.isFrozen(result);
     });
 
@@ -34,27 +34,30 @@ describe('@bayou/doc-common/SessionInfo', () => {
         assert.throws(() => new SessionInfo(...args));
       }
 
-      test('',                   'x', 'y', 'z');
-      test('not-a-url',          'x', 'y', 'z');
-      test('http://x.com/stuff', 'x', 'y', 'z'); // Not origin-only.
+      test('',                  'x', 'y', 'z');
+      test('not-a-real-url',    'x', 'y', 'z');
+      test('/stuff/etc',        'x', 'y', 'z');
+      test('//milk.com/stuff',  'x', 'y', 'z');
+      test('http//x.com/stuff', 'x', 'y', 'z');
+      test('http://milk.com',   'x', 'y', 'z'); // Needs to have a path, even if just `/`.
 
-      test(ORIGIN_URL, null, 'x', 'y');
-      test(ORIGIN_URL, 123,  'x', 'y');
-      test(ORIGIN_URL, [],   'x', 'y');
+      test(SERVER_URL, null, 'x', 'y');
+      test(SERVER_URL, 123,  'x', 'y');
+      test(SERVER_URL, [],   'x', 'y');
 
-      test(ORIGIN_URL, 'token', null,      'y');
-      test(ORIGIN_URL, 'token', false,     'y');
-      test(ORIGIN_URL, 'token', { x: 10 }, 'y');
+      test(SERVER_URL, 'token', null,      'y');
+      test(SERVER_URL, 'token', false,     'y');
+      test(SERVER_URL, 'token', { x: 10 }, 'y');
 
-      test(ORIGIN_URL, 'token', 'x', true);
-      test(ORIGIN_URL, 'token', 'x', new Set());
+      test(SERVER_URL, 'token', 'x', true);
+      test(SERVER_URL, 'token', 'x', new Set());
     });
   });
 
   describe('.authorToken', () => {
     it('should be the constructed value', () => {
       const token  = 'florp';
-      const result = new SessionInfo(ORIGIN_URL, token, 'x');
+      const result = new SessionInfo(SERVER_URL, token, 'x');
       assert.strictEqual(result.authorToken, token);
     });
   });
@@ -62,14 +65,14 @@ describe('@bayou/doc-common/SessionInfo', () => {
   describe('.documentId', () => {
     it('should be the constructed value', () => {
       const id     = 'blort';
-      const result = new SessionInfo(ORIGIN_URL, 'token', id);
+      const result = new SessionInfo(SERVER_URL, 'token', id);
       assert.strictEqual(result.documentId, id);
     });
   });
 
   describe('.serverUrl', () => {
     it('should be the constructed value', () => {
-      const url    = 'https://milk.com:1231';
+      const url    = 'https://milk.com:1234/florp';
       const result = new SessionInfo(url, 'token', 'x');
       assert.strictEqual(result.serverUrl, url);
     });
@@ -78,12 +81,12 @@ describe('@bayou/doc-common/SessionInfo', () => {
   describe('.caretId', () => {
     it('should be the constructed value', () => {
       const id     = 'zorch';
-      const result = new SessionInfo(ORIGIN_URL, 'token', 'doc', id);
+      const result = new SessionInfo(SERVER_URL, 'token', 'doc', id);
       assert.strictEqual(result.caretId, id);
     });
 
     it('should be `null` if not passed in the constructor', () => {
-      const result = new SessionInfo(ORIGIN_URL, 'token', 'doc');
+      const result = new SessionInfo(SERVER_URL, 'token', 'doc');
       assert.isNull(result.caretId);
     });
   });
@@ -91,30 +94,30 @@ describe('@bayou/doc-common/SessionInfo', () => {
   describe('.logTag', () => {
     it('should be the `caretId` if non-`null`', () => {
       const id = 'caretness';
-      const si = new SessionInfo(ORIGIN_URL, 'token', 'doc', id);
+      const si = new SessionInfo(SERVER_URL, 'token', 'doc', id);
       assert.strictEqual(si.logTag, id);
     });
 
     it('should be the `documentId` if `caretId === null`', () => {
       const id = 'docness';
-      const si = new SessionInfo(ORIGIN_URL, 'token', id);
+      const si = new SessionInfo(SERVER_URL, 'token', id);
       assert.strictEqual(si.logTag, id);
     });
   });
 
   describe('deconstruct()', () => {
     it('should return a three-element array when constructed with three arguments', () => {
-      const si     = new SessionInfo(ORIGIN_URL, 'token', 'id');
+      const si     = new SessionInfo(SERVER_URL, 'token', 'id');
       const result = si.deconstruct();
 
-      assert.deepEqual(result, [ORIGIN_URL, 'token', 'id']);
+      assert.deepEqual(result, [SERVER_URL, 'token', 'id']);
     });
 
     it('should return a four-element array when constructed with four non-`null` arguments', () => {
-      const si     = new SessionInfo(ORIGIN_URL, 'token', 'id', 'c');
+      const si     = new SessionInfo(SERVER_URL, 'token', 'id', 'c');
       const result = si.deconstruct();
 
-      assert.deepEqual(result, [ORIGIN_URL, 'token', 'id', 'c']);
+      assert.deepEqual(result, [SERVER_URL, 'token', 'id', 'c']);
     });
   });
 });

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.6
+version = 1.1.7


### PR DESCRIPTION
This is mostly tweakage mostly in `SessionInfo` and `ApiClient`. Highlights:

* Get everything to expect full URLs and not just origin-only URLs, to keep our assumptions simpler. There's still code that thwacks the path of URLs to just be `/api`, but that will eventually go away.
* Make `DocSession` able to construct an `ApiClient` from a `SessionInfo`.
* Add a handful of logging that will help me understand how things get called, especially in cases where the modules are getting imported into a separate app environment (which is why I bumped the product version).