### PR TITLE
 Logging tweakage to help track down connection issues.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -95,7 +95,7 @@ export default class BodyClient extends StateMachine {
    *   the document body should be editable.
    */
   constructor(quill, docSession, editingEnabled = true) {
-    super('detached', docSession.log);
+    super('detached', docSession.log, true);
 
     /** {Quill} Editor object. */
     this._quill = quill;

--- a/local-modules/@bayou/doc-ui/CaretState.js
+++ b/local-modules/@bayou/doc-ui/CaretState.js
@@ -4,9 +4,10 @@
 
 import { CaretSnapshot } from '@bayou/doc-common';
 import { Delay } from '@bayou/promise-util';
+import { Errors } from '@bayou/util-common';
 
 /**
- * {object} Starting state for the caret redux store.
+ * {CaretSnapshot} Starting state for the caret redux store.
  */
 const INITIAL_STATE = CaretSnapshot.EMPTY;
 
@@ -116,6 +117,12 @@ export default class CaretState {
           docSession.log.detail(`Got caret change. ${snapshot.size} caret(s).`);
         }
       } catch (e) {
+        if (Errors.is_timedOut(e)) {
+          // Timeout is totally NBD; it just means that nothing changed. No need
+          // to log, and just iterate to retry the call.
+          continue;
+        }
+
         // Assume that the error isn't truly fatal. Most likely, it's because
         // the session got restarted or because the snapshot we have is too old
         // to get a change from. We just `null` out the snapshot and let the

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -130,6 +130,11 @@ export default class StateMachine {
     this._serviceEventQueue();
   }
 
+  /** {BaseLogger} The logger that this instance uses. */
+  get log() {
+    return this._log;
+  }
+
   /** {string} The name of the current state. */
   get state() {
     return this._stateName;

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -3,8 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Condition } from '@bayou/promise-util';
-import { Logger } from '@bayou/see-all';
-import { TObject } from '@bayou/typecheck';
+import { BaseLogger, Logger } from '@bayou/see-all';
+import { TBoolean, TObject, TString } from '@bayou/typecheck';
 import { Errors, Functor, PropertyIterable } from '@bayou/util-common';
 
 /**
@@ -69,11 +69,20 @@ export default class StateMachine {
    * Constructs an instance.
    *
    * @param {string} initialState The initial state.
-   * @param {Logger} [logger = null] Logger to use.
+   * @param {BaseLogger|null} [logger = null] Logger to use, or `null` to
+   *   use a newly-constructed instance.
+   * @param {boolean} [verboseLogging = false] Whether to be chatty in the logs.
+   *   `true` is useful for debugging but is arguably too much to leave on on
+   *   an ongoing basis.
    */
-  constructor(initialState, logger = null) {
-    /** {Logger} Logger to use. */
-    this._log = logger || new Logger('state-machine');
+  constructor(initialState, logger = null, verboseLogging = false) {
+    TString.check(initialState);
+
+    /** {BaseLogger} Logger to use. */
+    this._log = (logger === null) ? new Logger('state-machine') : BaseLogger.check(logger);
+
+    /** {boolean} Whether to be particularly chatty in the logs. */
+    this._verboseLogging = TBoolean.check(verboseLogging);
 
     /** {string} The name of the current state. Set below. */
     this._stateName = null;
@@ -149,7 +158,11 @@ export default class StateMachine {
         }
 
         const event = new Functor(name, ...args);
-        this._log.detail('Enqueued:', event);
+
+        if (this._verboseLogging) {
+          this._log.event.enqueued(event);
+        }
+
         this._eventQueue.push(event);
         this._anyEventPending.value = true;
       };
@@ -168,14 +181,20 @@ export default class StateMachine {
           return;
         }
 
-        this._log.detail('New state:', name);
+        if (this._verboseLogging) {
+          this._log.event.newState(name);
+        }
+
         this._stateName = name;
 
         // Trigger the awaiter for the state, if any.
         const condition = this._stateConditions.get(name);
         if (condition) {
           condition.onOff();
-          this._log.detail('Triggered awaiter for state:', name);
+
+          if (this._verboseLogging) {
+            this._log.event.triggeredWaiter(name);
+          }
 
           // Remove the condition, because in general, these kinds of state
           // awaiters are used only ephemerally.
@@ -185,15 +204,23 @@ export default class StateMachine {
 
       this[`when_${name}`] = () => {
         if (this._stateName === name) {
-          this._log.detail('Immediately-resolved awaiter for state:', name);
+          if (this._verboseLogging) {
+            this._log.event.immediatelyTriggeredWaiter(name);
+          }
+
           return Promise.resolve(true);
         } else {
-          this._log.detail('Awaiter added for state:', name);
+          if (this._verboseLogging) {
+            this._log.event.addedWaiter(name);
+          }
+
           let condition = this._stateConditions.get(name);
+
           if (!condition) {
             condition = new Condition();
             this._stateConditions.set(name, condition);
           }
+
           return condition.whenTrue();
         }
       };
@@ -247,8 +274,9 @@ export default class StateMachine {
     // Log the state name and event details (if not squelched), and occasional
     // count of how many events have been handled so far.
 
-    log.detail('In state:', stateName);
-    log.detail('Dispatching:', event);
+    if (this._verboseLogging) {
+      log.event.dequeued(event);
+    }
 
     // Dispatch the event. In case of exception, enqueue an `error` event.
     // (The default handler for the event will log an error and stop the queue.)
@@ -263,16 +291,13 @@ export default class StateMachine {
         this._anyEventPending.value = true; // "Wakes up" the servicer.
         return;
       } else {
-        log.detail('Uncaught error:', e);
         this.q_error(e);
       }
     }
 
-    log.detail('Done dispatching:', event);
-
     this._eventCount++;
     if ((this._eventCount % 25) === 0) {
-      log.info(`Handled ${this._eventCount} events.`);
+      log.event.eventsHandled(this._eventCount);
     }
   }
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.0
+version = 1.2.1


### PR DESCRIPTION
This PR reworks the chattier logging done by `StateMachine`, such that (a) it's done as structured `event` logs, and (b) it can be flipped on during instantiation. And in fact it gets turned on now in the `BodyClient` constructor, specifically to help track down what's happening (or really, I think, what's _failing to happen_) when trying to reconnect after a server connection is dropped.

During the course of the work, I noticed that we were stuffing full `BodySnapshot`s into a few of the events, when all we needed was a revision number. I went ahead and fixed that, because that will make future reading of the tea leaves a bit easier. (It's not actually a memory saving thing, because those snapshot instances will still end up existing for other reasons.)

**Bonus:** Miscellaneous tangentially-related log tweakage.