### PR TITLE
Allow session reëstablishment when using `SessionInfo`.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -226,6 +226,20 @@ export default class ApiClient extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance is the one that handles the given
+   * presumed-proxy. This returns `true` if the given `obj` is a `Proxy` that
+   * was returned by a call to {@link #getProxy} on this instance, _and_ it was
+   * not subsequently removed.
+   *
+   * @param {object} obj The presumed-proxy in question.
+   * @returns {boolean} `true` if `obj` is a proxy handled by this instance, or
+   *   `false` if not.
+   */
+  handles(obj) {
+    return this._targets.handles(obj);
+  }
+
+  /**
    * Opens the websocket. Once open, any pending messages will get sent to the
    * server side. If the socket is already open (or in the process of opening),
    * this does not re-open (that is, the existing open is allowed to continue).

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -240,6 +240,25 @@ export default class ApiClient extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance believes its connection is
+   * sufficiently open, such that it is possible to send messages. This method
+   * returns `true` if the instance is in the middle of opening (and is
+   * enqueuing messages) or is fully open and actively exchanging messages with
+   * a server.
+   *
+   * @returns {boolean} `true` iff this instance is open, per above.
+   */
+  isOpen() {
+    if (this._ws === null) {
+      return false;
+    }
+
+    const readyState = this._ws.readyState;
+
+    return (readyState === WebSocket.CONNECTING) || (readyState === WebSocket.OPEN);
+  }
+
+  /**
    * Opens the websocket. Once open, any pending messages will get sent to the
    * server side. If the socket is already open (or in the process of opening),
    * this does not re-open (that is, the existing open is allowed to continue).

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -181,6 +181,20 @@ export default class ApiClientNew extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance is the one that handles the given
+   * presumed-proxy. This returns `true` if the given `obj` is a `Proxy` that
+   * was returned by a call to {@link #getProxy} on this instance, _and_ it was
+   * not subsequently removed.
+   *
+   * @param {object} obj The presumed-proxy in question.
+   * @returns {boolean} `true` if `obj` is a proxy handled by this instance, or
+   *   `false` if not.
+   */
+  handles(obj) {
+    return this._targets.handles(obj);
+  }
+
+  /**
    * Opens the connection, if not already open. Once open, any pending messages
    * will get sent to the server side. If the connection is already open (or in
    * the process of opening), this does not re-open it; that is, the existing

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -195,6 +195,19 @@ export default class ApiClientNew extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance believes its connection is
+   * sufficiently open, such that it is possible to send messages. This method
+   * returns `true` if the instance is in the middle of opening (and is
+   * enqueuing messages) or is fully open and actively exchanging messages with
+   * a server.
+   *
+   * @returns {boolean} `true` iff this instance is open, per above.
+   */
+  isOpen() {
+    return this._connection.isOpen();
+  }
+
+  /**
    * Opens the connection, if not already open. Once open, any pending messages
    * will get sent to the server side. If the connection is already open (or in
    * the process of opening), this does not re-open it; that is, the existing

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -152,6 +152,18 @@ export default class BaseServerConnection extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance believes it is sufficiently open,
+   * such that it is possible to send messages. This method returns `true` if
+   * the instance is in the middle of opening (and is enqueuing messages) or is
+   * fully open and actively exchanging messages with a server.
+   *
+   * @returns {boolean} `true` iff this instance is open, per above.
+   */
+  isOpen() {
+    return this._connection.isOpen();
+  }
+
+  /**
    * Indicates that a new message has been received. This is meant to be used by
    * subclasses.
    *
@@ -181,6 +193,16 @@ export default class BaseServerConnection extends CommonBase {
    */
   async _impl_beReceiving() {
     this._mustOverride();
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #isOpen}.
+   *
+   * @abstract
+   * @returns {boolean} `true` iff this instance is open.
+   */
+  _impl_isOpen() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -37,8 +37,8 @@ export default class TargetMap extends CommonBase {
     this._sendMessage = TFunction.checkCallable(sendMessage);
 
     /**
-     * {Map<string, TargetHandler>} The targets being provided, as a map from ID
-     * to proxy.
+     * {Map<string, Proxy>} The targets being provided, as a map from ID to
+     * corresponding proxy.
      */
     this._targets = new Map();
 

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TargetId } from '@bayou/api-common';
-import { TFunction } from '@bayou/typecheck';
+import { TFunction, TObject } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
 import TargetHandler from './TargetHandler';
@@ -42,6 +42,9 @@ export default class TargetMap extends CommonBase {
      */
     this._targets = new Map();
 
+    /** {Set<Proxy>} The set of all proxies handled by this instance. */
+    this._proxies = new Set();
+
     Object.freeze(this);
   }
 
@@ -59,7 +62,10 @@ export default class TargetMap extends CommonBase {
     }
 
     const result = TargetHandler.makeProxy(this._sendMessage, id);
+
     this._targets.set(id, result);
+    this._proxies.add(result);
+
     return result;
   }
 
@@ -81,6 +87,7 @@ export default class TargetMap extends CommonBase {
    */
   clear() {
     this._targets.clear();
+    this._proxies.clear();
   }
 
   /**
@@ -111,5 +118,21 @@ export default class TargetMap extends CommonBase {
   getOrNull(id) {
     TargetId.check(id);
     return this._targets.get(id) || null;
+  }
+
+  /**
+   * Indicates whether or not this instance is the one that handles the given
+   * presumed-proxy. This returns `true` if the given `obj` is a `Proxy` that
+   * was returned by a call to {@link #add} or {@link #addOrGet} on this
+   * instance, _and_ it was not subsequently removed.
+   *
+   * @param {object} obj The presumed-proxy in question.
+   * @returns {boolean} `true` if `obj` is a proxy handled by this instance, or
+   *   `false` if not.
+   */
+  handles(obj) {
+    TObject.check(obj);
+
+    return this._proxies.has(obj);
   }
 }

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -50,11 +50,21 @@ export default class WsServerConnection extends BaseServerConnection {
 
   /**
    * Implementation as required by the superclass.
-   *
-   * @abstract
    */
   async _impl_beReceiving() {
     await this._ensureOpen();
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @returns {boolean} `true` iff this instance is open.
+   */
+  _impl_isOpen() {
+    // **TODO:** This is `true` on the theory that this class takes care of
+    // re-establishing dropped connections. However, eventually it shoud
+    // probably give up in the face of repeated failures and so return `false`.
+    return true;
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -353,18 +353,8 @@ export default class BodyClient extends StateMachine {
   async _handle_detached_start() {
     // **TODO:** This whole flow should probably be protected by a timeout.
 
-    // Open (or reopen) the connection to the server. Even though the connection
-    // won't become open synchronously, the API client code allows us to start
-    // sending messages over it immediately. (They'll just get queued up as
-    // necessary.)
-    try {
-      await this._docSession.apiClient.open();
-    } catch (e) {
-      this.q_apiError('open', e);
-      return;
-    }
-
-    // Perform necessary handshaking to gain access to the document.
+    // Open (or reopen) the connection to the server, and perform any necessary
+    // handshaking to gain access to the document.
     try {
       this._sessionProxy = await this._docSession.getSessionProxy();
     } catch (e) {

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -69,8 +69,8 @@ export default class DocSession extends CommonBase {
       : log.withAddedContext(this._sessionInfo.logTag);
 
     /**
-     * {ApiClient|null} API client instance. Set to non-`null` in the getter
-     * `apiClient`.
+     * {ApiClient|null} API client instance. Set to non-`null` in
+     * {@link #_getApiClient}.
      */
     this._apiClient = null;
 
@@ -101,39 +101,6 @@ export default class DocSession extends CommonBase {
    */
   get log() {
     return this._log;
-  }
-
-  /**
-   * {ApiClient} API client instance to use. This is always the same instance
-   * for any given instance of this class. (That is, this value is never
-   * updated.) The client is not guaranteed to be open at the time it is
-   * returned; however, `open()` will have been called on it, which means that
-   * it will at least be in the _process_ of opening.
-   *
-   * @returns {ApiClient} API client interface.
-   */
-  get apiClient() {
-    const url = (this._sessionInfo !== null)
-      ? this._sessionInfo.serverUrl
-      : this._key.url;
-
-    if (this._apiClient === null) {
-      this._log.event.opening(url);
-      this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
-
-      (async () => {
-        try {
-          await this._apiClient.open();
-          this._log.event.opened(url);
-        } catch (e) {
-          // (a) Log the problem, and (b) make sure an error doesn't percolate
-          // back to the top as an uncaught promise rejection.
-          this._log.event.openFailed(url);
-        }
-      })();
-    }
-
-    return this._apiClient;
   }
 
   /** {CaretTracker} Caret tracker for this session. */
@@ -189,11 +156,12 @@ export default class DocSession extends CommonBase {
       return this._sessionProxyPromise;
     }
 
+    const api = this._getApiClient();
     let proxyPromise;
 
     if (this._sessionInfo !== null) {
       const info        = this._sessionInfo;
-      const authorProxy = this.apiClient.getProxy(info.authorToken);
+      const authorProxy = api.getProxy(info.authorToken);
 
       if (info.caretId === null) {
         proxyPromise = authorProxy.makeNewSession(info.documentId);
@@ -203,7 +171,7 @@ export default class DocSession extends CommonBase {
     } else {
       // **TODO:** Remove the `if` and this clause once {@link #_sessionInfo}
       // is used ubiquitously.
-      proxyPromise = this.apiClient.authorizeTarget(this._key);
+      proxyPromise = api.authorizeTarget(this._key);
     }
 
     this._sessionProxyPromise = proxyPromise;
@@ -237,5 +205,38 @@ export default class DocSession extends CommonBase {
     }
 
     return proxy;
+  }
+
+  /**
+   * {ApiClient} API client instance to use. This is always the same instance
+   * for any given instance of this class. (That is, this value is never
+   * updated.) The client is not guaranteed to be open at the time it is
+   * returned; however, `open()` will have been called on it, which means that
+   * it will at least be in the _process_ of opening.
+   *
+   * @returns {ApiClient} API client interface.
+   */
+  _getApiClient() {
+    const url = (this._sessionInfo !== null)
+      ? this._sessionInfo.serverUrl
+      : this._key.url;
+
+    if (this._apiClient === null) {
+      this._log.event.opening(url);
+      this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
+
+      (async () => {
+        try {
+          await this._apiClient.open();
+          this._log.event.opened(url);
+        } catch (e) {
+          // (a) Log the problem, and (b) make sure an error doesn't percolate
+          // back to the top as an uncaught promise rejection.
+          this._log.event.openFailed(url);
+        }
+      })();
+    }
+
+    return this._apiClient;
   }
 }


### PR DESCRIPTION
This PR makes it so that, when using `SessionInfo` to establish an editing session, the same session can be **re**-established across a connection restart boundary. The code to achieve this in `DocSession` is a _little_ messy; I think I'll be able to clean it up significantly as support for old-style sessions gets removed.