### PR TITLE
Kill off the challenge-response authorization code.

### DIFF
--- a/local-modules/@bayou/api-common/BaseKey.js
+++ b/local-modules/@bayou/api-common/BaseKey.js
@@ -115,7 +115,7 @@ export default class BaseKey extends CommonBase {
    *
    * @param {string} challenge The challenge. This must be a string which was
    *   previously returned as the `challenge` binding from a call to
-   *   {@link #makeChallenge} (either in this process or any other).
+   *   {@link #makeChallengePair} (either in this process or any other).
    * @returns {string} The challenge response. It is guaranteed to be at least
    *   16 characters long.
    */

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -209,10 +209,10 @@ export default class Context extends CommonBase {
 
   /**
    * Gets a {@link Remote} which can be used with this instance to refer to
-   * the given {@link ProxiedObject}. If `obj` has been encountered before, the
-   * result will be a pre-existing instance; otherwise, it will be a
-   * newly-constructed instance (and will get added to this instance's set of
-   * targets).
+   * the given {@link ProxiedObject}. If `proxiedObject` has been encountered
+   * before, the result will be a pre-existing instance of {@link Remote};
+   * otherwise, it will be a newly-constructed instance (and will get added to
+   * this instance's set of targets).
    *
    * @param {ProxiedObject} proxiedObject Object to proxy.
    * @returns {Remote} Corresponding remote representation.

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -60,7 +60,7 @@ export default class Context extends CommonBase {
     this._map = new Map();
 
     /**
-     * {Map<object, string>} Map from target objects (the things wrapped by
+     * {Map<object, Remote>} Map from target objects (the things wrapped by
      * instances of {@link Target}) to their corresponding {@link Remote}
      * instances.
      */

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -144,10 +144,9 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Gets an authorized target. This will find _uncontrolled_ (already
-   * authorized) targets that were previously added via {@link #addTarget} as
-   * well as those authorized by virtue of this method being passed a valid
-   * authority-bearing token (in string form).
+   * Gets an authorized target. This will find targets that were previously
+   * added via {@link #addTarget} as well as those authorized by virtue of this
+   * method being passed a valid authority-bearing token (in string form).
    *
    * @param {string} idOrToken The target ID or a bearer token (in string form)
    *   which authorizes access to a target.

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -209,24 +209,6 @@ export default class Context extends CommonBase {
   }
 
   /**
-   * Gets the target associated with the indicated ID, but only if it is
-   * controlled (that is, it requires auth). This will throw an error if the
-   * so-identified target does not exist.
-   *
-   * @param {string} id The target ID.
-   * @returns {Target} The so-identified target.
-   */
-  async getControlled(id) {
-    const result = this._getOrNull(id);
-
-    if ((result === null) || (result.key === null)) {
-      throw this._targetError(id, 'Not a controlled target');
-    }
-
-    return result;
-  }
-
-  /**
    * Gets a {@link Remote} which can be used with this instance to refer to
    * the given {@link ProxiedObject}. If `obj` has been encountered before, the
    * result will be a pre-existing instance; otherwise, it will be a
@@ -266,19 +248,6 @@ export default class Context extends CommonBase {
    */
   hasId(id) {
     return this._getOrNull(id) !== null;
-  }
-
-  /**
-   * Removes the key that controls the target with the given ID. It is an error
-   * to try to operate on a nonexistent or uncontrolled target. This replaces
-   * the `target` with a newly-constructed one that has no auth control; it
-   * does _not_ modify the original `target` object (which is immutable).
-   *
-   * @param {string} id The ID of the target whose key is to be removed.
-   */
-  async removeControl(id) {
-    const target = await this.getControlled(id);
-    this._map.set(id, target.withoutKey());
   }
 
   /**

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -2,13 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TString } from '@bayou/typecheck';
-import { Delay } from '@bayou/promise-util';
-import { Errors } from '@bayou/util-common';
-
-/** {Int} How long an unanswered challenge remains active for, in msec. */
-const CHALLENGE_TIMEOUT_MSEC = 5 * 60 * 1000; // Five minutes.
-
 /**
  * Class to handle meta-requests.
  */
@@ -24,52 +17,6 @@ export default class MetaHandler {
 
     /** {Logger} The connection-specific logger. */
     this._log = connection.log;
-
-    /**
-     * {Map<challenge, {id, response}>} Map from challenge string to associated
-     * ID and response.
-     */
-    this._activeChallenges = new Map();
-  }
-
-  /**
-   * Called to respond to a successful challenge (which was presumably made via
-   * `makeChallenge()`. If `challenge` and `response` correspond to an active
-   * challenge-response pair, then this method will remove the key that controls
-   * the associated target, in the current session. (Other sessions will not be
-   * affected, including sessions created later.) It is only ever valid to
-   * respond to any given challenge once.
-   *
-   * This method will throw an error if the arguments don't refer to an active
-   * challenge (because it never existed, because it was already used, or
-   * because it expired).
-   *
-   * @param {string} challenge The challenge string.
-   * @param {string} response The challenge response.
-   */
-  async authWithChallengeResponse(challenge, response) {
-    TString.check(challenge);
-    TString.check(response);
-
-    const challengeInfo = this._activeChallenges.get(challenge);
-
-    if (!challengeInfo || (response !== challengeInfo.response)) {
-      // **Note:** We don't differentiate reasons for rejection (beyond type
-      // checking, above), as that could reveal security-sensitive info.
-      throw Errors.badUse('Invalid challenge pair.');
-    }
-
-    const id = challengeInfo.id;
-
-    // Remove the challenge from the active set, so that a given challenge can
-    // only be used once.
-    this._activeChallenges.delete(challenge);
-
-    // The main action: Replace the target for `id` with an equivalent one
-    // except without auth control.
-    await this._connection.context.removeControl(id);
-
-    this._log.event.authedChallenge(id, challenge);
   }
 
   /**
@@ -81,54 +28,6 @@ export default class MetaHandler {
    */
   connectionId() {
     return this._connection.connectionId;
-  }
-
-  /**
-   * Generates and returns a challenge for the key that controls the target with
-   * the given ID. It is an error to request a challenge for a nonexistent or
-   * uncontrolled target. Once returned, challenges are considered active only
-   * for a limited amount of time (approximately five minutes), after which
-   * they are expired.
-   *
-   * @param {string} id Target whose key is to be challenged.
-   * @returns {string} A challenge string that can subsequently be answered so
-   *   as to remove key control for the target, in the context of the current
-   *   session.
-   */
-  async makeChallenge(id) {
-    const target = await this._connection.context.getControlled(id);
-
-    let challengePair;
-    for (;;) {
-      challengePair = target.key.makeChallengePair();
-      if (!this._activeChallenges.get(challengePair.challenge)) {
-        break;
-      }
-
-      // We managed to get a duplicate challenge. This is highly unusual, but
-      // it _can_ happen. So, just iterate and try again.
-    }
-
-    const { challenge, response } = challengePair;
-
-    // Store the challenge, and arrange for its expiry.
-
-    this._activeChallenges.set(challenge, { id, response });
-
-    (async () => {
-      await Delay.resolve(CHALLENGE_TIMEOUT_MSEC);
-      if (this._activeChallenges.delete(challenge)) {
-        // `delete` returns `true` to indicate that the value was found. In this
-        // case, it means that it expired.
-        this._log.event.challengeExpired(id, challenge);
-      }
-    })();
-
-    // **Note:** It's probably okay to log the expected response, but may be
-    // worth thinking a bit more about. (Attention: Security professionals!)
-    this._log.event.newChallenge(id, challenge, response);
-
-    return challenge;
   }
 
   /**

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -17,6 +17,8 @@ export default class MetaHandler {
 
     /** {Logger} The connection-specific logger. */
     this._log = connection.log;
+
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -9,17 +9,13 @@ import { PropertyIterable } from '@bayou/util-common';
  * Schema for an object. Represents what actions are available. More
  * specifically:
  *
- * * Methods whose names start with an underscore (`_`) are excluded from
- *   schemas.
- * * Methods whose names are symbols (e.g. `Symbol('foo')`) are excluded from
- *   schemas.
- * * Constructor methods are excluded from schemas.
- * * Methods inherited from the base `Object` prototype are excluded from
- *   schemas.
- * * All other public methods are included in schemas.
- * * Static methods are excluded from schemas. (This may change in the future.)
- * * Non-method properties are excluded from schemas. (This may change in the
- *   future.)
+ * * Non-method properties are excluded. (This may change in the future.)
+ * * Static methods are excluded. (This may change in the future.)
+ * * Methods whose names start with an underscore (`_`) are excluded.
+ * * Methods whose names are symbols (e.g. `Symbol('foo')`) are excluded.
+ * * Constructor methods are excluded.
+ * * Methods inherited from the base `Object` prototype are excluded.
+ * * All other public methods are included.
  */
 export default class Schema {
   /**

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -22,7 +22,7 @@ export default class Schema {
    * Constructs an instance based on the given object.
    *
    * **Note:** The resulting instance doesn't remember (keep a reference to) the
-   * target object. (The `Target` class does that.)
+   * target object. (The class {@link Target} does that.)
    *
    * @param {object} target Object from which to derive the schema.
    */


### PR DESCRIPTION
This PR is another increment of post-new-session cleanup. Specifically, it removes the challenge-response mechanism that used to be used to establish the authenticity of a `SplitKey`. I also ended up fixing up a bunch of tangentially-related comments whose accuracy had drifted over time.