### PR TITLE
Targets no longer get automatically idled out of `Context`s.

### DIFF
--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -20,11 +20,6 @@ import Target from './Target';
  * incoming message data, but without the actual transport of bytes over a
  * lower-level connection (or the like). This class in turn mostly bottoms out
  * by calling on target objects, which perform the actual application services.
- *
- * **Note:** The `context` used for the connection is set up as a separate
- * instance (effectively cloned) from the one passed into the constructor and
- * always has an extra binding of `meta` to a meta-control object that is
- * specific to the connection.
  */
 export default class Connection extends CommonBase {
   /**

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -23,8 +23,7 @@ import Target from './Target';
  */
 export default class Connection extends CommonBase {
   /**
-   * Constructs an instance. Each instance corresponds to a separate client
-   * connection.
+   * Constructs an instance.
    *
    * @param {ContextInfo} contextInfo Construction info for the {@link Context}
    *   to use.

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -33,7 +33,7 @@ export default class Connection extends CommonBase {
 
     /**
      * {string} Short label string used to identify this connection in logs.
-     * _Probably_ but not _guaranteed_ to be unique.
+     * _Probably_ but not _guaranteed to be_ unique.
      */
     this._connectionId = Random.shortLabel('conn');
 

--- a/local-modules/@bayou/api-server/Connection.js
+++ b/local-modules/@bayou/api-server/Connection.js
@@ -60,7 +60,6 @@ export default class Connection extends CommonBase {
     // Add a `meta` binding to the initial set of targets, which is specific to
     // this instance/connection.
     const metaTarget = new Target('meta', new MetaHandler(this));
-    metaTarget.setEvergreen();
     this._context.addTarget(metaTarget);
 
     this._log.event.open();

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -51,12 +51,6 @@ export default class Context extends CommonBase {
      */
     this._remoteMap = new Map();
 
-    /**
-     * {Int} Msec timestamp indicating the most recent time that idle cleanup
-     * was performed.
-     */
-    this._lastIdleCleanup = Date.now();
-
     Object.seal(this);
   }
 

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -46,7 +46,7 @@ export default class Target extends CommonBase {
     /** {Schema} Schema for {@link #_directObject}. */
     this._schema = schema || new Schema(directObject);
 
-    Object.seal(this);
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -135,14 +135,6 @@ export default class Target extends CommonBase {
   }
 
   /**
-   * Sets this instance to be "evergreen," that is, to never be considered
-   * idle.
-   */
-  setEvergreen() {
-    this._lastAccess = EVERGREEN;
-  }
-
-  /**
    * Takes a timestamp (standard Unix-ish msec) and indicates whether this
    * instance was considered idle as of that time.
    *

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -133,22 +133,4 @@ export default class Target extends CommonBase {
       this._lastAccess = Date.now();
     }
   }
-
-  /**
-   * Takes a timestamp (standard Unix-ish msec) and indicates whether this
-   * instance was considered idle as of that time.
-   *
-   * @param {Int} whenMsec Timestamp which the questions is with respect to.
-   * @returns {boolean} `true` iff this instance has been idle since `whenMsec`
-   *   or earlier.
-   */
-  wasIdleAsOf(whenMsec) {
-    const lastAccess = this._lastAccess;
-
-    if (lastAccess === EVERGREEN) {
-      return false;
-    } else {
-      return (lastAccess <= whenMsec);
-    }
-  }
 }

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -46,15 +46,6 @@ export default class Target extends CommonBase {
     /** {Schema} Schema for {@link #_directObject}. */
     this._schema = schema || new Schema(directObject);
 
-    /**
-     * {Int|'evergreen'} Timestamp (msec) when the {@link #directObject} was
-     * last accessed or called, or the string constant `evergreen` to indicate
-     * that this instance should never be considered idle. This is used to drive
-     * automated cleanup of idle targets mapped by instances of
-     * {@link api-server.Context}.
-     */
-    this._lastAccess = Date.now();
-
     Object.seal(this);
   }
 

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -9,12 +9,6 @@ import { CommonBase, Errors, Functor } from '@bayou/util-common';
 import Schema from './Schema';
 
 /**
- * {string} Constant that indicates an "evergreen" (never idle / immortal)
- * instance.
- */
-const EVERGREEN = 'evergreen';
-
-/**
  * Wrapper for an object which is callable through the API. A target can be
  * either "controlled" by a key (that is, have access restricted by a key) or be
  * "uncontrolled" (that is, be generally available without additional permission
@@ -70,7 +64,6 @@ export default class Target extends CommonBase {
   * _not_ currently idle.
   */
   get directObject() {
-    this.refresh();
     return this._directObject;
   }
 
@@ -114,23 +107,9 @@ export default class Target extends CommonBase {
     // Listed in the schema as a method. So it exists, is public, is in
     // fact bound to a function, etc.
 
-    this.refresh();
-
     const obj  = this._directObject;
     const impl = obj[name];
 
     return impl.apply(obj, payload.args);
-  }
-
-  /**
-   * "Refreshes" this instance in terms of access time. This is no different
-   * than just saying `this.directObject` (and ignoring the result). It exists
-   * as an explicitly different method so as to provide a solid way to convey
-   * intent at call sites.
-   */
-  refresh() {
-    if (this._lastAccess !== EVERGREEN) {
-      this._lastAccess = Date.now();
-    }
   }
 }

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -29,42 +29,46 @@ const INVALID_DIRECTS = [
 
 describe('@bayou/api-server/Target', () => {
   describe('constructor()', () => {
-    it('should accept a key as the first argument', () => {
+    it('accepts a key as the first argument', () => {
       assert.doesNotThrow(() => new Target(new BearerToken('x', 'y'), {}));
     });
 
-    it('should accept a valid ID string as the first argument', () => {
+    it('accepts a valid ID string as the first argument', () => {
       assert.doesNotThrow(() => new Target('x', {}));
     });
 
-    it('should reject a non-key object as the first argument', () => {
+    it('rejects a non-key object as the first argument', () => {
       assert.throws(() => new Target(new Set('bad'), {}), /badValue/);
     });
 
-    it('should reject an invalid ID string as the first argument', () => {
+    it('rejects an invalid ID string as the first argument', () => {
       assert.throws(() => new Target('***bad***', {}), /badValue/);
     });
 
-    it('should accept arbitrary objects as the second argument', () => {
+    it('accepts arbitrary objects as the second argument', () => {
       for (const d of VALID_DIRECTS) {
         assert.doesNotThrow(() => new Target('x', d), inspect(d));
       }
     });
 
-    it('should reject non-objects as the second argument', () => {
+    it('rejects non-objects as the second argument', () => {
       for (const d of INVALID_DIRECTS) {
         assert.throws(() => new Target('x', d), /badValue/, inspect(d));
       }
     });
 
-    it('should accept a `Schema` as the third argument', () => {
+    it('accepts a `Schema` as the third argument', () => {
       const schema = new Schema({});
       assert.doesNotThrow(() => new Target('x', {}, schema));
+    });
+
+    it('accepts `null` as the third argument', () => {
+      assert.doesNotThrow(() => new Target('x', {}, null));
     });
   });
 
   describe('.directObject', () => {
-    it('should be the same as the `directObject` passed to the constructor', () => {
+    it('is the same as the `directObject` passed to the constructor', () => {
       for (const obj of VALID_DIRECTS) {
         const str = inspect(obj);
         const t   = new Target('x', obj);
@@ -74,13 +78,13 @@ describe('@bayou/api-server/Target', () => {
   });
 
   describe('.id', () => {
-    it('should be the same as a string `idOrKey` passed to the constructor', () => {
+    it('is the same as a string `idOrKey` passed to the constructor', () => {
       const id = 'some-id';
       const t  = new Target(id, {});
       assert.strictEqual(t.id, id);
     });
 
-    it('should be the same as the key\'s `id` when a key is passed as `idOrKey` to the constructor', () => {
+    it('is the same as the key\'s `id` when a key is passed as `idOrKey` to the constructor', () => {
       const id  = 'some-key-id';
       const key = new BearerToken(id, 'this-is-secret');
       const t   = new Target(key, {});
@@ -89,14 +93,14 @@ describe('@bayou/api-server/Target', () => {
   });
 
   describe('.key', () => {
-    it('should be the same as a key `idOrKey` passed to the constructor', () => {
+    it('is the same as a key `idOrKey` passed to the constructor', () => {
       const id  = 'some-key-id';
       const key = new BearerToken(id, 'this-is-secret');
       const t  = new Target(key, {});
       assert.strictEqual(t.key, key);
     });
 
-    it('should be `null` when a string is passed as `idOrKey` to the constructor', () => {
+    it('is `null` when a string is passed as `idOrKey` to the constructor', () => {
       const id  = 'some-id';
       const t   = new Target(id, {});
       assert.isNull(t.key);
@@ -104,16 +108,32 @@ describe('@bayou/api-server/Target', () => {
   });
 
   describe('.schema', () => {
-    it('should be the same as the `schema` passed to the constructor', () => {
+    it('is the same as the non-`null` `schema` passed to the constructor', () => {
       const schema = new Schema({});
       const t      = new Target('x', {}, schema);
 
       assert.strictEqual(t.schema, schema);
     });
+
+    it('is a reasonably-constructed instance when `schema` was omitted from the constructor', () => {
+      class Florp {
+        blort() { /*empty*/ }
+        zorch() { /*empty*/ }
+      }
+
+      const t      = new Target('x', new Florp());
+      const result = t.schema;
+
+      assert.instanceOf(result, Schema);
+
+      const props = result.propertiesObject;
+
+      assert.deepEqual(props, { blort: 'method', zorch: 'method' });
+    });
   });
 
   describe('call()', () => {
-    it('should call through to the `directObject`', () => {
+    it('calls through to the `directObject`', () => {
       const obj = {
         florp(x, y) {
           return `<${x} ${y}>`;
@@ -126,7 +146,7 @@ describe('@bayou/api-server/Target', () => {
       assert.strictEqual(result, '<hey buddy>');
     });
 
-    it('should be transparent with respect to thrown errors', () => {
+    it('is transparent with respect to thrown errors', () => {
       const err = new Error('eek!');
       const obj = {
         blort() {

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -65,6 +65,11 @@ describe('@bayou/api-server/Target', () => {
     it('accepts `null` as the third argument', () => {
       assert.doesNotThrow(() => new Target('x', {}, null));
     });
+
+    it('produces frozen instances', () => {
+      const t = new Target('x', {});
+      assert.isFrozen(t);
+    });
   });
 
   describe('.directObject', () => {


### PR DESCRIPTION
This PR is another chunk of simplification enabled by switching to the new-style sessions. Specifically, `Context` used to have logic to remove targets that were idle beyond a defined threshold, which was mainly of use in the per-server global context which held all session authorizations, and which was arguably counterproductive for any other context. Since we no longer have global contexts, there was no more point in having the idle-out mechanism. RELETED!