### PR TITLE
Miscellaneous stuff for new sessions and related bits.

### DIFF
--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -33,8 +33,8 @@ import TargetId from './TargetId';
 export default class BaseKey extends CommonBase {
   /**
    * Redacts a string for use in error messages and logging. This is generally
-   * done in error-handling code which expects that its string argument _might_
-   * be security-sensitive.
+   * done in logging and error-handling code which expects that its string
+   * argument _might_ be security-sensitive.
    *
    * @param {string} origString The original string.
    * @returns {string} The redacted form.

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -28,7 +28,7 @@ export default class SessionInfo extends CommonBase {
   constructor(serverUrl, authorToken, documentId, caretId = null) {
     super();
 
-    // **TODO:** Consider performing more validation of the arguements. If
+    // **TODO:** Consider performing more validation of the arguments. If
     // they're problematic, we'll _eventually_ get errors back from the server,
     // but arguably it's better to know sooner.
 

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -38,9 +38,7 @@ export default class SessionInfo extends CommonBase {
      * {string} Token which identifies the author (user) under whose authority
      * the session is to be run.
      */
-    this._authorToken = (authorToken instanceof BearerToken)
-      ? authorToken.secretToken
-      : TString.check(authorToken);
+    this._authorToken = (authorToken instanceof BearerToken) ? authorToken : TString.check(authorToken);
 
     /** {string} ID of the document to be edited in the session. */
     this._documentId = TString.check(documentId);

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -82,6 +82,31 @@ export default class SessionInfo extends CommonBase {
   }
 
   /**
+   * {object} Ad-hoc object with the contents of this instance, suitable for
+   * logging. In particular, the {@link #authorToken} is represented in redacted
+   * form.
+   */
+  get logInfo() {
+    const caretId       = this._caretId;
+    const token         = this._authorToken;
+    const redactedToken = (token instanceof BearerToken)
+      ? token.safeString
+      : BearerToken.redactString(token);
+
+    const result = {
+      serverUrl:   this._serverUrl,
+      authorToken: redactedToken,
+      documentId:  this._documentId
+    };
+
+    if (caretId !== null) {
+      result.caretId = caretId;
+    }
+
+    return result;
+  }
+
+  /**
    * {string} Most-specific log tag to use with this instance. This is the caret
    * ID if non-`null` or otherwise the document ID.
    */

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -18,8 +18,7 @@ export default class SessionInfo extends CommonBase {
    * @param {string} serverUrl URL of the server to connect to in order to use
    *   the session.
    * @param {string|BearerToken} authorToken Token which identifies the author
-   *   (user) under whose authority the session is to be run. If passed as a
-   *   {@link BearerToken}, gets converted to its `secretToken` string.
+   *   (user) under whose authority the session is to be run.
    * @param {string} documentId ID of the document to be edited in the session.
    * @param {string|null} [caretId = null] ID of a pre-existing caret to control
    *   with the session. If `null`, a new caret will ultimately be created for
@@ -95,22 +94,24 @@ export default class SessionInfo extends CommonBase {
   }
 
   /**
-   * Gets reconstruction arguments for this instance.
+   * Gets reconstruction arguments for this instance. In deconstructed form,
+   * the `authorToken` is always represented as a string.
    *
    * @returns {array<*>} Reconstruction arguments.
    */
   deconstruct() {
-    const most = [this._serverUrl, this._authorToken, this._documentId];
+    const origToken   = this._authorToken;
+    const authorToken = (origToken instanceof BearerToken) ? origToken.secretToken : origToken;
+    const maybeCaret  = (this._caretId === null) ? [] : [this._caretId];
 
-    return (this._caretId === null) ? most : [...most, this._caretId];
+    return [this._serverUrl, authorToken, this._documentId, ...maybeCaret];
   }
 
   /**
    * Makes an instance just like this one, except with a new value for
    * `authorToken`.
    *
-   * @param {string|BearerToken} authorToken New token to use. If passed as a
-   *   {@link BearerToken}, gets converted to its `secretToken` string.
+   * @param {string|BearerToken} authorToken New token to use.
    * @returns {SessionInfo} An appropriately-constructed instance.
    */
   withAuthorToken(authorToken) {

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -68,11 +68,10 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.strictEqual(result.authorToken, token);
     });
 
-    it('should be the `secretToken` from a `BearerToken` if that was used in construction', () => {
-      const secret = 'the-secret';
-      const token  = new BearerToken('the-id', secret);
+    it('should be the constructed value if constructed from a `BearerToken`', () => {
+      const token  = new BearerToken('the-id', 'the-secret');
       const result = new SessionInfo(SERVER_URL, token, 'boop');
-      assert.strictEqual(result.authorToken, secret);
+      assert.strictEqual(result.authorToken, token);
     });
   });
 
@@ -160,11 +159,11 @@ describe('@bayou/doc-common/SessionInfo', () => {
 
       function test(token) {
         const result1 = orig1.withAuthorToken(token);
-        const expect1 = new SessionInfo(orig1.serverUrl, token.secretToken, orig1.documentId, orig1.caretId);
+        const expect1 = new SessionInfo(orig1.serverUrl, token, orig1.documentId, orig1.caretId);
         assert.deepEqual(result1, expect1);
 
         const result2 = orig2.withAuthorToken(token);
-        const expect2 = new SessionInfo(orig2.serverUrl, token.secretToken, orig2.documentId, orig2.caretId);
+        const expect2 = new SessionInfo(orig2.serverUrl, token, orig2.documentId, orig2.caretId);
         assert.deepEqual(result2, expect2);
       }
 

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -104,6 +104,51 @@ describe('@bayou/doc-common/SessionInfo', () => {
     });
   });
 
+  describe('.logInfo', () => {
+    it('should reflect the constructed `serverUrl`', () => {
+      const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
+      const info = si.logInfo;
+
+      assert.strictEqual(info.serverUrl, si.serverUrl);
+    });
+
+    it('should reflect the constructed `documentId`', () => {
+      const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
+      const info = si.logInfo;
+
+      assert.strictEqual(info.documentId, si.documentId);
+    });
+
+    it('should reflect the constructed `caretId` if present', () => {
+      const si   = new SessionInfo(SERVER_URL, 'token', 'doc', 'the-present-id');
+      const info = si.logInfo;
+
+      assert.strictEqual(info.caretId, si.caretId);
+    });
+
+    it('should not bind `caretId` if the instance has no `caretId`', () => {
+      const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
+      const info = si.logInfo;
+
+      assert.doesNotHaveAnyKeys(info, { caretId: null });
+    });
+
+    it('should include a redacted form of `authorToken` if it is a string', () => {
+      const si   = new SessionInfo(SERVER_URL, 'token-token-whee-whee-whee-whee', 'doc');
+      const info = si.logInfo;
+
+      assert.strictEqual(info.authorToken, 'token-token-whee...');
+    });
+
+    it('should include the `safeString` of `authorToken` if it is a `BearerToken`', () => {
+      const token = new BearerToken('token-id', 'the-full-secret');
+      const si    = new SessionInfo(SERVER_URL, token, 'doc');
+      const info  = si.logInfo;
+
+      assert.strictEqual(info.authorToken, token.safeString);
+    });
+  });
+
   describe('.logTag', () => {
     it('should be the `caretId` if non-`null`', () => {
       const id = 'caretness';

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -214,7 +214,7 @@ export default class EditorComplex extends CommonBase {
   _initSession(keyOrInfo, fromConstructor) {
     // **TODO:** Simplify this once we stop using `SplitKey`s.
     if (keyOrInfo instanceof SessionInfo) {
-      log.event.usingInfo(keyOrInfo);
+      log.event.usingInfo(keyOrInfo.logInfo);
     } else {
       SplitKey.check(keyOrInfo);
       log.event.usingKey(keyOrInfo.toString());

--- a/local-modules/@bayou/see-all-server/HumanSink.js
+++ b/local-modules/@bayou/see-all-server/HumanSink.js
@@ -14,9 +14,6 @@ import { TBoolean, TString } from '@bayou/typecheck';
 
 import Redactor from './Redactor';
 
-// The whole point of this file is to use `console.<whatever>`, so...
-/* eslint-disable no-console */
-
 /**
  * {Int} Default width of output, in columns. This is used when _not_ outputting
  * to an actual console or when the width of the console cannot be determined.
@@ -56,10 +53,12 @@ export default class HumanSink extends BaseSink {
   static patchConsole() {
     const consoleLogger = new Logger('node-console');
 
+    /* eslint-disable no-console */
     console.info  = (...args) => { consoleLogger.info(format(...args));  };
     console.warn  = (...args) => { consoleLogger.warn(format(...args));  };
     console.error = (...args) => { consoleLogger.error(format(...args)); };
     console.log   = console.info;
+    /* eslint-enable no-console */
   }
 
   /**

--- a/local-modules/@bayou/see-all-server/HumanSink.js
+++ b/local-modules/@bayou/see-all-server/HumanSink.js
@@ -9,7 +9,7 @@ import stripAnsi from 'strip-ansi';
 import { format } from 'util';
 import wrapAnsi from 'wrap-ansi';
 
-import { BaseSink, LogRecord, LogTag, Logger, SeeAll } from '@bayou/see-all';
+import { BaseSink, Logger, SeeAll } from '@bayou/see-all';
 import { TBoolean, TString } from '@bayou/typecheck';
 
 import Redactor from './Redactor';
@@ -40,17 +40,6 @@ const PREFIX_ADJUST_INCREMENT = 4;
  * characters.
  */
 const MAX_EVENT_STRING_LENGTH = 200;
-
-/**
- * {Int} Maximum number of "skippable" events to not-skip in a burst.
- */
-const MAX_SKIPPABLE_BURST_COUNT = 5;
-
-/**
- * {Int} Number of msec which should be considered the burst duration, when
- * figuring out whether a skippable message should be skipped.
- */
-const SKIPPABLE_BURST_MSEC = 2000; // Two seconds.
 
 /**
  * Implementation of the `@bayou/see-all` logging sink protocol which writes
@@ -133,18 +122,6 @@ export default class HumanSink extends BaseSink {
      */
     this._recentLineCount = 0;
 
-    /**
-     * {Int} Timestamp after which any current log skipping activity should end
-     * and / or reset.
-     */
-    this._skipEndTime = 0;
-
-    /**
-     * {Int} Number of log records that are accounted for in the current burst
-     * of skippable log records.
-     */
-    this._skipCount = 0;
-
     SeeAll.theOne.add(this);
   }
 
@@ -154,10 +131,6 @@ export default class HumanSink extends BaseSink {
    * @param {LogRecord} logRecord The record to write.
    */
   _impl_sinkLog(logRecord) {
-    if (this._shouldSkip(logRecord)) {
-      return;
-    }
-
     logRecord = Redactor.redact(logRecord);
 
     const prefix = this._makePrefix(logRecord);
@@ -307,47 +280,6 @@ export default class HumanSink extends BaseSink {
   }
 
   /**
-   * Handle the possibility of skipping output for a given record.
-   *
-   * @param {LogRecord} logRecord Record in question.
-   * @returns {boolean} `true` if the record should be skipped in the output.
-   */
-  _shouldSkip(logRecord) {
-    const emitSkipLogIfNecessary = () => {
-      const skipCount = this._skipCount;
-      if (skipCount > 0) {
-        this._skipCount   = 0;
-        this._skipEndTime = 0;
-
-        if (skipCount > MAX_SKIPPABLE_BURST_COUNT) {
-          const count      = skipCount - MAX_SKIPPABLE_BURST_COUNT;
-          const countStr   = (count === 1) ? '1 log record' : `${count} log records`;
-          const msg        = chalk.dim(`Skipped ${countStr}.`);
-          const skipRecord = LogRecord.forMessage(logRecord.timeMsec, null, LogTag.LOG, 'info', msg);
-
-          this._impl_sinkLog(skipRecord);
-        }
-      }
-    };
-
-    const timeMsec = logRecord.timeMsec;
-    const skipEnd  = this._skipEndTime;
-
-    if (!HumanSink._isSkippable(logRecord)) {
-      emitSkipLogIfNecessary();
-      return false;
-    } else if (timeMsec >= skipEnd) {
-      emitSkipLogIfNecessary();
-      this._skipEndTime = timeMsec + SKIPPABLE_BURST_MSEC;
-      this._skipCount = 0;
-      return false;
-    } else {
-      this._skipCount++;
-      return (this._skipCount > MAX_SKIPPABLE_BURST_COUNT);
-    }
-  }
-
-  /**
    * Creates a colorized message string from a time record.
    *
    * @param {LogRecord} logRecord Time log record.
@@ -379,16 +311,5 @@ export default class HumanSink extends BaseSink {
     if (this._path !== null) {
       fs.appendFileSync(this._path, text);
     }
-  }
-
-  /**
-   * Is the given log record skippable for the purposes of human-oriented
-   * logging?
-   *
-   * @param {LogRecord} logRecord Record in question.
-   * @returns {boolean} `true` if it should be considered skippable.
-   */
-  static _isSkippable(logRecord) {
-    return logRecord.isEvent() || (logRecord.payload.name === 'detail');
   }
 }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.14
+version = 1.1.16


### PR DESCRIPTION
Highlights:

* Made `SessionInfo` have an explicit way to provide a log-safe redacted form.
* Got rid of the console-log-skipping behavior. It was causing more problems that it was solving.
