### PR TITLE
Stop cloning `Context`.

### DIFF
--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -74,6 +74,14 @@ export default class Context extends CommonBase {
     return this._info.codec;
   }
 
+  /**
+   * {Logger} The logger used by this instance, and for use by interrelated
+   * code.
+   */
+  get log() {
+    return this._log;
+  }
+
   /** {TokenAuthorizer|null} The token authorizer to use. */
   get tokenAuthorizer() {
     return this._info.tokenAuthorizer;

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -44,9 +44,6 @@ export default class Context extends CommonBase {
      */
     this._info = ContextInfo.check(info);
 
-    /** {string} Tag to use as part of the logging prefix. */
-    this._logTag = TString.check(logTag);
-
     /** {Logger} Logger for this instance. */
     this._log = log.withAddedContext(logTag);
 
@@ -121,28 +118,6 @@ export default class Context extends CommonBase {
     this._remoteMap.set(obj, remote);
 
     return remote;
-  }
-
-  /**
-   * Clones this instance. The resulting clone has a separate underlying map.
-   * That is, adding targets to the clone does not affect its progenitor.
-   *
-   * @param {string|null} [logTag = null] New tag to use for logging, or `null`
-   *   to use the original from this instance.
-   * @returns {Context} The newly-cloned instance.
-   */
-  clone(logTag = null) {
-    if (logTag === null) {
-      logTag = this._logTag;
-    }
-
-    const result = new Context(this._info, logTag);
-
-    for (const t of this._map.values()) {
-      result.addTarget(t);
-    }
-
-    return result;
   }
 
   /**

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -1,0 +1,48 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Codec } from '@bayou/codec';
+import { CommonBase } from '@bayou/util-common';
+
+import TokenAuthorizer from './TokenAuthorizer';
+
+/**
+ * All the info needed to construct instances of {@link Context}, except for
+ * logging-related stuff (which tends to be different for every instance).
+ */
+export default class ContextInfo extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Codec} codec Codec to use for all connections / sessions.
+   * @param {TokenAuthorizer|null} [tokenAuthorizer = null] Optional authorizer
+   *   for bearer tokens. If non-`null`, this is used to map bearer tokens into
+   *   usable target objects.
+   */
+  constructor(codec, tokenAuthorizer = null) {
+    super();
+
+    /** {Codec} The codec to use for connections / sessions. */
+    this._codec = Codec.check(codec);
+
+    /**
+     * {TokenAuthorizer|null} If non-`null`, authorizer to use in order to
+     * translate bearer tokens to target objects.
+     */
+    this._tokenAuthorizer =
+      (tokenAuthorizer === null) ? null : TokenAuthorizer.check(tokenAuthorizer);
+
+    Object.freeze(this);
+  }
+
+  /** {Codec} The codec to use for connections / sessions. */
+  get codec() {
+    return this._codec;
+  }
+
+  /** {TokenAuthorizer|null} The token authorizer to use. */
+  get tokenAuthorizer() {
+    return this._tokenAuthorizer;
+  }
+}

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -5,6 +5,7 @@
 import { Codec } from '@bayou/codec';
 import { CommonBase } from '@bayou/util-common';
 
+import Context from './Context';
 import TokenAuthorizer from './TokenAuthorizer';
 
 /**
@@ -44,5 +45,16 @@ export default class ContextInfo extends CommonBase {
   /** {TokenAuthorizer|null} The token authorizer to use. */
   get tokenAuthorizer() {
     return this._tokenAuthorizer;
+  }
+
+  /**
+   * Makes a new instance of {@link Context}, with this instance as the `info`
+   * and with the given log tag.
+   *
+   * @param {string} logTag The log tag to use.
+   * @returns {Context} An appropriately-constructed instance.
+   */
+  makeContext(logTag) {
+    return new Context(this, logTag);
   }
 }

