### PR TITLE
Caret tracking rework and post-old-session cleanup.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -245,18 +245,6 @@ export default class ApiClient extends CommonBase {
     // or `https`.
     url.protocol = url.protocol.replace(/^http/, 'ws');
 
-    // Drop the original path, and replace it with just `/api`. **TODO:** We
-    // should instead assume that the path is valid, instead of forcing one
-    // particular value.
-    url.pathname = '/api';
-
-    if (url.pathname !== '/api') {
-      // Per the **TODO** above, note when we get what (today) is an unexpected
-      // path. If we never see this, it means we can address the **TODO** by
-      // removing the statement it's commenting on.
-      this._log.event.unusualUrlPath(url.pathname);
-    }
-
     return url.href;
   }
 

--- a/local-modules/@bayou/api-client/WsServerConnection.js
+++ b/local-modules/@bayou/api-client/WsServerConnection.js
@@ -226,11 +226,6 @@ export default class WsServerConnection extends BaseServerConnection {
     // or `https`.
     url.protocol = url.protocol.replace(/^http/, 'ws');
 
-    // Drop the original path, and replace it with just `/api`. **TODO:** We
-    // should instead assume that the path is valid, instead of forcing one
-    // particular value.
-    url.pathname = '/api';
-
     return url.href;
   }
 }

