### PR TITLE
A little more new-session stuff.

### DIFF
--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -6,7 +6,7 @@ import { TString } from '@bayou/typecheck';
 import { Errors, UtilityClass } from '@bayou/util-common';
 
 /** {RegExp} Regular expression which matches valid target IDs. */
-const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,64}$/;
+const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,256}$/;
 
 /**
  * Type representation of target IDs. The values themselves are always just
@@ -18,7 +18,7 @@ const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,64}$/;
  *
  * Syntactically, a target ID must be a string of consisting of ASCII-range
  * alphanumerics, underscore (`_`), dash (`-`), or period (`.`), which is at
- * least one and no longer than 64 characters.
+ * least one and no longer than 256 characters.
  */
 export default class TargetId extends UtilityClass {
   /**

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -25,7 +25,7 @@ describe('@bayou/api-common/TargetId', () => {
       test('_X_Y_');
       test('.x.Y.');
 
-      for (let len = 10; len <= 64; len++) {
+      for (let len = 200; len <= 256; len++) {
         test('x'.repeat(len));
         test(`-${'x'.repeat(len - 2)}-`);
         test(`_${'Y'.repeat(len - 2)}_`);
@@ -49,8 +49,8 @@ describe('@bayou/api-common/TargetId', () => {
     });
 
     it('should reject too-long strings', () => {
-      for (let i = 65; i < 100; i++) {
-        assert.throws(() => TargetId.check('x'.repeat(i)), /badValue/);
+      for (let i = 257; i < 500; i++) {
+        assert.throws(() => TargetId.check('x'.repeat(i)), /badValue/, `length ${i}`);
       }
     });
 

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -32,7 +32,7 @@ export default class RootAccess extends CommonBase {
     this._context = Context.check(context);
 
     /**
-     * {Map<string,string>} Map from author IDs to corresponding tokens, as
+     * {Map<string,BearerToken>} Map from author IDs to corresponding tokens, as
      * registered by {@link #useToken}.
      */
     this._tokenMap = new Map();
@@ -146,14 +146,14 @@ export default class RootAccess extends CommonBase {
     TString.check(authorId);
     TString.check(authorToken);
 
-    this._tokenMap.set(authorId, authorToken);
+    this._tokenMap.set(authorId, Auth.tokenFromString(authorToken));
   }
 
   /**
    * Gets a token to use for the given author ID.
    *
    * @param {string} authorId The author ID.
-   * @param {string} authorToken The corresponding author token.
+   * @param {BearerToken} authorToken The corresponding author token.
    */
   async _getAuthorToken(authorId) {
     TString.check(authorId);

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -8,6 +8,7 @@ import { Auth, Network, Storage } from '@bayou/config-server';
 import { SessionInfo } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';
+import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 /** Logger. */
@@ -29,6 +30,12 @@ export default class RootAccess extends CommonBase {
 
     /** {Context} The API context to use. */
     this._context = Context.check(context);
+
+    /**
+     * {Map<string,string>} Map from author IDs to corresponding tokens, as
+     * registered by {@link #useToken}.
+     */
+    this._tokenMap = new Map();
 
     Object.freeze(this);
   }
@@ -66,7 +73,7 @@ export default class RootAccess extends CommonBase {
     // Remove this -- heck, remove this whole method -- once new-style sessions
     // are consistently used.
     try {
-      const authorToken = await Auth.getAuthorToken(authorId);
+      const authorToken = await this._getAuthorToken(authorId);
       const authority   = await Auth.tokenAuthority(authorToken);
       log.event.gotAuthorToken({ where: 'makeAccessKey', token: authorToken.safeString, authority });
     } catch (e) {
@@ -113,7 +120,7 @@ export default class RootAccess extends CommonBase {
     log.event.sessionInfoValid(authorId, documentId);
 
     const url         = `${Network.baseUrl}/api`;
-    const authorToken = await Auth.getAuthorToken(authorId);
+    const authorToken = await this._getAuthorToken(authorId);
 
     // As a bit of extra visibility / validation as we transition to new-style
     // sessions, get and log the "authority" granted to `authorToken`. This had
@@ -126,5 +133,35 @@ export default class RootAccess extends CommonBase {
     // ultimately need to pass it back in full. (Usually it's a bad idea to
     // return unredacted tokens; this (kind of) case is the main exception.)
     return new SessionInfo(url, authorToken, documentId);
+  }
+
+  /**
+   * Registers a token to use for the given author ID. When done, the registered
+   * token is used in favor of calling {@link Auth#getAuthorToken}.
+   *
+   * @param {string} authorId The author ID.
+   * @param {string} authorToken The corresponding author token.
+   */
+  useToken(authorId, authorToken) {
+    TString.check(authorId);
+    TString.check(authorToken);
+
+    this._tokenMap.set(authorId, authorToken);
+  }
+
+  /**
+   * Gets a token to use for the given author ID.
+   *
+   * @param {string} authorId The author ID.
+   * @param {string} authorToken The corresponding author token.
+   */
+  async _getAuthorToken(authorId) {
+    TString.check(authorId);
+
+    const found = this._tokenMap.get(authorId);
+
+    return (found !== undefined)
+      ? found
+      : Auth.getAuthorToken(authorId);
   }
 }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -153,7 +153,7 @@ export default class RootAccess extends CommonBase {
    * Gets a token to use for the given author ID.
    *
    * @param {string} authorId The author ID.
-   * @param {BearerToken} authorToken The corresponding author token.
+   * @returns {BearerToken} The corresponding author token.
    */
   async _getAuthorToken(authorId) {
     TString.check(authorId);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.17
+version = 1.1.18


### PR DESCRIPTION
This PR adds a bit of support for the new-session effort:

* Added a new debugging endpoint `use-token` which lets one specify an arbitrary token to associate with a given user ID. Without this, the debug `edit` endpoint would — usually helpfully, but not in this case — create a new token out of whole cloth such that the system would accept it and move on.

* Increased the length of allowed "target ID"s in the API from 64 to 256 characters, because tokens get used as target IDs, and actual tokens can be significantly larger than 64 characters.

