### PR TITLE
Small follow-on. 

### DIFF
--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -59,7 +59,7 @@ export default class AppAuthorizer extends TokenAuthorizer {
       }
 
       case Auth.TYPE_author: {
-        return new AuthorAccess(authority.authorId, this._application.context);
+        return new AuthorAccess(authority.authorId);
       }
 
       default: {

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -82,13 +82,6 @@ export default class Application extends CommonBase {
   }
 
   /**
-   * {Context} The top-level ID / token binding context.
-   */
-  get context() {
-    return this._context;
-  }
-
-  /**
    * {RootAccess} The "root access" object. This is the object which tokens
    * bearing {@link Auth#TYPE_root} authority grant access to.
    */

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -49,7 +49,7 @@ export default class Application extends CommonBase {
      * {RootAccess} The "root access" object. This is the object which tokens
      * bearing {@link Auth#TYPE_root} authority grant access to.
      */
-    this._rootAccess = new RootAccess(this._context);
+    this._rootAccess = new RootAccess();
 
     /**
      * {function} The top-level "Express application" run by this instance. It

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -24,10 +24,8 @@ export default class AuthorAccess extends CommonBase {
    *
    * @param {string} authorId ID of the author on whose behalf this instance
    *  acts.
-   * @param {Context} context_unused The API context that is managed by this
-   *   instance, that is, where auth-controlled resources end up getting bound.
    */
-  constructor(authorId, context_unused) {
+  constructor(authorId) {
     super();
 
     /**

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Context } from '@bayou/api-server';
 import { Auth, Network, Storage } from '@bayou/config-server';
 import { SessionInfo } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
@@ -20,15 +19,9 @@ const log = new Logger('root-access');
 export default class RootAccess extends CommonBase {
   /**
    * Constructs an instance.
-   *
-   * @param {Context} context The API context that is managed by this instance,
-   *   that is, where auth-controlled resources end up getting bound.
    */
-  constructor(context) {
+  constructor() {
     super();
-
-    /** {Context} The API context to use. */
-    this._context = Context.check(context);
 
     /**
      * {Map<string,BearerToken>} Map from author IDs to corresponding tokens, as


### PR DESCRIPTION
This small follow-on to my last PR gets us ready to stop treating (some) `Context` instances as a sorta-kinda prototype with `clone()`. A future and somewhat more involved PR will untangle the mess.
