### PR TITLE
New sessions: first signs of life!

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -268,20 +268,6 @@ export default class ApiClient extends CommonBase {
       throw e;
     }
 
-    // Test to make sure newly-proxied objects get returned as expected.
-    // **TODO:** Remove this once we have unit test coverage for this
-    // functionality.
-    /*
-    (async () => {
-      const counter = await this.meta.makeCounter();
-      this._log.info('Got counter:', counter);
-      const c0 = await counter.count();
-      const c1 = await counter.count();
-      const c2 = await counter.count();
-      this._log.info('Got counts:', c0, c1, c2);
-    })();
-    */
-
     return true;
   }
 

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -199,20 +199,6 @@ export default class ApiClientNew extends CommonBase {
 
     this.connectionId = id;
     this.log.event.open();
-
-    // Test to make sure newly-proxied objects get returned as expected.
-    // **TODO:** Remove this once we have unit test coverage for this
-    // functionality.
-    /*
-    (async () => {
-      const counter = await this.meta.makeCounter();
-      this.log.info('Got counter:', counter);
-      const c0 = await counter.count();
-      const c1 = await counter.count();
-      const c2 = await counter.count();
-      this.log.info('Got counts:', c0, c1, c2);
-    })();
-    */
   }
 
   /**

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -42,14 +42,14 @@ export default class Connection extends CommonBase {
   constructor(context) {
     super();
 
-    /** {Context} The binding context to provide access to. */
-    this._context = Context.check(context).clone();
-
     /**
      * {string} Short label string used to identify this connection in logs.
      * _Probably_ but not _guaranteed_ to be unique.
      */
     this._connectionId = Random.shortLabel('conn');
+
+    /** {Context} The binding context to provide access to. */
+    this._context = Context.check(context).clone(this._connectionId);
 
     /** {Codec} The codec to use. */
     this._codec = context.codec;

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -3,13 +3,13 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ConnectionError, Message, Response } from '@bayou/api-common';
-import { ProxiedObject } from '@bayou/api-server';
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
 import ApiLog from './ApiLog';
 import Context from './Context';
 import MetaHandler from './MetaHandler';
+import ProxiedObject from './ProxiedObject';
 import Target from './Target';
 
 /** {Logger} Logger. */

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -246,7 +246,7 @@ export default class Context extends CommonBase {
       return already;
     }
 
-    const targetId = this.randomId();
+    const targetId = this._randomId();
     const target   = new Target(targetId, obj);
     const remote   = this.addTarget(target);
 
