### PR TITLE
In re automatically-managed Quill enabled state.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -292,10 +292,12 @@ export default class BodyClient extends StateMachine {
     }
 
     // Note the time of the error, and determine if we've hit the point of
-    // unrecoverability. If so, transition into the `unrecoverableError` state.
-    // When this happens, higher-level logic can notice and take further action.
+    // unrecoverability. If so, inform the session and transition into the
+    // `unrecoverableError` state. When this happens, higher-level logic can
+    // notice and take further action.
     this._addErrorStamp();
     if (this._isUnrecoverablyErrored()) {
+      this._docSession.reportError(reason);
       this.log.event.cannotRecover();
       this.s_unrecoverableError();
       return;

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -91,12 +91,14 @@ export default class BodyClient extends StateMachine {
    *
    * @param {QuillProm} quill Quill editor instance for the body.
    * @param {DocSession} docSession Server session control / manager.
-   * @param {boolean} [editingEnabled = true] Flag that determines whether
-   *   the document body should be editable.
+   * @param {boolean} [manageEnabledState = true] Flag that determines whether
+   *   (`true`) or not (`false`) this instance should automatically manage the
+   *   "enabled" state of `quill`. If `false`, it is up to clients of this class
+   *   to use `quill.enable()` and `quill.disable()`.
    * @param {int} [pollingDelayMsec = 0] Delay in msecs to wait before
    *   transitioning from `wantInputAfterDelay` to `wantInput`.
    */
-  constructor(quill, docSession, editingEnabled = true, pollingDelayMsec = 0) {
+  constructor(quill, docSession, manageEnabledState = true, pollingDelayMsec = 0) {
     super('detached', docSession.log);
 
     /** {Quill} Editor object. */
@@ -105,8 +107,11 @@ export default class BodyClient extends StateMachine {
     /** {DocSession} Server session control / manager. */
     this._docSession = DocSession.check(docSession);
 
-    /** {boolean} Editing enabled flag, true by default. */
-    this._editingEnabled = editingEnabled;
+    /**
+     * {boolean} Whether this instance should manage {@link #_quill}'s enabled /
+     * disabled state.
+     */
+    this._manageEnabledState = manageEnabledState;
 
     /** {int} Delay between polling for changes, 0 by default. */
     this._pollingDelayMsec = pollingDelayMsec;
@@ -153,9 +158,11 @@ export default class BodyClient extends StateMachine {
      */
     this._errorStamps = [];
 
-    // The Quill instance should already be in read-only mode. We explicitly
-    // set that here, though, to be safe and resilient.
-    quill.disable();
+    if (this._manageEnabledState) {
+      // The Quill instance should already be in read-only mode. We explicitly
+      // set that here, though, to be safe and resilient.
+      quill.disable();
+    }
   }
 
   /**
@@ -271,8 +278,10 @@ export default class BodyClient extends StateMachine {
    * @param {InfoError} reason Error reason.
    */
   _handle_any_apiError(method, reason) {
-    // Stop the user from trying to do more edits, as they'd get lost.
-    this._quill.disable();
+    if (this._manageEnabledState) {
+      // Stop the user from trying to do more edits, as they'd get lost.
+      this._quill.disable();
+    }
 
     if (reason instanceof ConnectionError) {
       // It's connection-related and probably no big deal.
@@ -425,7 +434,7 @@ export default class BodyClient extends StateMachine {
 
     // And with that, it's now safe to enable Quill so that it will accept user
     // input, if editing is enabled.
-    if (this._editingEnabled) {
+    if (this._manageEnabledState) {
       this._quill.enable();
 
       // Focus the editor area so the user can start typing right away

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -405,7 +405,12 @@ export default class BodyClient extends StateMachine {
     }
 
     // Save the result as the current (latest known) revision of the document,
-    // and tell Quill about it.
+    // and tell Quill about it. **TODO:** In the case where we are recovering
+    // from network trouble, it's possible that `_quill`'s content contains
+    // changes that were never successfully reported to the server. In such
+    // cases, instead of calling `_updateWithSnapshot()` -- which will lose
+    // whatever work hadn't been reported -- we should reproduce the change
+    // request that was in progress.
     const firstEvent = this._quill.currentEvent;
     this._updateWithSnapshot(snapshot);
 

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -17,6 +17,18 @@ const log = new Logger('doc');
 
 /**
  * Manager of the API connection(s) needed to maintain a server session.
+ *
+ * Instances of this class emit events which indicate the instantaneous state of
+ * of their network connections along with any higher-level errors (which get
+ * reported to the instance). Events are as follows:
+ *
+ * * `closed()` &mdash; The network connection has been closed.
+ * * `error(e)` &mdash; There was an error either in establishing a connection
+ *   or at a higher layer (e.g. an unexpected failure in an API call). `e` is
+ *   an `Error` instance if there is a salient error, or `null` if not.
+ * * `opening()` &mdash; The instance is trying to establish a network
+ *   connection with a server.
+ * * `open()` &mdash; The network connection has been established.
  */
 export default class DocSession extends CommonBase {
   /**

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -237,6 +237,21 @@ export default class DocSession extends CommonBase {
   }
 
   /**
+   * Reports trouble. This call can be used by associated objects to indicate to
+   * this one that there is a higher-level error of some sort. This instance in
+   * turn emits that fact as an event, which downstream client code can use to
+   * inform its own behavior.
+   *
+   * @param {Error|null} [error = null] Salient `Error` instance, if any.
+   */
+  reportError(error) {
+    const eventArgs = (error === null) ? [] : [error];
+
+    this._eventSource.emit(new Functor('error', ...eventArgs));
+    this._log.event.errorReported(...eventArgs);
+  }
+
+  /**
    * Gets the API client instance to use. The client will have been successfully
    * opened before this method returns (if it returns normally instead of
    * throwing an error), but there is no guarantee that it won't have gotten

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -23,9 +23,10 @@ const log = new Logger('doc');
  * reported to the instance). Events are as follows:
  *
  * * `closed()` &mdash; The network connection has been closed.
- * * `error(e)` &mdash; There was an error either in establishing a connection
- *   or at a higher layer (e.g. an unexpected failure in an API call). `e` is
- *   an `Error` instance if there is a salient error, or `null` if not.
+ * * `error(?e)` &mdash; There was an error either in establishing a connection
+ *   or at a higher layer (e.g. an unexpected failure in an API call). If there
+ *   is a salient error which is associated with the problem, it is passed as an
+ *   argument to the event.
  * * `opening()` &mdash; The instance is trying to establish a network
  *   connection with a server.
  * * `open()` &mdash; The network connection has been established.

--- a/local-modules/@bayou/promise-util/EventSource.js
+++ b/local-modules/@bayou/promise-util/EventSource.js
@@ -112,7 +112,7 @@ export default class EventSource extends CommonBase {
   }
 
   /**
-   * {Promise<ChainedEvent>} Promise for the current (Latest / most recent)
+   * {Promise<ChainedEvent>} Promise for the current (latest / most recent)
    * event emitted by this instance. This is an immediately-resolved promise in
    * all cases _except_ when this instance has never emitted an event. In the
    * latter case, it becomes resolved as soon as the first event is emitted.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.7
+version = 1.2.8


### PR DESCRIPTION
The point of this PR is to make it possible for clients of the `doc-client` module to usefully take over the responsibility of enabling and disabling the associated `Quill` instance. Two items on that front:

* Change the `editingEnabled` constructor flag on `BodyClient` to control all calls to `Quill.{en,dis}able`, and rename it to `manageEnabledState` to memorialize its now somewhat-wider purview.
* Make `DocSession` become an event source which emits events about the network state and any detected (reported to it) higher-level errors. Code which wants to manage Quill's enabled state can now use these events to help it determine when it ought to enable / disable the Quill instance.