### PR TITLE
Document ID plumbing

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -58,20 +58,20 @@ export default class AuthorAccess extends CommonBase {
    * **TODO:** Context binding ought to happen at a different layer of the
    * system. See comment about this in {@link #makeNewSession} for more details.
    *
-   * @param {string} docId ID of the document which the session is for.
+   * @param {string} documentId ID of the document which the session is for.
    * @param {string} caretId ID of the caret.
    * @returns {string} Target ID within the API context which refers to the
    *   session. This is _not_ the same as the `caretId`.
    */
-  async findExistingSession(docId, caretId) {
+  async findExistingSession(documentId, caretId) {
     // We only check the document ID syntax here, because we can count on the
     // call to `getFileComplex()` to do a full validity check as part of its
     // work.
-    Storage.dataStore.checkDocumentIdSyntax(docId);
+    Storage.dataStore.checkDocumentIdSyntax(documentId);
 
     CaretId.check(caretId);
 
-    const fileComplex = await DocServer.theOne.getFileComplex(docId);
+    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
     const session     = await fileComplex.findExistingSession(this._authorId, caretId);
     const targetId    = this._context.randomId();
 
@@ -79,10 +79,10 @@ export default class AuthorAccess extends CommonBase {
 
     log.info(
       'Bound session for pre-existing caret.\n',
-      `  target: ${targetId}\n`,
-      `  doc:    ${docId}\n`,
-      `  author: ${this._authorId}\n`,
-      `  caret:  ${caretId}`);
+      `  target:   ${targetId}\n`,
+      `  document: ${documentId}\n`,
+      `  author:   ${this._authorId}\n`,
+      `  caret:    ${caretId}`);
 
     return targetId;
   }
@@ -103,18 +103,18 @@ export default class AuthorAccess extends CommonBase {
    * possible, such as (a) a similar change to `RootAccess`, and (b) the
    * possibility of un-exposing `_context` from `Application`.
    *
-   * @param {string} docId ID of the document which the resulting bound object
-   *   allows access to.
+   * @param {string} documentId ID of the document which the resulting bound
+   *   object allows access to.
    * @returns {string} Target ID within the API context which refers to the
    *   session. This is _not_ the same as the `caretId`.
    */
-  async makeNewSession(docId) {
+  async makeNewSession(documentId) {
     // We only check the document ID syntax here, because we can count on the
     // call to `getFileComplex()` to do a full validity check as part of its
     // work.
-    Storage.dataStore.checkDocumentIdSyntax(docId);
+    Storage.dataStore.checkDocumentIdSyntax(documentId);
 
-    const fileComplex = await DocServer.theOne.getFileComplex(docId);
+    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
     const targetId    = this._context.randomId();
 
     // **Note:** This call includes data store back-end validation of the author
@@ -125,10 +125,10 @@ export default class AuthorAccess extends CommonBase {
 
     log.info(
       'Created session for new caret.\n',
-      `  target: ${targetId}\n`,
-      `  doc:    ${docId}\n`,
-      `  author: ${this._authorId}\n`,
-      `  caret:  ${session.getCaretId()}`);
+      `  target:   ${targetId}\n`,
+      `  document: ${documentId}\n`,
+      `  author:   ${this._authorId}\n`,
+      `  caret:    ${session.getCaretId()}`);
 
     return targetId;
   }

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -17,10 +17,10 @@
  * If that's successful, we report it back up through the layers.
  */
 function BAYOU_RECOVER(keyOrInfo) {
-  var docId    = DEBUG_DOCUMENT_ID;
-  var authorId = DEBUG_AUTHOR_ID;
-  var origin   = new URL(keyOrInfo.url || keyOrInfo.serverUrl).origin;
-  var url      = `${origin}/debug/key/${docId}/${authorId}`;
+  var documentId = DEBUG_DOCUMENT_ID;
+  var authorId   = DEBUG_AUTHOR_ID;
+  var origin     = new URL(keyOrInfo.url || keyOrInfo.serverUrl).origin;
+  var url        = `${origin}/debug/key/${documentId}/${authorId}`;
 
   return new Promise((res, rej_unused) => {
     var req = new XMLHttpRequest();

--- a/local-modules/@bayou/config-server/HtmlExport.js
+++ b/local-modules/@bayou/config-server/HtmlExport.js
@@ -13,11 +13,11 @@ export default class HtmlExport extends UtilityClass {
   /**
    * Converts the snapshot of given revision number to html.
    *
-   * @param {string} docId The id for the document in question.
+   * @param {string} documentId The id for the document in question.
    * @param {BodySnapshot} bodySnapshot The snapshot to convert
    *   to html.
    */
-  static async exportHtml(docId, bodySnapshot) {
-    use.HtmlExport.exportHtml(bodySnapshot, docId);
+  static async exportHtml(documentId, bodySnapshot) {
+    use.HtmlExport.exportHtml(bodySnapshot, documentId);
   }
 }

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -416,7 +416,7 @@ export default class BodyClient extends StateMachine {
     } else {
       const source = QuillEvents.propsOf(firstChange).source;
       if (source !== CLIENT_SOURCE) {
-        // We expected the change to be the one we generated from the doc
+        // We expected the change to be the one we generated from the document
         // update (above), but the `source` we got speaks otherwise.
         throw Errors.wtf('Bad `source` for initial change.');
       }
@@ -479,7 +479,7 @@ export default class BodyClient extends StateMachine {
 
     // Ask the server for any changes, but only if there isn't already a pending
     // request for same. (Otherwise, we would flood the server for new change
-    // requests while the local user is updating the doc.)
+    // requests while the local user is updating the document.)
     if (!this._pendingChangeAfter) {
       this._pendingChangeAfter = true;
 
@@ -652,8 +652,8 @@ export default class BodyClient extends StateMachine {
    */
   _handle_collecting_wantToUpdate(baseSnapshot) {
     if (this._snapshot.revNum !== baseSnapshot.revNum) {
-      // As with the `gotQuillEvent` event, we ignore this event if the doc has
-      // changed out from under us.
+      // As with the `gotQuillEvent` event, we ignore this event if the document
+      // has changed out from under us.
       this._becomeIdle();
       return;
     }
@@ -777,7 +777,7 @@ export default class BodyClient extends StateMachine {
     //    Quill's current document state, yielding a document that includes
     //    the server's current state along with `dMore`. Update both the
     //    local document model and Quill to include the changes from the
-    //    server. At this point, the local doc still doesn't know about
+    //    server. At this point, the local document still doesn't know about
     //    `dMore`.
     // 3. Transform (rebase) `dMore` with regard to (on top of)
     //    `dCorrection`, yielding `dNewMore` This is the delta which can be

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -198,7 +198,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
           assert.deepEqual(result.ops, change.ops);
         });
 
-        it('should produce the new doc when composing the orig doc with the diff', () => {
+        it('should produce the new document when composing the orig document with the diff', () => {
           const diff   = origDoc.diff(newDoc);
           const result = origDoc.compose(diff, true);
           assert.instanceOf(result, BodyDelta);

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -109,16 +109,16 @@ export default class BodyControl extends DurableControl {
   /**
    * Queues up an HTML export of the current body snapshot.
    *
-   * @param {RevisionNumber} revNum The revision number of the
-   *   body snapshot to conver to HTML.
-   * @param {string} docId The document Id.
+   * @param {RevisionNumber} revNum The revision number of the body snapshot to
+   *   convert to HTML.
+   * @param {string} documentId The document ID.
    */
-  async queueHtmlExport(revNum, docId) {
+  async queueHtmlExport(revNum, documentId) {
     RevisionNumber.check(revNum);
-    Storage.dataStore.checkDocumentIdSyntax(docId);
+    Storage.dataStore.checkDocumentIdSyntax(documentId);
 
     const snapshot = await this._impl_getSnapshot(revNum);
-    await HtmlExport.exportHtml(snapshot, docId);
+    await HtmlExport.exportHtml(snapshot, documentId);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -56,7 +56,7 @@ export default class DocServer extends Singleton {
     // here, because that would be a waste if it turns out we've already cached
     // a valid result. Once we determine that we need to construct a new
     // complex (below), we'll call through to the back-end to get a file ID, and
-    // that call implicitly validates the doc ID.
+    // that call implicitly validates the document ID.
     Storage.dataStore.checkDocumentIdSyntax(docId);
 
     // Look for a cached or in-progress result.
@@ -109,7 +109,8 @@ export default class DocServer extends Singleton {
         if (docId === fileId) {
           result.log.info('Constructed new complex.');
         } else {
-          // Only explicitly note the file ID when it differs from the doc ID.
+          // Only explicitly note the file ID when it differs from the document
+          // ID.
           result.log.info(`Constructed new complex, with file ID \`${fileId}\`.`);
         }
 
@@ -139,15 +140,15 @@ export default class DocServer extends Singleton {
    * @returns {function} An appropriately-constructed function.
    */
   _complexReaper(docId) {
-    // **Note:** This function _used to_ remove the doc binding from the
+    // **Note:** This function _used to_ remove the document binding from the
     // `_complexes` map on the presumption that it was a known-dead weak
     // reference. That code has been deleted. First of all, the only benefit
     // would have been that it meant that the weak reference itself could get
     // GC'ed (and a dead weakref doesn't actually take up significant storage).
     // Second, and more importantly, this could fail due to a race condition: If
-    // the same doc was requested _after_ the old one was GC'ed and _before_
-    // this reaper was called, the cleanup code here would have incorrectly
-    // removed a perfectly valid binding.
+    // the same document was requested _after_ the old one was GC'ed and
+    // _before_ this reaper was called, the cleanup code here would have
+    // incorrectly removed a perfectly valid binding.
     return () => {
       log.info('Reaped idle file complex:', docId);
     };

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -94,7 +94,7 @@ export default class DocServer extends Singleton {
         const fileId  = docInfo.fileId;
 
         const file   = await Storage.fileStore.getFile(fileId);
-        const result = new FileComplex(this._codec, file);
+        const result = new FileComplex(this._codec, docId, file);
 
         result.log.info('Initializing...');
         await result.init();

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -48,20 +48,20 @@ export default class DocServer extends Singleton {
    * Gets the `FileComplex` for the document with the given ID. It is okay (not
    * an error) if the underlying file doesn't happen to exist.
    *
-   * @param {string} docId The document ID.
+   * @param {string} documentId The document ID.
    * @returns {FileComplex} The corresponding `FileComplex`.
    */
-  async getFileComplex(docId) {
-    // **Note:** We don't make an `async` back-end call to check the `docId`
-    // here, because that would be a waste if it turns out we've already cached
-    // a valid result. Once we determine that we need to construct a new
-    // complex (below), we'll call through to the back-end to get a file ID, and
-    // that call implicitly validates the document ID.
-    Storage.dataStore.checkDocumentIdSyntax(docId);
+  async getFileComplex(documentId) {
+    // **Note:** We don't make an `async` back-end call to check the
+    // `documentId` here, because that would be a waste if it turns out we've
+    // already cached a valid result. Once we determine that we need to
+    // construct a new complex (below), we'll call through to the back-end to
+    // get a file ID, and that call implicitly validates the document ID.
+    Storage.dataStore.checkDocumentIdSyntax(documentId);
 
     // Look for a cached or in-progress result.
 
-    const already = this._complexes.get(docId);
+    const already = this._complexes.get(documentId);
     if (already) {
       // There's something in the cache. There are two possibilities...
       if (already instanceof Promise) {
@@ -79,7 +79,7 @@ export default class DocServer extends Singleton {
         }
         // The weak reference is dead. We'll fall through and construct a new
         // result.
-        log.withAddedContext(docId).info('Cached complex was gc\'ed.');
+        log.withAddedContext(documentId).info('Cached complex was gc\'ed.');
       }
     }
 
@@ -90,23 +90,23 @@ export default class DocServer extends Singleton {
       try {
         // This validates the document ID and lets us find out the corresponding
         // file ID.
-        const docInfo = await Storage.dataStore.getDocumentInfo(docId);
+        const docInfo = await Storage.dataStore.getDocumentInfo(documentId);
         const fileId  = docInfo.fileId;
 
         const file   = await Storage.fileStore.getFile(fileId);
-        const result = new FileComplex(this._codec, docId, file);
+        const result = new FileComplex(this._codec, documentId, file);
 
         result.log.info('Initializing...');
         await result.init();
         result.log.info('Done initializing.');
 
-        const resultRef = weak(result, this._complexReaper(docId));
+        const resultRef = weak(result, this._complexReaper(documentId));
 
         // Replace the promise in the cache with a weak reference to the actaul
         // result.
-        this._complexes.set(docId, resultRef);
+        this._complexes.set(documentId, resultRef);
 
-        if (docId === fileId) {
+        if (documentId === fileId) {
           result.log.info('Constructed new complex.');
         } else {
           // Only explicitly note the file ID when it differs from the document
@@ -116,11 +116,11 @@ export default class DocServer extends Singleton {
 
         return result;
       } catch (e) {
-        log.error(`Trouble constructing complex ${docId}.`, e);
+        log.error(`Trouble constructing complex ${documentId}.`, e);
 
         // Remove the promise in the cache, so that we will try again instead of
         // continuing to report this error.
-        this._complexes.delete(docId);
+        this._complexes.delete(documentId);
 
         throw e; // Becomes the rejection value of the promise.
       }
@@ -128,18 +128,18 @@ export default class DocServer extends Singleton {
 
     // Store the the promise for the result in the cache, and return it.
 
-    log.withAddedContext(docId).info('About to construct complex.');
-    this._complexes.set(docId, resultPromise);
+    log.withAddedContext(documentId).info('About to construct complex.');
+    this._complexes.set(documentId, resultPromise);
     return resultPromise;
   }
 
   /**
    * Returns a weak reference callback function for the indicated document ID.
    *
-   * @param {string} docId Document ID of the file complex to remove.
+   * @param {string} documentId Document ID of the file complex to remove.
    * @returns {function} An appropriately-constructed function.
    */
-  _complexReaper(docId) {
+  _complexReaper(documentId) {
     // **Note:** This function _used to_ remove the document binding from the
     // `_complexes` map on the presumption that it was a known-dead weak
     // reference. That code has been deleted. First of all, the only benefit
@@ -150,7 +150,7 @@ export default class DocServer extends Singleton {
     // _before_ this reaper was called, the cleanup code here would have
     // incorrectly removed a perfectly valid binding.
     return () => {
-      log.info('Reaped idle file complex:', docId);
+      log.info('Reaped idle file complex:', documentId);
     };
   }
 }

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -306,9 +306,7 @@ export default class DocSession extends CommonBase {
    * @returns {string} The document ID.
    */
   getDocumentId() {
-    // **TODO:** This is incorrect, because the file ID isn't necessarily the
-    // same thing as its document ID!
-    return this._fileComplex.fileAccess.file.id;
+    return this._fileComplex.fileAccess.documentId;
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -22,7 +22,7 @@ export default class DocSession extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {fileComplex} fileComplex File complex representing the underlying
+   * @param {FileComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -109,11 +109,11 @@ export default class DocSession extends CommonBase {
     // revision would result if the `delta` were able to be applied directly. If
     // we get "lucky" (win any races) that will be the actual revision number,
     // but the ultimate result might have a higher `revNum`.
-    const change = new BodyChange(baseRevNum + 1, delta, Timestamp.now(), this._authorId);
+    const change           = new BodyChange(baseRevNum + 1, delta, Timestamp.now(), this._authorId);
     const bodyChangeResult = await this._bodyControl.update(change);
-    const docId = this.getDocumentId();
+    const documentId       = this.getDocumentId();
 
-    this._bodyControl.queueHtmlExport(bodyChangeResult.revNum, docId);
+    this._bodyControl.queueHtmlExport(bodyChangeResult.revNum, documentId);
 
     return bodyChangeResult;
   }

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -278,17 +278,25 @@ export default class DocSession extends CommonBase {
 
   /**
    * Returns a bit of identifying info about this instance, for the purposes of
-   * logging. Specifically, the client side will call this method and log the
-   * results during session initiation.
+   * logging. Specifically, the client will call this method and log the result
+   * during session initiation.
    *
    * @returns {object} Succinct identification.
    */
   getLogInfo() {
-    const file   = this._fileComplex.file.id;
-    const caret  = this._caretId;
-    const author = this._authorId;
+    const result = {
+      author:   this.getAuthorId(),
+      caret:    this.getCaretId(),
+      document: this.getDocumentId(),
+      file:     this.getFileId()
+    };
 
-    return { file, caret, author };
+    // Only include the file ID if it's not the same as the document ID.
+    if (result.file === result.document) {
+      delete result.file;
+    }
+
+    return result;
   }
 
   /**
@@ -301,7 +309,16 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * Returns the document ID of the file controlled by this instance.
+   * Returns the caret ID of this instance.
+   *
+   * @returns {string} The caret ID.
+   */
+  getCaretId() {
+    return this._caretId;
+  }
+
+  /**
+   * Returns the ID of the document controlled by this instance.
    *
    * @returns {string} The document ID.
    */
@@ -310,11 +327,11 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * Returns the caret ID of this instance.
+   * Returns the ID of the file controlled by this instance.
    *
-   * @returns {string} The caret ID.
+   * @returns {string} The file ID.
    */
-  getCaretId() {
-    return this._caretId;
+  getFileId() {
+    return this._fileComplex.fileAccess.file.id;
   }
 }

--- a/local-modules/@bayou/doc-server/FileAccess.js
+++ b/local-modules/@bayou/doc-server/FileAccess.js
@@ -5,6 +5,7 @@
 import { Codec } from '@bayou/codec';
 import { BaseFile, FileCodec } from '@bayou/file-store';
 import { BaseLogger, Logger } from '@bayou/see-all';
+import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 /** {Logger} Logger to use for this module. */
@@ -22,15 +23,24 @@ export default class FileAccess extends CommonBase {
    * Constructs an instance.
    *
    * @param {Codec} codec Codec instance to use.
+   * @param {string} documentId ID of the document associated with this
+   *   instance.
    * @param {BaseFile} file The underlying document storage.
    * @param {BaseLogger} [logger = null] If non-`null`, logger to use instead of
    *   the usual one. This is only meant to be used for unit testing.
    */
-  constructor(codec, file, logger = null) {
+  constructor(codec, documentId, file, logger = null) {
     super();
 
     /** {Codec} Codec instance to use. */
     this._codec = Codec.check(codec);
+
+    /**
+     * {string} ID of the document associated with this instance. **Note:** Just
+     * verified to be a string, because the actual ID syntax should have been
+     * checked at a higher layer.
+     */
+    this._documentId = TString.check(documentId);
 
     /** {BaseFile} The underlying document storage. */
     this._file = BaseFile.check(file);
@@ -48,6 +58,11 @@ export default class FileAccess extends CommonBase {
   /** {Codec} Codec instance to use with the underlying file. */
   get codec() {
     return this._codec;
+  }
+
+  /** {string} ID of the document associated with this instance. */
+  get documentId() {
+    return this._documentId;
   }
 
   /** {BaseFile} The underlying document storage. */

--- a/local-modules/@bayou/doc-server/FileBootstrap.js
+++ b/local-modules/@bayou/doc-server/FileBootstrap.js
@@ -262,11 +262,11 @@ export default class FileBootstrap extends BaseDataManager {
 
     await this.file.create();
 
-    // `revNum` is the next available in order to append migration or
-    // error note `FileChange` to the end of the doc, while retaining
-    // history. In the future, we will presumably replace the entire
-    // notion of conveying information through appending notes in the
-    // document itself, and this entire code block will disappear.
+    // `revNum` is the next available in order to append migration or error note
+    // `FileChange` to the end of the document, while retaining history. In the
+    // future, we will presumably replace the entire notion of conveying
+    // information through appending notes in the document itself, and this
+    // entire code block will disappear.
     const currentRevNum = this.file.currentSnapshot.revNum;
     const initialFileChange = new FileChange(currentRevNum + 1, initOps);
     await this.file.appendChange(initialFileChange, FILE_CREATE_TIMEOUT_MSEC);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -33,10 +33,12 @@ export default class FileComplex extends BaseComplexMember {
    * Constructs an instance.
    *
    * @param {Codec} codec Codec instance to use.
+   * @param {string} documentId ID of the document associated with this
+   *   instance.
    * @param {BaseFile} file The underlying document storage.
    */
-  constructor(codec, file) {
-    super(new FileAccess(codec, file), 'complex');
+  constructor(codec, documentId, file) {
+    super(new FileAccess(codec, documentId, file), 'complex');
 
     /**
      * {FileBootstrap} Bootstrap handler, and also where the complex members are

--- a/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
@@ -17,7 +17,7 @@ describe('@bayou/doc-server/BaseComplexMember', () => {
     it('should accept a `FileAccess` and reflect it in the getters', () => {
       const codec  = appCommon_TheModule.modelCodec;
       const file   = new MockFile('blort');
-      const fa     = new FileAccess(codec, file);
+      const fa     = new FileAccess(codec, 'x', file);
       const result = new BaseComplexMember(fa, 'boop');
 
       assert.strictEqual(result.codec,      codec);
@@ -37,7 +37,7 @@ describe('@bayou/doc-server/BaseComplexMember', () => {
     it('should use the `logLabel` to create an appropriate `log`', () => {
       const codec  = appCommon_TheModule.modelCodec;
       const log    = new MockLogger();
-      const fa     = new FileAccess(codec, new MockFile('file-id'), log);
+      const fa     = new FileAccess(codec, 'x', new MockFile('file-id'), log);
       const result = new BaseComplexMember(fa, 'boop');
 
       result.log.info('florp', 'like');

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -25,7 +25,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   mocks_TheModule.registerCodecs(CODEC.registry);
 
   /** {FileAccess} Convenient instance of `FileAccess`. */
-  const FILE_ACCESS = new FileAccess(CODEC, new MockFile('blort'));
+  const FILE_ACCESS = new FileAccess(CODEC, 'doc-xyz', new MockFile('blort'));
 
   describe('.changeClass', () => {
     it('should reflect the subclass\'s implementation', () => {
@@ -176,7 +176,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   describe('appendChange()', () => {
     it('should perform an appropriate transaction given a valid change', async () => {
       const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control = new MockControl(fileAccess, 'boop');
       const expectedMockChangeRevNum = 99;
       const change = new MockChange(expectedMockChangeRevNum, [['x', 'f'], ['y', 'b']]);
@@ -212,10 +212,10 @@ describe('@bayou/doc-server/BaseControl', () => {
     });
 
     it('should provide a default for `null` and clamp an out-of-range (but otherwise valid) timeout', async () => {
-      const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
-      const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
+      const file       = new MockFile('blort');
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
+      const control    = new MockControl(fileAccess, 'boop');
+      const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       let actualFileChange;
       let actualTimeout;
@@ -259,10 +259,10 @@ describe('@bayou/doc-server/BaseControl', () => {
     });
 
     it('should call the snapshot maybe-writer and html exporter, and return `true` if the transaction succeeds', async () => {
-      const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
-      const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
+      const file       = new MockFile('blort');
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
+      const control    = new MockControl(fileAccess, 'boop');
+      const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
         get: () => new MockSnapshot(100, [['yes']])
@@ -279,10 +279,10 @@ describe('@bayou/doc-server/BaseControl', () => {
     });
 
     it('should return `false` if the transaction fails due to a precondition failure', async () => {
-      const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
-      const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
+      const file       = new MockFile('blort');
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
+      const control    = new MockControl(fileAccess, 'boop');
+      const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
         get: () => new MockSnapshot(100, [['yes']])
@@ -305,10 +305,10 @@ describe('@bayou/doc-server/BaseControl', () => {
     });
 
     it('should rethrow any transaction error other than a precondition failure and timeout', async () => {
-      const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
-      const control = new MockControl(fileAccess, 'boop');
-      const change = new MockChange(99, [['x', 'f'], ['y', 'b']]);
+      const file       = new MockFile('blort');
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
+      const control    = new MockControl(fileAccess, 'boop');
+      const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
       Object.defineProperty(file, 'currentSnapshot', {
         get: () => new MockSnapshot(100, [['x']])
@@ -332,7 +332,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
     it('should reject an empty change', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(101, []);
 
@@ -341,7 +341,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
     it('should reject a change of the wrong type', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
 
       await assert.isRejected(control.appendChange('not_a_change'), /badValue/);
@@ -349,7 +349,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
     it('should reject an invalid timeout value', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
@@ -368,9 +368,9 @@ describe('@bayou/doc-server/BaseControl', () => {
 
   describe('currentRevNum()', () => {
     it('should use the result of the transaction it performed', async () => {
-      const file = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
-      const control = new MockControl(fileAccess, 'boop');
+      const file           = new MockFile('blort');
+      const fileAccess     = new FileAccess(CODEC, 'doc-1', file);
+      const control        = new MockControl(fileAccess, 'boop');
       const expectedRevNum = 1234;
 
       const fileOp = FileOp.op_writePath('/mock_control/revision_number', CODEC.encodeJsonBuffer(expectedRevNum));
@@ -384,9 +384,9 @@ describe('@bayou/doc-server/BaseControl', () => {
 
     it('should reject improper transaction results', async () => {
       async function test(revNum) {
-        const file = new MockFile('blort');
-        const fileAccess = new FileAccess(CODEC, file);
-        const control = new MockControl(fileAccess, 'boop');
+        const file       = new MockFile('blort');
+        const fileAccess = new FileAccess(CODEC, 'doc-1', file);
+        const control    = new MockControl(fileAccess, 'boop');
 
         // TODO: Replace with stub
         Object.defineProperty(file, 'currentSnapshot', {
@@ -966,7 +966,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   describe('whenRevNum()', () => {
     it('should return promptly if the revision is already available', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
 
       file._impl_transact = (spec_unused) => {
@@ -984,7 +984,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
     it.skip('should issue transactions until the revision is written', async () => {
       const file       = new MockFile('blort');
-      const fileAccess = new FileAccess(CODEC, file);
+      const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
 
       let revNum = 11;

--- a/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
@@ -11,7 +11,7 @@ import { TransactionSpec } from '@bayou/file-store-ot';
 import { MockFile } from '@bayou/file-store/mocks';
 
 /** {FileAccess} Convenient instance of `FileAccess`. */
-const FILE_ACCESS = new FileAccess(appCommon_TheModule.modelCodec, new MockFile('blort'));
+const FILE_ACCESS = new FileAccess(appCommon_TheModule.modelCodec, 'doc-123', new MockFile('blort'));
 
 describe('@bayou/doc-server/BaseDataManager', () => {
   describe('.initSpec', () => {

--- a/local-modules/@bayou/file-store-ot/TransactionOp.js
+++ b/local-modules/@bayou/file-store-ot/TransactionOp.js
@@ -34,7 +34,7 @@ const TYPE_Hash    = 'Hash';
 const TYPE_Index   = 'Index';
 const TYPE_Path    = 'Path';
 
-// Operation schemata. See the doc for {@link TransactionOp#propsFromName} for
+// Operation schemata. See the docs for {@link TransactionOp#propsFromName} for
 // details.
 //
 // **Note:** The comments below aren't "real" JSDoc comments, because JSDoc

--- a/local-modules/@bayou/see-all/LogRecord.js
+++ b/local-modules/@bayou/see-all/LogRecord.js
@@ -372,7 +372,7 @@ export default class LogRecord extends CommonBase {
       result.push('\n');
     }
 
-    // Append the stack if available and appropriate. See the header doc for
+    // Append the stack if available and appropriate. See the header comment for
     // more info.
     if (   this.isMessage()
         && (this.stack !== null)


### PR DESCRIPTION
The actually-useful bit in this PR is that the document ID is now being made available to `DocSession` users, which is something that's needed especially _during_ the transition to new-style sessions.

The other thing in this PR is me fixing _some_ of our[*] inconsistency with regard to whether we refer to documents as `doc`s or `document`s in the code. The latter won the `grep|wc`-based popularity contest, so I did a handful of renaming to increase that popularity, mostly by changing `docId` to `documentId`.

[*] historically speaking _my_