### PR TITLE
More info!

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -240,10 +240,10 @@ export default class Application extends CommonBase {
    * @returns {string} The server ID string.
    */
   static _makeIdString() {
-    const { name, version, commit_id } = ProductInfo.theOne.INFO;
+    const { name, version, commitId } = ProductInfo.theOne.INFO;
 
-    const id = ((typeof commit_id === 'string') && commit_id !== '')
-      ? `-${commit_id.slice(0, 8)}`
+    const id = ((typeof commitId === 'string') && commitId !== '')
+      ? `-${commitId.slice(0, 8)}`
       : '';
 
     return `${name}-${version}${id}`;

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -5,7 +5,7 @@
 import express from 'express';
 import http from 'http';
 
-import { ProductInfo } from '@bayou/env-server';
+import { ProductInfo, ServerEnv } from '@bayou/env-server';
 import { Logger } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
@@ -86,7 +86,10 @@ export default class Monitor extends CommonBase {
     });
 
     app.get('/info', async (req_unused, res) => {
-      Monitor._sendJsonResponse(res, ProductInfo.theOne.INFO);
+      Monitor._sendJsonResponse(res, {
+        build:   ProductInfo.theOne.INFO,
+        runtime: ServerEnv.theOne.info
+      });
     });
 
     const varInfo = new VarInfo();

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -30,8 +30,6 @@ export default class PidFile extends Singleton {
     /** {string} Path for the PID file. */
     this._pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
 
-    log.event.pid(process.pid);
-
     Object.freeze(this);
   }
 
@@ -49,7 +47,7 @@ export default class PidFile extends Singleton {
     // Write the PID file.
     fs.writeFileSync(this._pidPath, `${process.pid}\n`);
 
-    log.event.pidInitialized();
+    log.event.pidInitialized({ pid: process.pid });
   }
 
   /**

--- a/local-modules/@bayou/env-server/ProductInfo.js
+++ b/local-modules/@bayou/env-server/ProductInfo.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { camelCase } from 'lodash';
 import path from 'path';
 
 import { Proppy } from '@bayou/proppy';
@@ -20,9 +21,17 @@ export default class ProductInfo extends Singleton {
   constructor() {
     super();
 
+    // Parse the info file and convert keys to `camelCase` for consistency with
+    // how other things tend to be named in this system.
+    const origInfo = Proppy.parseFile(path.resolve(Dirs.theOne.BASE_DIR, 'product-info.txt'));
+    const info     = {};
+
+    for (const [key, value] of Object.entries(origInfo)) {
+      info[camelCase(key)] = value;
+    }
+
     /** {object} Product info object. */
-    this._productInfo = Proppy.parseFile(
-      path.resolve(Dirs.theOne.BASE_DIR, 'product-info.txt'));
+    this._productInfo = Object.freeze(info);
   }
 
   /**

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -23,6 +23,10 @@ export default class ServerEnv extends Singleton {
   /**
    * {object} Ad-hoc object with generally-useful runtime info, intended for
    * logging / debugging.
+   *
+   * **Note:** This isn't all-caps `INFO` because it's not a constant value,
+   * due to the fact that `process.cwd()` and `process.ppid` could possibly
+   * change.
    */
   get info() {
     return {

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -21,6 +21,25 @@ const log = new Logger('env-server');
  */
 export default class ServerEnv extends Singleton {
   /**
+   * {object} Ad-hoc object with generally-useful runtime info, intended for
+   * logging / debugging.
+   */
+  get info() {
+    return {
+      nodeVersion: process.version.replace(/^v/, ''),
+      platform:    process.platform,
+      arch:        process.arch,
+      pid:         process.pid,
+      ppid:        process.ppid,
+      directories: {
+        product: Dirs.theOne.BASE_DIR,
+        var:     Dirs.theOne.VAR_DIR,
+        cwd:     process.cwd()
+      }
+    };
+  }
+
+  /**
    * {string} The base URL to use for loopback requests from this machine. This
    * is always an `http://localhost/` URL.
    */

--- a/local-modules/@bayou/env-server/tests/test_ProductInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_ProductInfo.js
@@ -10,10 +10,16 @@ import { TObject } from '@bayou/typecheck';
 
 describe('@bayou/env-server/ProductInfo', () => {
   describe('.INFO', () => {
-    it('should return an object full of product info', () => {
+    it('is a frozen value', () => {
+      const info = ProductInfo.theOne.INFO;
+
+      assert.isFrozen(info);
+    });
+
+    it('is an object full of the expected product info', () => {
       const info = ProductInfo.theOne.INFO;
       const productKeys = [
-        'name', 'version', 'commit_id', 'commit_date', 'build_date', 'node_version'
+        'name', 'version', 'commitId', 'commitDate', 'buildDate', 'nodeVersion'
       ];
 
       assert.doesNotThrow(() => TObject.withExactKeys(info, productKeys));

--- a/local-modules/@bayou/see-all-server/HumanSink.js
+++ b/local-modules/@bayou/see-all-server/HumanSink.js
@@ -36,7 +36,7 @@ const PREFIX_ADJUST_INCREMENT = 4;
  * {Int} Maximum allowed length of an untruncated structured event string, in
  * characters.
  */
-const MAX_EVENT_STRING_LENGTH = 200;
+const MAX_EVENT_STRING_LENGTH = 500;
 
 /**
  * Implementation of the `@bayou/see-all` logging sink protocol which writes

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -270,12 +270,13 @@ export default class Action extends CommonBase {
       platform:    process.platform,
       arch:        process.arch,
       pid:         process.pid,
-      ppid:        process.ppid
+      ppid:        process.ppid,
+      directories: {
+        product: Dirs.theOne.BASE_DIR,
+        var:     Dirs.theOne.VAR_DIR,
+        cwd:     process.cwd()
+      }
     });
-
-    // A little spew to indicate where in the filesystem we live.
-    log.event.productDirectory(Dirs.theOne.BASE_DIR);
-    log.event.varDirectory(Dirs.theOne.VAR_DIR);
 
     /** The main app server. */
     const theApp = new Application(devRoutes);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -265,18 +265,7 @@ export default class Action extends CommonBase {
     }
 
     log.event.buildInfo(buildInfo);
-    log.event.runtimeInfo({
-      nodeVersion: process.version.replace(/^v/, ''),
-      platform:    process.platform,
-      arch:        process.arch,
-      pid:         process.pid,
-      ppid:        process.ppid,
-      directories: {
-        product: Dirs.theOne.BASE_DIR,
-        var:     Dirs.theOne.VAR_DIR,
-        cwd:     process.cwd()
-      }
-    });
+    log.event.runtimeInfo(ServerEnv.theOne.info);
 
     /** The main app server. */
     const theApp = new Application(devRoutes);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -4,7 +4,6 @@
 
 import { camelCase, kebabCase } from 'lodash';
 import path from 'path';
-import process from 'process';
 
 import { Application, Monitor } from '@bayou/app-setup';
 import { ClientBundle } from '@bayou/client-bundle';
@@ -263,7 +262,9 @@ export default class Action extends CommonBase {
     log.event.runtimeInfo({
       nodeVersion: process.version.replace(/^v/, ''),
       platform:    process.platform,
-      arch:        process.arch
+      arch:        process.arch,
+      pid:         process.pid,
+      ppid:        process.ppid
     });
 
     // A little spew to indicate where in the filesystem we live.

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -4,6 +4,7 @@
 
 import { camelCase, kebabCase } from 'lodash';
 import path from 'path';
+import process from 'process';
 
 import { Application, Monitor } from '@bayou/app-setup';
 import { ClientBundle } from '@bayou/client-bundle';
@@ -257,8 +258,13 @@ export default class Action extends CommonBase {
     // Set up the server environment bits (including, e.g. the PID file).
     await ServerEnv.theOne.init();
 
-    // A little spew to identify the build.
+    // A little spew to identify the build and our environment.
     log.event.buildInfo(ProductInfo.theOne.INFO);
+    log.event.runtimeInfo({
+      nodeVersion: process.version.replace(/^v/, ''),
+      platform:    process.platform,
+      arch:        process.arch
+    });
 
     // A little spew to indicate where in the filesystem we live.
     log.event.productDirectory(Dirs.theOne.BASE_DIR);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -259,15 +259,10 @@ export default class Action extends CommonBase {
 
     // A little spew to identify the build and our environment.
 
-    const buildInfo = {};
-    for (const [key, value] of Object.entries(ProductInfo.theOne.INFO)) {
-      buildInfo[camelCase(key)] = value;
-    }
-
-    log.event.buildInfo(buildInfo);
+    log.event.buildInfo(ProductInfo.theOne.INFO);
     log.event.runtimeInfo(ServerEnv.theOne.info);
 
-    /** The main app server. */
+    /** {Application} The main app server. */
     const theApp = new Application(devRoutes);
 
     // Start the app! The result is the port that it ends up listening on.

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -258,7 +258,13 @@ export default class Action extends CommonBase {
     await ServerEnv.theOne.init();
 
     // A little spew to identify the build and our environment.
-    log.event.buildInfo(ProductInfo.theOne.INFO);
+
+    const buildInfo = {};
+    for (const [key, value] of Object.entries(ProductInfo.theOne.INFO)) {
+      buildInfo[camelCase(key)] = value;
+    }
+
+    log.event.buildInfo(buildInfo);
     log.event.runtimeInfo({
       nodeVersion: process.version.replace(/^v/, ''),
       platform:    process.platform,


### PR DESCRIPTION
This adds a bit to the init-time spew and report from the `/info` monitor endpoint, to log/report stuff about the runtime environment. I also made a tweak-for-consistency to the build/product info reporting.

**Bonus:** Allow a bit longer event log text before truncating it when displaying on the console.