### PR TITLE
Fix one reason why session reconnect would fail.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -57,8 +57,8 @@ export default class AuthorAccess extends CommonBase {
    *
    * @param {string} documentId ID of the document which the session is for.
    * @param {string} caretId ID of the caret.
-   * @returns {string} Target ID within the API context which refers to the
-   *   session. This is _not_ the same as the `caretId`.
+   * @returns {ProxiedObject} Proxy wrapper (for return via API) of the found
+   *   session.
    */
   async findExistingSession(documentId, caretId) {
     // We only check the document ID syntax here, because we can count on the
@@ -89,8 +89,8 @@ export default class AuthorAccess extends CommonBase {
    *
    * @param {string} documentId ID of the document which the resulting bound
    *   object allows access to.
-   * @returns {string} Target ID within the API context which refers to the
-   *   session. This is _not_ the same as the `caretId`.
+   * @returns {ProxiedObject} Proxy wrapper (for return via API) of the
+   *   newly-created session.
    */
   async makeNewSession(documentId) {
     // We only check the document ID syntax here, because we can count on the

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -95,7 +95,7 @@ export default class BodyClient extends StateMachine {
    *   the document body should be editable.
    */
   constructor(quill, docSession, editingEnabled = true) {
-    super('detached', docSession.log, true);
+    super('detached', docSession.log);
 
     /** {Quill} Editor object. */
     this._quill = quill;

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -22,13 +22,13 @@ export default class BaseFileStore extends CommonBase {
    * @param {string} fileId The file ID to validate, which must be a
    *   syntactically valid ID, per {@link Storage#isFileId}.
    * @returns {string} `fileId` if it is indeed valid.
-   * @throws {Error} `badData` error indicating an invalid file ID.
+   * @throws {Error} `badId` error indicating an invalid file ID.
    */
   async checkFileId(fileId) {
     const info = await this.getFileInfo(fileId);
 
     if (!info.valid) {
-      throw Errors.badData(`Invalid file ID: \`${fileId}\``);
+      throw Errors.badId(fileId);
     }
 
     return fileId;
@@ -53,7 +53,8 @@ export default class BaseFileStore extends CommonBase {
 
   /**
    * Gets the accessor for the file with the given ID. The file need not exist
-   * prior to calling this method.
+   * prior to calling this method, but it must be considered "valid" (having the
+   * potential to exist).
    *
    * @param {string} fileId The ID of the file to access. Must be a valid file
    *   ID as defined by the concrete subclass.

--- a/local-modules/@bayou/util-core/Errors.js
+++ b/local-modules/@bayou/util-core/Errors.js
@@ -57,6 +57,24 @@ export default class Errors extends UtilityClass {
   }
 
   /**
+   * Constructs an instance which indicates that a function, class, or module
+   * has received an invalid string ID of some sort (e.g. a file ID, document
+   * ID, etc.). The error includes the ID in question.
+   *
+   * This error is typically used to report a problem that crosses a line of
+   * responsibility.
+   *
+   * @param {Error} [cause] Error which caused this problem. **Note:** It is
+   *   optional. If the first argument isn't an `Error`, then it is taken to be
+   *   the `message`.
+   * @param {string} id The ID in question.
+   * @returns {InfoError} An appropriately-constructed error.
+   */
+  static badId(cause, id) {
+    return Errors._make('badId', cause, id);
+  }
+
+  /**
    * Constructs an instance which indicates that a function, class, or module is
    * somehow being misused. The error includes a human-oriented description of
    * the problem.
@@ -180,6 +198,16 @@ export default class Errors extends UtilityClass {
    */
   static wtf(cause, message) {
     return Errors._make('wtf', cause, message);
+  }
+
+  /**
+   * Indicates whether or not the given error is a `badId`.
+   *
+   * @param {Error} error Error in question.
+   * @returns {boolean} `true` iff it represents an ID problem.
+   */
+  static is_badId(error) {
+    return InfoError.hasName(error, 'badId');
   }
 
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.2
+version = 1.2.3


### PR DESCRIPTION
This PR addresses _one_ reason (probably not the only one though) why session reconnect could fail: If a session got established but then the server dropped it because it seemed to go idle, the client would never figure out that the caret ID for the session was no longer valid. This would lead it to iteratively keep looking up and then failing to find the session, and it would eventually give up.

What I ended up doing is (approximately) formally defining the error that indicates the "no such caret" problem, such that when it bubbles up to the high layer, it can recognize it as such. And should that be the case, instead of retrying the bad ID, it explicitly asks for a new one.