### PR TITLE
More hookup of new sessions.

### DIFF
--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -250,7 +250,7 @@ export default class DebugTools {
     const head =
       '<title>Editor</title>\n' +
       '<script>\n' +
-      `  BAYOU_KEY         = ${quotedInfo};\n` +
+      `  BAYOU_INFO        = ${quotedInfo};\n` +
       `  DEBUG_AUTHOR_ID   = ${quotedAuthorId};\n` +
       `  DEBUG_DOCUMENT_ID = ${quotedDocumentId};\n` +
       '</script>\n' +

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -60,11 +60,11 @@ window.addEventListener('load', () => {
     throw new Error('Could not find editor node!');
   }
 
-  // This gets used by `boot-from-key`.
+  // This gets used by `boot-from-info`.
   window.BAYOU_NODE = editorNode;
 
   // Add the standard bootstrap code to the page.
   var elem = document.createElement('script');
-  elem.src = '/boot-from-key.js';
+  elem.src = '/boot-from-info.js';
   document.head.appendChild(elem);
 })

--- a/local-modules/@bayou/assets-client/files/boot-from-info.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-info.js
@@ -14,7 +14,8 @@
 //   from connection trouble. It gets passed the `SessionInfo` or `SplitKey`
 //   which was initially used to establish the connection.
 //
-// See `TopControl` for more details about these parameters.
+// See {@link @bayou/top-client/TopControl} for more details about these
+// parameters.
 
 // Disable Eslint, because this file is delivered as-is and has to be fairly
 // conservative.

--- a/local-modules/@bayou/assets-client/files/boot-from-key.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-key.js
@@ -6,8 +6,9 @@
 // become/embed a Bayou editor. It assumes that the `window` object (that is,
 // the global context) contains the following bindings:
 //
-// * `BAYOU_KEY` -- The JSON-encoded form of an instance of `SplitKey`, to be
-//   used to authenticate access to a particular documemt.
+// * `BAYOU_INFO` -- The JSON-encoded form of an instance of `SessionInfo` or
+//   `SplitKey`, to be used to identify and authenticate access to a particular
+//   document.
 // * `BAYOU_NODE` -- The DOM node into which the editor should be embedded.
 // * `BAYOU_RECOVER` (optional) -- Function to use when attempting to recover
 //   from connection trouble. It gets passed the `SessionInfo` or `SplitKey`
