### PR TITLE
Another chunk of session rework.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -328,7 +328,7 @@ export default class ApiClient extends CommonBase {
    * @param {object} event Event that caused this callback.
    */
   _handleError(event) {
-    this._log.event.error(event);
+    this._log.event.websocketError(event);
 
     // **Note:** The error event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it for the

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -102,13 +102,13 @@ export default class WsServerConnection extends BaseServerConnection {
         this._ws.onopen    = this._handleOpen.bind(this);
 
         this._updateLogger();
-        this.log.event.wsState('opening');
+        this.log.event.websocketState('opening');
       }
 
       switch (this._ws.readyState) {
         case WebSocket.CLOSED: {
           // Clear out `_ws` and iterate to retry.
-          this.log.event.wsState('closed');
+          this.log.event.websocketState('closed');
           this._ws.onclose   = null;
           this._ws.onerror   = null;
           this._ws.onmessage = null;
@@ -119,21 +119,21 @@ export default class WsServerConnection extends BaseServerConnection {
 
         case WebSocket.CLOSING: {
           // Wait for it to be closed.
-          this.log.event.wsState('closing');
+          this.log.event.websocketState('closing');
           await this._wsStateChange.whenTrue();
           break;
         }
 
         case WebSocket.CONNECTING: {
           // Wait for it to be open (or fail to connect).
-          this.log.event.wsState('connecting');
+          this.log.event.websocketState('connecting');
           await this._wsStateChange.whenTrue();
           break;
         }
 
         case WebSocket.OPEN: {
           // What we've wanted all along!
-          this.log.event.wsState('open');
+          this.log.event.websocketState('open');
           break;
         }
       }
@@ -149,7 +149,7 @@ export default class WsServerConnection extends BaseServerConnection {
     const code = WebsocketCodes.close(event.code);
     const desc = event.reason ? `${code}: ${event.reason}` : code;
 
-    this.log.event.wsCloseEvent(event, desc);
+    this.log.event.websocketClose(event, desc);
     this._wsStateChange.onOff(); // Intercom with `_ensureOpen()`.
   }
 
@@ -163,7 +163,7 @@ export default class WsServerConnection extends BaseServerConnection {
     // **Note:** The error event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it as a "description"
     // (or similar).
-    this.log.event.wsErrorEvent(event);
+    this.log.event.websocketError(event);
 
     this._wsStateChange.onOff(); // Intercom with `_ensureOpen()`.
   }
@@ -174,7 +174,7 @@ export default class WsServerConnection extends BaseServerConnection {
    * @param {object} event Event that caused this callback.
    */
   _handleMessage(event) {
-    this.log.event.wsRawMessage(event.data);
+    this.log.event.rawMessage(event.data);
     this.received(event.data);
   }
 
@@ -187,7 +187,7 @@ export default class WsServerConnection extends BaseServerConnection {
     // **Note:** The open event does not have any particularly useful extra
     // info, so -- alas -- there is nothing to get out of it as a "description"
     // (or similar).
-    this.log.event.wsOpenEvent(event);
+    this.log.event.websocketOpen(event);
     this._wsStateChange.onOff(); // Intercom with `_ensureOpen()`.
   }
 

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -237,12 +237,12 @@ export default class DebugTools {
   async _handle_edit(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
-    const key        = await this._makeEncodedKey(documentId, authorId);
+    const info       = await this._makeEncodedInfo(documentId, authorId);
 
-    // These are already strings (JSON-encoded even, in the case of `key`),
+    // These are already strings (JSON-encoded even, in the case of `info`),
     // but we still have to JSON-encode _those_ strings, so as to make them
     // proper JS source within the <script> block below.
-    const quotedKey        = JSON.stringify(key);
+    const quotedInfo       = JSON.stringify(info);
     const quotedDocumentId = JSON.stringify(documentId);
     const quotedAuthorId   = JSON.stringify(authorId);
 
@@ -250,7 +250,7 @@ export default class DebugTools {
     const head =
       '<title>Editor</title>\n' +
       '<script>\n' +
-      `  BAYOU_KEY         = ${quotedKey};\n` +
+      `  BAYOU_KEY         = ${quotedInfo};\n` +
       `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
       `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
       '</script>\n' +
@@ -271,9 +271,9 @@ export default class DebugTools {
   async _handle_key(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
-    const key        = await this._makeEncodedKey(documentId, authorId);
+    const info       = await this._makeEncodedInfo(documentId, authorId);
 
-    this._jsonResponse(res, key);
+    this._jsonResponse(res, info);
   }
 
   /**
@@ -393,14 +393,15 @@ export default class DebugTools {
   }
 
   /**
-   * Makes and returns a new authorization key for the given document / author
+   * Makes and returns new authorization info for the given document / author
    * combo, as a JSON-encoded string.
    *
    * @param {string} documentId The document ID.
    * @param {string} authorId The author ID.
    * @returns {string} A new `SplitKey` encoded as JSON.
    */
-  async _makeEncodedKey(documentId, authorId) {
+  async _makeEncodedInfo(documentId, authorId) {
+    // **TODO:** Replace this with construction of `SessionInfo`.
     const key = await this._rootAccess.makeAccessKey(authorId, documentId);
     return appCommon_TheModule.fullCodec.encodeJson(key);
   }

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -401,7 +401,11 @@ export default class DebugTools {
    * @returns {string} A new `SplitKey` encoded as JSON.
    */
   async _makeEncodedInfo(documentId, authorId) {
-    // **TODO:** Replace this with construction of `SessionInfo`.
+    // **TODO:** This is just a "dry run" for now. Ultimately this should get
+    // returned.
+    await this._rootAccess.makeSessionInfo(authorId, documentId);
+
+    // **TODO:** Replace this with construction of `SessionInfo` (above).
     const key = await this._rootAccess.makeAccessKey(authorId, documentId);
     return appCommon_TheModule.fullCodec.encodeJson(key);
   }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -105,11 +105,10 @@ export default class RootAccess extends CommonBase {
     const url         = `${Network.baseUrl}/api`;
     const authorToken = await Auth.getAuthorToken(authorId);
 
-    // **Note:** `authorToken` is a bearer token, which means it will get safely
-    // redacted in the logs.
-    log.event.gotAuthorToken(authorToken);
+    // Only log the safe (redacted) form of the token.
+    log.event.gotAuthorToken(authorToken.safeString);
 
-    // ...but we just want to return the string form of the token.
+    // ...but we do need to return the full string to the caller.
     return new SessionInfo(url, authorToken.secretToken, docId);
   }
 }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -54,10 +54,10 @@ export default class RootAccess extends CommonBase {
 
     const fileComplex = await DocServer.theOne.getFileComplex(docId);
 
-    const url       = `${Network.baseUrl}/api`;
+    const url      = `${Network.baseUrl}/api`;
     const targetId = this._context.randomSplitKeyId();
-    const session   = await fileComplex.makeNewSession(authorId);
-    const key       = new SplitKey(url, targetId);
+    const session  = await fileComplex.makeNewSession(authorId);
+    const key      = new SplitKey(url, targetId);
     this._context.addTarget(new Target(key, session));
 
     log.info(

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -77,12 +77,10 @@ export default class RootAccess extends CommonBase {
    * author editing a specific document, on the server (or server cluster)
    * running this method.
    *
-   * @param {string} authorId ID which corresponds to the author of changes that
-   *   are made using the resulting authorization.
-   * @param {string} docId ID of the document which the resulting authorization
-   *   allows access to.
-   * @returns {SplitKey} A split token (ID + secret) which provides the
-   *   requested access.
+   * @param {string} authorId ID of the author (user) who will be driving the
+   *   session.
+   * @param {string} docId ID of the document to be accessed.
+   * @returns {SessionInfo} Corresponding info struct.
    */
   async makeSessionInfo(authorId, docId) {
     log.event.sessionRequested(authorId, docId);

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -382,7 +382,7 @@ export default class BodyClient extends StateMachine {
 
     try {
       const info = await infoPromise;
-      this._log.info('Session info:', info);
+      this._log.event.sessionInfo(info);
     } catch (e) {
       this.q_apiError('getLogInfo', e);
       return;

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -31,9 +31,6 @@ export default class CaretTracker extends CommonBase {
     /** {DocSession} Session that this instance is tied to. */
     this._docSession = DocSession.check(docSession);
 
-    /** {Logger} Logger specific to the session. */
-    this._log = docSession.log;
-
     /**
      * {Proxy|null} Proxy for the server-side session object. Becomes non-`null`
      * when the promise for same resolves, as arranged for in this constructor,
@@ -69,7 +66,7 @@ export default class CaretTracker extends CommonBase {
       this._caretId      = await this._sessionProxy.getCaretId();
       this._updating     = false;
 
-      this._log.info(`Caret tracker ready; caret ID \`${this._caretId}\`.`);
+      this._docSession.log.event.nowTrackingCaret(this._caretId);
 
       // Give the update loop a chance to send caret updates that happened
       // during initialization (if any).

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -183,21 +183,25 @@ export default class DocSession extends CommonBase {
    * @returns {Proxy} A proxy for the server-side session.
    */
   async getSessionProxy() {
-    // **TODO:** Allow `sessionInfo`!
+    if (this._sessionProxyPromise !== null) {
+      // **Note:** Because this is an `async` method, it's okay to return a
+      // promise.
+      return this._sessionProxyPromise;
+    }
+
     if (this._sessionInfo !== null) {
+      // **TODO:** Allow `sessionInfo`!
       throw Errors.wtf('Cannot use `sessionInfo`... yet!');
-    }
-
-    if (this._sessionProxyPromise === null) {
+    } else {
+      // **TODO:** Remove the `if` and this clause once {@link #_sessionInfo}
+      // is used ubiquitously.
       this._sessionProxyPromise = this.apiClient.authorizeTarget(this._key);
-
-      // Log a note once the promise resolves.
-      await this._sessionProxyPromise;
-      this._log.info('Received session proxy.');
     }
 
-    // **Note:** Because this is an `async` method, it's okay to return a
-    // promise.
-    return this._sessionProxyPromise;
+    // Log a note once the promise resolves.
+    const proxy = await this._sessionProxyPromise;
+    this._log.event.gotSessionProxy();
+
+    return proxy;
   }
 }

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -201,8 +201,6 @@ export default class DocSession extends CommonBase {
       } else {
         proxyPromise = authorProxy.findExistingSession(info.documentId, info.caretId);
       }
-
-      throw Errors.wtf('Cannot use `sessionInfo`... yet!');
     } else {
       // **TODO:** Remove the `if` and this clause once {@link #_sessionInfo}
       // is used ubiquitously.

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -7,7 +7,7 @@ import { BaseKey } from '@bayou/api-common';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { SessionInfo } from '@bayou/doc-common';
 import { Logger } from '@bayou/see-all';
-import { CommonBase, Errors } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import CaretTracker from './CaretTracker';
 import PropertyClient from './PropertyClient';

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -189,17 +189,30 @@ export default class DocSession extends CommonBase {
       return this._sessionProxyPromise;
     }
 
+    let proxyPromise;
+
     if (this._sessionInfo !== null) {
-      // **TODO:** Allow `sessionInfo`!
+      const info        = this._sessionInfo;
+      const api         = this._apiClient;
+      const authorProxy = api.getProxy(info.authorToken);
+
+      if (info.caretId === null) {
+        proxyPromise = authorProxy.makeNewSession(info.documentId);
+      } else {
+        proxyPromise = authorProxy.findExistingSession(info.documentId, info.caretId);
+      }
+
       throw Errors.wtf('Cannot use `sessionInfo`... yet!');
     } else {
       // **TODO:** Remove the `if` and this clause once {@link #_sessionInfo}
       // is used ubiquitously.
-      this._sessionProxyPromise = this.apiClient.authorizeTarget(this._key);
+      proxyPromise = this.apiClient.authorizeTarget(this._key);
     }
 
+    this._sessionProxyPromise = proxyPromise;
+
     // Log a note once the promise resolves.
-    const proxy = await this._sessionProxyPromise;
+    const proxy = await proxyPromise;
     this._log.event.gotSessionProxy();
 
     return proxy;

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -91,6 +91,8 @@ export default class DocSession extends CommonBase {
      * non-`null` in `getSessionProxy()`.
      */
     this._sessionProxyPromise = null;
+
+    Object.seal(this);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -281,14 +281,14 @@ export default class DocSession extends CommonBase {
    * logging. Specifically, the client side will call this method and log the
    * results during session initiation.
    *
-   * @returns {string} A succinct identification string.
+   * @returns {object} Succinct identification.
    */
   getLogInfo() {
-    const fileId   = this._fileComplex.file.id;
-    const caretId  = this._caretId;
-    const authorId = this._authorId;
+    const file   = this._fileComplex.file.id;
+    const caret  = this._caretId;
+    const author = this._authorId;
 
-    return `file ${fileId}; caret ${caretId}; author ${authorId}`;
+    return { file, caret, author };
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -14,9 +14,9 @@ import FileComplex from './FileComplex';
  * author, and caret. Instances of this class are exposed across the API
  * boundary, and as such all public methods are available for client use.
  *
- * For document access methods, this passes non-mutating methods through to the
- * underlying {@link BodyControl} while implicitly adding an author argument to
- * methods that modify the document.
+ * For access methods, this passes non-mutating methods through to the
+ * underlying `*Control` instances, while implicitly adding author ID and/or
+ * caret ID as appropriate to methods that perform modifications.
  */
 export default class DocSession extends CommonBase {
   /**

--- a/local-modules/@bayou/top-client/Client.js
+++ b/local-modules/@bayou/top-client/Client.js
@@ -32,13 +32,12 @@ export default class Client extends UtilityClass {
    *   fundamental system setup is performed.
    */
   static async run(configFunction) {
-    Client._init(configFunction, 'Starting...');
+    Client._init(configFunction);
 
     const control = new TopControl(window);
-    log.detail('Made `control`.');
 
     await control.start();
-    log.info('Now running!');
+    log.event.started();
   }
 
   /**
@@ -53,7 +52,7 @@ export default class Client extends UtilityClass {
    *   non-test client bundle).
    */
   static async runUnitTests(configFunction, testsClass) {
-    Client._init(configFunction, 'Starting up testing environment...');
+    Client._init(configFunction);
 
     const testFilter = window.BAYOU_TEST_FILTER || null;
 
@@ -62,6 +61,8 @@ export default class Client extends UtilityClass {
     document.body.appendChild(elem);
 
     (async () => {
+      log.event.testsRunning();
+
       const failures = await testsClass.runAll(testFilter);
 
       let msg;
@@ -72,6 +73,8 @@ export default class Client extends UtilityClass {
       }
 
       elem.innerHTML = msg;
+
+      log.event.testsDone();
     })();
   }
 
@@ -80,16 +83,15 @@ export default class Client extends UtilityClass {
    *
    * @param {function} configFunction Function to call in order to perform
    *   system configuration.
-   * @param {string} msg Message to log to indicate startup is in progress.
    */
-  static _init(configFunction, msg) {
+  static _init(configFunction) {
     // Init logging.
     ClientSink.init();
-    log.info(msg);
+    log.event.starting();
 
     // Inject all the system configs.
     configFunction();
-    log.detail('System configured.');
+    log.event.configured();
 
     // Init the environment utilities.
     ClientEnv.init(window);


### PR DESCRIPTION
This PR makes it so that `SessionInfo` is _nearly_ usable to authorize editing sessions, but it's still not fully hooked up. In particular, this _might_ work in a local-dev environment now, but it definitely won't work if you try to use it with a real token that would require back-end intercommunication to validate. 

**Bonus:** Cleaned up a bunch of logging, specifically getting more stuff to be logged as events instead of ad-hoc strings.