### PR TITLE
Slight cleverness wrt token redaction.

### DIFF
--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -79,6 +79,9 @@ export default class BearerToken extends CommonBase {
     /** {string} Complete token, which contains a secret. */
     this._secretToken = TString.check(secretToken);
 
+    /** {string} Logging-safe (redacted) form of the token. */
+    this._safeString = BearerToken._redactToken(secretToken, id);
+
     Object.freeze(this);
   }
 
@@ -93,7 +96,7 @@ export default class BearerToken extends CommonBase {
    * full token value.
    */
   get safeString() {
-    return `${this.id}-...`;
+    return this._safeString;
   }
 
   /**
@@ -138,5 +141,22 @@ export default class BearerToken extends CommonBase {
     BearerToken.check(other);
 
     return (this.id === other.id) && (this._secretToken === other._secretToken);
+  }
+
+  /**
+   * Produces the redacted form of the given token, by finding the `id` within
+   * it and putting `...-` and/or `-...` around it as appropriate, along with
+   * reasonable fallback behavior.
+   *
+   * @param {string} secretToken Complete secret-bearing token.
+   * @param {string} id The token ID.
+   * @returns {string} The redacted form.
+   */
+  static _redactToken(secretToken, id) {
+    const idAt      = secretToken.indexOf(id);
+    const startDots = (idAt > 0);
+    const endDots   = (idAt < 0) || ((idAt + id.length) < secretToken.length);
+
+    return `${startDots ? '...-' : ''}${id}${endDots ? '-...' : ''}`;
   }
 }

--- a/local-modules/@bayou/api-common/tests/test_BearerToken.js
+++ b/local-modules/@bayou/api-common/tests/test_BearerToken.js
@@ -54,10 +54,18 @@ describe('@bayou/api-common/BearerToken', () => {
   });
 
   describe('.safeString', () => {
-    it('is the `id` with the expected suffix', () => {
-      const token = new BearerToken('foo', 'bar');
+    it('is the `id` with the expected prefix and/or suffix', () => {
+      function test(id, secret, expect) {
+        const token = new BearerToken(id, secret);
+        assert.strictEqual(token.safeString, expect);
+      }
 
-      assert.strictEqual(token.safeString, 'foo-...');
+      test('foo', 'foo-bar', 'foo-...');
+      test('bar', 'foo-bar', '...-bar');
+      test('bar', 'foo-bar-baz', '...-bar-...');
+
+      // Fallback case: The ID doesn't actually appear within the full token.
+      test('blortch', 'splorp', 'blortch-...');
     });
   });
 


### PR DESCRIPTION
[A little PR to fill in a brief lull.]

This PR adds just a bit of smarts to `BearerToken` such that it no longer assumes that the ID part of a token string is necessarily a prefix.