### PR TITLE
Hook for `RootAccess`.

### DIFF
--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -90,8 +90,9 @@ export default class Schema extends CommonBase {
    */
   static _makeSchemaFor(target) {
     const result = new Map();
+    const skip = (target instanceof CommonBase) ? CommonBase : Object;
     const iter =
-      new PropertyIterable(target).skipClass(CommonBase).onlyPublicMethods().skipNames(VERBOTEN_NAMES);
+      new PropertyIterable(target).skipClass(skip).onlyPublicMethods().skipNames(VERBOTEN_NAMES);
 
     for (const desc of iter) {
       result.set(desc.name, 'method');

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -45,7 +45,7 @@ export default class Application extends CommonBase {
     this._contextInfo = new ContextInfo(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
 
     /**
-     * {RootAccess} The "root access" object. This is the object which tokens
+     * {object} The "root access" object. This is the object which tokens
      * bearing {@link Auth#TYPE_root} authority grant access to.
      */
     this._rootAccess = this._makeRootAccess();
@@ -75,8 +75,8 @@ export default class Application extends CommonBase {
   }
 
   /**
-   * {RootAccess} The "root access" object. This is the object which tokens
-   * bearing {@link Auth#TYPE_root} authority grant access to.
+   * {object} The "root access" object. This is the object which tokens bearing
+   * {@link Auth#TYPE_root} authority grant access to.
    */
   get rootAccess() {
     return this._rootAccess;

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -48,7 +48,7 @@ export default class Application extends CommonBase {
      * {RootAccess} The "root access" object. This is the object which tokens
      * bearing {@link Auth#TYPE_root} authority grant access to.
      */
-    this._rootAccess = new RootAccess();
+    this._rootAccess = this._makeRootAccess();
 
     /**
      * {function} The top-level "Express application" run by this instance. It
@@ -226,5 +226,15 @@ export default class Application extends CommonBase {
     for (const dir of Deployment.ASSET_DIRS) {
       app.use('/', express.static(dir));
     }
+  }
+
+  /**
+   * Makes and returns the root access object, that is, the thing that gets
+   * called to answer API calls on the root token(s).
+   *
+   * @returns {object} The root access object.
+   */
+  _makeRootAccess() {
+    return new RootAccess();
   }
 }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -13,8 +13,8 @@ import { CommonBase } from '@bayou/util-common';
 const log = new Logger('root-access');
 
 /**
- * "Root access" object. This is the object which is protected by the root
- * bearer token(s).
+ * "Root access" object. An instance of this class (or a subclass of it) is
+ * what the root bearer token(s) grant access to.
  */
 export default class RootAccess extends CommonBase {
   /**

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -13,8 +13,9 @@ import { CommonBase } from '@bayou/util-common';
 const log = new Logger('root-access');
 
 /**
- * "Root access" object. An instance of this class (or a subclass of it) is
- * what the root bearer token(s) grant access to.
+ * "Root access" object. An instance of this class is what the root bearer
+ * token(s) grant access to (along with whatever else is configured by the
+ * hook {@link config-server.Deployment#rootAccess}).
  */
 export default class RootAccess extends CommonBase {
   /**

--- a/local-modules/@bayou/app-setup/index.js
+++ b/local-modules/@bayou/app-setup/index.js
@@ -4,6 +4,5 @@
 
 import Application from './Application';
 import Monitor from './Monitor';
-import RootAccess from './RootAccess';
 
-export { Application, Monitor, RootAccess };
+export { Application, Monitor };

--- a/local-modules/@bayou/app-setup/index.js
+++ b/local-modules/@bayou/app-setup/index.js
@@ -4,5 +4,6 @@
 
 import Application from './Application';
 import Monitor from './Monitor';
+import RootAccess from './RootAccess';
 
-export { Application, Monitor };
+export { Application, Monitor, RootAccess };

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -63,6 +63,17 @@ export default class Deployment extends UtilityClass {
   /**
    * Implementation of standard configuration point.
    *
+   * This implementation always returns `null`.
+   *
+   * @returns {null} `null`, always.
+   */
+  static rootAccess() {
+    return null;
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
    * @returns {object} Ad-hoc information about the server.
    */
   static serverInfo() {

--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -70,6 +70,20 @@ export default class Deployment extends UtilityClass {
   }
 
   /**
+   * Gets an object whose instance methods are to be provided via the API as
+   * part of the root authority. The methods are provided in addition to what is
+   * provided by default by {@link app-setup.RootAccess}. If no additional
+   * methods are required by this configuration, this method should return
+   * `null`.
+   *
+   * @returns {object|null} Object with additional methods to be provided as
+   *   part of root access, or `null` if there are none.
+   */
+  static rootAccess() {
+    return use.Deployment.rootAccess();
+  }
+
+  /**
    * Gets arbitrary server-identifying information, which gets returned to
    * clients via {@link MetaHandler#serverInfo}.
    *


### PR DESCRIPTION
This PR adds a new server configuration hook which lets one add new methods to the object which answers root access calls (that is, the thing that responds to API calls on a root token).