### PR TITLE
Better log redaction for tokens in `Message`.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { CodableError, ConnectionError, Message, Remote, Response, TargetId } from '@bayou/api-common';
+import { CodableError, ConnectionError, Message, Remote, Response } from '@bayou/api-common';
 import { Codec } from '@bayou/codec';
 import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
@@ -440,8 +440,8 @@ export default class ApiClient extends CommonBase {
    * in turn called by a proxy object representing an object on the far side of
    * the connection.
    *
-   * @param {string} idOrTarget ID or token which identifies the target object
-   *   on the other side of the API connection.
+   * @param {string|BearerToken} idOrTarget ID or token which identifies the
+   *   target object on the other side of the API connection.
    * @param {Functor} payload The name of the method to call and the arguments
    *   to call it with.
    * @returns {*} Result or error returned by the remote call. In the case of an
@@ -474,7 +474,7 @@ export default class ApiClient extends CommonBase {
     const id = this._nextId;
     this._nextId++;
 
-    const message = new Message(id, TargetId.targetString(idOrTarget), payload);
+    const message = new Message(id, idOrTarget, payload);
     const msgJson = this._codec.encodeJson(message);
 
     switch (wsState) {

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -408,7 +408,7 @@ export default class ApiClient extends CommonBase {
     for (const id in this._callbacks) {
       const { message, reject } = this._callbacks[id];
 
-      this._log.event.rejectDuringTermination(...message.deconstruct());
+      this._log.event.rejectDuringTermination(message.logInfo);
       reject(error);
     }
 

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -34,7 +34,7 @@ export default class Message extends CommonBase {
       : TString.minLen(id, 8);
 
     /** {string|BearerToken} ID of the target object. */
-    this._targetId = (targetId instanceof BearerToken) ? targetId : TargetId.check(targetId);
+    this._targetId = TargetId.orToken(targetId);
 
     /**
      * {Functor} The name of the method to call and the arguments to call it
@@ -72,6 +72,9 @@ export default class Message extends CommonBase {
     const rawTargetId = this._targetId;
     const targetId    = (rawTargetId instanceof BearerToken) ? rawTargetId.safeString : rawTargetId;
     const payload     = this._payload;
+
+    // **TODO:** Ultimately, we probably want to perform redaction on the
+    // `payload`.
 
     return { id, targetId, payload };
   }

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -63,6 +63,20 @@ export default class Message extends CommonBase {
   }
 
   /**
+   * {object} Ad-hoc object with the contents of this instance, suitable for
+   * logging. In particular, the {@link #targetId} is represented in redacted
+   * form if this instance was constructed with a {@link BearerToken}.
+   */
+  get logInfo() {
+    const id          = this._id;
+    const rawTargetId = this._targetId;
+    const targetId    = (rawTargetId instanceof BearerToken) ? rawTargetId.safeString : rawTargetId;
+    const payload     = this._payload;
+
+    return { id, targetId, payload };
+  }
+
+  /**
    * {Functor} The name of the method to call and the arguments to call it
    * with.
    */

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -95,4 +95,16 @@ export default class Message extends CommonBase {
 
     return (targetId instanceof BearerToken) ? targetId.secretToken : targetId;
   }
+
+  /**
+   * Returns a new instance just like `this` except with the `targetId` as
+   * given.
+   *
+   * @param {string|BearerToken} targetId The new target ID (or token
+   *   representative of same).
+   * @returns {Message} An appropriately-constructed instance.
+   */
+  withTargetId(targetId) {
+    return new Message(this._id, targetId, this._payload);
+  }
 }

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -96,15 +96,4 @@ export default class Message extends CommonBase {
 
     return (targetId instanceof BearerToken) ? targetId.secretToken : targetId;
   }
-
-  /**
-   * Returns a new instance just like `this` except with the `targetId` as
-   * given.
-   *
-   * @param {string} targetId The new target ID.
-   * @returns {Message} An appropriately-constructed instance.
-   */
-  withTargetId(targetId) {
-    return new Message(this._id, targetId, this._payload);
-  }
 }

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -68,10 +68,9 @@ export default class Message extends CommonBase {
    * form if this instance was constructed with a {@link BearerToken}.
    */
   get logInfo() {
-    const id          = this._id;
-    const rawTargetId = this._targetId;
-    const targetId    = (rawTargetId instanceof BearerToken) ? rawTargetId.safeString : rawTargetId;
-    const payload     = this._payload;
+    const id       = this._id;
+    const targetId = TargetId.safeString(this._targetId);
+    const payload  = this._payload;
 
     // **TODO:** Ultimately, we probably want to perform redaction on the
     // `payload`.

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -73,19 +73,4 @@ export default class TargetId extends UtilityClass {
 
     return (idOrToken instanceof BearerToken) ? idOrToken.safeString : idOrToken;
   }
-
-  /**
-   * Gets the string to use as an ID across an API boundary for the given value
-   * which must be either a target ID string or a {@link BearerToken}.
-   *
-   * @param {string|BearerToken} idOrToken The ID or token which identifies the
-   *   target.
-   * @returns {string} The string to use to refer to `idOrToken` across an API
-   *   boundary.
-   */
-  static targetString(idOrToken) {
-    TargetId.orToken(idOrToken);
-
-    return (idOrToken instanceof BearerToken) ? idOrToken.secretToken : idOrToken;
-  }
 }

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -145,4 +145,41 @@ describe('@bayou/api-common/Message', () => {
       assert.strictEqual(msg.targetId, token.secretToken);
     });
   });
+
+  describe('withTargetId()', () => {
+    it('returns an instance with a replaced string `targetId`', () => {
+      const msg    = new Message(123, 'target-first', VALID_FUNCTOR);
+      const result = msg.withTargetId('target-second');
+
+      assert.strictEqual(result.targetId, 'target-second');
+      assert.strictEqual(result.id, 123);
+      assert.strictEqual(result.payload, VALID_FUNCTOR);
+    });
+
+    it('returns an instance with a replaced `BearerToken` `targetId`', () => {
+      const token  = new BearerToken('whoah', 'yeahhhh');
+      const msg    = new Message(999, 'target-first', VALID_FUNCTOR);
+      const result = msg.withTargetId(token);
+
+      assert.strictEqual(result.targetId, token.secretToken);
+      assert.strictEqual(result.logInfo.targetId, token.safeString);
+      assert.strictEqual(result.id, 999);
+      assert.strictEqual(result.payload, VALID_FUNCTOR);
+    });
+
+    it('rejects an invalid `targetId`', () => {
+      const msg = new Message(123, 'target-first', VALID_FUNCTOR);
+
+      function test(tid) {
+        assert.throws(() => msg.withTargetId(tid), /badValue/);
+      }
+
+      test(null);
+      test(123);
+      test('');
+      test('&');
+      test(new Map());
+      test({ x : 123 });
+    });
+  });
 });

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -145,28 +145,4 @@ describe('@bayou/api-common/Message', () => {
       assert.strictEqual(msg.targetId, token.secretToken);
     });
   });
