### PR TITLE
Another round of shutdown-time work.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -21,7 +21,7 @@ import RequestLogger from './RequestLogger';
 import RootAccess from './RootAccess';
 import ServerUtil from './ServerUtil';
 
-/** {Logger} Logger. */
+/** {Logger} Logger for this class. */
 const log = new Logger('app');
 
 /**
@@ -107,6 +107,10 @@ export default class Application extends CommonBase {
     const resultPort = await ServerUtil.listen(server, port);
 
     log.event.applicationPort(resultPort);
+
+    // **Note:** This is an `async` method but we don't actually want to wait
+    // for it to return, because that'd be when the system is shutting down!
+    ServerUtil.handleSystemShutdown(server);
 
     if ((port !== 0) && (port !== resultPort)) {
       log.warn(`Originally requested port: ${port}`);

--- a/local-modules/@bayou/app-setup/ServerUtil.js
+++ b/local-modules/@bayou/app-setup/ServerUtil.js
@@ -2,14 +2,50 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { ServerEnv } from '@bayou/env-server';
+import { Logger } from '@bayou/see-all';
 import { UtilityClass } from '@bayou/util-common';
 
+/** {Logger} Logger for this class. */
+const log = new Logger('app');
 
 /**
  * Utility functions for dealing with `Server`s (e.g., HTTP server objects and
  * the like).
  */
 export default class ServerUtil extends UtilityClass {
+  /**
+   * Arranges for the given `Server` to stop listening for connections when
+   * the system is trying to shut down.
+   *
+   * @param {Server} server `Server` to manage.
+   */
+  static async handleSystemShutdown(server) {
+    const shutdownManager = ServerEnv.theOne.shutdownManager;
+    const address = server.address(); // For logging.
+
+    // Promise that resolves when the server gets closed. We need this so it can
+    // race with the shutdown condition and, when shutdown is in progress, so
+    // the shutdown manager can wait for it. **Note:** The `close` event is only
+    // supposed to be emitted once there are no more active connections on the
+    // server's socket.
+    const closePromise = new Promise((resolve) => {
+      server.on('close', () => {
+        log.event.serverClosed(address);
+        resolve(true);
+      });
+    });
+
+    await Promise.race([closePromise, shutdownManager.whenShuttingDown()]);
+
+    // Only bother with further action if the server socket is still open.
+    if (server.listening) {
+      log.event.serverShutdown(address);
+      shutdownManager.waitFor(closePromise);
+      server.close();
+    }
+  }
+
   /**
    * Issues a `listen()` to a `Server` instance, converting the subsequent
    * events to a promise.
@@ -19,7 +55,7 @@ export default class ServerUtil extends UtilityClass {
    * callback argument in the Node-standard way. Specifically, it won't report
    * errors through that callback.
    *
-   * @param {Server} server Server to tell to `listen()`.
+   * @param {Server} server `Server` to tell to `listen()`.
    * @param {Int} port Port to listen on, or `0` to have the system pick an
    *   available port.
    * @returns {Int} The port actually being listened on.

--- a/local-modules/@bayou/env-server/ProcessControl.js
+++ b/local-modules/@bayou/env-server/ProcessControl.js
@@ -7,6 +7,7 @@ import path from 'path';
 
 import { Condition, Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
+import { TObject } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import Dirs from './Dirs';
@@ -16,6 +17,18 @@ import Dirs from './Dirs';
  * polling loop.
  */
 const SHUTDOWN_POLL_DELAY_MSEC = 60 * 1000; // One minute.
+
+/**
+ * {Int} How long (in msec) to wait during shutdown to allow the shutdown
+ * promise list to be populated.
+ */
+const SHUTDOWN_PROMISE_POPULATION_DELAY_MSEC = 500; // Half a second.
+
+/**
+ * {Int} The maximum amount of time (in msec) that should be spent waiting for
+ * shutdown promises before giving up and just exiting.
+ */
+const MAX_SHUTDOWN_TIME_MSEC = 15 * 1000; // Fifteen seconds.
 
 /** {Logger} Logger for this class. */
 const log = new Logger('control');
@@ -28,8 +41,8 @@ const log = new Logger('control');
 export default class ProcessControl extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
-   * action to take place (such as writing the PID file); that stuff happens in
-   * {@link #init}.
+   * action to take place (i.e. reacting to the control files); that stuff
+   * happens in {@link #init}.
    */
   constructor() {
     super();
@@ -48,6 +61,12 @@ export default class ProcessControl extends CommonBase {
      */
     this._shutdownCondition = new Condition();
 
+    /**
+     * {array<Promise>} Promises representing the completion of tasks that
+     * should be done before the system exits.
+     */
+    this._shutdownPromises = [];
+
     Object.freeze(this);
   }
 
@@ -60,6 +79,18 @@ export default class ProcessControl extends CommonBase {
    */
   shouldShutDown() {
     return this._shutdownCondition.value;
+  }
+
+  /**
+   * Indicates that the given promise should get resolved before the system
+   * exits.
+   *
+   * @param {Promise} promise Promise that the system should wait for before
+   * exiting.
+   */
+  waitFor(promise) {
+    TObject.check(promise, Promise);
+    this._shutdownPromises.push(promise);
   }
 
   /**
@@ -110,12 +141,63 @@ export default class ProcessControl extends CommonBase {
         }
       }
 
-      this._shutdownCondition.value = true;
-      log.event.shutdownRequested();
-
-      // Arrange for the `stopped` file to get written during process exit.
-      process.once('exit', () => this._writeStoppedFile());
+      this._doShutdown();
     })();
+  }
+
+  /**
+   * Perform all of the shutdown actions, and then exit the process.
+   */
+  async _doShutdown() {
+    this._shutdownCondition.value = true;
+    log.event.shutdownRequested();
+
+    // Arrange for the `stopped` file to get written during process exit.
+    process.once('exit', () => this._writeStoppedFile());
+
+    // Wait for all the registered shutdown promises, including ones that get
+    // added while waiting for earlier-registered ones. But stop after the
+    // overall timeout. That is, give things a reasonable amount of time to
+    // shutdown cleanly, but pull the plug if things just drag on too long.
+
+    const timeoutPromise = Delay.resolve(MAX_SHUTDOWN_TIME_MSEC);
+    let   timedOut       = false;
+    const promises       = this._shutdownPromises;
+
+    (async () => {
+      await timeoutPromise;
+      timedOut = true;
+    })();
+
+    while (!timedOut) {
+      if (promises.length === 0) {
+        // When there's nothing (apparently) left to do, give the system just a
+        // moment more in case just-resolved promises (or similar) trigger the
+        // addition of new shutdown promises. This notably allows the original
+        // `await`ers of the `_shutdownCondition` time to register their
+        // promises.
+        await Delay.resolve(SHUTDOWN_PROMISE_POPULATION_DELAY_MSEC);
+
+        if (promises.length === 0) {
+          // Nothing more added, so we're done!
+          break;
+        }
+      }
+
+      const currentLength       = promises.length;
+      const allCurrentPromises = Promise.all(promises.slice(0));
+      promises.splice(0, currentLength); // Clear it out; ready for new ones.
+
+      log.event.awaitingShutdownPromises(currentLength);
+      await Promise.race([allCurrentPromises, timeoutPromise]);
+    }
+
+    if (timedOut) {
+      log.event.shutdownTimedOut();
+    }
+
+    log.event.shutdownComplete();
+    process.exit(0);
   }
 
   /**

--- a/local-modules/@bayou/env-server/ProcessControl.js
+++ b/local-modules/@bayou/env-server/ProcessControl.js
@@ -184,7 +184,7 @@ export default class ProcessControl extends CommonBase {
         }
       }
 
-      const currentLength       = promises.length;
+      const currentLength      = promises.length;
       const allCurrentPromises = Promise.all(promises.slice(0));
       promises.splice(0, currentLength); // Clear it out; ready for new ones.
 

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -59,6 +59,11 @@ export default class ServerEnv extends Singleton {
     };
   }
 
+  /** {ProcessControl} The shutdown management instance to use. */
+  get shutdownManager() {
+    return this._processControl;
+  }
+
   /**
    * Initializes this module. This sets up the info for the `Dirs` class, sets
    * up the PID file, and gathers the product metainfo.

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -11,8 +11,8 @@ import { Errors, Singleton } from '@bayou/util-common';
 
 import Dirs from './Dirs';
 import PidFile from './PidFile';
-import ProcessControl from './ProcessControl';
 import ProductInfo from './ProductInfo';
+import ShutdownManager from './ShutdownManager';
 
 /** {Logger} Logger. */
 const log = new Logger('env-server');
@@ -30,8 +30,8 @@ export default class ServerEnv extends Singleton {
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();
 
-    /** {ProcessControl} The process control instance. */
-    this._processControl = new ProcessControl();
+    /** {ShutdownManager} The shutdown manager. */
+    this._shutdownManager = new ShutdownManager();
 
     Object.freeze(this);
   }
@@ -59,9 +59,9 @@ export default class ServerEnv extends Singleton {
     };
   }
 
-  /** {ProcessControl} The shutdown management instance to use. */
+  /** {ShutdownManager} The shutdown manager. */
   get shutdownManager() {
-    return this._processControl;
+    return this._shutdownManager;
   }
 
   /**
@@ -71,8 +71,8 @@ export default class ServerEnv extends Singleton {
   async init() {
     Dirs.theOne;
 
-    this._processControl.init();
-    if (this._processControl.shouldShutDown()) {
+    this._shutdownManager.init();
+    if (this._shutdownManager.shouldShutDown()) {
       log.error('Server found shutdown indicator(s) during startup.');
       throw Errors.aborted('Server told not to run.');
     }

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -28,7 +28,7 @@ const SHUTDOWN_PROMISE_POPULATION_DELAY_MSEC = 500; // Half a second.
  * {Int} The maximum amount of time (in msec) that should be spent waiting for
  * shutdown promises before giving up and just exiting.
  */
-const MAX_SHUTDOWN_TIME_MSEC = 15 * 1000; // Fifteen seconds.
+const MAX_SHUTDOWN_TIME_MSEC = 60 * 1000; // One minute.
 
 /** {Logger} Logger for this class. */
 const log = new Logger('control');

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -34,11 +34,12 @@ const MAX_SHUTDOWN_TIME_MSEC = 15 * 1000; // Fifteen seconds.
 const log = new Logger('control');
 
 /**
- * Manager for the `control` directory, including writing / erasing the PID file
- * and heeding shutdown requests issued by virtue of the presence of a
- * signalling file.
+ * System shutown manager. This includes handling shutdown requests that are
+ * presented in the `control` directory, along with the mechanism which other
+ * parts of the system can use to notice when shutdown is happening and have a
+ * chance to exit cleanly.
  */
-export default class ProcessControl extends CommonBase {
+export default class ShutdownManager extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (i.e. reacting to the control files); that stuff


### PR DESCRIPTION
This PR refines the controlled-shutdown mechanism a bit and adds its first client. On the latter front, it's now the case that the server will explicitly stop accepting new connections once it's been asked to shut down. However, it's still missing any logic to cause _existing_ connections to get closed. That'll come in a later PR.