### PR TITLE
More convenient event emission.

### DIFF
--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -5,7 +5,7 @@
 import { EventSource, CallPiler } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { TBoolean, TString } from '@bayou/typecheck';
-import { CommonBase, Functor } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 /** {string} Value used for an unknown connection ID. */
 const UNKNOWN_CONNECTION_ID = 'id_unknown';
@@ -59,7 +59,7 @@ export default class BaseServerConnection extends CommonBase {
 
     /** {EventSource} Emitter used for the events of this instance. */
     this._events = new EventSource();
-    this._events.emit(new Functor(BaseServerConnection.EVENT_start));
+    this._events.emit[BaseServerConnection.EVENT_start]();
 
     /**
      * {ChainedEvent} The "head" of the event chain after which any `receive`
@@ -148,7 +148,7 @@ export default class BaseServerConnection extends CommonBase {
    */
   async enqueue(message) {
     TString.check(message);
-    this._events.emit(new Functor(BaseServerConnection.EVENT_send, message));
+    this._events.emit[BaseServerConnection.EVENT_send](message);
   }
 
   /**
@@ -181,7 +181,7 @@ export default class BaseServerConnection extends CommonBase {
    */
   async received(message) {
     TString.check(message);
-    this._events.emit(new Functor(BaseServerConnection.EVENT_receive, message));
+    this._events.emit[BaseServerConnection.EVENT_receive](message);
   }
 
   /**

--- a/local-modules/@bayou/api-client/BaseServerConnection.js
+++ b/local-modules/@bayou/api-client/BaseServerConnection.js
@@ -59,7 +59,7 @@ export default class BaseServerConnection extends CommonBase {
 
     /** {EventSource} Emitter used for the events of this instance. */
     this._events = new EventSource();
-    this._events.emit[BaseServerConnection.EVENT_start]();
+    this._events.emit(BaseServerConnection.EVENT_start);
 
     /**
      * {ChainedEvent} The "head" of the event chain after which any `receive`
@@ -148,7 +148,7 @@ export default class BaseServerConnection extends CommonBase {
    */
   async enqueue(message) {
     TString.check(message);
-    this._events.emit[BaseServerConnection.EVENT_send](message);
+    this._events.emit(BaseServerConnection.EVENT_send, message);
   }
 
   /**
@@ -181,7 +181,7 @@ export default class BaseServerConnection extends CommonBase {
    */
   async received(message) {
     TString.check(message);
-    this._events.emit[BaseServerConnection.EVENT_receive](message);
+    this._events.emit(BaseServerConnection.EVENT_receive, message);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -7,7 +7,7 @@ import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { CaretId, SessionInfo } from '@bayou/doc-common';
 import { EventSource } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
-import { CommonBase, Functor } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import CaretTracker from './CaretTracker';
 import PropertyClient from './PropertyClient';
@@ -219,7 +219,7 @@ export default class DocSession extends CommonBase {
       return proxy;
     } catch (e) {
       // Emit an event for and log the problem, and rethrow.
-      this._eventSource.emit(new Functor('closed'));
+      this._eventSource.emit.closed();
       this._log.event.sessionSetupFailed(e);
       throw e;
     }
@@ -260,7 +260,7 @@ export default class DocSession extends CommonBase {
   reportError(error) {
     const eventArgs = (error === null) ? [] : [error];
 
-    this._eventSource.emit(new Functor('error', ...eventArgs));
+    this._eventSource.emit.error(...eventArgs);
     this._log.event.errorReported(...eventArgs);
   }
 
@@ -280,19 +280,19 @@ export default class DocSession extends CommonBase {
 
     const url = this._sessionInfo.serverUrl;
 
-    this._eventSource.emit(new Functor('opening'));
+    this._eventSource.emit.opening();
     this._log.event.apiAboutToOpen(url);
     this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
 
     try {
       this._log.event.apiOpening();
       await this._apiClient.open();
-      this._eventSource.emit(new Functor('open'));
+      this._eventSource.emit.open();
       this._log.event.apiOpened();
     } catch (e) {
       // Emit an event for and log the problem, and rethrow. **TODO:** Consider
       // this as a spot to add retry logic.
-      this._eventSource.emit(new Functor('closed'));
+      this._eventSource.emit.closed();
       this._log.event.apiOpenFailed(e);
       throw e;
     }

--- a/local-modules/@bayou/promise-util/EmitHandler.js
+++ b/local-modules/@bayou/promise-util/EmitHandler.js
@@ -1,0 +1,53 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TFunction } from '@bayou/typecheck';
+import { Functor, MethodCacheProxyHandler } from '@bayou/util-common';
+
+/**
+ * Proxy handler which gets bound as {@link EventSource#emit}. It allows itself
+ * to be called as a function which takes a {@link Functor} payload, and &mdash;
+ * more interestingly &mdash; offers any property as a function which emits an
+ * event with that property's name.
+ */
+export default class EmitHandler extends MethodCacheProxyHandler {
+  /**
+   * Constructs an instance.
+   *
+   * @param {function} emit Function to call to actually emit an event. Takes
+   *   a single {@link Functor} argument.
+   */
+  constructor(emit) {
+    super();
+
+    /** {function} Function to call to actually emit an event. */
+    this._emit = TFunction.checkCallable(emit);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Standard `Proxy` handler method.
+   *
+   * @param {object} target_unused The proxy target.
+   * @param {object} thisArg_unused The `this` argument passed to the call.
+   * @param {array} args List of arguments passed to the call.
+   * @returns {*} Result from underlying `emit()` call.
+   */
+  apply(target_unused, thisArg_unused, args) {
+    return this._emit(...args);
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {string} name The method name.
+   * @returns {function} An appropriately-constructed handler.
+   */
+  _impl_methodFor(name) {
+    return (...args) => {
+      this._emit(new Functor(name, ...args));
+    };
+  }
+}

--- a/local-modules/@bayou/promise-util/EmitHandler.js
+++ b/local-modules/@bayou/promise-util/EmitHandler.js
@@ -15,8 +15,9 @@ export default class EmitHandler extends MethodCacheProxyHandler {
   /**
    * Constructs an instance.
    *
-   * @param {function} emit Function to call to actually emit an event. Takes
-   *   a single {@link Functor} argument.
+   * @param {function} emit Function to call to actually emit an event. Called
+   *   with a single {@link Functor} argument and is expected to return a
+   *   {@link ChainedEvent} instance.
    */
   constructor(emit) {
     super();
@@ -47,7 +48,7 @@ export default class EmitHandler extends MethodCacheProxyHandler {
    */
   _impl_methodFor(name) {
     return (...args) => {
-      this._emit(new Functor(name, ...args));
+      return this._emit(new Functor(name, ...args));
     };
   }
 }

--- a/local-modules/@bayou/promise-util/EventSource.js
+++ b/local-modules/@bayou/promise-util/EventSource.js
@@ -167,7 +167,8 @@ export default class EventSource extends CommonBase {
 
   /**
    * {function} When called as a regular method, emits an event with the given
-   * payload which must be a {@link Functor}. When accessed as an object, will
+   * payload which must either be a single {@link Functor} argument or a name
+   * followed by event payload arguments. When accessed as an object, will
    * return any named property as a function of arbitrary arguments which emits
    * an event of the same name as the property.
    */
@@ -178,10 +179,16 @@ export default class EventSource extends CommonBase {
   /**
    * Emits an event with the given payload.
    *
-   * @param {Functor} payload The event payload.
+   * @param {Functor|string} payloadOrName The event payload _or_ the name of
+   *   the event.
+   * @param {...*} args If `payloadOrName` is a string, the arguments to include
+   *   with the event.
    * @returns {ChainedEvent} The emitted event.
    */
-  _emit(payload) {
+  _emit(payloadOrName, ...args) {
+    const payload = (payloadOrName instanceof Functor)
+      ? payloadOrName
+      : new Functor(payloadOrName, ...args);
     const event = new ChainedEvent(this, payload);
 
     this._currentEvent._resolveNext(event);

--- a/local-modules/@bayou/promise-util/tests/test_ChainedEvent.js
+++ b/local-modules/@bayou/promise-util/tests/test_ChainedEvent.js
@@ -10,67 +10,67 @@ import { Functor } from '@bayou/util-common';
 
 describe('@bayou/promise-util/ChainedEvent', () => {
   describe('constructor()', () => {
-    it('should work', async () => {
+    it('constructs an instance', async () => {
       const source = new EventSource();
-      new ChainedEvent(source, new Functor('blort'));
+      assert.doesNotThrow(() => new ChainedEvent(source, new Functor('blort')));
     });
   });
 
   describe('.next', () => {
-    it('should be an unresolved promise if there is no next event', async () => {
+    it('is an unresolved promise if there is no next event', async () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
 
       const race = await Promise.race([event.next, Delay.resolve(10, 123)]);
       assert.strictEqual(race, 123);
     });
 
-    it('should eventually resolve to the chained event', async () => {
+    it('eventually resolves to the chained event', async () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
 
       const next = event.next;
       await Delay.resolve(10);
-      source.emit(new Functor('florp'));
+      source.emit.florp();
       const got = await next;
       assert.strictEqual(got.payload.name, 'florp');
     });
   });
 
   describe('.nextNow', () => {
-    it('should be `null` if there is no next events', () => {
+    it('is `null` if there is no next event', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
 
       assert.isNull(event.nextNow);
     });
 
-    it('should be the next event once emitted', () => {
+    it('is the next event once emitted', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
 
-      source.emit(new Functor('florp'));
+      source.emit.florp();
       assert.strictEqual(event.nextNow.payload.name, 'florp');
     });
   });
 
   describe('withNewPayload()', () => {
-    it('should produce an instance with the indicated payload', () => {
+    it('produces an instance with the indicated payload', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
       const expect = new Functor('florp');
 
       const result = event.withNewPayload(expect);
       assert.strictEqual(result.payload, expect);
     });
 
-    it('should produce an instance whose `nextNow` tracks the original', async () => {
+    it('produces an instance whose `nextNow` tracks the original', async () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
       const result = event.withNewPayload(new Functor('florp'));
 
       assert.isNull(result.nextNow);
-      source.emit(new Functor('like'));
+      source.emit.like();
       assert.strictEqual(event.nextNow.payload.name, 'like');
 
       // The result is allowed to (and expected to) asynchronously update
@@ -80,15 +80,15 @@ describe('@bayou/promise-util/ChainedEvent', () => {
       assert.strictEqual(result.nextNow.payload.name, 'like');
     });
 
-    it('should produce an instance whose `next` tracks the original', async () => {
+    it('produces an instance whose `next` tracks the original', async () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort'));
+      const event  = source.emit.blort();
       const result = event.withNewPayload(new Functor('florp'));
 
       const race = await Promise.race([result.next, Delay.resolve(10, 123)]);
       assert.strictEqual(race, 123);
 
-      source.emit(new Functor('like'));
+      source.emit.like();
       const eventNext  = await event.next;
       const resultNext = await result.next;
       assert.strictEqual(eventNext.payload.name, 'like');
@@ -97,9 +97,9 @@ describe('@bayou/promise-util/ChainedEvent', () => {
   });
 
   describe('withPushedHead()', () => {
-    it('should produce a result with the default payload', () => {
+    it('produces an instance with the default payload', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const event  = source.emit.blort(1, 2, 3);
       const result = event.withPushedHead();
 
       assert.strictEqual(result.payload.name, 'none');
@@ -108,27 +108,27 @@ describe('@bayou/promise-util/ChainedEvent', () => {
   });
 
   describe('withPushedHead(payload)', () => {
-    it('should produce a result with the indicated payload', () => {
+    it('produces an instance with the indicated payload', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const event  = source.emit.blort(1, 2, 3);
       const expect = new Functor('florp', 'x');
       const result = event.withPushedHead(expect);
 
       assert.strictEqual(result.payload, expect);
     });
 
-    it('should produce a result with `next` bound a promise to the original event', async () => {
+    it('produces an instance with `next` bound a promise to the original event', async () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const event  = source.emit.blort(1, 2, 3);
       const result = event.withPushedHead(new Functor('florp'));
 
       const next = await result.next;
       assert.strictEqual(next, event);
     });
 
-    it('should produce a result with `nextNow` bound to the original event', () => {
+    it('produces an instance with `nextNow` bound to the original event', () => {
       const source = new EventSource();
-      const event  = source.emit(new Functor('blort', 1, 2, 3));
+      const event  = source.emit.blort(1, 2, 3);
       const result = event.withPushedHead(new Functor('florp'));
 
       assert.strictEqual(result.nextNow, event);

--- a/local-modules/@bayou/promise-util/tests/test_EventSource.js
+++ b/local-modules/@bayou/promise-util/tests/test_EventSource.js
@@ -100,16 +100,36 @@ describe('@bayou/promise-util/EventSource', () => {
   });
 
   describe('emit()', () => {
-    it('works when called as a function', () => {
+    it('works when called as a function and passed a `Functor`', () => {
       const source = new EventSource();
 
-      function test(name, ...args) {
-        const f     = new Functor(name, ...args);
+      function test(...args) {
+        const f     = new Functor(...args);
         const event = source.emit(f);
 
         assert.instanceOf(event, ChainedEvent);
         assert.strictEqual(source.currentEventNow, event);
         assert.strictEqual(event.payload, f);
+      }
+
+      test('blort');
+      test('florp', 1, 2, 3);
+      test('zorch', { x: 'splat' });
+    });
+
+    it('works when called as a function and passed `Functor` construction arguments', () => {
+      const source = new EventSource();
+
+      function test(...args) {
+        const expect = new Functor(...args);
+        const event  = source.emit(...args);
+
+        assert.instanceOf(event, ChainedEvent);
+        assert.strictEqual(source.currentEventNow, event);
+
+        const payload = event.payload;
+        assert.instanceOf(payload, Functor);
+        assert.deepEqual(payload, expect);
       }
 
       test('blort');

--- a/local-modules/@bayou/promise-util/tests/test_EventSource.js
+++ b/local-modules/@bayou/promise-util/tests/test_EventSource.js
@@ -30,17 +30,17 @@ describe('@bayou/promise-util/EventSource', () => {
       const currentEvent = source.currentEvent;
 
       await Delay.resolve(100);
-      source.emit(new Functor('blort'));
+      source.emit.blort();
       const got = await currentEvent;
       assert.strictEqual(got.payload.name, 'blort');
     });
 
     it('resolves to the most recently emitted event', async () => {
       const source = new EventSource();
-      source.emit(new Functor('blort'));
-      source.emit(new Functor('florp'));
+      source.emit.blort();
+      source.emit.florp();
       const ce1 = source.currentEvent;
-      source.emit(new Functor('like'));
+      source.emit.like();
       const ce2 = source.currentEvent;
 
       const got1 = await ce1;
@@ -59,10 +59,10 @@ describe('@bayou/promise-util/EventSource', () => {
     it('is the most recently emitted event if there were ever any emitted events', () => {
       const source = new EventSource();
 
-      source.emit(new Functor('blort'));
-      source.emit(new Functor('florp'));
+      source.emit.blort();
+      source.emit.florp();
       assert.strictEqual(source.currentEventNow.payload.name, 'florp');
-      source.emit(new Functor('like'));
+      source.emit.like();
       assert.strictEqual(source.currentEventNow.payload.name, 'like');
     });
   });
@@ -85,7 +85,7 @@ describe('@bayou/promise-util/EventSource', () => {
       }
 
       emitter.addListener('blort', listener);
-      source.emit(new Functor('blort', 1, 2, 3));
+      source.emit.blort(1, 2, 3);
 
       assert.strictEqual(listened, 1);
       assert.deepEqual(gotArgs, [1, 2, 3]);
@@ -100,9 +100,35 @@ describe('@bayou/promise-util/EventSource', () => {
   });
 
   describe('emit()', () => {
-    it('trivially appears to work', () => {
+    it('works when called as a function', () => {
       const source = new EventSource();
-      assert.doesNotThrow(() => { source.emit(new Functor('blort')); });
+
+      function test(name, ...args) {
+        const f = new Functor(name, ...args);
+        source.emit(f);
+        assert.strictEqual(source.currentEventNow.payload, f);
+      }
+
+      test('blort');
+      test('florp', 1, 2, 3);
+      test('zorch', { x: 'splat' });
+    });
+
+    it('works when properties it offers are called', () => {
+      const source = new EventSource();
+
+      function test(name, ...args) {
+        const expect = new Functor(name, ...args);
+        source.emit[name](...args);
+
+        const payload = source.currentEventNow.payload;
+        assert.instanceOf(payload, Functor);
+        assert.deepEqual(payload, expect);
+      }
+
+      test('blort');
+      test('florp', 1, 2, 3);
+      test('zorch', { x: 'splat' });
     });
   });
 });

--- a/local-modules/@bayou/quill-util/PromSubclasser.js
+++ b/local-modules/@bayou/quill-util/PromSubclasser.js
@@ -54,14 +54,16 @@ export default class PromSubclasser extends UtilityClass {
         // constructor.
         const origEmitter = this.emitter;
 
-        /** {EventSource} Event source (emitter) for this instance. */
-        this._emitter = new EventSource();
+        /**
+         * {EventSource} Event source (modern-style emitter) for this instance.
+         */
+        this._eventSource = new EventSource();
 
         /**
          * {ChainableEvent} The most recent resolved event. It is initialized as
          * defined by the documentation for `currentEvent`.
          */
-        this._currentEvent = this._emitter.emit(QuillEvents.EMPTY_TEXT_CHANGE_PAYLOAD);
+        this._currentEvent = this._eventSource.emit(QuillEvents.EMPTY_TEXT_CHANGE_PAYLOAD);
 
         // We override `emitter.emit()` to _synchronously_ emit an event to the
         // promise chain. We do it this way instead of relying on an event
@@ -95,7 +97,7 @@ export default class PromSubclasser extends UtilityClass {
             // server state will tragically diverge).
 
             this._currentEvent =
-              QuillEvents.emitQuillPayload(this._emitter, new Functor(...rest));
+              QuillEvents.emitQuillPayload(this._eventSource, new Functor(...rest));
           }
 
           // This is the moral equivalent of `super.emit(...)`.

--- a/local-modules/@bayou/util-common/BaseProxyHandler.js
+++ b/local-modules/@bayou/util-common/BaseProxyHandler.js
@@ -20,6 +20,23 @@ import { CommonBase, Errors } from '@bayou/util-core';
 export default class BaseProxyHandler extends CommonBase {
   /**
    * Constructs and returns a proxy which wraps an instance of this class,
+   * and with a frozen no-op function as the target. The instance of this class
+   * is constructed with whatever arguments get passed to this method.
+   *
+   * @param {...*} args Construction arguments to pass to this class's
+   *   constructor.
+   * @returns {Proxy} Proxy instance which uses an instance of this class as its
+   *   handler and which adopts a baseline identity as a function.
+   */
+  static makeFunctionProxy(...args) {
+    // **Note:** `this` in the context of a static method is the class.
+    const handler = new this(...args);
+
+    return new Proxy(Object.freeze(() => undefined), handler);
+  }
+
+  /**
+   * Constructs and returns a proxy which wraps an instance of this class,
    * and with a frozen empty object as the target. The instance of this class
    * is constructed with whatever arguments get passed to this method.
    *

--- a/local-modules/@bayou/util-common/tests/test_BaseProxyHandler.js
+++ b/local-modules/@bayou/util-common/tests/test_BaseProxyHandler.js
@@ -8,8 +8,57 @@ import { describe, it } from 'mocha';
 import { BaseProxyHandler } from '@bayou/util-common';
 
 describe('@bayou/util-common/BaseProxyHandler', () => {
+  describe('makeFunctionProxy()', () => {
+    it('constructs a function-like proxy around an instance of the called-upon subclass', () => {
+      let gotArgs     = null;
+      let gotProperty = null;
+      let gotTarget   = null;
+      let gotThis     = null;
+
+      class Subclass extends BaseProxyHandler {
+        constructor(...args) {
+          super();
+          gotArgs = args;
+        }
+
+        apply(target, thisArg, args) {
+          gotTarget = target;
+          gotThis   = thisArg;
+          gotArgs   = args;
+
+          return 'boop';
+        }
+
+        get(target, property, receiver_unused) {
+          gotTarget   = target;
+          gotProperty = property;
+        }
+      }
+
+      const proxy = Subclass.makeFunctionProxy('x', 'y', 'z');
+
+      assert.deepEqual(gotArgs, ['x', 'y', 'z']);
+
+      assert.isUndefined(proxy.florp);
+      assert.frozen(gotTarget);
+      assert.isFunction(gotTarget);
+      assert.strictEqual(gotProperty, 'florp');
+
+      const callResult = proxy(1, 2, 3);
+      assert.strictEqual(callResult, 'boop');
+      assert.isFunction(gotTarget);
+      assert.isUndefined(gotThis);
+      assert.deepEqual(gotArgs, [1, 2, 3]);
+
+      const someThis = { yes: 'yes', p: proxy };
+      someThis.p('xyz');
+      assert.strictEqual(gotThis, someThis);
+      assert.deepEqual(gotArgs, ['xyz']);
+    });
+  });
+
   describe('makeProxy()', () => {
-    it('should construct a proxy around an instance of the called-upon subclass', () => {
+    it('constructs a proxy around an instance of the called-upon subclass', () => {
       let gotArgs = null;
       let gotTarget = null;
       let gotProperty = null;
@@ -38,13 +87,13 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('constructor', () => {
-    it('should construct an instance', () => {
+    it('constructs an instance', () => {
       assert.doesNotThrow(() => new BaseProxyHandler());
     });
   });
 
   describe('apply()', () => {
-    it('should always throw', () => {
+    it('always throws', () => {
       const func = () => { throw new Error('should not have been called'); };
       const bph = new BaseProxyHandler();
       const proxy = new Proxy(func, bph);
@@ -53,7 +102,7 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('construct()', () => {
-    it('should always throw', () => {
+    it('always throws', () => {
       const func = () => { throw new Error('should not have been called'); };
       const bph = new BaseProxyHandler();
       const proxy = new Proxy(func, bph);
@@ -62,21 +111,21 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('defineProperty()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const bph = new BaseProxyHandler();
       assert.isFalse(bph.defineProperty({}, 'blort', { value: 123 }));
     });
   });
 
   describe('deleteProperty()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const bph = new BaseProxyHandler();
       assert.isFalse(bph.deleteProperty({ blort: 10 }, 'blort'));
     });
   });
 
   describe('get()', () => {
-    it('should always return `undefined`', () => {
+    it('always returns `undefined`', () => {
       const bph = new BaseProxyHandler();
 
       assert.isUndefined(bph.get({}, 'x', {}));
@@ -85,14 +134,14 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('getOwnPropertyDescriptor()', () => {
-    it('should always throw', () => {
+    it('always throws', () => {
       const bph = new BaseProxyHandler();
       assert.throws(() => bph.getOwnPropertyDescriptor({ blort: 123 }, 'blort'));
     });
   });
 
   describe('getPrototypeOf()', () => {
-    it('should return the target\'s prototype', () => {
+    it('returns the target\'s prototype', () => {
       const bph = new BaseProxyHandler();
       const obj = new Map();
       assert.strictEqual(bph.getPrototypeOf(obj), Object.getPrototypeOf(obj));
@@ -100,35 +149,35 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('has()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const bph = new BaseProxyHandler();
       assert.isFalse(bph.has({ blort: 10 }, 'blort'));
     });
   });
 
   describe('isExtensible()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const bph = new BaseProxyHandler();
       assert.isFalse(bph.isExtensible({}));
     });
   });
 
   describe('ownKeys()', () => {
-    it('should always return `[]`', () => {
+    it('always returns `[]`', () => {
       const bph = new BaseProxyHandler();
       assert.deepEqual(bph.ownKeys({ a: 10, b: 20 }), []);
     });
   });
 
   describe('preventExstensions()', () => {
-    it('should always return `true`', () => {
+    it('always returns `true`', () => {
       const bph = new BaseProxyHandler();
       assert.isTrue(bph.preventExtensions({}));
     });
   });
 
   describe('set()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const func = () => { throw new Error('should not have been called'); };
       const bph = new BaseProxyHandler();
       const proxy = new Proxy(func, bph);
@@ -137,7 +186,7 @@ describe('@bayou/util-common/BaseProxyHandler', () => {
   });
 
   describe('setPrototypeOf()', () => {
-    it('should always return `false`', () => {
+    it('always returns `false`', () => {
       const bph = new BaseProxyHandler();
 
       assert.isFalse(bph.setPrototypeOf({}, null));


### PR DESCRIPTION
`EventSource.emit()` had a bit of a rough API, which until recently wasn't that much of an issue, because the class wasn't used that much. A couple of recent (or at least recent-ish) PRs started using it more, which suggested to me it was time to give a little love to this method, so that's what this PR does.

Specifically, `EventSource.emit()` can now be used in three different ways, all of which are reasonably idiomatic and natural-feeling in context[*]:

* `source.emit(payload)` where payload is an instance of the `Functor` class that's used all over the system to encapsulate "name and arbitrary arguments." This is the original API of this method.
* `source.emit(name, ...args)` where `name` is a string and `args` are arbitrary arguments. This is directly parallel to the traditional JavaScript `EventEmitter` API. In this case, it's implemented as (fairly directly) `source.emit(new Functor(name, ...args))`. This form is most handy when `name` _isn't_ a literal string.
* `source.emit.name(...args)` where `name` is (of necessity) syntactically a JavaScript identifier and `args` are arbitrary arguments. As with the previous form, this bottoms out as `source.emit(new Functor(name, ...args))`. But in this case it has the advantage of reading a bit better/cleaner and gets JavaScript identifier syntax checking too. This form is parallel to how one performs event logging in this system (`log.event.name(...args)`).

[*] I will admit that by default I am more of a "one way to do things" sort of person. In this case, though, the JavaScript environment in which this system is embedded doesn't make any one of these ways the clearly superior "one way." C'est la guerre.
