### PR TITLE
New-session code cleanup.

### DIFF
--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -22,32 +22,18 @@ export default class DocSession extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {BaseKey|SessionInfo|null} keyOrInfo Key or info object that
-   *   identifies the session and grants access to it. **Note:** A session is
-   *   tied to a specific caret, which is associated with a single document and
-   *   author. If passed a `SessionInfo` without a caret ID, then the act of
-   *   establishing the session will cause a new caret to be created. If `null`,
-   *   the remaining arguments are used to construct a `SessionInfo`.
-   * @param {string|null} [authorToken = null] `SessionInfo` constructor
-   *   argument. **TODO:** Remove this once call sites consistently pass a
-   *   `SessionInfo`.
-   * @param {string|null} [documentId = null] `SessionInfo` constructor
-   *   argument. **TODO:** Remove this once call sites consistently pass a
-   *   `SessionInfo`.
-   * @param {string|null} [caretId = null] `SessionInfo` constructor argument.
-   *   **TODO:** Remove this once call sites consistently pass a `SessionInfo`.
+   * @param {BaseKey|SessionInfo} keyOrInfo Key or info object that identifies
+   *   the session and grants access to it. **Note:** A session is tied to a
+   *   specific caret, which is associated with a single document and author. If
+   *   passed a `SessionInfo` without a caret ID, then the act of establishing
+   *   the session will cause a new caret to be created.
    */
-  constructor(keyOrInfo, authorToken = null, documentId = null, caretId = null) {
+  constructor(keyOrInfo) {
     super();
 
-    // **TODO:** Remove this when the extra arguments are removed.
-    if (keyOrInfo === null) {
-      keyOrInfo = new SessionInfo('http://localhost:8080/api', authorToken, documentId, caretId);
-    }
-
     /**
-     * {SessionInfo} Identifying and authorizing information for the session.
-     * If `null`, then {@link #_key} is being used instead of this.
+     * {SessionInfo|null} Identifying and authorizing information for the
+     * session. If `null`, then {@link #_key} is being used instead of this.
      */
     this._sessionInfo = (keyOrInfo instanceof SessionInfo) ? keyOrInfo : null;
 
@@ -213,11 +199,13 @@ export default class DocSession extends CommonBase {
 
       if (info.caretId === null) {
         // The session got started without a caret ID, which means a new caret
-        // will have been created. Update `_sessionInfo` accordingly.
+        // will have been created. Update `_sessionInfo` and `_log` accordingly.
         const caretId = await proxy.getCaretId();
 
-        this._sessionInfo = info.withCaretId(caretId);
         this._log.event.gotCaret(caretId);
+
+        this._sessionInfo = info.withCaretId(caretId);
+        this._log         = log.withAddedContext(this._sessionInfo.logTag);
       }
     }
 

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -107,6 +107,18 @@ export default class SessionInfo extends CommonBase {
 
   /**
    * Makes an instance just like this one, except with a new value for
+   * `authorToken`.
+   *
+   * @param {string|BearerToken} authorToken New token to use. If passed as a
+   *   {@link BearerToken}, gets converted to its `secretToken` string.
+   * @returns {SessionInfo} An appropriately-constructed instance.
+   */
+  withAuthorToken(authorToken) {
+    return new SessionInfo(this._serverUrl, authorToken, this._documentId, this._caretId);
+  }
+
+  /**
+   * Makes an instance just like this one, except with a new value for
    * `caretId`.
    *
    * @param {string} caretId ID of a pre-existing caret to control with the

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -135,7 +135,58 @@ describe('@bayou/doc-common/SessionInfo', () => {
     });
   });
 
-  describe('withCaretId', () => {
+  describe('withAuthorToken()', () => {
+    it('should return a new instance given a string', () => {
+      const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
+      const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
+
+      function test(token) {
+        const result1 = orig1.withAuthorToken(token);
+        const expect1 = new SessionInfo(orig1.serverUrl, token, orig1.documentId, orig1.caretId);
+        assert.deepEqual(result1, expect1);
+
+        const result2 = orig2.withAuthorToken(token);
+        const expect2 = new SessionInfo(orig2.serverUrl, token, orig2.documentId, orig2.caretId);
+        assert.deepEqual(result2, expect2);
+      }
+
+      test('blort');
+      test('boop');
+    });
+
+    it('should return a new instance given a `BearerToken`', () => {
+      const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
+      const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
+
+      function test(token) {
+        const result1 = orig1.withAuthorToken(token);
+        const expect1 = new SessionInfo(orig1.serverUrl, token.secretToken, orig1.documentId, orig1.caretId);
+        assert.deepEqual(result1, expect1);
+
+        const result2 = orig2.withAuthorToken(token);
+        const expect2 = new SessionInfo(orig2.serverUrl, token.secretToken, orig2.documentId, orig2.caretId);
+        assert.deepEqual(result2, expect2);
+      }
+
+      test(new BearerToken('abc', '123'));
+      test(new BearerToken('blort', 'florp'));
+    });
+
+    it('should reject invalid arguments', () => {
+      const si = new SessionInfo(SERVER_URL, 'token', 'doc');
+
+      function test(value) {
+        assert.throws(() => si.withAuthorToken(value), /badValue/);
+      }
+
+      test(undefined);
+      test(null);
+      test(914);
+      test(['x']);
+    });
+  });
+
+  describe('withCaretId()', () => {
     it('should return a new instance given a valid `caretId`', () => {
       const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
       const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
@@ -168,7 +219,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
     });
   });
 
-  describe('withoutCaretId', () => {
+  describe('withoutCaretId()', () => {
     it('should return a new instance with `caretId === null`', () => {
       function test(orig) {
         const result = orig.withoutCaretId();

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.13
+version = 1.1.14


### PR DESCRIPTION
This PR removes a bit of cruft that was added as part of the new-session transition, that we didn't end up using. Also adds a `SessionInfo.withAuthorToken()`, which looks to be useful.