### PR TITLE
Work around a Babel issue.

### DIFF
--- a/local-modules/@bayou/api-server/TokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/TokenAuthorizer.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken } from '@bayou/api-common';
+import { BaseKey, BearerToken } from '@bayou/api-common';
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
@@ -76,7 +76,7 @@ export default class TokenAuthorizer extends CommonBase {
     if (!this.isToken(tokenString)) {
       // Redact the token string in the error to avoid leaking
       // security-sensitive information.
-      throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
+      throw Errors.badValue(BaseKey.redactString(tokenString), 'bearer token');
     }
 
     const result = this._impl_tokenFromString(tokenString);

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken } from '@bayou/api-common';
+import { BaseKey, BearerToken } from '@bayou/api-common';
 import { TokenMint } from '@bayou/api-server';
 import { BaseAuth } from '@bayou/config-server';
 import { TString } from '@bayou/typecheck';
@@ -144,6 +144,6 @@ export default class Auth extends BaseAuth {
 
     // **Note:** We redact the value to reduce the likelihood of leaking
     // security-sensitive info.
-    throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
+    throw Errors.badValue(BaseKey.redactString(tokenString), 'bearer token');
   }
 }

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken } from '@bayou/api-common';
+import { BaseKey, BearerToken } from '@bayou/api-common';
 import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
@@ -91,7 +91,7 @@ export default class SessionInfo extends CommonBase {
     const token         = this._authorToken;
     const redactedToken = (token instanceof BearerToken)
       ? token.safeString
-      : BearerToken.redactString(token);
+      : BaseKey.redactString(token);
 
     const result = {
       serverUrl:   this._serverUrl,

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.18
+version = 1.1.19


### PR DESCRIPTION
When building modules with `--compile`, the Babel conversion seems to mess with the inheritance of `static` methods. This PR changes the use of `BearerToken.redactString()` to instead be `BaseKey.redactString()` to avoid the deficiency.