### PR TITLE
WIP on process control files.

### DIFF
--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -27,6 +27,15 @@ export default class Network extends UtilityClass {
   }
 
   /**
+   * {string} Implementation of standard configuration point. This
+   * implementation returns the recommended value per
+   * {@link config-server.Network#loopbackUrl}.
+   */
+  static get loopbackUrl() {
+    return `http://localhost:${this.listenPort}`;
+  }
+
+  /**
    * {Int|null} Implementation of standard configuration point. This
    * implementation defines it as `8888`.
    */

--- a/local-modules/@bayou/config-server-default/tests/test_Network.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Network.js
@@ -9,19 +9,25 @@ import { Network } from '@bayou/config-server-default';
 
 describe('@bayou/config-server-default/Network', () => {
   describe('.baseUrl', () => {
-    it('should be `http://localhost:8080`', () => {
+    it('is `http://localhost:8080`', () => {
       assert.strictEqual(Network.baseUrl, 'http://localhost:8080');
     });
   });
 
   describe('.listenPort', () => {
-    it('should be `8080`', () => {
+    it('is `8080`', () => {
       assert.strictEqual(Network.listenPort, 8080);
     });
   });
 
+  describe('.loopbackUrl', () => {
+    it('is the documented-suggested value', () => {
+      assert.strictEqual(Network.loopbackUrl, 'http://localhost:8080');
+    });
+  });
+
   describe('.monitorPort', () => {
-    it('should be `8888`', () => {
+    it('is `8888`', () => {
       assert.strictEqual(Network.monitorPort, 8888);
     });
   });

--- a/local-modules/@bayou/config-server/Network.js
+++ b/local-modules/@bayou/config-server/Network.js
@@ -29,6 +29,16 @@ export default class Network extends UtilityClass {
   }
 
   /**
+   * {string} The URL origin to use for loopback requests to this instance from
+   * the machine it is running on. This is typically configured to be
+   * `http://localhost:${Network.listenPort}` though some configurations may
+   * need to be less trivial.
+   */
+  static get loopbackUrl() {
+    return use.Network.loopbackUrl;
+  }
+
+  /**
    * {Int|null} The local port to use for internal monitoring, or `null` to
    * not expose monitoring endpoints.
    */

--- a/local-modules/@bayou/env-server/Dirs.js
+++ b/local-modules/@bayou/env-server/Dirs.js
@@ -46,6 +46,18 @@ export default class Dirs extends Singleton {
   }
 
   /**
+   * The directory to write control files to (and read them from). Accessing
+   * this value guarantees the existence of the directory (that is, it will
+   * create the directory if necessary).
+   */
+  get CONTROL_DIR() {
+    const result = path.resolve(this.VAR_DIR, 'control');
+
+    Dirs._ensureDir(result);
+    return result;
+  }
+
+  /**
    * The directory to write log files to. Accessing this value guarantees the
    * existence of the directory (that is, it will create the directory if
    * necessary).

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -28,7 +28,7 @@ export default class PidFile extends Singleton {
     super();
 
     /** {string} Path for the PID file. */
-    this._pidPath = path.resolve(Dirs.theOne.VAR_DIR, 'pid.txt');
+    this._pidPath = path.resolve(Dirs.theOne.CONTROL_DIR, 'pid.txt');
 
     Object.freeze(this);
   }
@@ -82,18 +82,6 @@ export default class PidFile extends Singleton {
   }
 
   /**
-   * Handles a signal by erasing the PID file (if it exists) and then
-   * re-raising the same signal.
-   *
-   * @param {string} id Signal ID.
-   */
-  _handleSignal(id) {
-    log.event.receivedSignal(id);
-    this._erasePid();
-    process.kill(process.pid, id);
-  }
-
-  /**
    * Erases the PID file if it exists.
    */
   _erasePid() {
@@ -103,5 +91,17 @@ export default class PidFile extends Singleton {
     } catch (e) {
       // Ignore errors. We're about to exit anyway.
     }
+  }
+
+  /**
+   * Handles a signal by erasing the PID file (if it exists) and then
+   * re-raising the same signal.
+   *
+   * @param {string} id Signal ID.
+   */
+  _handleSignal(id) {
+    log.event.receivedSignal(id);
+    this._erasePid();
+    process.kill(process.pid, id);
   }
 }

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { Logger } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
-import { Singleton } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import Dirs from './Dirs';
 
@@ -15,10 +15,10 @@ import Dirs from './Dirs';
 const log = new Logger('pid');
 
 /**
- * This writes a PID file when `init()` is called, and tries to remove it when
- * the app is shutting down.
+ * This writes a PID file when {@link #init()} is called, and tries to remove it
+ * when the process is shutting down.
  */
-export default class PidFile extends Singleton {
+export default class PidFile extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (such as writing the PID file); that stuff happens in

--- a/local-modules/@bayou/env-server/ProcessControl.js
+++ b/local-modules/@bayou/env-server/ProcessControl.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { Condition, Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
-import { Singleton } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import Dirs from './Dirs';
 
@@ -25,7 +25,7 @@ const log = new Logger('control');
  * and heeding shutdown requests issued by virtue of the presence of a
  * signalling file.
  */
-export default class ProcessControl extends Singleton {
+export default class ProcessControl extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (such as writing the PID file); that stuff happens in

--- a/local-modules/@bayou/env-server/ProcessControl.js
+++ b/local-modules/@bayou/env-server/ProcessControl.js
@@ -15,7 +15,7 @@ import Dirs from './Dirs';
  * {Int} How long (in msec) to wait between iterations in the shutdown-file
  * polling loop.
  */
-const SHUTDOWN_POLL_DELAY_MSEC = 10 * 1000; // Ten seconds.
+const SHUTDOWN_POLL_DELAY_MSEC = 60 * 1000; // One minute.
 
 /** {Logger} Logger for this class. */
 const log = new Logger('control');

--- a/local-modules/@bayou/env-server/ProcessControl.js
+++ b/local-modules/@bayou/env-server/ProcessControl.js
@@ -1,0 +1,127 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import fs from 'fs';
+import path from 'path';
+
+import { Condition, Delay } from '@bayou/promise-util';
+import { Logger } from '@bayou/see-all';
+import { Singleton } from '@bayou/util-common';
+
+import Dirs from './Dirs';
+
+/**
+ * {Int} How long (in msec) to wait between iterations in the shutdown-file
+ * polling loop.
+ */
+const SHUTDOWN_POLL_DELAY_MSEC = 10 * 1000; // Ten seconds.
+
+/** {Logger} Logger for this class. */
+const log = new Logger('control');
+
+/**
+ * Manager for the `control` directory, including writing / erasing the PID file
+ * and heeding shutdown requests issued by virtue of the presence of a
+ * signalling file.
+ */
+export default class ProcessControl extends Singleton {
+  /**
+   * Constructs an instance. Logging aside, this doesn't cause any external
+   * action to take place (such as writing the PID file); that stuff happens in
+   * {@link #init}.
+   */
+  constructor() {
+    super();
+
+    const CONTROL_PATH = Dirs.theOne.CONTROL_DIR;
+
+    /** {string} Path for the shutdown-command file. */
+    this._shutdownPath = path.resolve(CONTROL_PATH, 'shutdown');
+
+    /** {string} Path for the stopped-indicator file. */
+    this._stoppedPath = path.resolve(CONTROL_PATH, 'stopped');
+
+    /**
+     * {Condition} Condition which becomes `true` when the server should be
+     * shutting down.
+     */
+    this._shutdownCondition = new Condition();
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Returns an instantaneous indicator of whether or not the system should be
+   * shutting down (or not running in the first place).
+   *
+   * @returns {boolean} `true` if the system should be shutting down, or `false`
+   *   if it should be running as normal.
+   */
+  shouldShutDown() {
+    return this._shutdownCondition.value;
+  }
+
+  /**
+   * Returns a promise that becomes `true` when the control files indicate that
+   * the server should shut down.
+   *
+   * @returns {Promise<boolean>} Promise that resolves to `true` per above.
+   */
+  whenShuttingDown() {
+    return this._shutdownCondition.whenTrue();
+  }
+
+  /**
+   * Initializes the control-file handlers, including dealing with the
+   * possibility that the server is getting started up in a state where the
+   * control files indicate it shouldn't be running.
+   */
+  init() {
+    // If the `shutdown` or `stopped` files exist, then this server shouldn't
+    // start up in the first place.
+    if (fs.existsSync(this._stoppedPath)) {
+      log.event.alreadyStopped();
+      this._shutdownCondition.value = true;
+    } else if (fs.existsSync(this._shutdownPath)) {
+      // Write the `stopped` file to acknowledge to the world that the server
+      // got the request to shut down. (If we don't do this, the controlling
+      // environment might mistakenly believe the server still needs to run.)
+      this._writeStoppedFile();
+      log.event.alreadyShuttingDown();
+      this._shutdownCondition.value = true;
+    }
+
+    if (this._shutdownCondition.value) {
+      // We already know we're shutting down, so don't bother with the polling.
+      return;
+    }
+
+    // Loop forever, waiting/polling for the shutdown file to exist, and
+    // reacting to that by flipping `_shutdownCondition` to `true`.
+    (async () => {
+      for (;;) {
+        await Delay.resolve(SHUTDOWN_POLL_DELAY_MSEC);
+
+        log.event.checkingForShutdownRequest();
+
+        if (fs.existsSync(this._shutdownPath)) {
+          break;
+        }
+      }
+
+      this._shutdownCondition.value = true;
+      log.event.shutdownRequested();
+
+      // Arrange for the `stopped` file to get written during process exit.
+      process.once('exit', () => this._writeStoppedFile());
+    })();
+  }
+
+  /**
+   * Writes the `stopped` indicator file.
+   */
+  _writeStoppedFile() {
+    fs.writeFileSync(this._stoppedPath, 'stopped\n');
+  }
+}

--- a/local-modules/@bayou/env-server/ProductInfo.js
+++ b/local-modules/@bayou/env-server/ProductInfo.js
@@ -51,12 +51,16 @@ export default class ProductInfo extends Singleton {
    * @returns {string} The build ID string.
    */
   static _makeBuildIdString(info) {
-    const { name, version, commitId } = info;
+    const { buildNumber, commitId, name, version } = info;
 
-    const id = ((typeof commitId === 'string') && commitId !== '')
+    const id = ((typeof commitId === 'string') && (commitId !== '') && (commitId !== 'unknown'))
       ? `-${commitId.slice(0, 8)}`
       : '';
 
-    return `${name}-${version}${id}`;
+    const num = ((typeof buildNumber === 'string') && /^[0-9]+$/.test(buildNumber))
+      ? `-${buildNumber}`
+      : '';
+
+    return `${name}-${version}${num}${id}`;
   }
 }

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -28,10 +28,10 @@ export default class ServerEnv extends Singleton {
     super();
 
     /** {PidFile} The PID file manager. */
-    this._pidFile = PidFile.theOne;
+    this._pidFile = new PidFile();
 
     /** {ProcessControl} The process control instance. */
-    this._processControl = ProcessControl.theOne;
+    this._processControl = new ProcessControl();
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -44,14 +44,6 @@ export default class ServerEnv extends Singleton {
   }
 
   /**
-   * {string} The base URL to use for loopback requests from this machine. This
-   * is always an `http://localhost/` URL.
-   */
-  get loopbackUrl() {
-    return `http://localhost:${Network.listenPort}`;
-  }
-
-  /**
    * Initializes this module. This sets up the info for the `Dirs` class, sets
    * up the PID file, and gathers the product metainfo.
    */
@@ -103,7 +95,7 @@ export default class ServerEnv extends Singleton {
     // dead.
 
     const isActive = new Promise((resolve, reject_unused) => {
-      const request = http.get(this.loopbackUrl);
+      const request = http.get(Network.loopbackUrl);
 
       request.setTimeout(10 * 1000); // Give the server 10 seconds to respond.
       request.end();

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -21,6 +21,18 @@ const log = new Logger('env-server');
  */
 export default class ServerEnv extends Singleton {
   /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /** {PidFile} The PID file manager. */
+    this._pidFile = PidFile.theOne;
+
+    Object.freeze(this);
+  }
+
+  /**
    * {object} Ad-hoc object with generally-useful runtime info, intended for
    * logging / debugging.
    *
@@ -58,7 +70,7 @@ export default class ServerEnv extends Singleton {
       throw Errors.aborted('Another server is already running.');
     }
 
-    PidFile.theOne.init();
+    this._pidFile.init();
     ProductInfo.theOne;
   }
 
@@ -77,7 +89,7 @@ export default class ServerEnv extends Singleton {
     // to say there is no server running. And if it _does_ exist and _is_ valid,
     // then the so-identified process needs to be running.
 
-    const pid = PidFile.theOne.readFile();
+    const pid = this._pidFile.readFile();
 
     if (pid === null) {
       return false;

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -11,6 +11,7 @@ import { Errors, Singleton } from '@bayou/util-common';
 
 import Dirs from './Dirs';
 import PidFile from './PidFile';
+import ProcessControl from './ProcessControl';
 import ProductInfo from './ProductInfo';
 
 /** {Logger} Logger. */
@@ -28,6 +29,9 @@ export default class ServerEnv extends Singleton {
 
     /** {PidFile} The PID file manager. */
     this._pidFile = PidFile.theOne;
+
+    /** {ProcessControl} The process control instance. */
+    this._processControl = ProcessControl.theOne;
 
     Object.freeze(this);
   }
@@ -61,6 +65,12 @@ export default class ServerEnv extends Singleton {
    */
   async init() {
     Dirs.theOne;
+
+    this._processControl.init();
+    if (this._processControl.shouldShutDown()) {
+      log.error('Server found shutdown indicator(s) during startup.');
+      throw Errors.aborted('Server told not to run.');
+    }
 
     const alreadyRunning = await this.isAlreadyRunningLocally();
     if (alreadyRunning) {

--- a/local-modules/@bayou/env-server/package.json
+++ b/local-modules/@bayou/env-server/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@bayou/config-server": "local",
     "@bayou/deps-util-server": "local",
+    "@bayou/promise-util": "local",
     "@bayou/proppy": "local",
     "@bayou/see-all": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/env-server/tests/test_Dirs.js
+++ b/local-modules/@bayou/env-server/tests/test_Dirs.js
@@ -12,7 +12,7 @@ import { Dirs } from '@bayou/env-server';
 
 describe('@bayou/env-server/Dirs', () => {
   describe('.BASE_DIR', () => {
-    it('should return a directory path that exists', () => {
+    it('is a directory path that exists', () => {
       const baseDir = Dirs.theOne.BASE_DIR;
 
       assert.isTrue(fs.existsSync(baseDir));
@@ -20,41 +20,51 @@ describe('@bayou/env-server/Dirs', () => {
   });
 
   describe('.CLIENT_DIR', () => {
-    it('should return a known subdirectory off of `BASE_DIR`', () => {
+    it('is a known subdirectory off of `BASE_DIR`', () => {
       const baseDir = Dirs.theOne.BASE_DIR;
       const clientDir = path.join(baseDir, 'client');
 
-      assert.strictEqual(clientDir, Dirs.theOne.CLIENT_DIR);
+      assert.strictEqual(Dirs.theOne.CLIENT_DIR, clientDir);
       assert.isTrue(fs.existsSync(clientDir));
     });
   });
 
+  describe('.CONTROL_DIR', () => {
+    it('is a known subdirectory off of `VAR_DIR`', () => {
+      const varDir = Dirs.theOne.VAR_DIR;
+      const controlDir = path.join(varDir, 'control');
+
+      assert.strictEqual(Dirs.theOne.CONTROL_DIR, controlDir);
+      assert.isTrue(fs.existsSync(controlDir));
+    });
+  });
+
   describe('.LOG_DIR', () => {
-    it('should return a known subdirectory off of `VAR_DIR`', () => {
+    it('is a known subdirectory off of `VAR_DIR`', () => {
       const varDir = Dirs.theOne.VAR_DIR;
       const logDir = path.join(varDir, 'log');
 
-      assert.strictEqual(logDir, Dirs.theOne.LOG_DIR);
+      assert.strictEqual(Dirs.theOne.LOG_DIR, logDir);
       assert.isTrue(fs.existsSync(logDir));
     });
   });
 
   describe('.SERVER_DIR', () => {
-    it('should return a known subdirectory off of BASE_DIR', () => {
+    it('is a known subdirectory off of `BASE_DIR`', () => {
       const baseDir = Dirs.theOne.BASE_DIR;
       const serverDir = path.join(baseDir, 'server');
 
-      assert.strictEqual(serverDir, Dirs.theOne.SERVER_DIR);
+      assert.strictEqual(Dirs.theOne.SERVER_DIR, serverDir);
       assert.isTrue(fs.existsSync(serverDir));
     });
   });
 
   describe('.VAR_DIR', () => {
-    it('should return a known subdirectory off of BASE_DIR', () => {
+    it('should return a known subdirectory off of `BASE_DIR`', () => {
       const baseDir = Dirs.theOne.BASE_DIR;
       const varDir = path.join(baseDir, 'var');
 
-      assert.strictEqual(varDir, Dirs.theOne.VAR_DIR);
+      assert.strictEqual(Dirs.theOne.VAR_DIR, varDir);
       assert.isTrue(fs.existsSync(varDir));
     });
   });

--- a/local-modules/@bayou/env-server/tests/test_ProductInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_ProductInfo.js
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { ProductInfo } from '@bayou/env-server';
-import { TObject } from '@bayou/typecheck';
 
 describe('@bayou/env-server/ProductInfo', () => {
   describe('.INFO', () => {
@@ -18,11 +17,12 @@ describe('@bayou/env-server/ProductInfo', () => {
 
     it('is an object full of the expected product info', () => {
       const info = ProductInfo.theOne.INFO;
-      const productKeys = [
-        'buildDate', 'buildId', 'commitId', 'commitDate', 'name', 'nodeVersion', 'version'
+      const requiredKeys = [
+        'buildDate', 'buildId', 'buildNumber', 'commitId', 'commitDate', 'name', 'nodeVersion', 'version'
       ];
 
-      assert.doesNotThrow(() => TObject.withExactKeys(info, productKeys));
+      assert.isObject(info);
+      assert.hasAllKeys(info, requiredKeys);
     });
   });
 });

--- a/scripts/build
+++ b/scripts/build
@@ -451,6 +451,13 @@ function build-product-info {
     # `git log` command, above.
     local buildDate="build_date = '$(date '+%Y-%m-%d %H:%M:%S %z')'"
 
+    # The build number, if available.
+    local buildNumber="${BUILD_NUMBER}"
+    if [[ ${buildNumber} == '' ]]; then
+        buildNumber='unknown'
+    fi
+    buildNumber="build_number = ${buildNumber}"
+
     # The version of Node that was used for the build. This is important because
     # the version of Node used to _run_ the product needs to be the same major
     # version. (Most specifically, the native module API needs to be compatible,
@@ -468,6 +475,7 @@ function build-product-info {
         echo '# The following lines were added automatically by the build script.'
         echo "${commitInfo}"
         echo "${buildDate}"
+        echo "${buildNumber}"
         echo "${nodeVersion}"
     ) > "${outFile}"
 }


### PR DESCRIPTION
This PR consists of a round of cleanup in `env-server` along with the start of a new class `ProcessControl`, which is where the newly-defined "shutdown" file will get handled. The idea is that the ops-ish control surrounding a server can drop a shutdown file where the server will find it — in the directory `control` under the `var` directory — and it's the server's responsibility to react to this by performing an orderly shutdown. This PR is only the start of the effort; specifically, as of this PR:

* `ProcessControl` provides both synchronous and `async` methods to notice when shutdown is to be initiated.
* The system knows not to start in the first place if it's being told to shut down.
* If the system does shut down after being told, it drops a "stopped" file in the same control directory, to indicate affirmatively that it finished shutting down cleanly.
* But nothing beyond the initial startup check will actually act in response to a shutdown request.

**Bonuses:**
* The PID file now also lives in `control` (instead of at the top of the `var` directory).
* Include the `BUILD_NUMBER` in the generated build ID string, when available.
