### PR TITLE
`BodyClient.stop()`

### DIFF
--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -98,7 +98,7 @@ export default class Deployment extends UtilityClass {
    * JavaScript bundles). It is typical (but not necessary) for this to be
    * `true` in development environments and `false` in production environments.
    *
-   * @returns {boolean} `true` if this server should server code assets, or
+   * @returns {boolean} `true` if this server should serve code assets, or
    *   `false` if not.
    */
   static shouldServeClientCode() {

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -440,11 +440,12 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Handler for all `stop` events.
+   * Handler for `stop` events in most states (all of them except for the ones
+   * which are active when there are in-flight changes to deal with).
    */
   _handle_any_stop() {
     if (this._running) {
-      this.log.event.stopping();
+      this.log.event.stopped();
       this._running = false;
     }
 

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -894,11 +894,17 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Sets up the state machine to idle while waiting for input.
+   * Sets up the client to idle while waiting for input. Or, if the client has
+   * been asked to stop, this is the safe point where we can transition back
+   * into the `detached` state.
    */
   _becomeIdle() {
-    this.s_idle();
-    this.q_wantInputAfterDelay(this._pollingDelayMsec);
+    if (this._running) {
+      this.s_idle();
+      this.q_wantInputAfterDelay(this._pollingDelayMsec);
+    } else {
+      this.s_detached();
+    }
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -268,6 +268,15 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
+   * Validates a `wantInputAfterDelay` event.
+   *
+   * @param {int} delayMsec Msec to wait before firing `wantInput`.
+   */
+  _check_wantInputAfterDelay(delayMsec) {
+    TInt.nonNegative(delayMsec);
+  }
+
+  /**
    * Validates a `wantToUpdate` event. This indicates that it is time to
    * send collected local changes up to the server.
    *
@@ -276,34 +285,6 @@ export default class BodyClient extends StateMachine {
    */
   _check_wantToUpdate(baseRevNum) {
     TInt.check(baseRevNum);
-  }
-
-  /**
-   * Handler for all `error` events (errors that were uncaught by other handlers
-   * and which would by default just cause the state machine to die). In this
-   * case, we make it turn into an "unrecoverable" error, which is the same as
-   * what happens when the instance receives too many API errors.
-   *
-   * @param {Error} error The error.
-   */
-  _handle_any_error(error) {
-    this.log.error('Unexpected error in handler', error);
-    this.s_unrecoverableError();
-  }
-
-  /**
-   * Handler for all `stop` events.
-   */
-  _handle_any_stop() {
-    if (this._running) {
-      this.log.event.stopping();
-      this._running = false;
-    }
-
-    // Go into the `detached` state. In that state, additional incoming events
-    // will get ignored, except for `start` which will bring the client back to
-    // life.
-    this.s_detached();
   }
 
   /**
@@ -362,6 +343,44 @@ export default class BodyClient extends StateMachine {
     })();
 
     this.s_errorWait();
+  }
+
+  /**
+   * Handler for all `error` events (errors that were uncaught by other handlers
+   * and which would by default just cause the state machine to die). In this
+   * case, we make it turn into an "unrecoverable" error, which is the same as
+   * what happens when the instance receives too many API errors.
+   *
+   * @param {Error} error The error.
+   */
+  _handle_any_error(error) {
+    this.log.error('Unexpected error in handler', error);
+    this.s_unrecoverableError();
+  }
+
+  /**
+   * Handler for all `stop` events.
+   */
+  _handle_any_stop() {
+    if (this._running) {
+      this.log.event.stopping();
+      this._running = false;
+    }
+
+    // Go into the `detached` state. In that state, additional incoming events
+    // will get ignored, except for `start` which will bring the client back to
+    // life.
+    this.s_detached();
+  }
+
+  /**
+   * In any state but `idle`, handles event `wantInputAfterDelay`. We ignore
+   * the event, because the client is in the middle of doing something else.
+   * When it's done with whatever it may be, it will send a new
+   * `wantInputAfterDelay` event.
+   */
+  _handle_any_wantInputAfterDelay() {
+    // Nothing to do.
   }
 
   /**
@@ -905,25 +924,6 @@ export default class BodyClient extends StateMachine {
     } else {
       this.s_detached();
     }
-  }
-
-  /**
-   * In any state but `idle`, handles event `wantInputAfterDelay`. We ignore
-   * the event, because the client is in the middle of doing something else.
-   * When it's done with whatever it may be, it will send a new
-   * `wantInputAfterDelay` event.
-   */
-  _handle_any_wantInputAfterDelay() {
-    // Nothing to do.
-  }
-
-  /**
-   * Validates a `wantInputAfterDelay` event.
-   *
-   * @param {int} delayMsec Msec to wait before firing `wantInput`.
-   */
-  _check_wantInputAfterDelay(delayMsec) {
-    TInt.nonNegative(delayMsec);
   }
 
   /**

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -195,7 +195,7 @@ export default class EditorComplex extends CommonBase {
   }
 
   /**
-   * Initialize the session, based on the given key.
+   * Initialize the session, based on the given session connection info.
    *
    * @param {SessionInfo} info Info object that identifies the session and
    *   grants access to it.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.10
+version = 1.2.11


### PR DESCRIPTION
This PR adds a `stop()` method to `BodyClient`, which is perhaps a bit more complicated than the first clause of this sentence might lead you to believe. Specifically, the system needs to ensure, to the extent possible, that when the user is in the middle of making document changes that those changes actually get recorded by the server before the `BodyClient` quiesces and stops doing its whole change-synch thing.

**Important Note:** If the client code of `BodyClient` is explicitly managing the Quill enabled state, it is important to disable editing before issuing `BodyClient.stop()` (or at least doing so soon thereafter). If this is not done, it's possible for the user to keep on editing and thus keep the set of pending changes non-empty (because the user could keep editing during the server synch-up), which would make `BodyClient` never actually be in a safe-to-stop state. (The failure mode is that the user would permanently lose some of their edits.)

BTW / for the record, I tested this all by adding the following code right after the `BodyClient` instance gets `start()`ed (it just stops and starts the client every ten seconds):

```javascript
    (async () => {
      for (;;) {
        await Delay.resolve(10000);
        log.event.zzzStop();
        this._bodyClient.stop();
        await Delay.resolve(10000);
        log.event.zzzStart();
        this._bodyClient.start();
      }
    })();
```

**Bonus:** It was a little hard to mentally track all of what needed to happen in the event handlers, and so as a tactic I went ahead and sorted / collated the methods, adding in a couple of section header comments. Apologies that this no doubt makes the whole-PR diffs a bit harder to read.