### PR TITLE
Catch a case where proxy re-setup needs to happen. Also logging.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -75,7 +75,7 @@ export default class Application extends CommonBase {
 
     if (devMode) {
       this._addDevModeRoutes();
-      log.info('Enabled development / debugging endpoints.');
+      log.event.addedDebugEndpoints();
     }
 
     Object.freeze(this);
@@ -113,7 +113,7 @@ export default class Application extends CommonBase {
     const port       = pickPort ? 0 : Network.listenPort;
     const resultPort = await ServerUtil.listen(server, port);
 
-    log.info(`Application server port: ${resultPort}`);
+    log.event.applicationPort(resultPort);
 
     if ((port !== 0) && (port !== resultPort)) {
       log.warn(`Originally requested port: ${port}`);

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -61,7 +61,7 @@ export default class Monitor extends CommonBase {
     const port       = this._port;
     const resultPort = await ServerUtil.listen(server, port);
 
-    log.info(`Monitor server port: ${resultPort}`);
+    log.event.monitorPort(resultPort);
 
     if ((port !== 0) && (port !== resultPort)) {
       log.warn(`Originally requested port: ${port}`);

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -125,16 +125,24 @@ export default class DocSession extends CommonBase {
       this._log.event.initialSessionSetup();
     } else {
       this._log.event.checkingSessionValidity();
-      const proxy = await this._sessionProxyPromise;
 
-      if (api.handles(proxy)) {
-        // The session proxy we already had is still apparently valid, so it's
-        // safe to return it.
-        this._log.event.sessionStillValid();
-        return proxy;
+      try {
+        const proxy = await this._sessionProxyPromise;
+        if (api.handles(proxy)) {
+          // The session proxy we already had is still apparently valid, so it's
+          // safe to return it.
+          this._log.event.sessionStillValid();
+          return proxy;
+        }
+      } catch (e) {
+        // A previous attempt to set up the session failed in the call to
+        // `_fetchSessionProxy()` below.
+        this._log.event.previousSessionSetupFailed(e);
       }
 
-      // Fall through to re-set-up the session.
+      // Either the proxy never got set up or it used to be valid but on a
+      // different API session/connection. Fall through to re-set-up the
+      // session.
       this._log.event.mustReestablishSession();
     }
 

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -30,7 +30,7 @@ export default class PidFile extends Singleton {
     /** {string} Path for the PID file. */
     this._pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
 
-    log.info('PID:', process.pid);
+    log.event.pid(process.pid);
 
     Object.freeze(this);
   }
@@ -49,7 +49,7 @@ export default class PidFile extends Singleton {
     // Write the PID file.
     fs.writeFileSync(this._pidPath, `${process.pid}\n`);
 
-    log.info('PID file initialized.');
+    log.event.pidInitialized();
   }
 
   /**
@@ -71,7 +71,7 @@ export default class PidFile extends Singleton {
       // `TInt.check()` ensures it's a "safe" integer.
       const result = TInt.check(parseInt(match));
 
-      log.info(`Server already running: PID ${result}`);
+      log.event.serverAlreadyRunning({ pid: result });
 
       return result;
     } catch (e) {
@@ -90,7 +90,7 @@ export default class PidFile extends Singleton {
    * @param {string} id Signal ID.
    */
   _handleSignal(id) {
-    log.info('Received signal:', id);
+    log.event.receivedSignal(id);
     this._erasePid();
     process.kill(process.pid, id);
   }
@@ -101,7 +101,7 @@ export default class PidFile extends Singleton {
   _erasePid() {
     try {
       fs.unlinkSync(this._pidPath);
-      log.info('Removed PID file.');
+      log.event.removedPidFile();
     } catch (e) {
       // Ignore errors. We're about to exit anyway.
     }

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -69,7 +69,9 @@ export default class ServerEnv extends Singleton {
     }
 
     if (!is_running(pid)) {
-      log.warn(`Stale PID file indicates non-existent process: ${pid}`);
+      // Indicates that the last incarnation of the server crashed instead of
+      // shutting down cleanly.
+      log.event.stalePidFile({ pid });
       return false;
     }
 

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -44,7 +44,7 @@ export default class LocalFileStore extends BaseFileStore {
      */
     this._ensuredDir = false;
 
-    log.info('File storage directory:', this._dir);
+    log.event.storageDirectory(this._dir);
   }
 
   /**
@@ -107,11 +107,9 @@ export default class LocalFileStore extends BaseFileStore {
       return;
     }
 
-    if (await fse.pathExists(this._dir)) {
-      log.detail('File storage directory already exists.');
-    } else {
+    if (!(await fse.pathExists(this._dir))) {
       await fse.mkdir(this._dir);
-      log.info('Created file storage directory.');
+      log.event.createdStorageDirectory();
     }
 
     this._ensuredDir = true;

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -165,7 +165,7 @@ export default class Action extends CommonBase {
   async _run_dev() {
     await Action._startServer(false, true, true);
 
-    log.info('Now running in the development configuration.');
+    log.event.runningConfiguration('dev');
 
     // Start the system that live-syncs the client source and arranges to exit
     // if / when the server needs to be rebuilt.
@@ -204,7 +204,7 @@ export default class Action extends CommonBase {
   async _run_production() {
     await Action._startServer(false, true, false);
 
-    log.info('Now running in the production configuration.');
+    log.event.runningConfiguration('production');
     return null;
   }
 
@@ -257,17 +257,18 @@ export default class Action extends CommonBase {
     // Set up the server environment bits (including, e.g. the PID file).
     await ServerEnv.theOne.init();
 
-    // A little spew to identify us.
-    const info = ProductInfo.theOne.INFO;
-    for (const k of Object.keys(info)) {
-      log.info(k, '=', info[k]);
-    }
+    // A little spew to identify the build.
+    log.event.buildInfo(ProductInfo.theOne.INFO);
+    //const info = ProductInfo.theOne.INFO;
+    //for (const k of Object.keys(info)) {
+    //  log.event(k, '=', info[k]);
+    //}
 
     // A little spew to indicate where in the filesystem we live.
-    log.info(
-      'Directories:\n' +
-      `  product: ${Dirs.theOne.BASE_DIR}\n` +
-      `  var:     ${Dirs.theOne.VAR_DIR}`);
+    log.event.directories({
+      product: Dirs.theOne.BASE_DIR,
+      var:     Dirs.theOne.VAR_DIR
+    });
 
     /** The main app server. */
     const theApp = new Application(devRoutes);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -259,16 +259,10 @@ export default class Action extends CommonBase {
 
     // A little spew to identify the build.
     log.event.buildInfo(ProductInfo.theOne.INFO);
-    //const info = ProductInfo.theOne.INFO;
-    //for (const k of Object.keys(info)) {
-    //  log.event(k, '=', info[k]);
-    //}
 
     // A little spew to indicate where in the filesystem we live.
-    log.event.directories({
-      product: Dirs.theOne.BASE_DIR,
-      var:     Dirs.theOne.VAR_DIR
-    });
+    log.event.productDirectory(Dirs.theOne.BASE_DIR);
+    log.event.varDirectory(Dirs.theOne.VAR_DIR);
 
     /** The main app server. */
     const theApp = new Application(devRoutes);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.5
+version = 1.2.6


### PR DESCRIPTION
This PR fixes one more spot where the session setup code needed to retry getting the session proxy, but was failing to do so. The problem occurred when a connection was successfully established but the attempt to get the session proxy over that connection failed. The proxy would then get stuck in a permanently-broken state.

**Bonus:** Moved a bunch of logging that happens during system init over to be structured events instead of ad-hoc text.