@@ -22,20 +23,31 @@
 // We wrap everything in an immediately-executed function so as to avoid
 // polluting the global namespace.
 (function () {
-  if (!(window.BAYOU_KEY && window.BAYOU_NODE)) {
+  if (!(window.BAYOU_INFO && window.BAYOU_NODE)) {
     // **Note:** This code is run too early to be able to use
     // `@bayou/util-common`'s error facilities.
     throw new Error('Missing configuration.');
   }
 
-  // Grab the base URL out of the encoded key. This is kinda gross, but when
+  // Grab the base URL out of the encoded info. This is kinda gross, but when
   // we're here we haven't yet loaded the API code, and in order to load that
   // code we need to know the base URL, whee! So we just do the minimal bit of
   // parsing needed to get the URL and then head on our merry way. See
-  // {@link @bayou/api-common/SplitKey}, the encoded form in particular, if you
+  // {@link @bayou/api-common/SessionInfo} and
+  // {@link @bayou/api-common/SplitKey}, the encoded forms in particular, if you
   // want to understand what's going on.
-  var key = JSON.parse(window.BAYOU_KEY);
-  var url = key.SplitKey[0];
+  var info = JSON.parse(window.BAYOU_INFO);
+  var url;
+
+  if (info.SessionInfo) {
+    url = info.SessionInfo[0];
+  } else if (info.SplitKey) {
+    // **TODO:** Remove this once `SessionInfo` is used ubiquitously.
+    url = info.SplitKey[0];
+  } else {
+    throw new Error('Unrecognized format for `BAYOU_INFO`.');
+  }
+
   var baseUrl = ((url === '*') ? window.location : new URL(url)).origin;
 
   // Add the main JavaScript bundle to the page. Once loaded, this continues

--- a/local-modules/@bayou/assets-client/files/boot-from-key.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-key.js
@@ -31,7 +31,7 @@
 
   // Grab the base URL out of the encoded info. This is kinda gross, but when
   // we're here we haven't yet loaded the API code, and in order to load that
-  // code we need to know the base URL, whee! So we just do the minimal bit of
+  // code we need to know the server URL, whee! So we just do the minimal bit of
   // parsing needed to get the URL and then head on our merry way. See
   // {@link @bayou/api-common/SessionInfo} and
   // {@link @bayou/api-common/SplitKey}, the encoded forms in particular, if you

--- a/local-modules/@bayou/config-client-default/Editor.js
+++ b/local-modules/@bayou/config-client-default/Editor.js
@@ -35,9 +35,9 @@ export default class Editor extends UtilityClass {
    *
    * @param {object} window_unused Window which will ultimately contain one or
    *   more editors.
-   * @param {string} baseUrl_unused Base URL that points to the server to use.
+   * @param {string} serverUrl_unused URL at which to contact the server.
    */
-  static aboutToRun(window_unused, baseUrl_unused) {
+  static aboutToRun(window_unused, serverUrl_unused) {
     // This space intentionally left blank.
   }
 

--- a/local-modules/@bayou/config-client/Editor.js
+++ b/local-modules/@bayou/config-client/Editor.js
@@ -35,12 +35,12 @@ export default class Editor extends UtilityClass {
    *
    * @param {object} window Window which will ultimately contain one or more
    *   editors.
-   * @param {string} baseUrl Base URL that points to the server to use.
+   * @param {string} serverUrl URL at which to contact the server.
    * @returns {Promise|undefined} A promise whose resolution indicates the end
    *   of hook activity, or `undefined` if there is nothing to wait for.
    */
-  static aboutToRun(window, baseUrl) {
-    return use.Editor.aboutToRun(window, baseUrl);
+  static aboutToRun(window, serverUrl) {
+    return use.Editor.aboutToRun(window, serverUrl);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -364,7 +364,7 @@ export default class BodyClient extends StateMachine {
       return;
     }
 
-    // Perform a challenge-response to authorize access to the document.
+    // Perform necessary handshaking to gain access to the document.
     try {
       this._sessionProxy = await this._docSession.getSessionProxy();
     } catch (e) {

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -280,7 +280,7 @@ export default class BodyClient extends StateMachine {
     // When this happens, higher-level logic can notice and take further action.
     this._addErrorStamp();
     if (this._isUnrecoverablyErrored()) {
-      this._log.info('Too many errors!');
+      this._log.event.cannotRecover();
       this.s_unrecoverableError();
       return;
     }
@@ -892,9 +892,10 @@ export default class BodyClient extends StateMachine {
     const errorCount      = this._errorStamps.length;
     const errorsPerMinute = (errorCount / ERROR_WINDOW_MSEC) * 60 * 1000;
 
-    this._log.info(
-      `Error window: ${errorCount} total; ` +
-      `${Math.round(errorsPerMinute * 100) / 100} per minute`);
+    this._log.event.errorWindow({
+      total:     errorCount,
+      perMinute: Math.round(errorsPerMinute * 100) / 100
+    });
 
     return errorsPerMinute >= ERROR_MAX_PER_MINUTE;
   }

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -63,10 +63,14 @@ export default class CaretTracker extends CommonBase {
     // Arrange for `_sessionProxy` to get set.
     (async () => {
       this._sessionProxy = await docSession.getSessionProxy();
-      this._caretId      = await this._sessionProxy.getCaretId();
-      this._updating     = false;
 
-      this._docSession.log.event.nowTrackingCaret(this._caretId);
+      // **TODO:** Once `SessionInfo` is always used, the `caretId` can be found
+      // from it.
+      this._caretId = await this._sessionProxy.getCaretId();
+
+      this._updating = false;
+
+      this._docSession.log.event.nowManagingCaret(this._caretId);
 
       // Give the update loop a chance to send caret updates that happened
       // during initialization (if any).

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -213,6 +213,19 @@ export default class DocSession extends CommonBase {
     const proxy = await proxyPromise;
     this._log.event.gotSessionProxy();
 
+    if (this._sessionInfo !== null) {
+      const info = this._sessionInfo;
+
+      if (info.caretId === null) {
+        // The session got started without a caret ID, which means a new caret
+        // will have been created. Update `_sessionInfo` accordingly.
+        const caretId = await proxy.getCaretId();
+
+        this._sessionInfo = info.withCaretId(caretId);
+        this._log.event.gotCaret(caretId);
+      }
+    }
+
     return proxy;
   }
 }

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -105,7 +105,7 @@ export default class SessionInfo extends CommonBase {
    * Makes an instance just like this one, except with a new value for
    * `caretId`.
    *
-   * @param {string|null} caretId ID of a pre-existing caret to control with the
+   * @param {string} caretId ID of a pre-existing caret to control with the
    *   session.
    * @returns {SessionInfo} An appropriately-constructed instance.
    */

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -100,4 +100,26 @@ export default class SessionInfo extends CommonBase {
 
     return (this._caretId === null) ? most : [...most, this._caretId];
   }
+
+  /**
+   * Makes an instance just like this one, except with a new value for
+   * `caretId`.
+   *
+   * @param {string|null} caretId ID of a pre-existing caret to control with the
+   *   session.
+   * @returns {SessionInfo} An appropriately-constructed instance.
+   */
+  withCaretId(caretId) {
+    TString.check(caretId);
+    return new SessionInfo(this._serverUrl, this._authorToken, this._documentId, caretId);
+  }
+
+  /**
+   * Makes an instance just like this one, except with `null` for `caretId`.
+   *
+   * @returns {SessionInfo} An appropriately-constructed instance.
+   */
+  withoutCaretId() {
+    return new SessionInfo(this._serverUrl, this._authorToken, this._documentId);
+  }
 }

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -120,4 +120,52 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.deepEqual(result, [SERVER_URL, 'token', 'id', 'c']);
     });
   });
+
+  describe('withCaretId', () => {
+    it('should return a new instance given a valid `caretId`', () => {
+      const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
+      const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
+
+      function test(c) {
+        const result1 = orig1.withCaretId(c);
+        const expect1 = new SessionInfo(orig1.serverUrl, orig1.authorToken, orig1.documentId, c);
+        assert.deepEqual(result1, expect1);
+
+        const result2 = orig2.withCaretId(c);
+        const expect2 = new SessionInfo(orig2.serverUrl, orig2.authorToken, orig2.documentId, c);
+        assert.deepEqual(result2, expect2);
+      }
+
+      test('beep');
+      test('boop');
+    });
+
+    it('should reject invalid IDs', () => {
+      const si = new SessionInfo(SERVER_URL, 'token', 'doc');
+
+      function test(value) {
+        assert.throws(() => si.withCaretId(value), /badValue/);
+      }
+
+      test(undefined);
+      test(null);
+      test(914);
+      test(['x']);
+    });
+  });
+
+  describe('withoutCaretId', () => {
+    it('should return a new instance with `caretId === null`', () => {
+      function test(orig) {
+        const result = orig.withoutCaretId();
+        const expect = new SessionInfo(orig.serverUrl, orig.authorToken, orig.documentId);
+
+        assert.isNull(result.caretId);
+        assert.deepEqual(result, expect);
+      }
+
+      test(new SessionInfo(SERVER_URL, 'a', 'b', 'c'));
+      test(new SessionInfo(`${SERVER_URL}/123`, 'd', 'e'));
+    });
+  });
 });

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -306,6 +306,8 @@ export default class DocSession extends CommonBase {
    * @returns {string} The document ID.
    */
   getDocumentId() {
+    // **TODO:** This is incorrect, because the file ID isn't necessarily the
+    // same thing as its document ID!
     return this._fileComplex.fileAccess.file.id;
   }
 

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -34,7 +34,7 @@ export default class EditorComplex extends CommonBase {
    * Constructs an instance.
    *
    * @param {SplitKey} sessionKey Access credentials to the session to use for
-   *   server communication.
+   *   server communication. **TODO:** Should also accept `SessionInfo`.
    * @param {Window} window The browser window in which we are operating.
    * @param {Element} topNode DOM element to attach the complex to.
    */
@@ -97,6 +97,8 @@ export default class EditorComplex extends CommonBase {
     // author overlay instances. And _all_ of this needs to be done before we
     // make a `BodyClient` (which gets done by `_initSession()`).
     (async () => {
+      log.event.starting();
+
       // Do all of the DOM setup for the instance.
       const [headerNode, titleNode, bodyNode, authorOverlayNode] =
         await this._domSetup(topNode, sessionKey.baseUrl);
@@ -177,10 +179,11 @@ export default class EditorComplex extends CommonBase {
   /**
    * Hook this instance up to a new session.
    *
-   * @param {SplitKey} sessionKey New session key to use.
+   * @param {SplitKey} sessionKey New session key to use. **TODO:** Should also
+   *   accept `SessionInfo`.
    */
   connectNewSession(sessionKey) {
-    log.info('Hooking up new session:', sessionKey.toString());
+    log.event.restarting();
     this._initSession(sessionKey, false);
   }
 
@@ -209,11 +212,14 @@ export default class EditorComplex extends CommonBase {
   /**
    * Initialize the session, based on the given key.
    *
-   * @param {SplitKey} sessionKey The session key.
+   * @param {SplitKey} sessionKey The session key. **TODO:** Should also accept
+   *   `SessionInfo`.
    * @param {boolean} fromConstructor `true` iff this call is from the
    *   constructor.
    */
   _initSession(sessionKey, fromConstructor) {
+    log.event.usingKey(sessionKey.toString());
+
     this._sessionKey  = SplitKey.check(sessionKey);
     this._docSession  = new DocSession(this._sessionKey);
     this._bodyClient  = new BodyClient(this._bodyQuill, this._docSession);
@@ -226,9 +232,9 @@ export default class EditorComplex extends CommonBase {
     (async () => {
       await this._bodyClient.when_idle();
       if (fromConstructor) {
-        log.info('Initialization complete!');
+        log.event.started();
       } else {
-        log.info('Done with reinitialization.');
+        log.event.restarted();
       }
     })();
   }

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -73,7 +73,12 @@ export default class TopControl {
    */
   async start() {
     // Let the outer app do its setup.
-    await Editor.aboutToRun(this._window, this._sessionInfo.baseUrl);
+
+    // **TODO:** Simplify this once `SessionInfo` is used ubiquitously.
+    const serverUrl = (this._sessionInfo instanceof SessionInfo)
+      ? this._sessionInfo.serverUrl
+      : this._sessionInfo.baseUrl;
+    await Editor.aboutToRun(this._window, serverUrl);
 
     // Arrange for the rest of initialization to happen once the initial page
     // contents are ready (from the browser's perspective).

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -128,7 +128,7 @@ export default class TopControl {
 
     const newInfo = await this._recover(this._editorComplex.docSession.keyOrInfo);
 
-    if (typeof newKey !== 'string') {
+    if (typeof newInfo !== 'string') {
       log.info('Nothing more to do. :\'(');
       return;
     }

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -5,6 +5,7 @@
 import { SplitKey } from '@bayou/api-common';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { Editor } from '@bayou/config-client';
+import { SessionInfo } from '@bayou/doc-common';
 import { EditorComplex } from '@bayou/doc-ui';
 import { Logger } from '@bayou/see-all';
 import { TFunction, TObject } from '@bayou/typecheck';
@@ -30,15 +31,15 @@ export default class TopControl {
     // variables. Validate that they're present before doing anything further.
 
     /**
-     * {SplitKey} The key that authorizes access to a session. Set initially
-     * based on the incoming parameter `BAYOU_KEY` (transmitted
-     * via a `window` global), which is expected to be a `SplitKey` in
-     * JSON-encoded form. The so-referenced session is tied to a specific
-     * document and a specific author, allowing general read access to the
-     * document and allowing modification to the document as the one specific
-     * author.
+     * {SplitKey|SessionInfo} The info that identifies and authorizes access to
+     * a session. Set initially based on the incoming parameter `BAYOU_INFO`
+     * (transmitted via a `window` global), which is expected to be the
+     * JSON-encoded form of `SplitKey` or `SessionInfo`. The so-referenced
+     * session is tied to a specific document and a specific author, allowing
+     * general read access to the document and allowing modification to the
+     * document as the one specific author.
      */
-    this._sessionKey = this._parseAndFixKey(window.BAYOU_KEY);
+    this._sessionInfo = this._parseAndFixInfo(window.BAYOU_INFO);
 
     /** {Element} DOM node to use for the editor. */
     this._editorNode = TObject.check(window.BAYOU_NODE, Element);
@@ -47,7 +48,7 @@ export default class TopControl {
      * {function} Function to call when the editor finds itself in an
      * unrecoverable (to it) situation. It gets called with the current key as
      * its sole argument. If it returns at all, it is expected to return a new
-     * key to use (instead of `BAYOU_KEY`), or a promise for same; if it does
+     * key to use (instead of `BAYOU_INFO`), or a promise for same; if it does
      * not return a string (or promise which resolves to a string) that can be
      * decoded into a `SplitKey`, the system will simply halt.
      *
@@ -72,7 +73,7 @@ export default class TopControl {
    */
   async start() {
     // Let the outer app do its setup.
-    await Editor.aboutToRun(this._window, this._sessionKey.baseUrl);
+    await Editor.aboutToRun(this._window, this._sessionInfo.baseUrl);
 
     // Arrange for the rest of initialization to happen once the initial page
     // contents are ready (from the browser's perspective).
@@ -100,7 +101,7 @@ export default class TopControl {
     // Make the editor "complex." This "fluffs" out the DOM and makes the
     // salient controller objects.
     this._editorComplex =
-      new EditorComplex(this._sessionKey, this._window, this._editorNode);
+      new EditorComplex(this._sessionInfo, this._window, this._editorNode);
 
     await this._editorComplex.whenReady();
     this._recoverySetup();
@@ -125,34 +126,41 @@ export default class TopControl {
   async _recoverIfPossible() {
     log.error('Editor gave up!');
 
-    const newKey    = await this._recover(this._editorComplex.docSession.keyOrInfo);
+    const newInfo = await this._recover(this._editorComplex.docSession.keyOrInfo);
 
     if (typeof newKey !== 'string') {
       log.info('Nothing more to do. :\'(');
       return;
     }
 
-    log.info('Attempting recovery with new key...');
-    const sessionKey = this._parseAndFixKey(newKey);
-    this._editorComplex.connectNewSession(sessionKey);
+    log.info('Attempting recovery with new session info...');
+    const sessionInfo = this._parseAndFixInfo(newInfo);
+    this._editorComplex.connectNewSession(sessionInfo);
     this._recoverySetup();
   }
 
   /**
-   * Parses a session key, and fixes it if necessary to have a real (not
-   * wildcard) URL.
+   * Parses session identification / authorization info, and fixes it if
+   * necessary to have a real (not wildcard) URL.
    *
-   * @param {string} keyJson The key, in JSON-encoded form.
-   * @returns {SplitKey} The parsed and fixed key.
+   * @param {string} infoJson The info, in JSON-encoded form.
+   * @returns {SplitKey|SessionInfo} The parsed and fixed info.
    */
-  _parseAndFixKey(keyJson) {
-    const key = SplitKey.check(appCommon_TheModule.fullCodec.decodeJson(keyJson));
+  _parseAndFixInfo(infoJson) {
+    const info = appCommon_TheModule.fullCodec.decodeJson(infoJson);
 
-    if (key.url === '*') {
-      const url = new URL(this._window.document.URL);
-      return key.withUrl(`${url.origin}/api`);
+    if (info instanceof SessionInfo) {
+      // No fixing needed, because the URL is guaranteed to be valid.
+      return info;
     }
 
-    return key;
+    SplitKey.check(info);
+
+    if (info.url === '*') {
+      const url = new URL(this._window.document.URL);
+      return info.withUrl(`${url.origin}/api`);
+    }
+
+    return info;
   }
 }


### PR DESCRIPTION
This PR is another chunk of work in the hookup of new-style sessions. Highlights:

* Started handling `SessionInfo` getting passed in on the salient `BAYOU_*` client global, which is now called `BAYOU_INFO` (was `BAYOU_KEY`).
* Added `with{,out}CaretId()` to `SessionInfo`, because the ID can and will change over time due to session reconnects and because initial bootstrap of a session will be without a caret ID.
* Note in the code (with `TODO`s) where I left off fixing the handling of `SessionInfo` coming in from the top.