--- a/local-modules/@bayou/api-server/PostConnection.js
+++ b/local-modules/@bayou/api-server/PostConnection.js
@@ -23,10 +23,6 @@ export default class PostConnection extends Connection {
   constructor(req, res, contextInfo) {
     super(contextInfo);
 
-    // **TODO:** Remove this once we're a bit more sure about what to expect.
-    this._log.info(`POST host: ${req.headers.host}`);
-    this._log.info(`POST origin: ${req.headers.origin}`);
-
     /** {object} The HTTP request. */
     this._req = req;
 

--- a/local-modules/@bayou/assets-client/files/static/content.css
+++ b/local-modules/@bayou/assets-client/files/static/content.css
@@ -13,9 +13,6 @@
  * to the main body text size. **Note:** If a Bayou editor is being embedded in
  * another page, it is possible that this rule will end up interacting with the
  * enclosing CSS in undesired ways.
- *
- * TODO: Make this particular bit configurable via a hook, should it turn out to
- * be useful.
  */
 html.bayou-page {
   font-size: 100%;

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -109,8 +109,8 @@ export default class CaretTracker extends CommonBase {
         let info = this._latestCaret;
         if (info === null) {
           await Promise.race([
-            Delay.resolve(MAX_IDLE_TIME_MSEC),
-            this._needUpdate.whenTrue()]);
+            this._needUpdate.whenTrue(),
+            Delay.resolve(MAX_IDLE_TIME_MSEC)]);
           info = this._latestCaret;
           if (info === null) {
             break;
@@ -122,8 +122,8 @@ export default class CaretTracker extends CommonBase {
         this._updateCount++;
 
         await Promise.all([
-          Delay.resolve(UPDATE_DELAY_MSEC),
-          sessionProxy.caret_update(...info)]);
+          sessionProxy.caret_update(...info),
+          Delay.resolve(UPDATE_DELAY_MSEC)]);
 
         if ((this._updateCount % 25) === 0) {
           this._docSession.log.event.caretUpdates(this._updateCount);

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -37,10 +37,8 @@ export default class CaretTracker extends CommonBase {
     this._docSession = DocSession.check(docSession);
 
     /**
-     * {boolean} Whether there is a caret update in progress. Starts out `true`
-     * while the session proxy is getting set up (which is a lie, but one which
-     * prevents failing server calls to be made), and then it is `false` in
-     * steady state. It is set temporarily to `true` in `update()`.
+     * {boolean} Whether the caret update loop is running. Used to prevent the
+     * method from running more than once concurrently.
      */
     this._updating = false;
 

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CaretId } from '@bayou/doc-common';
 import { RevisionNumber } from '@bayou/ot-common';
 import { Delay } from '@bayou/promise-util';
 import { TInt, TObject } from '@bayou/typecheck';
@@ -39,12 +38,6 @@ export default class CaretTracker extends CommonBase {
     this._sessionProxy = null;
 
     /**
-     * {string|null} The ID of the caret that this instance controls, if known.
-     * Becomes non-`null` during resolution of {@link #_sessionProxy}.
-     */
-    this._caretId = null;
-
-    /**
      * {boolean} Whether there is a caret update in progress. Starts out `true`
      * while the session proxy is getting set up (which is a lie, but one which
      * prevents failing server calls to be made), and then it is `false` in
@@ -63,14 +56,7 @@ export default class CaretTracker extends CommonBase {
     // Arrange for `_sessionProxy` to get set.
     (async () => {
       this._sessionProxy = await docSession.getSessionProxy();
-
-      // **TODO:** Once `SessionInfo` is always used, the `caretId` can be found
-      // from it.
-      this._caretId = await this._sessionProxy.getCaretId();
-
-      this._updating = false;
-
-      this._docSession.log.event.nowManagingCaret(this._caretId);
+      this._updating     = false;
 
       // Give the update loop a chance to send caret updates that happened
       // during initialization (if any).

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -79,24 +79,6 @@ export default class CaretTracker extends CommonBase {
   }
 
   /**
-   * Indicates whether the given caret ID identifies the caret controlled by
-   * this instance.
-   *
-   * **Note:** It is possible for this to return a false negative when the
-   * session is in the process of being established (because we don't yet know
-   * the ID we control).
-   *
-   * @param {string} caretId The caret ID in question.
-   * @returns {boolean} `true` if `caretId` is the ID that this instance
-   *   controls, or `false` if not.
-   */
-  isControlledHere(caretId) {
-    CaretId.check(caretId);
-
-    return (caretId === this._caretId);
-  }
-
-  /**
    * Updates the caret info for this session.
    *
    * @param {Int} docRevNum The document revision number for this info.

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -50,6 +50,12 @@ export default class CaretTracker extends CommonBase {
      */
     this._latestCaret = null;
 
+    /**
+     * {Int} Count of how many updates have been sent. Used for occasional
+     * logging.
+     */
+    this._updateCount = 0;
+
     Object.seal(this);
   }
 
@@ -104,11 +110,18 @@ export default class CaretTracker extends CommonBase {
           if (now >= (lastUpdateTime + MAX_IDLE_TIME_MSEC)) {
             break;
           }
+
           await loopDelay;
         } else {
           lastUpdateTime = now;
           this._latestCaret = null;
+          this._updateCount++;
+
           await Promise.all([loopDelay, sessionProxy.caret_update(...info)]);
+
+          if ((this._updateCount % 25) === 0) {
+            this._docSession.log.event.caretUpdates(this._updateCount);
+          }
         }
       }
 

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiClient } from '@bayou/api-client';
+import { CaretId } from '@bayou/doc-common';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { SessionInfo } from '@bayou/doc-common';
 import { Logger } from '@bayou/see-all';
@@ -105,6 +106,24 @@ export default class DocSession extends CommonBase {
    */
   get sessionInfo() {
     return this._sessionInfo;
+  }
+
+  /**
+   * Indicates whether the given caret ID identifies the caret controlled by
+   * this instance.
+   *
+   * **Note:** It is possible for this to return a false negative when the
+   * session is in the process of being established (because we don't yet know
+   * which caret the instance will ultimately control).
+   *
+   * @param {string} caretId The caret ID in question.
+   * @returns {boolean} `true` if `caretId` is the ID of the caret that this
+   *   instance controls, or `false` if not.
+   */
+  controlsCaret(caretId) {
+    CaretId.check(caretId);
+
+    return (caretId === this._sessionInfo.caretId);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Auth, Network, Storage } from '@bayou/config-server';
-import { BodyChange, CaretId, PropertyChange, SessionInfo } from '@bayou/doc-common';
+import { Storage } from '@bayou/config-server';
+import { BodyChange, CaretId, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import { CommonBase } from '@bayou/util-common';
 
@@ -333,25 +333,5 @@ export default class DocSession extends CommonBase {
    */
   getFileId() {
     return this._fileComplex.fileAccess.file.id;
-  }
-
-  /**
-   * Gets an instance of {@link SessionInfo} which when used will authorize the
-   * use of an instance of _this_ class which is equivalent (but not likely
-   * identical to) this instance.
-   *
-   * **TODO:** Remove this method once the transition to new-style sessions is
-   * complete.
-   *
-   * @returns {SessionInfo} Session info for constructing an instance like this
-   *   one.
-   */
-  async getSessionInfo() {
-    const url         = `${Network.baseUrl}/api`;
-    const authorToken = await Auth.getAuthorToken(this.getAuthorId());
-    const documentId  = this.getDocumentId();
-    const caretId     = this.getCaretId();
-
-    return new SessionInfo(url, authorToken, documentId, caretId);
   }
 }

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -211,7 +211,7 @@ export default class CaretOverlay {
         // snapshot ideally wouldn't actually represent the caret controlled by
         // this editor. The code that pushes the snapshot into the store should
         // be updated accordingly.
-        if (this._editorComplex.docSession.caretTracker.isControlledHere(caretId)) {
+        if (this._editorComplex.docSession.controlsCaret(caretId)) {
           continue;
         }
 
@@ -494,7 +494,7 @@ export default class CaretOverlay {
         case CaretOp.CODE_setField: {
           const caretId = props.caretId;
 
-          if (this._editorComplex.docSession.caretTracker.isControlledHere(caretId)) {
+          if (this._editorComplex.docSession.controlsCaret(caretId)) {
             continue;
           }
 


### PR DESCRIPTION
This PR is another round of tweakage and cleanup, in the aftermath of the transition to new-style sessions. The most notable bit is in `CaretTracker`, whose guts got a semi-major rework to account for the fact that the caret ID and session proxy can be expected to change over time.