### PR TITLE
Stop generating and accepting `SplitKey` authorization.

### DIFF
--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -64,13 +64,13 @@ export default class DebugTools extends CommonBase {
     this._bindParam('revNum');
     this._bindParam('testFilter');
 
+    this._bindHandler('access',      ':documentId');
+    this._bindHandler('access',      ':documentId/:authorId');
     this._bindHandler('change',      ':documentId/:revNum');
     this._bindHandler('client-test');
     this._bindHandler('client-test', ':testFilter');
     this._bindHandler('edit',        ':documentId');
     this._bindHandler('edit',        ':documentId/:authorId');
-    this._bindHandler('key',         ':documentId');
-    this._bindHandler('key',         ':documentId/:authorId');
     this._bindHandler('log');
     this._bindHandler('snapshot',    ':documentId');
     this._bindHandler('snapshot',    ':documentId/:revNum');
@@ -215,6 +215,21 @@ export default class DebugTools extends CommonBase {
   }
 
   /**
+   * Produces an access and authorization info for editing a document, and
+   * returns it directly, as JSON.
+   *
+   * @param {object} req HTTP request.
+   * @param {object} res HTTP response handler.
+   */
+  async _handle_access(req, res) {
+    const documentId = req.params.documentId;
+    const authorId   = this._getAuthorIdParam(req);
+    const info       = await this._makeEncodedInfo(documentId, authorId);
+
+    this._jsonResponse(res, info);
+  }
+
+  /**
    * Gets a particular change to a document.
    *
    * @param {object} req HTTP request.
@@ -286,21 +301,6 @@ export default class DebugTools extends CommonBase {
       '<div id="debugEditor"><p>Loading&hellip;</p></div>\n';
 
     this._htmlResponse(res, head, body);
-  }
-
-  /**
-   * Produces an authorization key for editing a document, and returns it
-   * directly, as JSON.
-   *
-   * @param {object} req HTTP request.
-   * @param {object} res HTTP response handler.
-   */
-  async _handle_key(req, res) {
-    const documentId = req.params.documentId;
-    const authorId   = this._getAuthorIdParam(req);
-    const info       = await this._makeEncodedInfo(documentId, authorId);
-
-    this._jsonResponse(res, info);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -443,16 +443,6 @@ export default class DebugTools extends CommonBase {
    * @returns {string} A new `SplitKey` encoded as JSON.
    */
   async _makeEncodedInfo(documentId, authorId) {
-    // As an aid to the transition to new-style sessions, if the `authorId` has
-    // the suffix `-key`, then we strip the suffix and produce an old-style
-    // session access key. **TODO:** Remove this once new-style sessions are
-    // used consistently.
-    if (authorId.endsWith('-key')) {
-      authorId = authorId.replace(/-key$/, '');
-      const key = await this._rootAccess.makeAccessKey(authorId, documentId);
-      return appCommon_TheModule.fullCodec.encodeJson(key);
-    }
-
     const info = await this._rootAccess.makeSessionInfo(authorId, documentId);
     return appCommon_TheModule.fullCodec.encodeJson(info);
   }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -41,57 +41,6 @@ export default class RootAccess extends CommonBase {
   }
 
   /**
-   * Makes an access key which specifically allows access to one document by
-   * one author. If the document doesn't exist, this will cause it to be
-   * created.
-   *
-   * @param {string} authorId ID which corresponds to the author of changes that
-   *   are made using the resulting authorization.
-   * @param {string} documentId ID of the document which the resulting
-   *   authorization allows access to.
-   * @returns {SplitKey} A split token (ID + secret) which provides the
-   *   requested access.
-   */
-  async makeAccessKey(authorId, documentId) {
-    // These checks round-trip with the back-end to do full (not just syntactic)
-    // validation.
-    await Promise.all([
-      Storage.dataStore.checkExistingAuthorId(authorId),
-      Storage.dataStore.checkExistingDocumentId(documentId)
-    ]);
-
-    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
-
-    const url      = `${Network.baseUrl}/api`;
-    const targetId = this._context.randomSplitKeyId();
-    const session  = await fileComplex.makeNewSession(authorId);
-    const key      = new SplitKey(url, targetId);
-    this._context.addTarget(new Target(key, session));
-
-    // As a "dry run" for the transition to new-style session management, try to
-    // get an author token for `authorId`, and log what happens. **TODO:**
-    // Remove this -- heck, remove this whole method -- once new-style sessions
-    // are consistently used.
-    try {
-      const authorToken = await this._getAuthorToken(authorId);
-      const authority   = await Auth.tokenAuthority(authorToken);
-      log.event.gotAuthorToken({ where: 'makeAccessKey', token: authorToken.safeString, authority });
-    } catch (e) {
-      log.event.failedToGetAuthorToken(e);
-    }
-
-    log.info(
-      'Newly-authorized access.\n',
-      `  author:   ${authorId}\n`,
-      `  document: ${documentId}\n`,
-      `  caret:    ${session.getCaretId()}\n`,
-      `  key id:   ${key.safeString}\n`, // This is safe to log (not security-sensitive).
-      `  key url:  ${key.url}`);
-
-    return key;
-  }
-
-  /**
    * Makes an instance of {@link SessionInfo} which corresponds to a specific
    * author editing a specific document, on the server (or server cluster)
    * running this method.

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -2,8 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { SplitKey } from '@bayou/api-common';
-import { Context, Target } from '@bayou/api-server';
+import { Context } from '@bayou/api-server';
 import { Auth, Network, Storage } from '@bayou/config-server';
 import { SessionInfo } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -13,14 +13,14 @@
 
 /**
  * This global function is what ultimately gets called to attempt recovery. In
- * this case, we rely on the `/key/*` debugging endpoints to generate a new key.
- * If that's successful, we report it back up through the layers.
+ * this case, we rely on the `/access/*` debugging endpoints to generate new
+ * access info. If that's successful, we report it back up through the layers.
  */
 function BAYOU_RECOVER(info) {
   var documentId = DEBUG_DOCUMENT_ID;
   var authorId   = DEBUG_AUTHOR_ID;
   var origin     = new URL(info.serverUrl).origin;
-  var url        = `${origin}/debug/key/${documentId}/${authorId}`;
+  var url        = `${origin}/debug/access/${documentId}/${authorId}`;
 
   return new Promise((res, rej_unused) => {
     var req = new XMLHttpRequest();

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -16,10 +16,10 @@
  * this case, we rely on the `/key/*` debugging endpoints to generate a new key.
  * If that's successful, we report it back up through the layers.
  */
-function BAYOU_RECOVER(keyOrInfo) {
+function BAYOU_RECOVER(info) {
   var documentId = DEBUG_DOCUMENT_ID;
   var authorId   = DEBUG_AUTHOR_ID;
-  var origin     = new URL(keyOrInfo.url || keyOrInfo.serverUrl).origin;
+  var origin     = new URL(info.serverUrl).origin;
   var url        = `${origin}/debug/key/${documentId}/${authorId}`;
 
   return new Promise((res, rej_unused) => {

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiClient } from '@bayou/api-client';
-import { BaseKey } from '@bayou/api-common';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { SessionInfo } from '@bayou/doc-common';
 import { Logger } from '@bayou/see-all';
@@ -22,27 +21,19 @@ export default class DocSession extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {BaseKey|SessionInfo} keyOrInfo Key or info object that identifies
-   *   the session and grants access to it. **Note:** A session is tied to a
-   *   specific caret, which is associated with a single document and author. If
-   *   passed a `SessionInfo` without a caret ID, then the act of establishing
-   *   the session will cause a new caret to be created.
+   * @param {SessionInfo} info Info object that identifies the session and
+   *   grants access to it. **Note:** A session is tied to a specific caret,
+   *   which is associated with a single document and author. If passed an
+   *   instance without a caret ID, then the act of establishing the session
+   *   will cause a new caret to be created.
    */
-  constructor(keyOrInfo) {
+  constructor(info) {
     super();
 
     /**
-     * {SessionInfo|null} Identifying and authorizing information for the
-     * session. If `null`, then {@link #_key} is being used instead of this.
+     * {SessionInfo} Identifying and authorizing information for the session.
      */
-    this._sessionInfo = (keyOrInfo instanceof SessionInfo) ? keyOrInfo : null;
-
-    /**
-     * {BaseKey|null} Key that identifies the server-side session and grants
-     * access to it. If `null`, then {@link #_sessionInfo} is being used
-     * instead of this.
-     */
-    this._key = (this._sessionInfo === null) ? BaseKey.check(keyOrInfo) : null;
+    this._sessionInfo = SessionInfo.check(info);
 
     /**
      * {Logger} Maximally-specific logger. **TODO:** Because {@link
@@ -50,9 +41,7 @@ export default class DocSession extends CommonBase {
      * _eventually_ have one, it probably doesn't make sense to have this
      * defined in this class.
      */
-    this._log = (this._key !== null)
-      ? log.withAddedContext(this._key.id)
-      : log.withAddedContext(this._sessionInfo.logTag);
+    this._log = log.withAddedContext(this._sessionInfo.logTag);
 
     /**
      * {ApiClient|null} API client instance. Set to non-`null` in
@@ -99,14 +88,14 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * {BaseKey|SessionInfo} Information which was originally used to construct
+   * {SessionInfo} Information which was originally used to construct
    * this instance. Used for recovery from connection trouble.
    *
    * **TODO:** This should be removed and its use sites switched to
    * `.sessionInfo`, once key-based session setup is retired.
    */
   get keyOrInfo() {
-    return this._key || this._sessionInfo;
+    return this._sessionInfo;
   }
 
   /** {PropertyClient} Property accessor this session. */
@@ -152,41 +141,11 @@ export default class DocSession extends CommonBase {
       this._log.event.mustReestablishSession();
     }
 
-    let proxyPromise;
-
-    if (this._sessionInfo !== null) {
-      const info        = this._sessionInfo;
-      const authorProxy = api.getProxy(info.authorToken);
-
-      if (info.caretId === null) {
-        proxyPromise = authorProxy.makeNewSession(info.documentId);
-      } else {
-        proxyPromise = authorProxy.findExistingSession(info.documentId, info.caretId);
-      }
-    } else if (api.isLocal()) {
-      // Transition an old-style session to a new-style one, but -- for now
-      // -- only if running in a local-dev situation, so as to limit the blast
-      // radius in case things aren't quite working. **TODO:** Remove the
-      // `isLocal()` test and the following `else`, once it is safe to always
-      // convert old sessions, and then remove this clause (and the `if`
-      // cladding) once {@link #_sessionInfo} is used ubiquitously.
-      proxyPromise = this._convertOldSession();
-    } else {
-      proxyPromise = api.authorizeTarget(this._key);
-
-      // "Dry run" of converting to a new-style session. This is done
-      // asynchronously with respect to the rest of this method, so as not to
-      // disturb the primary control flow.
-      (async () => {
-        try {
-          const dryRunProxy = await proxyPromise;
-          const sessionInfo = await dryRunProxy.getSessionInfo();
-          this._log.event.dryRunConverted(sessionInfo);
-        } catch (e) {
-          this._log.event.dryRunFailed(e);
-        }
-      })();
-    }
+    const info         = this._sessionInfo;
+    const authorProxy  = api.getProxy(info.authorToken);
+    const proxyPromise = (info.caretId === null)
+      ? authorProxy.makeNewSession(info.documentId)
+      : authorProxy.findExistingSession(info.documentId, info.caretId);
 
     this._sessionProxyPromise = proxyPromise;
 
@@ -194,19 +153,15 @@ export default class DocSession extends CommonBase {
     const proxy = await proxyPromise;
     this._log.event.gotSessionProxy();
 
-    if (this._sessionInfo !== null) {
-      const info = this._sessionInfo;
+    if (info.caretId === null) {
+      // The session got started without a caret ID, which means a new caret
+      // will have been created. Update `_sessionInfo` and `_log` accordingly.
+      const caretId = await proxy.getCaretId();
 
-      if (info.caretId === null) {
-        // The session got started without a caret ID, which means a new caret
-        // will have been created. Update `_sessionInfo` and `_log` accordingly.
-        const caretId = await proxy.getCaretId();
+      this._log.event.gotCaret(caretId);
 
-        this._log.event.gotCaret(caretId);
-
-        this._sessionInfo = info.withCaretId(caretId);
-        this._log         = log.withAddedContext(this._sessionInfo.logTag);
-      }
+      this._sessionInfo = info.withCaretId(caretId);
+      this._log         = log.withAddedContext(this._sessionInfo.logTag);
     }
 
     return proxy;
@@ -229,28 +184,6 @@ export default class DocSession extends CommonBase {
   }
 
   /**
-   * Converts the old-style session auth in {@link #_key} to the info which can
-   * be used to establish an equivalent, saving it in {@link #_sessionInfo}, and
-   * goes ahead and establishes the session in the new style.
-   *
-   * @returns {Proxy} Session authorization info.
-   */
-  async _convertOldSession() {
-    const api   = this._getApiClient();
-    const proxy = await api.authorizeTarget(this._key);
-
-    this._log.event.gotOldStyleSession();
-
-    const info = await proxy.getSessionInfo();
-
-    this._log.event.convertedToSessionInfo(info);
-
-    const authorProxy = api.getProxy(info.authorToken);
-
-    return authorProxy.findExistingSession(info.documentId, info.caretId);
-  }
-
-  /**
    * API client instance to use. The client is not guaranteed to be fully open
    * at the time it is returned; however, `open()` will have been called on it,
    * which means that it will at least be in the _process_ of opening and
@@ -259,9 +192,7 @@ export default class DocSession extends CommonBase {
    * @returns {ApiClient} API client interface.
    */
   _getApiClient() {
-    const url = (this._sessionInfo !== null)
-      ? this._sessionInfo.serverUrl
-      : this._key.url;
+    const url = this._sessionInfo.serverUrl;
 
     if ((this._apiClient === null) || !this._apiClient.isOpen()) {
       this._log.event.opening(url);

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -87,17 +87,6 @@ export default class DocSession extends CommonBase {
     return this._caretTracker;
   }
 
-  /**
-   * {SessionInfo} Information which was originally used to construct
-   * this instance. Used for recovery from connection trouble.
-   *
-   * **TODO:** This should be removed and its use sites switched to
-   * `.sessionInfo`, once key-based session setup is retired.
-   */
-  get keyOrInfo() {
-    return this._sessionInfo;
-  }
-
   /** {PropertyClient} Property accessor this session. */
   get propertyClient() {
     if (this._propertyClient === null) {

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { SplitKey } from '@bayou/api-common';
 import { Editor } from '@bayou/config-client';
 import { ClientStore } from '@bayou/data-model-client';
 import { BodyClient, DocSession } from '@bayou/doc-client';
@@ -29,17 +28,13 @@ export default class EditorComplex extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {SplitKey|SessionInfo} keyOrInfo Key or info object that identifies
-   *   the session and grants access to it.
+   * @param {SessionInfo} info Info object that identifies the session and
+   *   grants access to it.
    * @param {Window} window The browser window in which we are operating.
    * @param {Element} topNode DOM element to attach the complex to.
    */
-  constructor(keyOrInfo, window, topNode) {
-    // **TODO:** Simplify this once we stop using `SplitKey`s.
-    if (!(keyOrInfo instanceof SessionInfo)) {
-      SplitKey.check(keyOrInfo);
-    }
-
+  constructor(info, window, topNode) {
+    SessionInfo.check(info);
     TObject.check(window, Window);
     TObject.check(topNode, Element);
 
@@ -99,10 +94,7 @@ export default class EditorComplex extends CommonBase {
     (async () => {
       log.event.starting();
 
-      // **TODO:** Simplify this once we stop using `SplitKey`s.
-      const serverUrl = (keyOrInfo instanceof SessionInfo)
-        ? keyOrInfo.serverUrl
-        : keyOrInfo.baseUrl;
+      const serverUrl = info.serverUrl;
 
       // Do all of the DOM setup for the instance.
       const [headerNode_unused, titleNode, bodyNode, authorOverlayNode] =
@@ -123,8 +115,8 @@ export default class EditorComplex extends CommonBase {
       // Let the overlay do extra initialization.
       Editor.editorComplexInit(this);
 
-      // Do session setup using the initial key.
-      this._initSession(keyOrInfo, true);
+      // Do session setup using the initial info.
+      this._initSession(info, true);
 
       this._ready.value = true;
     })();
@@ -206,21 +198,17 @@ export default class EditorComplex extends CommonBase {
   /**
    * Initialize the session, based on the given key.
    *
-   * @param {SplitKey|SessionInfo} keyOrInfo Key or info object that
-   *   identifies the session and grants access to it.
+   * @param {SessionInfo} info Info object that identifies the session and
+   *   grants access to it.
    * @param {boolean} fromConstructor `true` iff this call is from the
    *   constructor.
    */
-  _initSession(keyOrInfo, fromConstructor) {
-    // **TODO:** Simplify this once we stop using `SplitKey`s.
-    if (keyOrInfo instanceof SessionInfo) {
-      log.event.usingInfo(keyOrInfo.logInfo);
-    } else {
-      SplitKey.check(keyOrInfo);
-      log.event.usingKey(keyOrInfo.toString());
-    }
+  _initSession(info, fromConstructor) {
+    SessionInfo.check(info);
 
-    this._sessionInfo = keyOrInfo;
+    log.event.usingInfo(info.logInfo);
+
+    this._sessionInfo = info;
     this._docSession  = new DocSession(this._sessionInfo);
     this._bodyClient  = new BodyClient(this._bodyQuill, this._docSession);
     this._titleClient = new TitleClient(this);

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -52,8 +52,8 @@ export default class EditorComplex extends CommonBase {
     this._ready = new Condition();
 
     /**
-     * {SessionInfo|SplitKey|null} Key or info object that identifies the
-     * session and grants access to it. Set in {@link #_initSession}.
+     * {SessionInfo|null} Key or info object that identifies the session and
+     * grants access to it. Set in {@link #_initSession}.
      */
     this._sessionInfo = null;
 

--- a/local-modules/@bayou/doc-ui/package.json
+++ b/local-modules/@bayou/doc-ui/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@bayou/api-common": "local",
     "@bayou/config-client": "local",
     "@bayou/data-model-client": "local",
     "@bayou/doc-client": "local",

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -131,7 +131,7 @@ export default class TopControl {
   async _recoverIfPossible() {
     log.error('Editor gave up!');
 
-    const newInfo = await this._recover(this._editorComplex.docSession.keyOrInfo);
+    const newInfo = await this._recover(this._editorComplex.docSession.sessionInfo);
 
     if (typeof newInfo !== 'string') {
       log.info('Nothing more to do. :\'(');

--- a/local-modules/@bayou/top-client/package.json
+++ b/local-modules/@bayou/top-client/package.json
@@ -3,7 +3,6 @@
   "testMain": "tests/index.js",
 
   "dependencies": {
-    "@bayou/api-common": "local",
     "@bayou/app-common": "local",
     "@bayou/config-client": "local",
     "@bayou/doc-ui": "local",

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.1.19
+version = 1.2.0


### PR DESCRIPTION
This PR is the first round of cleanup of old-style sessions. This cleanup was enabled by the webapp consistently using the new style to create Arugula sessions, which started being the case yesterday.

There will probably be at least two more rounds of cleanup.

This PR bumps the version to 1.2, to indicate the major change in (drop of old) functionality.[*]

**Note to semantic versioning pedants:** This would be a major version bump (1.x -> 2.x) if we were being strictly semver, but… ehhhh… we're only 1.x at all because npm semantics around 0.x versions is weird, and the reality is that we will almost certainly be continuing to break backward- and forward-compatibility for a while, such that we'd likely end up at like v95 by the time our _actual_ 1.0 is out the door, if we were being all semver-happy, and that'd just be silly.