@@ -266,32 +266,6 @@ export default class Context extends CommonBase {
    */
   hasId(id) {
     return this._getOrNull(id) !== null;
-  }
-
-  /**
-   * Makes a new random ID for use with this instance, which (a) is guaranteed
-   * not to be used by the instance already, and (b) will not be mistaken by
-   * the token handler (if any) for a token. **Note:** If not bound promptly
-   * (that is, within the same turn of execution when this method is called), it
-   * is conceivably possible for a duplicate ID to be returned and then
-   * ultimately result in a "duplicate target" error in {@link #addTarget}.
-   *
-   * @returns {string} A random unused target ID.
-   */
-  randomId() {
-    const tokenAuth = this._tokenAuth;
-    const prefix    = (tokenAuth === null) ? 'local-' : tokenAuth.nonTokenPrefix;
-
-    for (;;) {
-      const result = `${prefix}${Random.hexByteString(4)}`;
-
-      if (!this.hasId(result)) {
-        return result;
-      }
-
-      // We managed to get an ID collision. Unlikely, but it can happen. So,
-      // just iterate and try again.
-    }
   }
 
   /**
@@ -380,6 +354,32 @@ export default class Context extends CommonBase {
     }
 
     this._log.event.idleCleanup('done');
+  }
+
+  /**
+   * Makes a new random ID for use with this instance, which (a) is guaranteed
+   * not to be used by the instance already, and (b) will not be mistaken by
+   * the token handler (if any) for a token. **Note:** If not bound promptly
+   * (that is, within the same turn of execution when this method is called), it
+   * is conceivably possible for a duplicate ID to be returned and then
+   * ultimately result in a "duplicate target" error in {@link #addTarget}.
+   *
+   * @returns {string} A random unused target ID.
+   */
+  _randomId() {
+    const tokenAuth = this._tokenAuth;
+    const prefix    = (tokenAuth === null) ? 'local-' : tokenAuth.nonTokenPrefix;
+
+    for (;;) {
+      const result = `${prefix}${Random.hexByteString(4)}`;
+
+      if (!this.hasId(result)) {
+        return result;
+      }
+
+      // We managed to get an ID collision. Unlikely, but it can happen. So,
+      // just iterate and try again.
+    }
   }
 
   /**

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -3,12 +3,12 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Remote, SplitKey } from '@bayou/api-common';
-import { ProxiedObject } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
+import ProxiedObject from './ProxiedObject';
 import Target from './Target';
 import TokenAuthorizer from './TokenAuthorizer';
 
@@ -228,9 +228,17 @@ export default class Context extends CommonBase {
     const obj     = proxiedObject.target;
     const already = this._remoteMap.get(obj);
 
-    return (already === undefined)
-      ? this.addTarget(new Target(this.randomId(), obj))
-      : already;
+    if (already !== undefined) {
+      return already;
+    }
+
+    const targetId = this.randomId();
+    const target   = new Target(targetId, obj);
+    const remote   = this.addTarget(target);
+
+    log.event.newRemote(targetId, obj);
+
+    return remote;
   }
 
   /**

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -88,7 +88,7 @@ export default class Context extends CommonBase {
   /**
    * Adds a {@link Target} to this instance's map of same, and also adds the
    * remote map from the target's wrapped object to its corresponding
-   * {@link Remote} representative. The given `target`must not have an ID that
+   * {@link Remote} representative. The given `target` must not have an ID that
    * is already represented in the map. In addition, the object wrapped by
    * `target` must not already be bound to another ID. (That is, for any given
    * instance of this class, there is a one-to-one mapping between IDs and
@@ -102,6 +102,7 @@ export default class Context extends CommonBase {
    */
   addTarget(target) {
     Target.check(target);
+
     const id     = target.id;
     const obj    = target.directObject;
     const remote = new Remote(id);

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -6,8 +6,6 @@ import { TString } from '@bayou/typecheck';
 import { Delay } from '@bayou/promise-util';
 import { Errors } from '@bayou/util-common';
 
-import ProxiedObject from './ProxiedObject';
-
 /** {Int} How long an unanswered challenge remains active for, in msec. */
 const CHALLENGE_TIMEOUT_MSEC = 5 * 60 * 1000; // Five minutes.
 
@@ -141,28 +139,5 @@ export default class MetaHandler {
    */
   ping() {
     return true;
-  }
-
-  /**
-   * Makes a new counter, which is kept on the server and returned to the client
-   * as a proxied object. The method `count()` on the result returns the next
-   * number in sequence, starting with `0`.
-   *
-   * **TODO:** This method only exists for ad-hoc testing of the API mechanism
-   * and should be removed once we have real tests.
-   *
-   * @returns {ProxiedObject} A new counter.
-   */
-  makeCounter() {
-    let value = -1;
-
-    const result = {
-      count() {
-        value++;
-        return value;
-      }
-    };
-
-    return new ProxiedObject(result);
   }
 }

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -1,0 +1,86 @@
+// Copyright 2016-2018 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { BearerToken, Remote } from '@bayou/api-common';
+import { Context, ProxiedObject, TokenAuthorizer } from '@bayou/api-server';
+import { Codec } from '@bayou/codec';
+
+/**
+ * Mock `TokenAuthorizer` for testing.
+ */
+class MockAuth extends TokenAuthorizer {
+  get _impl_nonTokenPrefix() {
+    return 'nontoken-';
+  }
+
+  _impl_isToken(tokenString_unused) {
+    return true;
+  }
+
+  async _impl_targetFromToken(token_unused) {
+    return { some: 'authority' };
+  }
+
+  _impl_tokenFromString(tokenString) {
+    return new BearerToken(tokenString, tokenString);
+  }
+}
+
+describe('@bayou/api-server/Context', () => {
+  describe('constructor()', () => {
+    it('should accept two valid arguments', () => {
+      assert.doesNotThrow(() => new Context(new Codec(), 'some-tag'));
+    });
+
+    it('should accept three valid arguments', () => {
+      assert.doesNotThrow(() => new Context(new Codec(), 'some-other-tag', new MockAuth()));
+    });
+  });
+
+  describe('getRemoteFor', () => {
+    it('should return a `Remote` given a `ProxiedObject`', () => {
+      const ctx    = new Context(new Codec(), 'tag');
+      const obj    = { some: 'object' };
+      const po     = new ProxiedObject(obj);
+      const result = ctx.getRemoteFor(po);
+
+      assert.instanceOf(result, Remote);
+    });
+
+    it('should return a `Remote` whose `id` maps back to the underlying object', async () => {
+      const ctx    = new Context(new Codec(), 'tag');
+      const obj    = { some: 'object' };
+      const po     = new ProxiedObject(obj);
+      const result = ctx.getRemoteFor(po);
+
+      assert.isTrue(ctx.hasId(result.targetId));
+
+      const target = await ctx.getAuthorizedTarget(result.targetId);
+
+      assert.strictEqual(target.directObject, obj);
+    });
+
+    it('should return the same `Remote` when given the same `ProxiedObject`', () => {
+      const ctx     = new Context(new Codec(), 'tag');
+      const obj     = { some: 'object' };
+      const po      = new ProxiedObject(obj);
+      const result1 = ctx.getRemoteFor(po);
+      const result2 = ctx.getRemoteFor(po);
+
+      assert.strictEqual(result1, result2);
+    });
+
+    it('should return the same `Remote` when given two `ProxiedObject`s for the same underlying object', () => {
+      const ctx     = new Context(new Codec(), 'tag');
+      const obj     = { some: 'object' };
+      const result1 = ctx.getRemoteFor(new ProxiedObject(obj));
+      const result2 = ctx.getRemoteFor(new ProxiedObject(obj));
+
+      assert.strictEqual(result1, result2);
+    });
+  });
+});

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -43,7 +43,7 @@ export default class Application extends CommonBase {
      * other objects of use to the server.
      */
     this._context =
-      new Context(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
+      new Context(appCommon_TheModule.fullCodec, 'top-context', new AppAuthorizer(this));
 
     /**
      * {RootAccess} The "root access" object. This is the object which tokens

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -78,7 +78,7 @@ export default class AuthorAccess extends CommonBase {
       `  caret:    ${caretId}`);
 
     // The `ProxiedObject` wrapper tells the API to return this to the far side
-    // of the connection as a reference, not by encoding its contents.
+    // of the connection as a reference, instead of by encoding its contents.
     return new ProxiedObject(session);
   }
 
@@ -111,7 +111,7 @@ export default class AuthorAccess extends CommonBase {
       `  caret:    ${session.getCaretId()}`);
 
     // The `ProxiedObject` wrapper tells the API to return this to the far side
-    // of the connection as a reference, not by encoding its contents.
+    // of the connection as a reference, instead of by encoding its contents.
     return new ProxiedObject(session);
   }
 }

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -42,7 +42,7 @@ export default class AuthorAccess extends CommonBase {
     this._context = Context.check(context);
 
     /** {Logger} Logger for this instance. */
-    this._log = log.withContext(authorId);
+    this._log = log.withAddedContext(authorId);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -401,13 +401,18 @@ export default class DebugTools {
    * @returns {string} A new `SplitKey` encoded as JSON.
    */
   async _makeEncodedInfo(documentId, authorId) {
-    // **TODO:** This is just a "dry run" for now. Ultimately this should get
-    // returned.
-    await this._rootAccess.makeSessionInfo(authorId, documentId);
+    // As an aid to the transition to new-style sessions, if the `authorId` has
+    // the suffix `-key`, then we strip the suffix and produce an old-style
+    // session access key. **TODO:** Remove this once new-style sessions are
+    // used consistently.
+    if (authorId.endsWith('-key')) {
+      authorId = authorId.replace(/-key$/, '');
+      const key = await this._rootAccess.makeAccessKey(authorId, documentId);
+      return appCommon_TheModule.fullCodec.encodeJson(key);
+    }
 
-    // **TODO:** Replace this with construction of `SessionInfo` (above).
-    const key = await this._rootAccess.makeAccessKey(authorId, documentId);
-    return appCommon_TheModule.fullCodec.encodeJson(key);
+    const info = await this._rootAccess.makeSessionInfo(authorId, documentId);
+    return appCommon_TheModule.fullCodec.encodeJson(info);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -193,8 +193,7 @@ export default class DocSession extends CommonBase {
 
     if (this._sessionInfo !== null) {
       const info        = this._sessionInfo;
-      const api         = this._apiClient;
-      const authorProxy = api.getProxy(info.authorToken);
+      const authorProxy = this.apiClient.getProxy(info.authorToken);
 
       if (info.caretId === null) {
         proxyPromise = authorProxy.makeNewSession(info.documentId);


### PR DESCRIPTION
This PR fixes a couple bugs in new-style session handling, and enables them when using the `debug/edit` endpoint. It seems to work for an initial connection, but I'm confident that there are more lurking bugs, especially around what happens when a connection gets dropped and needs to be reëstablished. But — hey! — progress!

**Note:** I left an "escape hatch" in `/debug/edit` to use the old-style sessions. In particular, use the suffix `-key` on the author ID, and it will use the old code.
