### PR TITLE
Spring cleaning for promise code.

### DIFF
--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -117,11 +117,9 @@ export default class DebugTools extends CommonBase {
       : `/${name}/${paramPath}`;
     const handlerMethod = this[`_handle_${camelCase(name)}`].bind(this);
 
-    function handleRequest(req, res, next) {
+    async function handleRequest(req, res, next) {
       try {
-        Promise.resolve(handlerMethod(req, res)).catch((error) => {
-          next(error);
-        });
+        await handlerMethod(req, res);
       } catch (error) {
         next(error);
       }

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -22,7 +22,7 @@ function BAYOU_RECOVER(info) {
   var origin     = new URL(info.serverUrl).origin;
   var url        = `${origin}/debug/access/${documentId}/${authorId}`;
 
-  return new Promise((res, rej_unused) => {
+  return new Promise((res) => {
     var req = new XMLHttpRequest();
     req.open('GET', url);
     req.send();

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -22,7 +22,7 @@ function BAYOU_RECOVER(info) {
   var origin     = new URL(info.serverUrl).origin;
   var url        = `${origin}/debug/access/${documentId}/${authorId}`;
 
-  return new Promise((res) => {
+  return new Promise((resolve) => {
     var req = new XMLHttpRequest();
     req.open('GET', url);
     req.send();
@@ -41,7 +41,7 @@ function BAYOU_RECOVER(info) {
     // data. If so, report it back. If not, fall back to `reloadPage()`.
     function gotKey() {
       if (req.status === 200) {
-        res(req.response);
+        resolve(req.response);
       } else {
         reloadPage();
       }

--- a/local-modules/@bayou/client-bundle/ClientBundle.js
+++ b/local-modules/@bayou/client-bundle/ClientBundle.js
@@ -170,14 +170,14 @@ export default class ClientBundle extends Singleton {
    * @returns {Promise<Map<string,Buffer>>} The built artifacts.
    */
   build() {
-    const result = new Promise((res, rej) => {
+    const result = new Promise((resolve, reject) => {
       const compiler = this._newCompiler();
       compiler.run((error, stats) => {
         this._handleCompilation(error, stats);
         if (this._currentBundles.size !== 0) {
-          res(this._currentBundles);
+          resolve(this._currentBundles);
         } else {
-          rej('Trouble building client bundles.');
+          reject('Trouble building client bundles.');
         }
       });
     });

--- a/local-modules/@bayou/dev-mode/DevMode.js
+++ b/local-modules/@bayou/dev-mode/DevMode.js
@@ -374,7 +374,7 @@ export default class DevMode extends Singleton {
     // the system was just starting up.
 
     let resolveReady;
-    const ready = new Promise((res) => { resolveReady = res; });
+    const ready = new Promise((resolve) => { resolveReady = resolve; });
     const minTime = Date.now() - (10 * 1000); // Ten seconds in the past.
 
     watcher.on('ready', () => {

--- a/local-modules/@bayou/dev-mode/DevMode.js
+++ b/local-modules/@bayou/dev-mode/DevMode.js
@@ -374,7 +374,7 @@ export default class DevMode extends Singleton {
     // the system was just starting up.
 
     let resolveReady;
-    const ready = new Promise((res, rej_unused) => { resolveReady = res; });
+    const ready = new Promise((res) => { resolveReady = res; });
     const minTime = Date.now() - (10 * 1000); // Ten seconds in the past.
 
     watcher.on('ready', () => {

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -121,7 +121,7 @@ export default class ServerEnv extends Singleton {
     // However, if it's not answering HTTP requests, then we'll consider it
     // dead.
 
-    const isActive = new Promise((resolve, reject_unused) => {
+    const isActive = new Promise((resolve) => {
       const request = http.get(Network.loopbackUrl);
 
       request.setTimeout(10 * 1000); // Give the server 10 seconds to respond.

--- a/local-modules/@bayou/promise-util/ChainedEvent.js
+++ b/local-modules/@bayou/promise-util/ChainedEvent.js
@@ -79,7 +79,7 @@ export default class ChainedEvent extends CommonBase {
     if (this._nextProm === null) {
       // First time `next` has been called; need to set up the promise and
       // resolver.
-      this._nextProm = new Promise((res, rej_unused) => {
+      this._nextProm = new Promise((res) => {
         this._nextResolver = res;
       });
     }

--- a/local-modules/@bayou/promise-util/ChainedEvent.js
+++ b/local-modules/@bayou/promise-util/ChainedEvent.js
@@ -79,8 +79,8 @@ export default class ChainedEvent extends CommonBase {
     if (this._nextProm === null) {
       // First time `next` has been called; need to set up the promise and
       // resolver.
-      this._nextProm = new Promise((res) => {
-        this._nextResolver = res;
+      this._nextProm = new Promise((resolve) => {
+        this._nextResolver = resolve;
       });
     }
 

--- a/local-modules/@bayou/promise-util/Condition.js
+++ b/local-modules/@bayou/promise-util/Condition.js
@@ -121,8 +121,8 @@ export default class Condition {
     if (!this._became[idx]) {
       // There's not yet a promise. That is, there aren't yet any other waiters.
       // Make it, and hook up the corresponding trigger.
-      this._became[idx] = new Promise((res) => {
-        this._trigger[idx] = res;
+      this._became[idx] = new Promise((resolve) => {
+        this._trigger[idx] = resolve;
       });
     }
 

--- a/local-modules/@bayou/promise-util/Condition.js
+++ b/local-modules/@bayou/promise-util/Condition.js
@@ -121,7 +121,7 @@ export default class Condition {
     if (!this._became[idx]) {
       // There's not yet a promise. That is, there aren't yet any other waiters.
       // Make it, and hook up the corresponding trigger.
-      this._became[idx] = new Promise((res, rej_unused) => {
+      this._became[idx] = new Promise((res) => {
         this._trigger[idx] = res;
       });
     }

--- a/local-modules/@bayou/promise-util/Condition.js
+++ b/local-modules/@bayou/promise-util/Condition.js
@@ -5,12 +5,6 @@
 import { TBoolean } from '@bayou/typecheck';
 
 /**
- * Promise that is permanently resolved as `true`. Used as a result from
- * `when*()`.
- */
-const RESOLVED_TRUE = Promise.resolve(true);
-
-/**
  * Boolean condition with promise-attached level triggers.
  */
 export default class Condition {
@@ -117,10 +111,10 @@ export default class Condition {
    * @returns {Promise<boolean>} Promise that resolves to `true` on an
    *   appropriate value change.
    */
-  _whenX(value) {
+  async _whenX(value) {
     if (this._value === value) {
       // Value is already as desired.
-      return RESOLVED_TRUE;
+      return true;
     }
 
     const idx = value ? 1 : 0;

--- a/local-modules/@bayou/promise-util/Delay.js
+++ b/local-modules/@bayou/promise-util/Delay.js
@@ -22,8 +22,8 @@ export default class Delay extends UtilityClass {
    * @returns {Promise} The delayed promise.
    */
   static resolve(delayMsec, value = true) {
-    return new Promise((res) => {
-      setTimeout(() => { res(value); }, delayMsec);
+    return new Promise((resolve) => {
+      setTimeout(() => { resolve(value); }, delayMsec);
     });
   }
 
@@ -38,8 +38,8 @@ export default class Delay extends UtilityClass {
    * @returns {Promise} The delayed promise.
    */
   static reject(delayMsec, reason) {
-    return new Promise((res_unused, rej) => {
-      setTimeout(() => { rej(reason); }, delayMsec);
+    return new Promise((resolve_unused, reject) => {
+      setTimeout(() => { reject(reason); }, delayMsec);
     });
   }
 }

--- a/local-modules/@bayou/promise-util/Delay.js
+++ b/local-modules/@bayou/promise-util/Delay.js
@@ -22,7 +22,7 @@ export default class Delay extends UtilityClass {
    * @returns {Promise} The delayed promise.
    */
   static resolve(delayMsec, value = true) {
-    return new Promise((res, rej_unused) => {
+    return new Promise((res) => {
       setTimeout(() => { res(value); }, delayMsec);
     });
   }

--- a/local-modules/@bayou/promise-util/Mutex.js
+++ b/local-modules/@bayou/promise-util/Mutex.js
@@ -65,7 +65,7 @@ export default class Mutex extends CommonBase {
     if (this._lockedBy !== null) {
       // There's contention, so we have to queue up. The `release` function
       // queued up here gets called inside the returned unlock function below.
-      const released = new Promise((res, rej_unused) => {
+      const released = new Promise((res) => {
         const release = () => { res(true); };
         this._waiters.push({ key, release });
       });

--- a/local-modules/@bayou/promise-util/Mutex.js
+++ b/local-modules/@bayou/promise-util/Mutex.js
@@ -65,8 +65,8 @@ export default class Mutex extends CommonBase {
     if (this._lockedBy !== null) {
       // There's contention, so we have to queue up. The `release` function
       // queued up here gets called inside the returned unlock function below.
-      const released = new Promise((res) => {
-        const release = () => { res(true); };
+      const released = new Promise((resolve) => {
+        const release = () => { resolve(true); };
         this._waiters.push({ key, release });
       });
 

--- a/local-modules/@bayou/promise-util/tests/test_Condition.js
+++ b/local-modules/@bayou/promise-util/tests/test_Condition.js
@@ -9,11 +9,15 @@ import { Condition } from '@bayou/promise-util';
 
 describe('@bayou/promise-util/Condition', () => {
   describe('constructor()', () => {
-    it('should offer the constructed value', () => {
-      let cond;
-
-      cond = new Condition();
+    it('takes on the default value', () => {
+      const cond = new Condition();
       assert.strictEqual(cond.value, false, 'default');
+    });
+  });
+
+  describe('constructor(value)', () => {
+    it('takes on the constructed value', () => {
+      let cond;
 
       cond = new Condition(false);
       assert.strictEqual(cond.value, false, 'explicit `false`');
@@ -24,20 +28,28 @@ describe('@bayou/promise-util/Condition', () => {
   });
 
   describe('.value', () => {
-    it('should get a value that was previously set', () => {
-      const cond = new Condition();
+    it('gets the value that was previously set', () => {
+      const cond1 = new Condition(false);
 
-      cond.value = false;
-      assert.strictEqual(cond.value, false);
+      cond1.value = false;
+      assert.strictEqual(cond1.value, false);
 
-      cond.value = true;
-      assert.strictEqual(cond.value, true);
+      cond1.value = true;
+      assert.strictEqual(cond1.value, true);
 
-      cond.value = false;
-      assert.strictEqual(cond.value, false);
+      cond1.value = false;
+      assert.strictEqual(cond1.value, false);
+
+      const cond2 = new Condition(true);
+
+      cond2.value = false;
+      assert.strictEqual(cond2.value, false);
+
+      cond2.value = true;
+      assert.strictEqual(cond2.value, true);
     });
 
-    it('should trigger `true` waiters when set from `false` to `true`', async () => {
+    it('triggers `true` waiters when set from `false` to `true`', async () => {
       const cond = new Condition(false);
       let triggered = false;
 
@@ -52,7 +64,7 @@ describe('@bayou/promise-util/Condition', () => {
       assert.isTrue(triggered);
     });
 
-    it('should trigger `false` waiters when set from `true` to `false`', async () => {
+    it('triggers `false` waiters when set from `true` to `false`', async () => {
       const cond = new Condition(true);
       let triggered = false;
 
@@ -69,7 +81,7 @@ describe('@bayou/promise-util/Condition', () => {
   });
 
   describe('onOff()', () => {
-    it('should leave the value `false`', () => {
+    it('leaves the value `false`', () => {
       const cond = new Condition(false);
 
       cond.onOff();
@@ -80,7 +92,7 @@ describe('@bayou/promise-util/Condition', () => {
       assert.strictEqual(cond.value, false);
     });
 
-    it('should trigger `true` waiters when value started out `false`', async () => {
+    it('triggers `true` waiters when value started out `false`', async () => {
       const cond = new Condition(false);
       let triggered = false;
 
@@ -95,7 +107,7 @@ describe('@bayou/promise-util/Condition', () => {
       assert.isTrue(triggered);
     });
 
-    it('should trigger `false` waiters when value started out `true`', async () => {
+    it('triggers `false` waiters when value started out `true`', async () => {
       const cond = new Condition(true);
       let triggered = false;
 
@@ -112,7 +124,7 @@ describe('@bayou/promise-util/Condition', () => {
   });
 
   describe('whenFalse()', () => {
-    it('should trigger immediately if the value is already `false`', async () => {
+    it('triggers immediately if the value is already `false`', async () => {
       const cond = new Condition(false);
       let triggered = false;
 
@@ -127,7 +139,7 @@ describe('@bayou/promise-util/Condition', () => {
   });
 
   describe('whenTrue()', () => {
-    it('should trigger immediately if the value is already `true`', async () => {
+    it('triggers immediately if the value is already `true`', async () => {
       const cond = new Condition(true);
       let triggered = false;
 

--- a/local-modules/@bayou/promise-util/tests/test_Delay.js
+++ b/local-modules/@bayou/promise-util/tests/test_Delay.js
@@ -8,22 +8,22 @@ import { describe, it } from 'mocha';
 import { Delay } from '@bayou/promise-util';
 
 describe('@bayou/promise-util/Delay', () => {
-  describe('delay(delayMSec)', () => {
-    it('should eventually resolve to true', async () => {
+  describe('delay(delayMsec)', () => {
+    it('eventually resolves to `true`', async () => {
       await assert.isFulfilled(Delay.resolve(10));
       await assert.eventually.strictEqual(Delay.resolve(10), true);
     });
   });
 
-  describe('delay(delayMSec, value)', () => {
-    it('should eventually resolve to the supplied value', async () => {
+  describe('delay(delayMsec, value)', () => {
+    it('eventually resolves to the supplied value', async () => {
       await assert.isFulfilled(Delay.resolve(10, 'floopty'));
       await assert.eventually.strictEqual(Delay.resolve(10, 'floopty'), 'floopty');
     });
   });
 
-  describe('reject(delayMSec, reason)', () => {
-    it('should eventually be rejected with the specified reason', async () => {
+  describe('reject()', () => {
+    it('eventually gets rejected with the specified reason', async () => {
       await assert.isRejected(Delay.reject(10, 'you smell'));
       await assert.isRejected(Delay.reject(10, 'you smell'), /^you smell$/);
     });

--- a/local-modules/@bayou/promise-util/tests/test_Mutex.js
+++ b/local-modules/@bayou/promise-util/tests/test_Mutex.js
@@ -9,7 +9,7 @@ import { Mutex } from '@bayou/promise-util';
 
 describe('@bayou/promise-util/Mutex', () => {
   describe('lock()', () => {
-    it('should work when there is blatantly no contention', async () => {
+    it('works when there is blatantly no contention', async () => {
       const mutex = new Mutex();
       const unlock = await mutex.lock();
 
@@ -17,7 +17,7 @@ describe('@bayou/promise-util/Mutex', () => {
       unlock();
     });
 
-    it('should reject attempts to double-unlock with the same unlocker', async () => {
+    it('rejects attempts to double-unlock with the same unlocker', async () => {
       const mutex = new Mutex();
       const unlock = await mutex.lock();
 
@@ -25,7 +25,7 @@ describe('@bayou/promise-util/Mutex', () => {
       assert.throws(() => { unlock(); });
     });
 
-    it('should provide the lock in request order', async () => {
+    it('provides the lock in request order', async () => {
       const mutex       = new Mutex();
       const gotOrder    = [];
       const expectOrder = [];
@@ -56,7 +56,7 @@ describe('@bayou/promise-util/Mutex', () => {
   });
 
   describe('withLockHeld()', () => {
-    it('should work with a synchronous function when there is blatantly no contention', async () => {
+    it('works with a synchronous function when there is blatantly no contention', async () => {
       const mutex = new Mutex();
 
       const result = await mutex.withLockHeld(() => { return 'blort'; });
@@ -65,7 +65,7 @@ describe('@bayou/promise-util/Mutex', () => {
       await assert.isRejected(mutex.withLockHeld(() => { throw new Error('oy'); }));
     });
 
-    it('should work with an `async` function when there is blatantly no contention', async () => {
+    it('works with an `async` function when there is blatantly no contention', async () => {
       const mutex = new Mutex();
 
       const result = await mutex.withLockHeld(async () => { return 'blort'; });
@@ -74,7 +74,7 @@ describe('@bayou/promise-util/Mutex', () => {
       await assert.isRejected(mutex.withLockHeld(async () => { throw new Error('oy'); }));
     });
 
-    it('should provide the lock in request order', async () => {
+    it('provides the lock in request order', async () => {
       const mutex = new Mutex();
 
       let result = 'x';
@@ -89,7 +89,7 @@ describe('@bayou/promise-util/Mutex', () => {
       assert.strictEqual(result, 'x0123456789');
     });
 
-    it('should reject non-function arguments', async () => {
+    it('rejects non-function arguments', async () => {
       const mutex = new Mutex();
       async function test(v) {
         await assert.isRejected(mutex.withLockHeld(v));

--- a/local-modules/@bayou/see-all/LogStream.js
+++ b/local-modules/@bayou/see-all/LogStream.js
@@ -73,7 +73,6 @@ export default class LogStream extends CommonBase {
     if (callback) {
       // Make the callback happen in its own tick/turn.
       (async () => {
-        await Promise.resolve(true);
         callback();
       })();
     }

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -207,13 +207,13 @@ export default class StateMachine {
         }
       };
 
-      this[`when_${name}`] = () => {
+      this[`when_${name}`] = async () => {
         if (this._stateName === name) {
           if (this._verboseLogging) {
             this._log.event.immediatelyTriggeredWaiter(name);
           }
 
-          return Promise.resolve(true);
+          return true;
         } else {
           if (this._verboseLogging) {
             this._log.event.addedWaiter(name);

--- a/local-modules/@bayou/testing-client/Tests.js
+++ b/local-modules/@bayou/testing-client/Tests.js
@@ -49,7 +49,7 @@ export default class Tests extends UtilityClass {
     // which for the gory details).
     registerTests();
 
-    return new Promise((res, rej_unused) => {
+    return new Promise((res) => {
       mocha.run(res);
     });
   }

--- a/local-modules/@bayou/testing-client/Tests.js
+++ b/local-modules/@bayou/testing-client/Tests.js
@@ -49,8 +49,8 @@ export default class Tests extends UtilityClass {
     // which for the gory details).
     registerTests();
 
-    return new Promise((res) => {
-      mocha.run(res);
+    return new Promise((resolve) => {
+      mocha.run(resolve);
     });
   }
 }

--- a/local-modules/@bayou/util-client/DomUtil.js
+++ b/local-modules/@bayou/util-client/DomUtil.js
@@ -18,7 +18,7 @@ export default class DomUtil extends UtilityClass {
    *   been loaded.
    */
   static addStylesheet(document, url) {
-    return new Promise((res, rej_unused) => {
+    return new Promise((res) => {
       const elem = document.createElement('link');
       elem.href = url;
       elem.rel = 'stylesheet';

--- a/local-modules/@bayou/util-client/DomUtil.js
+++ b/local-modules/@bayou/util-client/DomUtil.js
@@ -18,11 +18,11 @@ export default class DomUtil extends UtilityClass {
    *   been loaded.
    */
   static addStylesheet(document, url) {
-    return new Promise((res) => {
+    return new Promise((resolve) => {
       const elem = document.createElement('link');
       elem.href = url;
       elem.rel = 'stylesheet';
-      elem.onload = () => { res(true); };
+      elem.onload = () => { resolve(true); };
 
       document.head.appendChild(elem);
 


### PR DESCRIPTION
I noticed a promise-related thing that could be improved during work on my last PR, and I figured I'd take this moment-of-breath to do a little related cleanup:

* Changed a bunch of places that used explicit calls to `Promise.resolve()` and `Promise.reject()` to instead have implicit promises by being inside `async` functions / methods. Most of the use sites predated our use of `async` / `await` (and I think predated that syntax being guaranteed-available).

* Made the arguments to the promise closures be consistently named `resolve` and `reject`, instead of the terse `res` and `rej`. (It was arguably a false efficiency.)

* Stopped naming an ignored `reject` argument, as it was more noisy than useful.

* Generally spruced up the test cases in the `promise-util` library.