### PR TITLE
Connection-error tweaks and fixes

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -74,10 +74,12 @@ export default class ApiClient extends CommonBase {
     this._nextId = 0;
 
     /**
-     * {object<Int,{resolve, reject}>} Map from message IDs to response
-     * callbacks. Each callback is an object that maps `resolve` and `reject` to
-     * functions that obey the usual promise contract for functions of those
-     * names. Initialized and reset in `_resetConnection()`.
+     * {object<Int,{message, resolve, reject}>} Map from message IDs to response
+     * callbacks and original message info (the latter for debugging). Each
+     * element is an object that maps `resolve` and `reject` to functions that
+     * obey the usual promise contract for functions of those names, and
+     * `message` to the originally-sent {@link Message}. Initialized and reset
+     * in {@link #_resetConnection()}.
      */
     this._callbacks = null;
 
@@ -406,7 +408,10 @@ export default class ApiClient extends CommonBase {
   _handleTermination(event_unused, error) {
     // Reject the promises of any currently-pending messages.
     for (const id in this._callbacks) {
-      this._callbacks[id].reject(error);
+      const { message, reject } = this._callbacks[id];
+
+      this._log.event.rejectDuringTermination(...message.deconstruct());
+      reject(error);
     }
 
     // Clear the state related to the websocket. It is safe to re-open the
@@ -485,18 +490,18 @@ export default class ApiClient extends CommonBase {
     const id = this._nextId;
     this._nextId++;
 
-    const msg     = new Message(id, target, payload);
-    const msgJson = this._codec.encodeJson(msg);
+    const message = new Message(id, target, payload);
+    const msgJson = this._codec.encodeJson(message);
 
     switch (wsState) {
       case WebSocket.CONNECTING: {
         // Not yet open. Need to queue it up.
-        this._log.detail('Queued:', msg);
+        this._log.detail('Queued:', message);
         this._pendingMessages.push(msgJson);
         break;
       }
       case WebSocket.OPEN: {
-        this._log.detail('Sent:', msg);
+        this._log.detail('Sent:', message);
         this._ws.send(msgJson);
         break;
       }
@@ -508,7 +513,7 @@ export default class ApiClient extends CommonBase {
     }
 
     return new Promise((resolve, reject) => {
-      this._callbacks[id] = { resolve, reject };
+      this._callbacks[id] = { message, resolve, reject };
     });
   }
 

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -257,11 +257,16 @@ export default class ApiClient extends CommonBase {
     this._updateLogger();
     this._log.event.opening();
 
-    const id = await this.meta.connectionId();
+    try {
+      const id = await this.meta.connectionId();
 
-    this._connectionId = id;
-    this._updateLogger();
-    this._log.event.open();
+      this._connectionId = id;
+      this._updateLogger();
+      this._log.event.open();
+    } catch (e) {
+      this._log.event.errorDuringOpen(e);
+      throw e;
+    }
 
     // Test to make sure newly-proxied objects get returned as expected.
     // **TODO:** Remove this once we have unit test coverage for this
@@ -303,7 +308,7 @@ export default class ApiClient extends CommonBase {
    * @param {object} event Event that caused this callback.
    */
   _handleClose(event) {
-    this._log.info('Closed:', event);
+    this._log.event.closed(event);
 
     const code = WebsocketCodes.close(event.code);
     const desc = event.reason ? `${code}: ${event.reason}` : code;
@@ -323,7 +328,7 @@ export default class ApiClient extends CommonBase {
    * @param {object} event Event that caused this callback.
    */
   _handleError(event) {
-    this._log.info('Error:', event);
+    this._log.event.error(event);
 
     // **Note:** The error event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it for the

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -16,10 +16,11 @@
  * this case, we rely on the `/key/*` debugging endpoints to generate a new key.
  * If that's successful, we report it back up through the layers.
  */
-function BAYOU_RECOVER(key) {
-  var docId = DEBUG_DOCUMENT_ID;
+function BAYOU_RECOVER(keyOrInfo) {
+  var docId    = DEBUG_DOCUMENT_ID;
   var authorId = DEBUG_AUTHOR_ID;
-  var url = `${new URL(key.url).origin}/debug/key/${docId}/${authorId}`;
+  var origin   = new URL(keyOrInfo.url || keyOrInfo.serverUrl).origin;
+  var url      = `${origin}/debug/key/${docId}/${authorId}`;
 
   return new Promise((res, rej_unused) => {
     var req = new XMLHttpRequest();

--- a/local-modules/@bayou/assets-client/files/boot-from-key.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-key.js
@@ -10,7 +10,8 @@
 //   used to authenticate access to a particular documemt.
 // * `BAYOU_NODE` -- The DOM node into which the editor should be embedded.
 // * `BAYOU_RECOVER` (optional) -- Function to use when attempting to recover
-//   from connection trouble.
+//   from connection trouble. It gets passed the `SessionInfo` or `SplitKey`
+//   which was initially used to establish the connection.
 //
 // See `TopControl` for more details about these parameters.
 

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -357,7 +357,12 @@ export default class BodyClient extends StateMachine {
     // won't become open synchronously, the API client code allows us to start
     // sending messages over it immediately. (They'll just get queued up as
     // necessary.)
-    await this._docSession.apiClient.open();
+    try {
+      await this._docSession.apiClient.open();
+    } catch (e) {
+      this.q_apiError('open', e);
+      return;
+    }
 
     // Perform a challenge-response to authorize access to the document.
     try {

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -137,6 +137,17 @@ export default class DocSession extends CommonBase {
     return this._caretTracker;
   }
 
+  /**
+   * {BaseKey|SessionInfo} Information which was originally used to construct
+   * this instance. Used for recovery from connection trouble.
+   *
+   * **TODO:** This should be removed and its use sites switched to
+   * `.sessionInfo`, once key-based session setup is retired.
+   */
+  get keyOrInfo() {
+    return this._key || this._sessionInfo;
+  }
+
   /** {PropertyClient} Property accessor this session. */
   get propertyClient() {
     if (this._propertyClient === null) {

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -120,8 +120,14 @@ export default class DocSession extends CommonBase {
       this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
 
       (async () => {
-        await this._apiClient.open();
-        this._log.event.opened(url);
+        try {
+          await this._apiClient.open();
+          this._log.event.opened(url);
+        } catch (e) {
+          // (a) Log the problem, and (b) make sure an error doesn't percolate
+          // back to the top as an uncaught promise rejection.
+          this._log.event.openFailed(url);
+        }
       })();
     }
 

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -125,7 +125,7 @@ export default class TopControl {
   async _recoverIfPossible() {
     log.error('Editor gave up!');
 
-    const newKey = await this._recover(this._editorComplex.docSession.key);
+    const newKey    = await this._recover(this._editorComplex.docSession.keyOrInfo);
 
     if (typeof newKey !== 'string') {
       log.info('Nothing more to do. :\'(');

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.7
+version = 1.1.8


### PR DESCRIPTION
This PR addresses a few connection-error-ish issues on the client side of things:

* Fixed a couple places that were insufficiently prepared to `catch` connection trouble.
* Fixed top-level recovery, which I'd broken in my previous PR.
* Added a bunch of logging around the errors that get thrown during connection trouble, including info about the calls that got promise-rejected.