-
-  describe('withTargetId()', () => {
-    it('returns an instance with a replaced `targetId`', () => {
-      const msg    = new Message(123, 'target-first', VALID_FUNCTOR);
-      const result = msg.withTargetId('target-second');
-
-      assert.strictEqual(result.targetId, 'target-second');
-      assert.strictEqual(result.id, 123);
-      assert.strictEqual(result.payload, VALID_FUNCTOR);
-    });
-
-    it('rejects an invalid `targetId`', () => {
-      const msg = new Message(123, 'target-first', VALID_FUNCTOR);
-
-      function test(tid) {
-        assert.throws(() => msg.withTargetId(tid), /badValue/);
-      }
-
-      test(null);
-      test(123);
-      test('');
-      test('&');
-    });
-  });
 });

--- a/local-modules/@bayou/api-common/tests/test_Message.js
+++ b/local-modules/@bayou/api-common/tests/test_Message.js
@@ -89,6 +89,23 @@ describe('@bayou/api-common/Message', () => {
     });
   });
 
+  describe('.logInfo', () => {
+    it('has all the constructed arguments if `targetId` was constructed as a string', () => {
+      const msg    = new Message(123, 'target-yep', VALID_FUNCTOR);
+      const result = msg.logInfo;
+
+      assert.deepEqual(result, { id: 123, targetId: 'target-yep', payload: VALID_FUNCTOR });
+    });
+
+    it('has the token\'s `safeString` if the instance was constructed with a `BearerToken`', () => {
+      const token = new BearerToken('florp', 'florp-like');
+      const msg   = new Message(914, token, VALID_FUNCTOR);
+      const result = msg.logInfo;
+
+      assert.deepEqual(result, { id: 914, targetId: token.safeString, payload: VALID_FUNCTOR });
+    });
+  });
+
   describe('.payload', () => {
     it('is the constructed `payload`', () => {
       const msg = new Message(123, 'target', VALID_FUNCTOR);

--- a/local-modules/@bayou/api-common/tests/test_TargetId.js
+++ b/local-modules/@bayou/api-common/tests/test_TargetId.js
@@ -137,42 +137,4 @@ describe('@bayou/api-common/TargetId', () => {
       test(new Map());
     });
   });
-
-  describe('targetString()', () => {
-    it('returns the argument if is is a valid ID string', () => {
-      function test(s) {
-        assert.strictEqual(TargetId.targetString(s), s);
-      }
-
-      test('abc_123');
-      test('0123.456-789');
-    });
-
-    it('returns the secret token out of a given `BearerToken`', () => {
-      function test(id, secret) {
-        const token = new BearerToken(id, `${id}-${secret}`);
-        assert.strictEqual(TargetId.targetString(token), token.secretToken);
-      }
-
-      test('foo',   '123123-8999');
-      test('x',     'abc_def');
-      test('b.c.d', 'zorch');
-    });
-
-    it('rejects invalid strings', () => {
-      assert.throws(() => TargetId.targetString('!?%'), /badValue/);
-    });
-
-    it('should reject non-`BearerToken` non-strings', () => {
-      function test(value) {
-        assert.throws(() => TargetId.targetString(value), /badValue/);
-      }
-
-      test(null);
-      test(undefined);
-      test(true);
-      test(123);
-      test(new Map());
-    });
-  });
 });

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -86,7 +86,7 @@ export default class ApiLog extends CommonBase {
    */
   incomingMessage(msg) {
     const details = {
-      msg: this._redactMessage(msg),
+      msg:       msg.logInfo,
       startTime: Date.now()
     };
 
@@ -111,26 +111,7 @@ export default class ApiLog extends CommonBase {
     };
 
     // **TODO:** This will ultimately need to redact some information beyond
-    // what `_redactMessage()` might have done.
+    // what `msg.logInfo` might have done.
     this._log.event.apiReturned(details);
-  }
-
-  /**
-   * Performs redaction on a message, so as to avoid logging sensitive security
-   * and user-data details.
-   *
-   * @param {Message} msg The original message.
-   * @returns {Message} The redacted form.
-   */
-  _redactMessage(msg) {
-    const targetId = msg.targetId;
-
-    if (this._tokenAuth.isToken(targetId)) {
-      const token = this._tokenAuth.tokenFromString(targetId);
-      msg = msg.withTargetId(token.safeString);
-    }
-
-    // **TODO:** This will ultimately need to do more redaction.
-    return msg;
   }
 }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -5,8 +5,6 @@
 import { BaseLogger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
 
-import BaseTokenAuthorizer from './BaseTokenAuthorizer';
-
 /**
  * Handler of the logging of API calls.
  */
@@ -15,17 +13,12 @@ export default class ApiLog extends CommonBase {
    * Constructs an instance.
    *
    * @param {Logger} log Logger to use.
-   * @param {BaseTokenAuthorizer} tokenAuth Token authorizer. Just used for
-   *   token parsing (to handle redaction).
    */
-  constructor(log, tokenAuth) {
+  constructor(log) {
     super();
 
     /** {BaseLogger} Logger to use. */
     this._log = BaseLogger.check(log);
-
-    /** {BaseTokenAuthorizer} Token authorizer. Just used for token parsing. */
-    this._tokenAuth = BaseTokenAuthorizer.check(tokenAuth);
 
     /**
      * {Map<Message,object>} Map from messages that haven't yet been completely

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -55,7 +55,7 @@ export default class BaseConnection extends CommonBase {
     this._codec = this._context.codec;
 
     /** {ApiLog} The API logger to use. */
-    this._apiLog = new ApiLog(this._log, this._context.tokenAuthorizer);
+    this._apiLog = new ApiLog(this._log);
 
     /** {boolean} Whether the connection should be aiming to become closed. */
     this._closing = false;

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -278,6 +278,15 @@ export default class BaseConnection extends CommonBase {
     }
 
     if (msg instanceof Message) {
+      const auth     = this._context.tokenAuthorizer;
+      const targetId = msg.targetId;
+
+      if (auth.isToken(targetId)) {
+        // The `targetId` is a token string. Replace the string with an actual
+        // `BearerToken` instance.
+        return msg.withTargetId(auth.tokenFromString(targetId));
+      }
+
       return msg;
     }
 

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -6,38 +6,19 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken, Message } from '@bayou/api-common';
-import { BaseTokenAuthorizer } from '@bayou/api-server';
 import { MockLogger } from '@bayou/see-all/mocks';
 import { Functor } from '@bayou/util-common';
 
 // Not an exported class, so we have to import it as a file.
 import ApiLog from '../ApiLog';
 
-/**
- * Partial and simple implementation of {@link BaseTokenAuthorizer}. Only
- * includes what's required for testing.
- */
-class MockTokenAuthorizer extends BaseTokenAuthorizer {
-  isToken(string) {
-    return /^token-/.test(string);
-  }
-
-  tokenFromString(string) {
-    const match = string.match(/^token-(.*)$/);
-    const id    = `id-${match[1]}`;
-
-    return new BearerToken(id, string);
-  }
-}
-
 describe('@bayou/api-server/ApiLog', () => {
   describe('incomingMessage()', () => {
     it('should log the redacted form of target when the target is a token', () => {
-      const logger  = new MockLogger();
-      const tokAuth = new MockTokenAuthorizer();
-      const apiLog  = new ApiLog(logger, tokAuth);
-      const token   = tokAuth.tokenFromString('token-123xyz');
-      const msg     = new Message(123, token, new Functor('x', 'y'));
+      const logger = new MockLogger();
+      const apiLog = new ApiLog(logger);
+      const token  = new BearerToken('foo', 'foo-bar');
+      const msg    = new Message(123, token, new Functor('x', 'y'));
 
       apiLog.incomingMessage(msg);
 

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -37,7 +37,7 @@ describe('@bayou/api-server/ApiLog', () => {
       const tokAuth = new MockTokenAuthorizer();
       const apiLog  = new ApiLog(logger, tokAuth);
       const token   = tokAuth.tokenFromString('token-123xyz');
-      const msg     = new Message(123, token.secretToken, new Functor('x', 'y'));
+      const msg     = new Message(123, token, new Functor('x', 'y'));
 
       apiLog.incomingMessage(msg);
 
@@ -49,17 +49,12 @@ describe('@bayou/api-server/ApiLog', () => {
       const payload = record[0][2];
 
       // The payload is of the form `apiReceived({ msg: ... })`, and we are
-      // just going to be asserting on the `msg` part.
+      // just going to be asserting on the `msg` part, which should be the
+      // result of `Message.logInfo`, which is an ad-hoc plain object. For this
+      // test, we _just_ care about the `targetId`.
       assert.instanceOf(payload, Functor);
       const loggedMsg = payload.args[0].msg;
-
-      // This should be the encoded form of a `Message`, which is itself a
-      // three-argument functor, the second argument being the ID.
-      assert.instanceOf(loggedMsg, Functor);
-      const loggedId = loggedMsg.args[1];
-
-      // The actual point of this unit test.
-      assert.strictEqual(loggedId, `${token.id}-...`);
+      assert.strictEqual(loggedMsg.targetId, token.safeString);
     });
   });
 });


### PR DESCRIPTION
When a connection gets closed, the client will report a bunch of `rejectDuringTermination` events. I noticed that I'd failed to redact the `Message` instances in these events. Fixing that redaction problem in a sensible way meant changing `Message` to accept `BearerToken` instances in addition to plain strings. (Strings are still used in the case where a `Message`'s target is a non-token target ID that's specific to the API session.) With the change to `Message` I could then (a) properly redact the termination events, and (b) remove redaction that was being performed in a more clumsy way elsewhere in the code.
