### PR TITLE
Session init tweaks and cleanup.

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -104,8 +104,6 @@ export default class AuthorAccess extends CommonBase {
     // work.
     Storage.dataStore.checkDocumentIdSyntax(documentId);
 
-    // **Note:** This call includes data store back-end validation of the author
-    // and document IDs.
     const { canEdit, canView } = await Storage.dataStore.getPermissions(this._authorId, documentId);
 
     if (!(canEdit || canView)) {

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -37,13 +37,19 @@ export default class RootAccess extends CommonBase {
    * author editing a specific document, on the server (or server cluster)
    * running this method.
    *
+   * **Note:** This method checks the validity of the IDs via back-end requests
+   * but does _not_ check to see if the author actually has permission to access
+   * the identified document. That permission check will end up getting done
+   * when the client comes back in through the "front door" and lands in a call
+   * to {@link AuthorAccess#makeNewSession}.
+   *
    * @param {string} authorId ID of the author (user) who will be driving the
    *   session.
    * @param {string} documentId ID of the document to be accessed.
    * @returns {SessionInfo} Corresponding info struct.
    */
   async makeSessionInfo(authorId, documentId) {
-    log.event.sessionRequested(authorId, documentId);
+    log.event.sessionInfoRequested(authorId, documentId);
 
     // These checks round-trip with the back-end to do full (not just syntactic)
     // validation.
@@ -58,22 +64,17 @@ export default class RootAccess extends CommonBase {
     // caller.
     await DocServer.theOne.getFileComplex(documentId);
 
-    log.event.sessionInfoValid(authorId, documentId);
-
     const url         = `${Network.baseUrl}/api`;
     const authorToken = await this._getAuthorToken(authorId);
+    const result      = new SessionInfo(url, authorToken, documentId);
 
-    // As a bit of extra visibility / validation as we transition to new-style
-    // sessions, get and log the "authority" granted to `authorToken`. This had
-    // better turn out to be that it grants edit access to the author in
-    // question! **Note:** Only log the safe (redacted) form of the token.
-    const authority = await Auth.tokenAuthority(authorToken);
-    log.event.gotAuthorToken({ where: 'makeSessionInfo', token: authorToken.safeString, authority });
+    log.event.madeSessionInfo(result);
 
-    // Return the full token string to the caller, as it (the client) will
-    // ultimately need to pass it back in full. (Usually it's a bad idea to
-    // return unredacted tokens; this (kind of) case is the main exception.)
-    return new SessionInfo(url, authorToken, documentId);
+    // **Note:** This returns the full token string to the caller, as it (the
+    // client) will ultimately need to pass it back in full. (Usually it's a bad
+    // idea to return unredacted tokens; this (kind of) case is the main
+    // exception.)
+    return result;
   }
 
   /**

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -68,7 +68,8 @@ export default class RootAccess extends CommonBase {
     const authorToken = await this._getAuthorToken(authorId);
     const result      = new SessionInfo(url, authorToken, documentId);
 
-    log.event.madeSessionInfo(result);
+    // Log using `logInfo` to avoid leaking the unredacted token to the logs.
+    log.event.madeSessionInfo(result.logInfo);
 
     // **Note:** This returns the full token string to the caller, as it (the
     // client) will ultimately need to pass it back in full. (Usually it's a bad

--- a/local-modules/@bayou/data-store/BaseDataStore.js
+++ b/local-modules/@bayou/data-store/BaseDataStore.js
@@ -169,7 +169,8 @@ export default class BaseDataStore extends CommonBase {
    *   well.
    * * `canView` &mdash; Whether the author can view the document.
    *
-   * It is an error if either of the given IDs is not a syntactically valid.
+   * It is an error if either of the given IDs is invalid, as reported by the
+   * back end (not just surface syntax).
    *
    * @param {string} authorId The ID of the author.
    * @param {string} documentId The ID of the document.

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -285,15 +285,15 @@ export default class DocSession extends CommonBase {
    */
   getLogInfo() {
     const result = {
-      author:   this.getAuthorId(),
-      caret:    this.getCaretId(),
-      document: this.getDocumentId(),
-      file:     this.getFileId()
+      authorId:   this.getAuthorId(),
+      caretId:    this.getCaretId(),
+      documentId: this.getDocumentId(),
+      fileId:     this.getFileId()
     };
 
     // Only include the file ID if it's not the same as the document ID.
-    if (result.file === result.document) {
-      delete result.file;
+    if (result.fileId === result.documentId) {
+      delete result.fileId;
     }
 
     return result;

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -193,14 +193,11 @@ export default class FileComplex extends BaseComplexMember {
   _activateSession(authorId, caretId) {
     const result = new DocSession(this, authorId, caretId);
     const reaper = this._sessionReaper(caretId);
+    const fileId = this.file.id;
 
     this._sessions.set(caretId, weak(result, reaper));
 
-    this.log.info(
-      `Session now active.\n`,
-      `  file:    ${this.file.id}\n`,
-      `  author:  ${authorId}\n`,
-      `  caret:   ${caretId}`);
+    this.log.sessionNowActive({ fileId, authorId, caretId });
 
     return result;
   }

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -220,7 +220,7 @@ export default class FileComplex extends BaseComplexMember {
   _sessionReaper(caretId) {
     return () => {
       this._sessions.delete(caretId);
-      this.log.info(`Reaped idle session; caret ${caretId}.`);
+      this.log.event.reapedIdleSession(caretId);
     };
   }
 }

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -197,7 +197,7 @@ export default class FileComplex extends BaseComplexMember {
 
     this._sessions.set(caretId, weak(result, reaper));
 
-    this.log.sessionNowActive({ fileId, authorId, caretId });
+    this.log.event.sessionNowActive({ fileId, authorId, caretId });
 
     return result;
   }


### PR DESCRIPTION
This PR adds a bit more up-front validity checking when setting up sessions, fixes a bunch of comments for nuanced accuracy, and cleans up related (and tangentially related) logging code.
