### PR TITLE
 Handle `BearerToken`s when used as `api-client` targets.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
@@ -139,11 +139,7 @@ export default class ApiClient extends CommonBase {
    *   server-side target.
    */
   getProxy(idOrToken) {
-    const id = (idOrToken instanceof BearerToken)
-      ? idOrToken.id
-      : TString.check(idOrToken);
-
-    return this._targets.addOrGet(id);
+    return this._targets.addOrGet(idOrToken);
   }
 
   /**

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -2,9 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { BearerToken, CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
-import { TString } from '@bayou/typecheck';
 import { CommonBase, WebsocketCodes } from '@bayou/util-common';
 
 import BaseServerConnection from './BaseServerConnection';
@@ -102,11 +101,7 @@ export default class ApiClientNew extends CommonBase {
    *   server-side target.
    */
   getProxy(idOrToken) {
-    const id = (idOrToken instanceof BearerToken)
-      ? idOrToken.id
-      : TString.check(idOrToken);
-
-    return this._targets.addOrGet(id);
+    return this._targets.addOrGet(idOrToken);
   }
 
   /**

--- a/local-modules/@bayou/api-client/ApiClientNew.js
+++ b/local-modules/@bayou/api-client/ApiClientNew.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
+import { CodableError, ConnectionError, Message, Remote, Response, TargetId } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
 import { CommonBase, WebsocketCodes } from '@bayou/util-common';
 
@@ -278,18 +278,25 @@ export default class ApiClientNew extends CommonBase {
    * in turn called by a proxy object representing an object on the far side of
    * the connection.
    *
-   * @param {string} target Name of the target object.
+   * @param {string} idOrTarget ID or token which identifies the target object
+   *   on the other side of the API connection.
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
    * @returns {Promise} Promise for the result (or error) of the call. In the
    *   case of an error, the rejection reason will always be an instance of
    *   `ConnectionError` (see which for details).
    */
-  async _send(target, payload) {
+  async _send(idOrTarget, payload) {
+    if (this._targets.getOrNull(idOrTarget) === null) {
+      // `idOrTarget` isn't in the map of same; that is it's totally unknown.
+      // Most likely indicates a bug in a higher layer of the system.
+      return Promise.reject(ConnectionError.unknownTarget(this._connectionId, idOrTarget));
+    }
+
     const id = this._nextId;
     this._nextId++;
 
-    const message = new Message(id, target, payload);
+    const message = new Message(id, TargetId.targetString(idOrTarget), payload);
     const msgJson = this._codec.encodeJson(message);
 
     this.log.info('Sending:', message);

--- a/local-modules/@bayou/api-client/TargetHandler.js
+++ b/local-modules/@bayou/api-client/TargetHandler.js
@@ -19,16 +19,17 @@ export default class TargetHandler extends MethodCacheProxyHandler {
    *
    * @param {function} sendMessage Function to call to send a message. See
    *   {@link TargetMap#constructor} for an explanation.
-   * @param {string} targetId The ID of the target to call on.
+   * @param {string|BearerToken} idOrToken The ID or token for the target to
+   *   call on.
    */
-  constructor(sendMessage, targetId) {
+  constructor(sendMessage, idOrToken) {
     super();
 
     /** {function} Function to call to send a message. */
     this._sendMessage = TFunction.checkCallable(sendMessage);
 
-    /** {string} The ID of the target. */
-    this._targetId = TargetId.check(targetId);
+    /** {string|BearerToken} The ID or token for the target to call on. */
+    this._idOrToken = TargetId.orToken(idOrToken);
 
     Object.freeze(this);
   }
@@ -41,10 +42,10 @@ export default class TargetHandler extends MethodCacheProxyHandler {
    */
   _impl_methodFor(name) {
     const sendMessage = this._sendMessage;  // Avoid re-(re-)lookup on every call.
-    const targetId    = this._targetId;     // Likewise.
+    const idOrToken   = this._idOrToken;     // Likewise.
 
     return (...args) => {
-      return sendMessage(targetId, new Functor(name, ...args));
+      return sendMessage(idOrToken, new Functor(name, ...args));
     };
   }
 }

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -58,7 +58,7 @@ export default class TargetMap extends CommonBase {
    */
   add(idOrToken) {
     if (this.getOrNull(idOrToken) !== null) {
-      throw Errors.badUse(`Already bound: ${TargetId.targetString(idOrToken)}`);
+      throw Errors.badUse(`Already bound: ${TargetId.safeString(idOrToken)}`);
     }
 
     const targetId = TargetId.targetString(idOrToken);
@@ -102,7 +102,7 @@ export default class TargetMap extends CommonBase {
     const result = this.getOrNull(idOrToken);
 
     if (result === null) {
-      throw Errors.badUse(`No such target: ${TargetId.targetString(idOrToken)}`);
+      throw Errors.badUse(`No such target: ${TargetId.safeString(idOrToken)}`);
     }
 
     return result;

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -50,8 +50,15 @@ export default class TargetMap extends CommonBase {
 
   /**
    * Creates and binds a proxy for the target with the given ID. Returns the
-   * so-created proxy. It is an error to try to add the same `id` more than
-   * once (except if {@link #clear} is called in the mean time).
+   * so-created proxy. It is an error to try to add the same `idOrToken` more
+   * than once (except if {@link #clear} is called in the mean time).
+   *
+   * **Note:** This class doesn't care (or notice) if multiple `BearerToken`s
+   * with the same _token_ ID get added, nor if a `BearerToken` gets added whose
+   * _token_ ID matches a plain string ID that was previously added. From this
+   * class's perspective, these are all separate bindings. However, in these
+   * cases the far side of the API connection very well might notice and report
+   * an error in various related circumstances.
    *
    * @param {string|BearerToken} idOrToken ID or token for the target.
    * @returns {Proxy} The newly-bound proxy.
@@ -61,8 +68,7 @@ export default class TargetMap extends CommonBase {
       throw Errors.badUse(`Already bound: ${TargetId.safeString(idOrToken)}`);
     }
 
-    const targetId = TargetId.targetString(idOrToken);
-    const result   = TargetHandler.makeProxy(this._sendMessage, targetId);
+    const result = TargetHandler.makeProxy(this._sendMessage, idOrToken);
 
     this._targets.set(idOrToken, result);
     this._proxies.add(result);

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -53,17 +53,18 @@ export default class TargetMap extends CommonBase {
    * so-created proxy. It is an error to try to add the same `id` more than
    * once (except if {@link #clear} is called in the mean time).
    *
-   * @param {string} id Target ID.
+   * @param {string|BearerToken} idOrToken ID or token for the target.
    * @returns {Proxy} The newly-bound proxy.
    */
-  add(id) {
-    if (this.getOrNull(id) !== null) {
-      throw Errors.badUse(`Already bound: ${id}`);
+  add(idOrToken) {
+    if (this.getOrNull(idOrToken) !== null) {
+      throw Errors.badUse(`Already bound: ${TargetId.targetString(idOrToken)}`);
     }
 
-    const result = TargetHandler.makeProxy(this._sendMessage, id);
+    const targetId = TargetId.targetString(idOrToken);
+    const result   = TargetHandler.makeProxy(this._sendMessage, targetId);
 
-    this._targets.set(id, result);
+    this._targets.set(idOrToken, result);
     this._proxies.add(result);
 
     return result;
@@ -73,13 +74,13 @@ export default class TargetMap extends CommonBase {
    * Adds the target as if by {@link #add} if not already bound, or returns the
    * pre-existing binding as if by {@link #get}.
    *
-   * @param {string} id Target ID.
+   * @param {string|BearerToken} idOrToken ID or token for the target.
    * @returns {Proxy} The corresponding proxy.
    */
-  addOrGet(id) {
-    const already = this.getOrNull(id);
+  addOrGet(idOrToken) {
+    const already = this.getOrNull(idOrToken);
 
-    return (already === null) ? this.add(id) : already;
+    return (already === null) ? this.add(idOrToken) : already;
   }
 
   /**
@@ -94,14 +95,14 @@ export default class TargetMap extends CommonBase {
    * Gets the proxy for the target with the given ID. It is an error to pass an
    * `id` that is not bound.
    *
-   * @param {string} id The target ID.
+   * @param {string|BearerToken} idOrToken ID or token for the target.
    * @returns {Proxy} The corresponding proxy.
    */
-  get(id) {
-    const result = this.getOrNull(id);
+  get(idOrToken) {
+    const result = this.getOrNull(idOrToken);
 
     if (result === null) {
-      throw Errors.badUse(`No such target: ${id}`);
+      throw Errors.badUse(`No such target: ${TargetId.targetString(idOrToken)}`);
     }
 
     return result;
@@ -111,13 +112,13 @@ export default class TargetMap extends CommonBase {
    * Gets the proxy for the target with the given ID, or `null` if there is no
    * such target.
    *
-   * @param {string} id The target ID.
+   * @param {string|BearerToken} idOrToken ID or token for the target.
    * @returns {Proxy|null} The corresponding proxy, or `null` if `id` isn't
    *   bound to a target.
    */
-  getOrNull(id) {
-    TargetId.check(id);
-    return this._targets.get(id) || null;
+  getOrNull(idOrToken) {
+    TargetId.orToken(idOrToken);
+    return this._targets.get(idOrToken) || null;
   }
 
   /**

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import { inspect } from 'util';
 
-import { BearerToken, TargetId } from '@bayou/api-common';
+import { BearerToken } from '@bayou/api-common';
 import { Functor } from '@bayou/util-common';
 
 import TargetMap from '@bayou/api-client/TargetMap';
@@ -112,7 +112,7 @@ describe('@bayou/api-client/TargetMap', () => {
 
       const proxy = tm.add(t);
 
-      checkProxy(proxy, mc, TargetId.targetString(t));
+      checkProxy(proxy, mc, t);
     });
 
     it('refuses to add the same string ID twice', () => {
@@ -161,7 +161,7 @@ describe('@bayou/api-client/TargetMap', () => {
 
       const proxy = tm.addOrGet(t);
 
-      checkProxy(proxy, mc, TargetId.targetString(t));
+      checkProxy(proxy, mc, t);
     });
 
     it('returns the same proxy when given the same string ID twice', () => {
@@ -277,7 +277,7 @@ describe('@bayou/api-client/TargetMap', () => {
 
       assert.isTrue(got === added);
 
-      checkProxy(got, mc, token.secretToken);
+      checkProxy(got, mc, token);
     });
 
     it('finds a string target added with `addOrGet()`', () => {

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -21,8 +21,8 @@ class MessageCollector {
   }
 
   get sendMessage() {
-    return (targetId, payload, ...rest) => {
-      this.messages.push({ targetId, payload, rest });
+    return (target, payload, ...rest) => {
+      this.messages.push({ target, payload, rest });
     };
   }
 }
@@ -40,9 +40,9 @@ class MessageCollector {
  *
  * @param {*} proxy (Alleged) target proxy.
  * @param {MessageCollector} mc Expected object to receive messages.
- * @param {string} targetId Expected target ID.
+ * @param {string|BearerToken} target Expected target.
  */
-function checkProxy(proxy, mc, targetId) {
+function checkProxy(proxy, mc, target) {
   function test(payload) {
     const inspectPayload = inspect(payload);
 
@@ -56,7 +56,7 @@ function checkProxy(proxy, mc, targetId) {
 
     const msg = got[0];
 
-    assert.strictEqual(msg.targetId, targetId, inspectPayload);
+    assert.strictEqual(msg.target, target, inspectPayload);
     assert.deepEqual(msg.payload, payload, inspectPayload);
     assert.deepEqual(msg.rest, [], inspectPayload);
   }

--- a/local-modules/@bayou/api-common/ConnectionError.js
+++ b/local-modules/@bayou/api-common/ConnectionError.js
@@ -7,6 +7,8 @@ import { inspect } from 'util';
 import { TString } from '@bayou/typecheck';
 import { InfoError } from '@bayou/util-common';
 
+import TargetId from './TargetId';
+
 /**
  * Error class for reporting errors coming from `ApiClient` related to the
  * connection or transport (as opposed to, e.g., being errors being relayed from
@@ -86,15 +88,16 @@ export default class ConnectionError extends InfoError {
 
   /**
    * Constructs an error indicating that the _local_ side of the API received a
-   * target ID that it didn't already know about.
+   * target (ID or token) that it didn't already know about.
    *
    * @param {string} connectionId Connection ID string.
-   * @param {string} targetId ID of the target in question.
+   * @param {string|BearerToken} idOrTarget ID or token that identifies the
+   *   target in question.
    * @returns {ConnectionError} An appropriately-constructed error.
    */
-  static unknownTargetId(connectionId, targetId) {
+  static unknownTarget(connectionId, idOrTarget) {
     TString.check(connectionId);
-    TString.check(targetId);
-    return new ConnectionError('unknownTargetId', connectionId, targetId);
+    TargetId.orToken(idOrTarget);
+    return new ConnectionError('unknownTarget', connectionId, TargetId.safeString(idOrTarget));
   }
 }

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -58,4 +58,19 @@ export default class TargetId extends UtilityClass {
       throw Errors.badValue(value, 'TargetId|BearerToken');
     }
   }
+
+  /**
+   * Gets the string to use as an ID across an API boundary for the given value
+   * which must be either a target ID string or a {@link BearerToken}.
+   *
+   * @param {string|BearerToken} idOrToken The ID or token which identifies the
+   *   target.
+   * @returns {string} The string to use to refer to `idOrToken` across an API
+   *   boundary.
+   */
+  static targetString(idOrToken) {
+    TargetId.orToken(idOrToken);
+
+    return (idOrToken instanceof BearerToken) ? idOrToken.secretToken : idOrToken;
+  }
 }

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -5,6 +5,8 @@
 import { TString } from '@bayou/typecheck';
 import { Errors, UtilityClass } from '@bayou/util-common';
 
+import BearerToken from './BearerToken';
+
 /** {RegExp} Regular expression which matches valid target IDs. */
 const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,256}$/;
 
@@ -25,7 +27,7 @@ export default class TargetId extends UtilityClass {
    * Checks a value of type `TargetId`.
    *
    * @param {*} value Value to check.
-   * @returns {string} `value`.
+   * @returns {string} `value` if it is in fact a valid target ID.
    */
   static check(value) {
     try {
@@ -33,6 +35,27 @@ export default class TargetId extends UtilityClass {
     } catch (e) {
       // Throw a higher-fidelity error.
       throw Errors.badValue(value, TargetId);
+    }
+  }
+
+  /**
+   * Checks a value which must either be a `TargetId` per se or an instance of
+   * {@link BearerToken}.
+   *
+   * @param {*} value The value in question.
+   * @returns {string|BearerToken} `value` if it is either valid target ID
+   *   string or is an instance of {@link BearerToken}.
+   */
+  static orToken(value) {
+    if (value instanceof BearerToken) {
+      return value;
+    }
+
+    try {
+      return TargetId.check(value);
+    } catch (e) {
+      // Throw a higher-fidelity error.
+      throw Errors.badValue(value, 'TargetId|BearerToken');
     }
   }
 }

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -60,6 +60,21 @@ export default class TargetId extends UtilityClass {
   }
 
   /**
+   * Gets the string to use when logging an ID or token. Plain IDs are returned
+   * as-is, and {@link BearerToken} instances are converted into their "safe
+   * string" (redacted) forms.
+   *
+   * @param {string|BearerToken} idOrToken The ID or token which identifies the
+   *   target.
+   * @returns {string} The string to use to refer to `idOrToken` in logs.
+   */
+  static safeString(idOrToken) {
+    TargetId.orToken(idOrToken);
+
+    return (idOrToken instanceof BearerToken) ? idOrToken.safeString : idOrToken;
+  }
+
+  /**
    * Gets the string to use as an ID across an API boundary for the given value
    * which must be either a target ID string or a {@link BearerToken}.
    *

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -5,11 +5,11 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { TargetId } from '@bayou/api-common';
+import { BearerToken, TargetId } from '@bayou/api-common';
 
 describe('@bayou/api-common/TargetId', () => {
   describe('check()', () => {
-    it('should accept valid ids', () => {
+    it('accepts valid IDs', () => {
       function test(value) {
         assert.strictEqual(TargetId.check(value), value);
       }
@@ -33,7 +33,7 @@ describe('@bayou/api-common/TargetId', () => {
       }
     });
 
-    it('should reject strings with invalid characters', () => {
+    it('rejects strings with invalid characters', () => {
       function test(value) {
         assert.throws(() => TargetId.check(value), /badValue/);
       }
@@ -44,19 +44,52 @@ describe('@bayou/api-common/TargetId', () => {
       test('what is happening?');
     });
 
-    it('should reject the empty string', () => {
+    it('rejects the empty string', () => {
       assert.throws(() => TargetId.check(''), /badValue/);
     });
 
-    it('should reject too-long strings', () => {
+    it('rejects too-long strings', () => {
       for (let i = 257; i < 500; i++) {
         assert.throws(() => TargetId.check('x'.repeat(i)), /badValue/, `length ${i}`);
       }
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       function test(value) {
         assert.throws(() => TargetId.check(value), /badValue/);
+      }
+
+      test(null);
+      test(undefined);
+      test(true);
+      test(123);
+      test(new Map());
+      test(new BearerToken('x', 'xy'));
+    });
+  });
+
+  describe('orToken()', () => {
+    it('accepts valid ID strings', () => {
+      function test(value) {
+        assert.strictEqual(TargetId.orToken(value), value);
+      }
+
+      test('abc_123');
+      test('0123.456-789');
+    });
+
+    it('accepts `BearerToken` instances', () => {
+      const token = new BearerToken('abc', 'abc-xyz');
+      assert.strictEqual(TargetId.orToken(token), token);
+    });
+
+    it('rejects invalid strings', () => {
+      assert.throws(() => TargetId.orToken('!?%'), /badValue/);
+    });
+
+    it('should reject non-`BearerToken` non-strings', () => {
+      function test(value) {
+        assert.throws(() => TargetId.orToken(value), /badValue/);
       }
 
       test(null);

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -99,4 +99,42 @@ describe('@bayou/api-common/TargetId', () => {
       test(new Map());
     });
   });
+
+  describe('targetString()', () => {
+    it('returns the argument if is is a valid ID string', () => {
+      function test(s) {
+        assert.strictEqual(TargetId.targetString(s), s);
+      }
+
+      test('abc_123');
+      test('0123.456-789');
+    });
+
+    it('returns the secret token out of a given `BearerToken`', () => {
+      function test(id, secret) {
+        const token = new BearerToken(id, `${id}-${secret}`);
+        assert.strictEqual(TargetId.targetString(token), token.secretToken);
+      }
+
+      test('foo',   '123123-8999');
+      test('x',     'abc_def');
+      test('b.c.d', 'zorch');
+    });
+
+    it('rejects invalid strings', () => {
+      assert.throws(() => TargetId.targetString('!?%'), /badValue/);
+    });
+
+    it('should reject non-`BearerToken` non-strings', () => {
+      function test(value) {
+        assert.throws(() => TargetId.targetString(value), /badValue/);
+      }
+
+      test(null);
+      test(undefined);
+      test(true);
+      test(123);
+      test(new Map());
+    });
+  });
 });

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -87,9 +87,47 @@ describe('@bayou/api-common/TargetId', () => {
       assert.throws(() => TargetId.orToken('!?%'), /badValue/);
     });
 
-    it('should reject non-`BearerToken` non-strings', () => {
+    it('rejects non-`BearerToken` non-strings', () => {
       function test(value) {
         assert.throws(() => TargetId.orToken(value), /badValue/);
+      }
+
+      test(null);
+      test(undefined);
+      test(true);
+      test(123);
+      test(new Map());
+    });
+  });
+
+  describe('safeString()', () => {
+    it('returns the argument if is is a valid ID string', () => {
+      function test(s) {
+        assert.strictEqual(TargetId.safeString(s), s);
+      }
+
+      test('abc_123');
+      test('0123.456-789');
+    });
+
+    it('returns the safe version of a given `BearerToken`', () => {
+      function test(id, secret) {
+        const token = new BearerToken(id, `${id}-${secret}`);
+        assert.strictEqual(TargetId.safeString(token), token.safeString);
+      }
+
+      test('foo',   '123123-8999');
+      test('x',     'abc_def');
+      test('b.c.d', 'zorch');
+    });
+
+    it('rejects invalid strings', () => {
+      assert.throws(() => TargetId.safeString('!?%'), /badValue/);
+    });
+
+    it('rejects non-`BearerToken` non-strings', () => {
+      function test(value) {
+        assert.throws(() => TargetId.safeString(value), /badValue/);
       }
 
       test(null);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.8
+version = 1.2.9


### PR DESCRIPTION
One aspect of the new-session work was that `BearerToken`s were supposed to be fully accepted up and down the stack on both client and server sides of an API connection, with them getting converted to and from raw strings only _at_ the API boundary. As an oversight, they were (a) getting converted to strings too early on the client side, and (b) when that was done the full-fidelity token was getting dropped in favor of just using the token ID (which was wrong, though somewhat confusing due to overloading of the term "ID").

This PR fixes both problems.
