### PR TITLE
Shutdown stuff, on a couple fronts.

### DIFF
--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -4,6 +4,7 @@
 
 import { ConnectionError, Message, Response } from '@bayou/api-common';
 import { Logger } from '@bayou/see-all';
+import { TBoolean } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
 import ApiLog from './ApiLog';
@@ -142,6 +143,25 @@ export default class BaseConnection extends CommonBase {
     }
 
     return encodedResponse;
+  }
+
+  /**
+   * Indicates whether or not this connection is currently open (able to
+   * receive and/or send data).
+   *
+   * @returns {boolean} `true` if the connection is open, or `false` if not.
+   */
+  isOpen() {
+    return TBoolean.check(this._impl_isOpen());
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #isOpen}.
+   *
+   * @returns {boolean} `true` if the connection is open, or `false` if not.
+   */
+  _impl_isOpen() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/api-server/PostConnection.js
+++ b/local-modules/@bayou/api-server/PostConnection.js
@@ -44,6 +44,17 @@ export default class PostConnection extends BaseConnection {
   }
 
   /**
+   * Implementation of method as required by the superclass.
+   *
+   * @returns {boolean} `true` if the connection is open, or `false` if not.
+   */
+  _impl_isOpen() {
+    const response = this._res;
+
+    return (response.socket !== null) && response.finished;
+  }
+
+  /**
    * Handles a `data` event coming from the request input stream.
    *
    * @param {Buffer} chunk Incoming data chunk.

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import WebSocket from 'ws';
+
 import { WebsocketCodes } from '@bayou/util-common';
 
 import BaseConnection from './BaseConnection';

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -33,6 +33,17 @@ export default class WsConnection extends BaseConnection {
   }
 
   /**
+   * Implementation of method as required by the superclass.
+   *
+   * @returns {boolean} `true` if the connection is open, or `false` if not.
+   */
+  _impl_isOpen() {
+    const readyState = this._ws.readyState;
+
+    return (readyState === WebSocket.CONNECTING) || (readyState === WebSocket.OPEN);
+  }
+
+  /**
    * Handles a `close` event coming from the underlying websocket.
    *
    * @param {number} code The reason code for why the socket was closed.

--- a/local-modules/@bayou/api-server/package.json
+++ b/local-modules/@bayou/api-server/package.json
@@ -3,6 +3,7 @@
     "@bayou/api-common": "local",
     "@bayou/codec": "local",
     "@bayou/config-server": "local",
+    "@bayou/deps-express": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/promise-util": "local",
     "@bayou/see-all": "local",

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -70,6 +70,9 @@ export default class Application extends CommonBase {
      */
     this._connections = new Set();
 
+    /** {Int} Count of connections that this server has ever had. */
+    this._connectionCountTotal = 0;
+
     /**
      * {function} The top-level "Express application" run by this instance. It
      * is a request handler function which is suitable for use with Node's
@@ -93,7 +96,17 @@ export default class Application extends CommonBase {
 
     this._connectionsUpdateLoop(); // This (async) method runs forever.
 
-    Object.freeze(this);
+    Object.seal(this);
+  }
+
+  /** {Int} Count of currently-active connections. */
+  get connectionCountNow() {
+    return this._connections.size;
+  }
+
+  /** {Int} Count of connections that this server has ever had. */
+  get connectionCountTotal() {
+    return this._connectionCountTotal;
   }
 
   /**
@@ -192,6 +205,7 @@ export default class Application extends CommonBase {
       try {
         const conn = new PostConnection(req, res, this._contextInfo);
         this._connections.add(conn);
+        this._connectionCountTotal++;
       } catch (e) {
         log.error('Trouble with API request:', e);
       }
@@ -235,6 +249,7 @@ export default class Application extends CommonBase {
       try {
         const conn = new WsConnection(wsSocket, req, this._contextInfo);
         this._connections.add(conn);
+        this._connectionCountTotal++;
       } catch (e) {
         log.error('Trouble with API websocket connection:', e);
       }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -21,6 +21,7 @@ import DebugTools from './DebugTools';
 import RequestLogger from './RequestLogger';
 import RootAccess from './RootAccess';
 import ServerUtil from './ServerUtil';
+import VarInfo from './VarInfo';
 
 /**
  * {Int} How long to wait (in msec) between {@link #_connections} update
@@ -56,6 +57,12 @@ export default class Application extends CommonBase {
      * bearing {@link Auth#TYPE_root} authority grant access to.
      */
     this._rootAccess = this._makeRootAccess();
+
+    /**
+     * {VarInfo} The "variable info" handler. This is what's responsible for
+     * producing the info sent back on the `/var` monitor endpoint.
+     */
+    this._varInfo = new VarInfo(this);
 
     /**
      * {Set<BaseConnection>} List of all currently active connections (or at
@@ -95,6 +102,14 @@ export default class Application extends CommonBase {
    */
   get rootAccess() {
     return this._rootAccess;
+  }
+
+  /**
+   * {VarInfo} The "variable info" handler. This is what's responsible for
+   * producing the info sent back on the `/var` monitor endpoint.
+   */
+  get varInfo() {
+    return this._varInfo;
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -94,6 +94,17 @@ export default class Application extends CommonBase {
   }
 
   /**
+   * Indicates whether or not this instance is currently listening for
+   * connections.
+   *
+   * @returns {boolean} `true` if this instance is listening for connections, or
+   *   `false` if not.
+   */
+  isListening() {
+    return this._server.listening;
+  }
+
+  /**
    * Starts up the server.
    *
    * @param {boolean} [pickPort = false] If `true`, causes the app to pick an

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -13,6 +13,8 @@ import { Logger } from '@bayou/see-all';
 import { RecentSink } from '@bayou/see-all-server';
 import { CommonBase, Errors } from '@bayou/util-common';
 
+import ServerUtil from './ServerUtil';
+
 /** Logger for this module. */
 const log = new Logger('app-debug');
 
@@ -226,7 +228,7 @@ export default class DebugTools extends CommonBase {
     const authorId   = this._getAuthorIdParam(req);
     const info       = await this._makeEncodedInfo(documentId, authorId);
 
-    this._jsonResponse(res, info);
+    ServerUtil.sendJsonResponse(res, info);
   }
 
   /**
@@ -241,7 +243,7 @@ export default class DebugTools extends CommonBase {
     const change = (await body).getChange(revNum);
     const result = appCommon_TheModule.modelCodec.encodeJson(await change, true);
 
-    this._textResponse(res, result);
+    ServerUtil.sendPlainTextResponse(res, result);
   }
 
   /**
@@ -280,7 +282,8 @@ export default class DebugTools extends CommonBase {
   async _handle_edit(req, res) {
     const documentId = req.params.documentId;
     const authorId   = this._getAuthorIdParam(req);
-    const info       = await this._makeEncodedInfo(documentId, authorId);
+    const infoObj    = await this._makeEncodedInfo(documentId, authorId);
+    const info       = JSON.stringify(infoObj);
 
     // These are already strings (JSON-encoded even, in the case of `info`),
     // but we still have to JSON-encode _those_ strings, so as to make them
@@ -349,7 +352,7 @@ export default class DebugTools extends CommonBase {
     const snapshot = (await body).getSnapshot(...args);
     const result = appCommon_TheModule.modelCodec.encodeJson(await snapshot, true);
 
-    this._textResponse(res, result);
+    ServerUtil.sendPlainTextResponse(res, result);
   }
 
   /**
@@ -364,7 +367,7 @@ export default class DebugTools extends CommonBase {
     const token    = req.params.token;
 
     this._rootAccess.useToken(authorId, token);
-    this._textResponse(res, 'Ok!');
+    ServerUtil.sendPlainTextResponse(res, 'Ok!');
   }
 
   /**
@@ -446,7 +449,7 @@ export default class DebugTools extends CommonBase {
    */
   async _makeEncodedInfo(documentId, authorId) {
     const info = await this._rootAccess.makeSessionInfo(authorId, documentId);
-    return appCommon_TheModule.fullCodec.encodeJson(info);
+    return appCommon_TheModule.fullCodec.encodeData(info);
   }
 
   /**
@@ -469,31 +472,5 @@ export default class DebugTools extends CommonBase {
       .status(200)
       .type('text/html; charset=utf-8')
       .send(html);
-  }
-
-  /**
-   * Responds with an `application/json` result.
-   *
-   * @param {object} res HTTP response.
-   * @param {string} json JSON text to respond with.
-   */
-  _jsonResponse(res, json) {
-    res
-      .status(200)
-      .type('application/json; charset=utf-8')
-      .send(json);
-  }
-
-  /**
-   * Responds with a `text/plain` result.
-   *
-   * @param {object} res HTTP response.
-   * @param {string} text Text to respond with.
-   */
-  _textResponse(res, text) {
-    res
-      .status(200)
-      .type('text/plain; charset=utf-8')
-      .send(text);
   }
 }

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -268,7 +268,7 @@ export default class DebugTools extends CommonBase {
       '<h1>Client Tests</h1>\n' +
       '<p>See console output for details.</p>';
 
-    this._htmlResponse(res, head, body);
+    ServerUtil.sendHtmlResponse(res, head, body);
   }
 
   /**
@@ -304,7 +304,7 @@ export default class DebugTools extends CommonBase {
     const body =
       '<div id="debugEditor"><p>Loading&hellip;</p></div>\n';
 
-    this._htmlResponse(res, head, body);
+    ServerUtil.sendHtmlResponse(res, head, body);
   }
 
   /**
@@ -336,7 +336,7 @@ export default class DebugTools extends CommonBase {
       '});\n' +
       '</script>';
 
-    this._htmlResponse(res, head, result);
+    ServerUtil.sendHtmlResponse(res, head, result);
   }
 
   /**
@@ -450,27 +450,5 @@ export default class DebugTools extends CommonBase {
   async _makeEncodedInfo(documentId, authorId) {
     const info = await this._rootAccess.makeSessionInfo(authorId, documentId);
     return appCommon_TheModule.fullCodec.encodeData(info);
-  }
-
-  /**
-   * Responds with a `text/html` result. The given string is used as the
-   * HTML body.
-   *
-   * @param {object} res HTTP response.
-   * @param {string|null} head HTML head text, if any.
-   * @param {string} body HTML body text.
-   */
-  _htmlResponse(res, head, body) {
-    head = (head === null)
-      ? ''
-      : `<head>\n\n${head}\n</head>\n\n`;
-    body = `<body>\n\n${body}\n</body>\n`;
-
-    const html = `<!doctype html>\n<html lang="en-US">\n${head}${body}</html>\n`;
-
-    res
-      .status(200)
-      .type('text/html; charset=utf-8')
-      .send(html);
   }
 }

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -99,7 +99,7 @@ export default class Monitor extends CommonBase {
       });
     });
 