--- a/local-modules/@bayou/api-server/PostConnection.js
+++ b/local-modules/@bayou/api-server/PostConnection.js
@@ -17,10 +17,11 @@ export default class PostConnection extends Connection {
    *
    * @param {object} req The HTTP request.
    * @param {object} res The HTTP response handler.
-   * @param {Context} context The binding context to provide access to.
+   * @param {ContextInfo} contextInfo Construction info for the {@link Context}
+   *   to use.
    */
-  constructor(req, res, context) {
-    super(context);
+  constructor(req, res, contextInfo) {
+    super(contextInfo);
 
     // **TODO:** Remove this once we're a bit more sure about what to expect.
     this._log.info(`POST host: ${req.headers.host}`);

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -16,10 +16,11 @@ export default class WsConnection extends Connection {
    *
    * @param {WebSocket} ws A websocket instance corresponding to the connection.
    * @param {object} req The HTTP request.
-   * @param {Context} context The binding context to provide access to.
+   * @param {ContextInfo} contextInfo Construction info for the {@link Context}
+   *   to use.
    */
-  constructor(ws, req, context) {
-    super(context);
+  constructor(ws, req, contextInfo) {
+    super(contextInfo);
 
     this._log.event.websocketOrigin(req.headers.origin);
 

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -4,6 +4,7 @@
 
 import Connection from './Connection';
 import Context from './Context';
+import ContextInfo from './ContextInfo';
 import PostConnection from './PostConnection';
 import ProxiedObject from './ProxiedObject';
 import Schema from './Schema';
@@ -15,6 +16,7 @@ import WsConnection from './WsConnection';
 export {
   Connection,
   Context,
+  ContextInfo,
   PostConnection,
   ProxiedObject,
   Schema,

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -32,14 +32,45 @@ class MockAuth extends TokenAuthorizer {
 
 describe('@bayou/api-server/Context', () => {
   describe('constructor()', () => {
-    it('should accept valid arguments', () => {
+    it('accepts valid arguments and produce a sealed instance', () => {
+      const info   = new ContextInfo(new Codec(), new MockAuth());
+      const result = new Context(info, 'some-tag');
+
+      assert.isSealed(result);
+    });
+  });
+
+  describe('.codec', () => {
+    it('is the `codec` from the `info` passed in on construction', () => {
       const info = new ContextInfo(new Codec(), new MockAuth());
-      assert.doesNotThrow(() => new Context(info, 'some-tag'));
+      const ctx  = new Context(info, 'some-tag');
+
+      assert.strictEqual(ctx.codec, info.codec);
+    });
+  });
+
+  describe('.log', () => {
+    it('includes the `logTag` passed in on construction', () => {
+      const info = new ContextInfo(new Codec(), new MockAuth());
+      const tag  = 'yowzers';
+      const ctx  = new Context(info, tag);
+
+      const logContext = ctx.log.tag.context;
+      assert.strictEqual(logContext[logContext.length - 1], tag);
+    });
+  });
+
+  describe('.tokenAuthorizer', () => {
+    it('is the `tokenAuthorizer` from the `info` passed in on construction', () => {
+      const info = new ContextInfo(new Codec(), new MockAuth());
+      const ctx  = new Context(info, 'some-tag');
+
+      assert.strictEqual(ctx.tokenAuthorizer, info.tokenAuthorizer);
     });
   });
 
   describe('getRemoteFor', () => {
-    it('should return a `Remote` given a `ProxiedObject`', () => {
+    it('returns a `Remote` given a `ProxiedObject`', () => {
       const info   = new ContextInfo(new Codec());
       const ctx    = new Context(info, 'tag');
       const obj    = { some: 'object' };
@@ -49,7 +80,7 @@ describe('@bayou/api-server/Context', () => {
       assert.instanceOf(result, Remote);
     });
 
-    it('should return a `Remote` whose `id` maps back to the underlying object', async () => {
+    it('returns a `Remote` whose `id` maps back to the underlying object', async () => {
       const info   = new ContextInfo(new Codec());
       const ctx    = new Context(info, 'tag');
       const obj    = { some: 'object' };
@@ -63,7 +94,7 @@ describe('@bayou/api-server/Context', () => {
       assert.strictEqual(target.directObject, obj);
     });
 
-    it('should return the same `Remote` when given the same `ProxiedObject`', () => {
+    it('returns the same `Remote` when given the same `ProxiedObject`', () => {
       const info    = new ContextInfo(new Codec());
       const ctx     = new Context(info, 'tag');
       const obj     = { some: 'object' };
@@ -74,7 +105,7 @@ describe('@bayou/api-server/Context', () => {
       assert.strictEqual(result1, result2);
     });
 
-    it('should return the same `Remote` when given two `ProxiedObject`s for the same underlying object', () => {
+    it('returns the same `Remote` when given two `ProxiedObject`s for the same underlying object', () => {
       const info    = new ContextInfo(new Codec());
       const ctx     = new Context(info, 'tag');
       const obj     = { some: 'object' };

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken, Remote } from '@bayou/api-common';
-import { Context, ProxiedObject, TokenAuthorizer } from '@bayou/api-server';
+import { Context, ContextInfo, ProxiedObject, TokenAuthorizer } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
 
 /**
@@ -32,18 +32,16 @@ class MockAuth extends TokenAuthorizer {
 
 describe('@bayou/api-server/Context', () => {
   describe('constructor()', () => {
-    it('should accept two valid arguments', () => {
-      assert.doesNotThrow(() => new Context(new Codec(), 'some-tag'));
-    });
-
-    it('should accept three valid arguments', () => {
-      assert.doesNotThrow(() => new Context(new Codec(), 'some-other-tag', new MockAuth()));
+    it('should accept valid arguments', () => {
+      const info = new ContextInfo(new Codec(), new MockAuth());
+      assert.doesNotThrow(() => new Context(info, 'some-tag'));
     });
   });
 
   describe('getRemoteFor', () => {
     it('should return a `Remote` given a `ProxiedObject`', () => {
-      const ctx    = new Context(new Codec(), 'tag');
+      const info   = new ContextInfo(new Codec());
+      const ctx    = new Context(info, 'tag');
       const obj    = { some: 'object' };
       const po     = new ProxiedObject(obj);
       const result = ctx.getRemoteFor(po);
@@ -52,7 +50,8 @@ describe('@bayou/api-server/Context', () => {
     });
 
     it('should return a `Remote` whose `id` maps back to the underlying object', async () => {
-      const ctx    = new Context(new Codec(), 'tag');
+      const info   = new ContextInfo(new Codec());
+      const ctx    = new Context(info, 'tag');
       const obj    = { some: 'object' };
       const po     = new ProxiedObject(obj);
       const result = ctx.getRemoteFor(po);
@@ -65,7 +64,8 @@ describe('@bayou/api-server/Context', () => {
     });
 
     it('should return the same `Remote` when given the same `ProxiedObject`', () => {
-      const ctx     = new Context(new Codec(), 'tag');
+      const info    = new ContextInfo(new Codec());
+      const ctx     = new Context(info, 'tag');
       const obj     = { some: 'object' };
       const po      = new ProxiedObject(obj);
       const result1 = ctx.getRemoteFor(po);
@@ -75,7 +75,8 @@ describe('@bayou/api-server/Context', () => {
     });
 
     it('should return the same `Remote` when given two `ProxiedObject`s for the same underlying object', () => {
-      const ctx     = new Context(new Codec(), 'tag');
+      const info    = new ContextInfo(new Codec());
+      const ctx     = new Context(info, 'tag');
       const obj     = { some: 'object' };
       const result1 = ctx.getRemoteFor(new ProxiedObject(obj));
       const result2 = ctx.getRemoteFor(new ProxiedObject(obj));

--- a/local-modules/@bayou/api-server/tests/test_ContextInfo.js
+++ b/local-modules/@bayou/api-server/tests/test_ContextInfo.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { ContextInfo, TokenAuthorizer } from '@bayou/api-server';
+import { Context, ContextInfo, TokenAuthorizer } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
 
 describe('@bayou/api-server/ContextInfo', () => {
@@ -53,6 +53,21 @@ describe('@bayou/api-server/ContextInfo', () => {
       const ci = new ContextInfo(new Codec());
 
       assert.isNull(ci.tokenAuthorizer);
+    });
+  });
+
+  describe('makeContext()', () => {
+    it('makes an instance of `Context` with this instance as the `info` and with the given tag', () => {
+      const ci     = new ContextInfo(new Codec(), new TokenAuthorizer());
+      const tag    = 'florp';
+      const result = ci.makeContext(tag);
+
+      assert.instanceOf(result, Context);
+      assert.strictEqual(result.codec, ci.codec);
+      assert.strictEqual(result.tokenAuthorizer, ci.tokenAuthorizer);
+
+      const logContext = result.log.tag.context;
+      assert.strictEqual(logContext[logContext.length - 1], tag);
     });
   });
 });

--- a/local-modules/@bayou/api-server/tests/test_ContextInfo.js
+++ b/local-modules/@bayou/api-server/tests/test_ContextInfo.js
@@ -1,0 +1,58 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ContextInfo, TokenAuthorizer } from '@bayou/api-server';
+import { Codec } from '@bayou/codec';
+
+describe('@bayou/api-server/ContextInfo', () => {
+  describe('constructor()', () => {
+    it('accepts a single valid argument and produces a frozen instance', () => {
+      const result = new ContextInfo(new Codec());
+      assert.isFrozen(result);
+    });
+
+    it('accepts two valid arguments and produces a frozen instance', () => {
+      const result = new ContextInfo(new Codec(), new TokenAuthorizer());
+      assert.isFrozen(result);
+    });
+
+    it('accepts `null` as the second argument', () => {
+      const result = new ContextInfo(new Codec(), null);
+      assert.isFrozen(result);
+    });
+  });
+
+  describe('.codec', () => {
+    it('is the value passed into the constructor', () => {
+      const codec = new Codec();
+      const ci    = new ContextInfo(codec);
+
+      assert.strictEqual(ci.codec, codec);
+    });
+  });
+
+  describe('.tokenAuthorizer', () => {
+    it('is the non-`null` value passed into the constructor', () => {
+      const ta = new TokenAuthorizer();
+      const ci = new ContextInfo(new Codec(), ta);
+
+      assert.strictEqual(ci.tokenAuthorizer, ta);
+    });
+
+    it('is `null` if passed into the constructor as such', () => {
+      const ci = new ContextInfo(new Codec(), null);
+
+      assert.isNull(ci.tokenAuthorizer);
+    });
+
+    it('is `null` if omitted from the constructor', () => {
+      const ci = new ContextInfo(new Codec());
+
+      assert.isNull(ci.tokenAuthorizer);
+    });
+  });
+});

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -7,7 +7,7 @@ import http from 'http';
 import path from 'path';
 import ws from 'ws';
 
-import { Context, PostConnection, WsConnection } from '@bayou/api-server';
+import { Context, ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
@@ -39,11 +39,16 @@ export default class Application extends CommonBase {
     super();
 
     /**
+     * {ContextInfo} The common info used to construct {@link Context}
+     * instances.
+     */
+    this._contextInfo = new ContextInfo(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
+
+    /**
      * {Context} All of the objects we provide access to via the API, along with
      * other objects of use to the server.
      */
-    this._context =
-      new Context(appCommon_TheModule.fullCodec, 'top-context', new AppAuthorizer(this));
+    this._context = new Context(this._contextInfo, 'top-context');
 
     /**
      * {RootAccess} The "root access" object. This is the object which tokens

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -7,7 +7,7 @@ import http from 'http';
 import path from 'path';
 import ws from 'ws';
 
-import { Context, ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
+import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
@@ -43,12 +43,6 @@ export default class Application extends CommonBase {
      * instances.
      */
     this._contextInfo = new ContextInfo(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
-
-    /**
-     * {Context} All of the objects we provide access to via the API, along with
-     * other objects of use to the server.
-     */
-    this._context = new Context(this._contextInfo, 'top-context');
 
     /**
      * {RootAccess} The "root access" object. This is the object which tokens
@@ -157,7 +151,7 @@ export default class Application extends CommonBase {
 
     const postHandler = (req, res) => {
       try {
-        new PostConnection(req, res, this._context);
+        new PostConnection(req, res, this._contextInfo);
       } catch (e) {
         log.error('Trouble with API request:', e);
       }
@@ -199,7 +193,7 @@ export default class Application extends CommonBase {
 
     wsServer.on('connection', (wsSocket, req) => {
       try {
-        new WsConnection(wsSocket, req, this._context);
+        new WsConnection(wsSocket, req, this._contextInfo);
       } catch (e) {
         log.error('Trouble with API websocket connection:', e);
       }

--- a/local-modules/@bayou/see-all/Logger.js
+++ b/local-modules/@bayou/see-all/Logger.js
@@ -39,6 +39,11 @@ export default class Logger extends BaseLogger {
     Object.freeze(this);
   }
 
+  /** {LogTag} The tag(s) used by this instance when logging. */
+  get tag() {
+    return this._tag;
+  }
+
   /**
    * Actual logging implementation for structured events, as specified by the
    * superclass.


### PR DESCRIPTION
This PR untangles (one of) the mess(es) around connection setup:

Originally, I thought each server was going to maintain a set of what amounted to global IDs that could be contacted over an API connection. As such, there was going to be a top-level `Context` instance that would hold these, and with each connection it would make a "child" `Context` that started as a clone of the original and then would end up getting new bindings per the API interactions over the connection. This is not how things shook out. With the removal of old-style sessions, there was no longer a need to have global IDs, and that made the whole cloning thing moot and probably confusing.

So, this PR removes the cloning mechanism / behavior, in favor of just keeping around `Context` instantiation parameters in a struct-like class (or, arguably a "factory" class), said class which has a `makeContext()` method.

There's probably some follow-on simplification I'll be able to do because of this rearrangement, but I'll save it for another day.