### PR TITLE
Minor yak shave, mostly about `PropertyIterable`.

### DIFF
--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -3,19 +3,22 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Deployment } from '@bayou/config-server';
+import { CommonBase } from '@bayou/util-common';
 
 import BaseConnection from './BaseConnection';
 
 /**
  * Class to handle meta-requests.
  */
-export default class MetaHandler {
+export default class MetaHandler extends CommonBase {
   /**
    * Constructs an instance.
    *
    * @param {BaseConnection} connection The connection.
    */
   constructor(connection) {
+    super();
+
     /** {BaseConnection} The connection. */
     this._connection = BaseConnection.check(connection);
 

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -33,7 +33,7 @@ const VERBOTEN_METHODS = new Set([
  * * Methods inherited from the base `Object` prototype are excluded.
  * * All other public methods are included.
  */
-export default class Schema {
+export default class Schema extends CommonBase {
   /**
    * Constructs an instance based on the given object.
    *
@@ -44,6 +44,8 @@ export default class Schema {
    */
   constructor(target) {
     TObject.check(target);
+
+    super();
 
     /**
      * {Map<string, string>} Map from each name to a property descriptor

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -6,6 +6,22 @@ import { TObject, TString } from '@bayou/typecheck';
 import { PropertyIterable } from '@bayou/util-common';
 
 /**
+ * Set<string> Set of method names that are _not_ to be offered across an API
+ * boundary.
+ */
+const VERBOTEN_METHODS = new Set([
+  // We don't support directly promise-like behavior across an API boundary.
+  // (Though note, on the client side all exposed methods return promises that
+  // are implemented locally.)
+  'then',
+  'catch',
+
+  // It'd be weird (and generally wrong) to call an instance's constructor
+  // directly.
+  'constructor'
+]);
+
+/**
  * Schema for an object. Represents what actions are available. More
  * specifically:
  *
@@ -84,7 +100,7 @@ export default class Schema {
     for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
       const name = desc.name;
 
-      if ((typeof name !== 'string') || name.match(/^_/) || (name === 'constructor')) {
+      if ((typeof name !== 'string') || name.match(/^_/) || VERBOTEN_METHODS.has(name)) {
         // Because we don't want properties whose names aren't strings (that is,
         // are symbols), are prefixed with `_`, or are constructor functions. In
         // all cases these are effectively private with respect to the API

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TObject, TString } from '@bayou/typecheck';
-import { PropertyIterable } from '@bayou/util-common';
+import { CommonBase, PropertyIterable } from '@bayou/util-common';
 
 /**
  * Set<string> Set of method names that are _not_ to be offered across an API
@@ -96,8 +96,9 @@ export default class Schema {
    */
   static _makeSchemaFor(target) {
     const result = new Map();
+    const iter   = new PropertyIterable(target).skipClass(CommonBase).onlyMethods();
 
-    for (const desc of new PropertyIterable(target).skipObject().onlyMethods()) {
+    for (const desc of iter) {
       const name = desc.name;
 
       if ((typeof name !== 'string') || name.match(/^_/) || VERBOTEN_METHODS.has(name)) {

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -307,8 +307,8 @@ export default class StateMachine {
   }
 
   /**
-   * Constructs a two-level map from state-event pairs to the methods which
-   * handle those pairs.
+   * Constructs a two-level map from each state-event pair to the method which
+   * handles that pair.
    *
    * @returns {object<string,object<string,function>>} The handler map.
    */
@@ -318,13 +318,10 @@ export default class StateMachine {
 
     // First pass: Find all methods with the right name form, including those
     // with `any` (wildcard) names.
-    for (const desc of new PropertyIterable(this).onlyMethods()) {
-      const match = desc.name.match(/^_handle_([a-zA-Z0-9]+)_([a-zA-Z0-9]+)$/);
-      if (!match) {
-        // Not the right name format.
-        continue;
-      }
-
+    const matcher = /^_handle_([a-zA-Z0-9]+)_([a-zA-Z0-9]+)$/;
+    const iter    = new PropertyIterable(this).onlyMethods().onlyNames(matcher);
+    for (const desc of iter) {
+      const match     = desc.name.match(matcher); // **TODO:** Ideally we'd avoid re-running the regex.
       const stateName = match[1];
       const eventName = match[2];
 
@@ -383,7 +380,7 @@ export default class StateMachine {
   }
 
   /**
-   * Constructs a map from each valid event names to its respective event
+   * Constructs a map from each valid event name to its respective event
    * validator method.
    *
    * @returns {object} The event validator map.
@@ -391,14 +388,12 @@ export default class StateMachine {
   _makeValidatorMap() {
     const result = {}; // Built-up result.
 
-    for (const desc of new PropertyIterable(this).onlyMethods()) {
-      const match = desc.name.match(/^_check_([a-zA-Z0-9]+)$/);
-      if (!match) {
-        // Not the right name format.
-        continue;
-      }
-
+    const matcher = /^_check_([a-zA-Z0-9]+)$/;
+    const iter    = new PropertyIterable(this).onlyMethods().onlyNames(matcher);
+    for (const desc of iter) {
+      const match     = desc.name.match(matcher); // **TODO:** Ideally we'd avoid re-running the regex.
       const eventName = match[1];
+
       result[eventName] = desc.value;
     }
 

--- a/local-modules/@bayou/util-common/ErrorUtil.js
+++ b/local-modules/@bayou/util-common/ErrorUtil.js
@@ -174,7 +174,7 @@ export default class ErrorUtil extends UtilityClass {
     const extra    = {};
     let   anyExtra = false;
 
-    const iter = new PropertyIterable(error).skipObject().skipSynthetic().skipMethods().skipPrivate();
+    const iter = new PropertyIterable(error).skipObject().skipSynthetic().skipMethods().onlyPublic();
     for (const prop of iter) {
       const name = prop.name;
       if ((name === 'name') || (name === 'message') || (name === 'stack')) {

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -152,16 +152,6 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an additional filter that
-   * skips properties in "private" form (that is, prefixed with `_`).
-   *
-   * @returns {PropertyIterable} The new iterator.
-   */
-  skipPrivate() {
-    return this.skipNames(/^_/);
-  }
-
-  /**
-   * Gets an instance that is like this one but with an additional filter that
    * only passes regular non-synthetic properties.
    *
    * @returns {PropertyIterable} The new iterator.

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -89,6 +89,25 @@ export default class PropertyIterable extends CommonBase {
   }
 
   /**
+   * Gets an instance that is like this one but with an additional filter which
+   * only passes names that do _not_ match the given expression. The test only
+   * applies to string names; symbol-named properties all pass this filter.
+   *
+   * @param {RegExp} regex Expression to use to test names.
+   * @returns {PropertyIterable} The new iterator.
+   */
+  skipNames(regex) {
+    TObject.check(regex, RegExp);
+
+    function filterFunc(desc) {
+      const name = desc.name;
+      return !((typeof name === 'string') && regex.test(name));
+    }
+
+    return this.filter(filterFunc);
+  }
+
+  /**
    * Gets an instance that is like this one but with an additional filter that
    * skips properties defined on the root `Object` prototype.
    *
@@ -105,7 +124,7 @@ export default class PropertyIterable extends CommonBase {
    * @returns {PropertyIterable} The new iterator.
    */
   skipPrivate() {
-    return this.filter(desc => !/^_/.test(desc.name));
+    return this.skipNames(/^_/);
   }
 
   /**

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -63,6 +63,27 @@ export default class PropertyIterable extends CommonBase {
   }
 
   /**
+   * Gets an instance that is like this one but with an additional filter which
+   * only passes names that are strings (not symbols) and that must additionally
+   * match the given regular expression (if given).
+   *
+   * @param {RegExp|null} [regex = null] Expression to use to test names.
+   * @returns {PropertyIterable} The new iterator.
+   */
+  onlyNames(regex = null) {
+    TObject.orNull(regex, RegExp);
+
+    function filterFunc(desc) {
+      const name = desc.name;
+
+      return (typeof name === 'string')
+        && ((regex === null) || regex.test(name));
+    }
+
+    return this.filter(filterFunc);
+  }
+
+  /**
    * Gets an instance that is like this one but with an additional filter that
    * only passes public properties (non-synthetic properties whose names are
    * strings (not symbols) which _don't_ start with `_` and are also not the
@@ -71,7 +92,7 @@ export default class PropertyIterable extends CommonBase {
    * @returns {PropertyIterable} The new iterator.
    */
   onlyPublic() {
-    return this.onlyStringNames().skipNames(/^(_|constructor$)/);
+    return this.onlyNames().skipNames(/^(_|constructor$)/);
   }
 
   /**
@@ -83,27 +104,6 @@ export default class PropertyIterable extends CommonBase {
    */
   onlyPublicMethods() {
     return this.onlyPublic().onlyMethods();
-  }
-
-  /**
-   * Gets an instance that is like this one but with an additional filter which
-   * only passes names that are strings (not symbols) and that must additionally
-   * match the given regular expression (if given).
-   *
-   * @param {RegExp|null} [regex = null] Expression to use to test names.
-   * @returns {PropertyIterable} The new iterator.
-   */
-  onlyStringNames(regex = null) {
-    TObject.orNull(regex, RegExp);
-
-    function filterFunc(desc) {
-      const name = desc.name;
-
-      return (typeof name === 'string')
-        && ((regex === null) || regex.test(name));
-    }
-
-    return this.filter(filterFunc);
   }
 
   /**

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -87,12 +87,23 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an additional filter which
-   * only passes names that are strings (not symbols).
+   * only passes names that are strings (not symbols) and that must additionally
+   * match the given regular expression (if given).
    *
+   * @param {RegExp|null} [regex = null] Expression to use to test names.
    * @returns {PropertyIterable} The new iterator.
    */
-  onlyStringNames() {
-    return this.filter(desc => typeof desc.name === 'string');
+  onlyStringNames(regex = null) {
+    TObject.orNull(regex, RegExp);
+
+    function filterFunc(desc) {
+      const name = desc.name;
+
+      return (typeof name === 'string')
+        && ((regex === null) || regex.test(name));
+    }
+
+    return this.filter(filterFunc);
   }
 
   /**

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -64,6 +64,28 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an additional filter that
+   * only passes public methods (non-synthetic function-valued properties whose
+   * names are strings (not symbols) which _don't_ start with `_` and are also
+   * not the special name `constructor`).
+   *
+   * @returns {PropertyIterable} The new iterator.
+   */
+  onlyPublicMethods() {
+    return this.skipSynthetic().onlyMethods().onlyStringNames().skipNames(/^(_|constructor$)/);
+  }
+
+  /**
+   * Gets an instance that is like this one but with an additional filter which
+   * only passes names that are strings (not symbols).
+   *
+   * @returns {PropertyIterable} The new iterator.
+   */
+  onlyStringNames() {
+    return this.filter(desc => typeof desc.name === 'string');
+  }
+
+  /**
+   * Gets an instance that is like this one but with an additional filter that
    * skips the instance properties of the indicated class and any of its
    * superclasses.
    *

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -27,10 +27,10 @@ export default class PropertyIterable extends CommonBase {
   constructor(object, filter = null) {
     super();
 
-    /** The object to iterate over. */
+    /** {object} The object to iterate over. */
     this._object = object;
 
-    /** The filter. */
+    /** {function|null} The filter. */
     this._filter = filter;
   }
 

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -64,14 +64,25 @@ export default class PropertyIterable extends CommonBase {
 
   /**
    * Gets an instance that is like this one but with an additional filter that
-   * only passes public methods (non-synthetic function-valued properties whose
-   * names are strings (not symbols) which _don't_ start with `_` and are also
-   * not the special name `constructor`).
+   * only passes public properties (non-synthetic properties whose names are
+   * strings (not symbols) which _don't_ start with `_` and are also not the
+   * special name `constructor`).
+   *
+   * @returns {PropertyIterable} The new iterator.
+   */
+  onlyPublic() {
+    return this.onlyStringNames().skipNames(/^(_|constructor$)/);
+  }
+
+  /**
+   * Gets an instance that is like this one but with an additional filter that
+   * only passes public methods (same as the intersection of {@link #onlyPublic}
+   * and {@link #onlyMethods}).
    *
    * @returns {PropertyIterable} The new iterator.
    */
   onlyPublicMethods() {
-    return this.skipSynthetic().onlyMethods().onlyStringNames().skipNames(/^(_|constructor$)/);
+    return this.onlyPublic().onlyMethods();
   }
 
   /**

--- a/local-modules/@bayou/util-common/PropertyIterable.js
+++ b/local-modules/@bayou/util-common/PropertyIterable.js
@@ -20,9 +20,9 @@ export default class PropertyIterable extends CommonBase {
    * @param {object} object What to iterate over.
    * @param {function|null} [filter = null] Filter to select which properties
    *   are of interest. Gets called with a single argument, namely the
-   *   `name`-augmented property descriptor as described in the class header.
-   *   Expected to return `true` (or truthy) for properties that are to be
-   *   selected.
+   *   `name`- and `target`-augmented property descriptor as described in the
+   *   class header. Expected to return `true` (or truthy) for properties that
+   *   are to be selected.
    */
   constructor(object, filter = null) {
     super();

--- a/local-modules/@bayou/util-common/tests/test_ErrorUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_ErrorUtil.js
@@ -9,7 +9,7 @@ import { ErrorUtil } from '@bayou/util-common';
 
 describe('@bayou/util-common/ErrorUtil', () => {
   describe('stackLines(error)', () => {
-    it('should return an array of strings', () => {
+    it('returns an array of strings', () => {
       const result = ErrorUtil.stackLines(new Error('oy'));
 
       assert.isArray(result);
@@ -20,7 +20,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
   });
 
   describe('stackLines(error, indent)', () => {
-    it('should return an array of strings, each with the specified indentation', () => {
+    it('returns an array of strings, each with the specified indentation', () => {
       const result = ErrorUtil.stackLines(new Error('oy\nyo'), '123');
 
       assert.isArray(result);
@@ -32,7 +32,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
   });
 
   describe('fullTraceLines(error)', () => {
-    it('should return an array of strings', () => {
+    it('returns an array of strings', () => {
       const result = ErrorUtil.fullTraceLines(new Error('oy'));
 
       assert.isArray(result);
@@ -41,7 +41,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
       }
     });
 
-    it('should have a first line that indicates the name and message', () => {
+    it('has a first line that indicates the name and message', () => {
       function test(value, expect) {
         const result = ErrorUtil.fullTraceLines(value);
         assert.strictEqual(result[0], expect);
@@ -59,7 +59,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
       test(error3, 'Foo: bar');
     });
 
-    it('should split a multi-line name and/or message into separate result elements', () => {
+    it('splits a multi-line name and/or message into separate result elements', () => {
       const error = new Error('what\nis\nhappening?');
       error.name = 'Who\nWhat';
 
@@ -71,7 +71,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
       }
     });
 
-    it('should have lines that indicate extra properties', () => {
+    it('has lines that indicate extra properties', () => {
       function test(value, expect) {
         const result = ErrorUtil.fullTraceLines(value);
         let   found  = false;
@@ -89,10 +89,20 @@ describe('@bayou/util-common/ErrorUtil', () => {
       const error = new Error('x');
       error.a = 10;
       error.b = 'twenty';
+
+      // Shouldn't be present (method).
+      error.c = () => 123;
+
+      // Shouldn't be present (private).
+      error._d = 123;
+
+      // Shouldn't be present (synthetic).
+      Object.defineProperty(error, 'e', { get: () => 123 });
+
       test(error, '  { a: 10, b: \'twenty\' }');
     });
 
-    it('should represent the cause if present', () => {
+    it('represents the cause if present', () => {
       function test(value, ...expect) {
         const result = ErrorUtil.fullTraceLines(value);
         let at = 0;
@@ -141,7 +151,7 @@ describe('@bayou/util-common/ErrorUtil', () => {
   });
 
   describe('fullTraceLines(error, indent)', () => {
-    it('should return an array of strings, each with the specified indentation', () => {
+    it('returns an array of strings, each with the specified indentation', () => {
       const error = new Error('oy');
       error.florp = 'like';
       error.cause = new Error('oy_cause');

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -157,6 +157,28 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
+  describe('onlyStringNames(regex)', () => {
+    it('omits symbol names and names that do not match `regex`', () => {
+      const sym1 = Symbol('abc_x_abc');
+      const sym2 = Symbol('zxy');
+      const obj = {
+        a: 'no',
+        [sym1]: 'no',
+        [sym2]() { /*empty*/ },
+        x1() { return 10; },
+        x2: 123,
+        zxv: 456,
+        b: 'no',
+        c: 'no'
+      };
+      const iter = new PropertyIterable(obj).onlyStringNames(/x/);
+      const expectedProperties = ['x1', 'x2', 'zxv'];
+      const unexpectedProperties = [sym1, sym2, 'a', 'b', 'c'];
+
+      testIteratable(iter, expectedProperties, unexpectedProperties);
+    });
+  });
+
   describe('skipClass()', () => {
     it('returns just properties that are "below" the given class', () => {
       const instance = new Bottom();

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -140,6 +140,38 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
+  describe('skipNames()', () => {
+    it('omits names that match', () => {
+      const obj = {
+        foo_no_1: 'x',
+        _no_2() { /*empty*/ },
+        get x_no_y() { return 10; },
+        yes1: 'yes',
+        yes2() { /*empty*/ },
+        set yes3(value_unused) { /*empty*/ }
+      };
+      const iter = new PropertyIterable(obj).skipNames(/_no_/);
+      const expectedProperties = ['yes1', 'yes2', 'yes3'];
+
+      testIteratable(iter, expectedProperties);
+    });
+
+    it('does not touch symbol-named properties', () => {
+      const sym1 = Symbol('_no_');
+      const sym2 = Symbol('_no_2');
+      const obj = {
+        [sym1]: 'x',
+        [sym2]() { /*empty*/ },
+        x_no_y() { return 10; },
+        yes: 'yes'
+      };
+      const iter = new PropertyIterable(obj).skipNames(/_no_/);
+      const expectedProperties = [sym1, sym2, 'yes'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
   describe('skipPrivate()', () => {
     it('omits private properties', () => {
       const obj = {

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -250,23 +250,6 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
-  describe('skipPrivate()', () => {
-    it('omits private properties', () => {
-      const obj = {
-        yes1: 'x',
-        yes2() { /*empty*/ },
-        get yes3() { return 10; },
-        _: 'no',
-        _no2: 'no',
-        get _no3() { return 10; }
-      };
-      const iter = new PropertyIterable(obj).skipPrivate();
-      const expectedProperties = ['yes1', 'yes2', 'yes3'];
-
-      testIteratable(iter, expectedProperties);
-    });
-  });
-
   describe('skipSynthetic()', () => {
     it('iterates solely over non-synthetic properties', () => {
       const obj = {

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -83,9 +83,40 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
+  describe('onlyPublic()', () => {
+    it('returns just the public properties of the object', () => {
+      const sym1 = Symbol('x123');
+      const sym2 = Symbol('x234');
+      class Blort {
+        [sym1]() { /*empty*/ }
+        constructor() { /*empty*/ }
+        foo() { /*empty*/ }
+        _bar() { /*empty*/ }
+        get blort() { return 10; }
+      }
+
+      Blort.prototype.x = 123;
+
+      const instance = new Blort();
+      instance.y     = 123;
+      instance.baz   = () => { /*empty*/ };
+      instance[sym2] = 123;
+
+      const iter = new PropertyIterable(instance);
+      const methodIter = iter.onlyPublic();
+      const expectedProperties = ['foo', 'baz', 'blort', 'x', 'y'];
+      const unexpectedProperties = ['constructor', '_bar', sym1, sym2];
+
+      testIteratable(methodIter, expectedProperties, unexpectedProperties);
+    });
+  });
+
   describe('onlyPublicMethods()', () => {
     it('returns just the public methods of the object', () => {
+      const sym1 = Symbol('x123');
+      const sym2 = Symbol('x234');
       class Blort {
+        [sym1]() { /*empty*/ }
         constructor() { /*empty*/ }
         foo() { /*empty*/ }
         _bar() { /*empty*/ }
@@ -95,13 +126,14 @@ describe('@bayou/util-common/PropertyIterable', () => {
       Blort.prototype.x = 123;
 
       const instance = new Blort();
-      instance.y   = 123;
-      instance.baz = () => { /*empty*/ };
+      instance.y     = 123;
+      instance.baz   = () => { /*empty*/ };
+      instance[sym2] = () => { /*empty*/ };
 
       const iter = new PropertyIterable(instance);
       const methodIter = iter.onlyPublicMethods();
       const expectedProperties = ['foo', 'baz'];
-      const unexpectedProperties = ['constructor', '_bar', 'blort', 'x', 'y'];
+      const unexpectedProperties = ['constructor', '_bar', 'blort', 'x', 'y', sym1, sym2];
 
       testIteratable(methodIter, expectedProperties, unexpectedProperties);
     });

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -15,89 +15,20 @@ const TEST_OBJECT = {
   objectItem: { a: 1 }
 };
 
-describe('@bayou/util-common/PropertyIterable', () => {
-  describe('iterating over all properties', () => {
-    it('should return all properties of the object', () => {
-      const iter = new PropertyIterable(TEST_OBJECT);
-      const expectedProperties = ['a', 'b', 'functionItem', 'classItem', 'objectItem'];
+class Top {
+  top1() { /*empty*/ }
+  top2() { /*empty*/ }
+}
 
-      testIteratable(iter, expectedProperties);
-    });
-  });
+class Middle extends Top {
+  middle1() { /*empty*/ }
+  middle2() { /*empty*/ }
+}
 
-  describe('onlyMethods()', () => {
-    it('should return just callable function elements of the object', () => {
-      const iter = new PropertyIterable(TEST_OBJECT);
-      const methodIter = iter.onlyMethods();
-      const expectedProperties = ['functionItem'];
-      const unexpectedProperties = ['a', 'b', 'classItem', 'objectItem'];
-
-      testIteratable(methodIter, expectedProperties, unexpectedProperties);
-    });
-  });
-
-  describe('skipObject()', () => {
-    it('should return just properties that are not part of Object', () => {
-      const iter = new PropertyIterable(TEST_OBJECT);
-      const nonObjectIter = iter.skipObject();
-      const expectedProperties = ['a', 'b', 'objectItem', 'functionItem', 'classItem'];
-
-      const result = testIteratable(nonObjectIter, expectedProperties);
-
-      assert.hasAllKeys(result, expectedProperties);
-    });
-  });
-
-  describe('skipSynthetic()', () => {
-    it('should iterate solely over non-synthetic properties', () => {
-      const obj = {
-        yes1: 'x',
-        yes2: 'y',
-        get no1() { return 10; },
-        get no2() { return 20; },
-        set no2(x) { /*empty*/ },
-        set no3(x) { /*empty*/ }
-      };
-      const iter = new PropertyIterable(obj).skipSynthetic();
-      const expectedProperties = ['yes1', 'yes2'];
-
-      testIteratable(iter, expectedProperties);
-    });
-  });
-
-  describe('skipMethods()', () => {
-    it('should iterate solely over non-methods', () => {
-      const obj = {
-        yes1: 'x',
-        yes2: 'y',
-        get yes3() { return 10; },
-        no1() { /*empty*/ },
-        no2: () => { /*empty*/ }
-      };
-      const iter = new PropertyIterable(obj).skipMethods();
-      const expectedProperties = ['yes1', 'yes2', 'yes3'];
-
-      testIteratable(iter, expectedProperties);
-    });
-  });
-
-  describe('skipPrivate()', () => {
-    it('should omit private properties', () => {
-      const obj = {
-        yes1: 'x',
-        yes2() { /*empty*/ },
-        get yes3() { return 10; },
-        _: 'no',
-        _no2: 'no',
-        get _no3() { return 10; }
-      };
-      const iter = new PropertyIterable(obj).skipPrivate();
-      const expectedProperties = ['yes1', 'yes2', 'yes3'];
-
-      testIteratable(iter, expectedProperties);
-    });
-  });
-});
+class Bottom extends Middle {
+  bottom1() { /*empty*/ }
+  bottom2() { /*empty*/ }
+}
 
 /**
  * Completes one full iteration cycle and gathers info about the results
@@ -130,3 +61,135 @@ function testIteratable(iter, expectedProperties, unexpectedProperties = []) {
 
   return result;
 }
+
+describe('@bayou/util-common/PropertyIterable', () => {
+  describe('iterating over all properties', () => {
+    it('returns all properties of the object', () => {
+      const iter = new PropertyIterable(TEST_OBJECT);
+      const expectedProperties = ['a', 'b', 'functionItem', 'classItem', 'objectItem'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
+  describe('onlyMethods()', () => {
+    it('returns just callable function elements of the object', () => {
+      const iter = new PropertyIterable(TEST_OBJECT);
+      const methodIter = iter.onlyMethods();
+      const expectedProperties = ['functionItem'];
+      const unexpectedProperties = ['a', 'b', 'classItem', 'objectItem'];
+
+      testIteratable(methodIter, expectedProperties, unexpectedProperties);
+    });
+  });
+
+  describe('skipClass()', () => {
+    it('returns just properties that are "below" the given class', () => {
+      const instance = new Bottom();
+      instance.x = 1;
+      instance.y = 2;
+
+      const iter = new PropertyIterable(instance).skipClass(Middle);
+      const expectedProperties = ['constructor', 'x', 'y', 'bottom1', 'bottom2'];
+
+      const result = testIteratable(iter, expectedProperties);
+
+      assert.hasAllKeys(result, expectedProperties);
+    });
+  });
+
+  describe('skipObject()', () => {
+    it('returns just properties of a plain object that are not part of `Object`', () => {
+      const iter = new PropertyIterable(TEST_OBJECT);
+      const nonObjectIter = iter.skipObject();
+      const expectedProperties = ['a', 'b', 'objectItem', 'functionItem', 'classItem'];
+
+      const result = testIteratable(nonObjectIter, expectedProperties);
+
+      assert.hasAllKeys(result, expectedProperties);
+    });
+
+    it('returns properties of an instance and its class hierarchy except for `Object`', () => {
+      const instance = new Bottom();
+      instance.aaa = 1;
+      instance.bbb = 2;
+
+      const iter = new PropertyIterable(instance).skipObject();
+      const expectedProperties = [
+        'constructor', 'aaa', 'bbb', 'bottom1', 'bottom2', 'middle1', 'middle2', 'top1', 'top2'];
+
+      const result = testIteratable(iter, expectedProperties);
+
+      assert.hasAllKeys(result, expectedProperties);
+    });
+  });
+
+  describe('skipMethods()', () => {
+    it('iterates solely over non-methods', () => {
+      const obj = {
+        yes1: 'x',
+        yes2: 'y',
+        get yes3() { return 10; },
+        no1() { /*empty*/ },
+        no2: () => { /*empty*/ }
+      };
+      const iter = new PropertyIterable(obj).skipMethods();
+      const expectedProperties = ['yes1', 'yes2', 'yes3'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
+  describe('skipPrivate()', () => {
+    it('omits private properties', () => {
+      const obj = {
+        yes1: 'x',
+        yes2() { /*empty*/ },
+        get yes3() { return 10; },
+        _: 'no',
+        _no2: 'no',
+        get _no3() { return 10; }
+      };
+      const iter = new PropertyIterable(obj).skipPrivate();
+      const expectedProperties = ['yes1', 'yes2', 'yes3'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
+  describe('skipSynthetic()', () => {
+    it('iterates solely over non-synthetic properties', () => {
+      const obj = {
+        yes1: 'x',
+        yes2: 'y',
+        get no1() { return 10; },
+        get no2() { return 20; },
+        set no2(x) { /*empty*/ },
+        set no3(x) { /*empty*/ }
+      };
+      const iter = new PropertyIterable(obj).skipSynthetic();
+      const expectedProperties = ['yes1', 'yes2'];
+
+      testIteratable(iter, expectedProperties);
+    });
+  });
+
+  describe('skipTarget()', () => {
+    it('returns just properties that are "below" the given target', () => {
+      const top = { top1: 1, top2: 2 };
+      const middle = Object.create(top);
+      middle.middle1 = 1;
+      middle.middle2 = 2;
+      const bottom = Object.create(middle);
+      bottom.bottom1 = 1;
+      bottom.bottom2 = 2;
+
+      const iter = new PropertyIterable(bottom).skipTarget(top);
+      const expectedProperties = ['middle1', 'middle2', 'bottom1', 'bottom2'];
+
+      const result = testIteratable(iter, expectedProperties);
+
+      assert.hasAllKeys(result, expectedProperties);
+    });
+  });
+});

--- a/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
+++ b/local-modules/@bayou/util-common/tests/test_PropertyIterable.js
@@ -139,7 +139,7 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
-  describe('onlyStringNames()', () => {
+  describe('onlyNames()', () => {
     it('omits symbol names', () => {
       const sym1 = Symbol('a');
       const sym2 = Symbol('b');
@@ -149,7 +149,7 @@ describe('@bayou/util-common/PropertyIterable', () => {
         c() { return 10; },
         d: 'yes'
       };
-      const iter = new PropertyIterable(obj).onlyStringNames();
+      const iter = new PropertyIterable(obj).onlyNames();
       const expectedProperties = ['c', 'd'];
       const unexpectedProperties = [sym1, sym2];
 
@@ -157,7 +157,7 @@ describe('@bayou/util-common/PropertyIterable', () => {
     });
   });
 
-  describe('onlyStringNames(regex)', () => {
+  describe('onlyNames(regex)', () => {
     it('omits symbol names and names that do not match `regex`', () => {
       const sym1 = Symbol('abc_x_abc');
       const sym2 = Symbol('zxy');
@@ -171,7 +171,7 @@ describe('@bayou/util-common/PropertyIterable', () => {
         b: 'no',
         c: 'no'
       };
-      const iter = new PropertyIterable(obj).onlyStringNames(/x/);
+      const iter = new PropertyIterable(obj).onlyNames(/x/);
       const expectedProperties = ['x1', 'x2', 'zxv'];
       const unexpectedProperties = [sym1, sym2, 'a', 'b', 'c'];
 


### PR DESCRIPTION
In reviewing the code for `api-server.Schema` I noticed a couple deficiencies. In addition to fixing up `Schema`, I ended up doing a bit of work on refining `PropertyIterable` and then fanned out the improvements to all its clients.