-    const varInfo = new VarInfo();
+    const varInfo = new VarInfo(this._mainApplication);
     app.get('/var', async (req_unused, res) => {
       const info = await varInfo.get();
 

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -13,7 +13,6 @@ import { CommonBase } from '@bayou/util-common';
 import Application from './Application';
 import RequestLogger from './RequestLogger';
 import ServerUtil from './ServerUtil';
-import VarInfo from './VarInfo';
 
 /** {Logger} Logger. */
 const log = new Logger('app-monitor');
@@ -72,7 +71,8 @@ export default class Monitor extends CommonBase {
    * Sets up the webserver routes.
    */
   _addRoutes() {
-    const app = this._app;
+    const app             = this._app;
+    const mainApplication = this._mainApplication;
 
     // Logging.
     app.use(this._requestLogger.expressMiddleware);
@@ -85,7 +85,7 @@ export default class Monitor extends CommonBase {
     });
 
     app.get('/health', async (req_unused, res) => {
-      const [status, text] = await this._mainApplication.isHealthy()
+      const [status, text] = await mainApplication.isHealthy()
         ? [200, '🍑 Everything\'s peachy! 🍑\n']
         : [503, '😿 Sorry to say we can\'t help you right now. 😿\n'];
 
@@ -99,7 +99,7 @@ export default class Monitor extends CommonBase {
       });
     });
 
-    const varInfo = new VarInfo(this._mainApplication);
+    const varInfo = mainApplication.varInfo;
     app.get('/var', async (req_unused, res) => {
       const info = await varInfo.get();
 

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -89,11 +89,11 @@ export default class Monitor extends CommonBase {
         ? [200, '🍑 Everything\'s peachy! 🍑\n']
         : [503, '😿 Sorry to say we can\'t help you right now. 😿\n'];
 
-      Monitor._sendTextResponse(res, status, 'text/plain', text);
+      ServerUtil.sendPlainTextResponse(res, text, status);
     });
 
     app.get('/info', async (req_unused, res) => {
-      Monitor._sendJsonResponse(res, {
+      ServerUtil.sendJsonResponse(res, {
         build:   ProductInfo.theOne.INFO,
         runtime: ServerEnv.theOne.info
       });
@@ -103,38 +103,7 @@ export default class Monitor extends CommonBase {
     app.get('/var', async (req_unused, res) => {
       const info = await varInfo.get();
 
-      Monitor._sendJsonResponse(res, info);
+      ServerUtil.sendJsonResponse(res, info);
     });
-  }
-
-  /**
-   * Sends a successful JSON-bearing HTTP response.
-   *
-   * @param {http.ServerResponse} res The response object representing the
-   *   connection to send to.
-   * @param {object} body The body of the response, as a JSON-encodable object.
-   */
-  static _sendJsonResponse(res, body) {
-    const text = `${JSON.stringify(body, null, 2)}\n`;
-
-    Monitor._sendTextResponse(res, 200, 'application/json', text);
-  }
-
-  /**
-   * Sends a text-content HTTP response.
-   *
-   * @param {http.ServerResponse} res The response object representing the
-   *   connection to send to.
-   * @param {int} statusCode The response status code.
-   * @param {string} contentType The content type, _without_ a charset. (The
-   *   charset is always set to be `utf-8`.)
-   * @param {string} body The body of the response, as a string.
-   */
-  static _sendTextResponse(res, statusCode, contentType, body) {
-    res
-      .status(statusCode)
-      .type(`${contentType}; charset=utf-8`)
-      .set('Cache-Control', 'no-cache, no-store, no-transform')
-      .send(body);
   }
 }

--- a/local-modules/@bayou/app-setup/ServerUtil.js
+++ b/local-modules/@bayou/app-setup/ServerUtil.js
@@ -90,4 +90,48 @@ export default class ServerUtil extends UtilityClass {
 
     return server.address().port;
   }
+
+  /**
+   * Sends a JSON-bearing HTTP response.
+   *
+   * @param {http.ServerResponse} res The response object representing the
+   *   connection to send to.
+   * @param {object} body The body of the response, as a JSON-encodable object.
+   * @param {int} [statusCode = 200] The response status code.
+   */
+  static sendJsonResponse(res, body, statusCode = 200) {
+    const text = `${JSON.stringify(body, null, 2)}\n`;
+
+    ServerUtil.sendTextResponse(res, text, 'application/json', statusCode);
+  }
+
+  /**
+   * Sends a plain-text HTTP response.
+   *
+   * @param {http.ServerResponse} res The response object representing the
+   *   connection to send to.
+   * @param {string} body The body of the response, as a string.
+   * @param {int} [statusCode = 200] The response status code.
+   */
+  static sendPlainTextResponse(res, body, statusCode = 200) {
+    ServerUtil.sendTextResponse(res, body, 'text/plain', statusCode);
+  }
+
+  /**
+   * Sends a text-content HTTP response.
+   *
+   * @param {http.ServerResponse} res The response object representing the
+   *   connection to send to.
+   * @param {string} body The body of the response, as a string.
+   * @param {string} contentType The content type, _without_ a charset. (The
+   *   charset is always set to be `utf-8`.)
+   * @param {int} [statusCode = 200] The response status code.
+   */
+  static sendTextResponse(res, body, contentType, statusCode = 200) {
+    res
+      .status(statusCode)
+      .type(`${contentType}; charset=utf-8`)
+      .set('Cache-Control', 'no-cache, no-store, no-transform')
+      .send(body);
+  }
 }

--- a/local-modules/@bayou/app-setup/ServerUtil.js
+++ b/local-modules/@bayou/app-setup/ServerUtil.js
@@ -92,6 +92,27 @@ export default class ServerUtil extends UtilityClass {
   }
 
   /**
+   * Responds with a `text/html` result.
+   *
+   * @param {object} res The response object representing the connection to send
+   *   to.
+   * @param {string|null} head HTML head text if any, or `null` to not include
+   *   a `<head>` section.
+   * @param {string} body HTML body text.
+   * @param {int} [statusCode = 200] The response status code.
+   */
+  static sendHtmlResponse(res, head, body, statusCode = 200) {
+    head = (head === null)
+      ? ''
+      : `<head>\n\n${head}\n</head>\n\n`;
+    body = `<body>\n\n${body}\n</body>\n`;
+
+    const html = `<!doctype html>\n<html lang="en-US">\n${head}${body}</html>\n`;
+
+    ServerUtil.sendTextResponse(res, html, 'text/html', statusCode);
+  }
+
+  /**
    * Sends a JSON-bearing HTTP response.
    *
    * @param {http.ServerResponse} res The response object representing the
@@ -125,9 +146,9 @@ export default class ServerUtil extends UtilityClass {
    * @param {string} body The body of the response, as a string.
    * @param {string} contentType The content type, _without_ a charset. (The
    *   charset is always set to be `utf-8`.)
-   * @param {int} [statusCode = 200] The response status code.
+   * @param {int} statusCode The response status code.
    */
-  static sendTextResponse(res, body, contentType, statusCode = 200) {
+  static sendTextResponse(res, body, contentType, statusCode) {
     res
       .status(statusCode)
       .type(`${contentType}; charset=utf-8`)

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -38,10 +38,9 @@ export default class VarInfo extends CommonBase {
     const connections = { now: app.connectionCountNow, total: app.connectionCountTotal };
     const health      = await app.isHealthy();
     const mode        = this._currentMode();
-    const pid         = process.pid;
     const rootTokens  = Auth.rootTokens.map(t => t.safeString);
 
-    return { connections, health, mode, pid, rootTokens };
+    return { connections, health, mode, rootTokens };
   }
 
   /**

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -33,12 +33,15 @@ export default class VarInfo extends CommonBase {
    * @returns {object} A JSON-encodable object with all of the variable info.
    */
   async get() {
-    const health     = await this._mainApplication.isHealthy();
-    const mode       = this._currentMode();
-    const pid        = process.pid;
-    const rootTokens = Auth.rootTokens.map(t => t.safeString);
+    const app = this._mainApplication;
 
-    return { health, mode, pid, rootTokens };
+    const connections = { now: app.connectionCountNow, total: app.connectionCountTotal };
+    const health      = await app.isHealthy();
+    const mode        = this._currentMode();
+    const pid         = process.pid;
+    const rootTokens  = Auth.rootTokens.map(t => t.safeString);
+
+    return { connections, health, mode, pid, rootTokens };
   }
 
   /**


### PR DESCRIPTION
This PR is another chunk of work on graceful shutdown. Much of it is more prepwork than actual shutdown handling. Details:

* Expose the shutdown state in the monitor endpoint `/var`.
* Track HTTP connections more durably in `Application`, in prep for a future PR in which active connections get told when shutdown is in progress.
* Make the shutdown handler recognize SIGHUP as a reason to check to see if the system is being asked to shut down.

**Bonuses:**

* Expose the health state and connection stats in the monitor endpoint `/var`.
* Factor out a bunch of common HTTP response code from `DebugTools` and `Monitor` into `ServerUtil`.