### PR TITLE
Add explicit `BodyClient` state transitions when it expects Quill to be enabled and disabled.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -212,19 +212,6 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Validates a `gotUpdate` event. This represents a successful result
-   * from the API call `body_update()`.
-   *
-   * @param {BodyDelta} delta The delta that was originally applied.
-   * @param {BodyChange} correctedChange The correction to the expected
-   *   result as returned from `body_update()`.
-   */
-  _check_gotUpdate(delta, correctedChange) {
-    BodyDelta.check(delta);
-    BodyChange.check(correctedChange);
-  }
-
-  /**
    * Validates a `gotChangeAfter` event. This represents a successful result
    * from the API call `body_getChangeAfter()`.
    *
@@ -250,6 +237,19 @@ export default class BodyClient extends StateMachine {
    */
   _check_gotQuillEvent(baseRevNum) {
     TInt.nonNegative(baseRevNum);
+  }
+
+  /**
+   * Validates a `gotUpdate` event. This represents a successful result
+   * from the API call `body_update()`.
+   *
+   * @param {BodyDelta} delta The delta that was originally applied.
+   * @param {BodyChange} correctedChange The correction to the expected
+   *   result as returned from `body_update()`.
+   */
+  _check_gotUpdate(delta, correctedChange) {
+    BodyDelta.check(delta);
+    BodyChange.check(correctedChange);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -463,16 +463,12 @@ export default class BodyClient extends StateMachine {
       this._running = false;
     }
 
-    if (this._manageEnabledState) {
-      // As soon as we're trying to stop, we should prevent the user from doing
-      // any editing.
-      this._quill.disable();
-    }
-
-    // Go into the `detached` state. In that state, additional incoming events
-    // will get ignored, except for `start` which will bring the client back to
-    // life.
-    this.s_detached();
+    // As soon as we're trying to stop, we should prevent the user from doing
+    // any editing. And having disabled editing, we should just go back to being
+    // in the `detached` state. In that state, additional incoming events will
+    // get ignored, except for `start` which will bring the client back to life.
+    this.s_becomeDisabled();
+    this.q_nextState(this.s_detached);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -6,7 +6,7 @@ import { ConnectionError } from '@bayou/api-common';
 import { BodyChange, BodyDelta, BodyOp, BodySnapshot } from '@bayou/doc-common';
 import { Delay } from '@bayou/promise-util';
 import { QuillEvents, QuillUtil } from '@bayou/quill-util';
-import { TInt, TString } from '@bayou/typecheck';
+import { TFunction, TInt, TString } from '@bayou/typecheck';
 import { StateMachine } from '@bayou/state-machine';
 import { Errors, Functor, InfoError } from '@bayou/util-common';
 
@@ -253,6 +253,19 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
+   * Validates a `nextState` event. This event is used when transitioning
+   * through the states `becomeEnabled` and `becomeDisables`, so that they (a)
+   * have an event to act on, and (b) know what state to transition to after the
+   * act of enabling or disabling.
+   *
+   * @param {function} stateFunction The `s_*` function which corresponds to the
+   *   desired next state.
+   */
+  _check_nextState(stateFunction) {
+    TFunction.checkCallable(stateFunction);
+  }
+
+  /**
    * Validates a `start` event. This is the event that kicks off the client.
    */
   _check_start() {
@@ -478,6 +491,36 @@ export default class BodyClient extends StateMachine {
    */
   _handle_any_wantInputAfterDelay() {
     // Nothing to do.
+  }
+
+  /**
+   * In state `becomeDisabled`, handles event `nextState`. This is where the
+   * Quill instance gets disabled, but only if this instance is managing the
+   * enabled state (depends on a constructor parameter); if not, it is during a
+   * transition to this state that clients of this class should tell the Quill
+   * instance to become disabled. In either case, this instance immediately
+   * transitions into the state indicated by `stateFunction`.
+   *
+   * @param {function} stateFunction The `s_*` function which corresponds to the
+   *   desired next state.
+   */
+  _handle_becomeDisabled_nextState(stateFunction) {
+    // **TODO:** Fill this in.
+  }
+
+  /**
+   * In state `becomeEnabled`, handles event `nextState`. This is where the
+   * Quill instance gets enabled, but only if this instance is managing the
+   * enabled state (depends on a constructor parameter); if not, it is during a
+   * transition to this state that clients of this class should tell the Quill
+   * instance to become enabled. In either case, this instance immediately
+   * transitions into the state indicated by `stateFunction`.
+   *
+   * @param {function} stateFunction The `s_*` function which corresponds to the
+   *   desired next state.
+   */
+  _handle_becomeEnabled_nextState(stateFunction) {
+    // **TODO:** Fill this in.
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -683,17 +683,8 @@ export default class BodyClient extends StateMachine {
 
     // And with that, it's now safe to enable Quill so that it will accept user
     // input, if editing is enabled.
-    if (this._manageEnabledState) {
-      this._quill.enable();
-
-      // Focus the editor area so the user can start typing right away
-      // rather than make them have to click-to-focus first.
-      QuillUtil.editorDiv(this._quill).focus();
-    }
-
-    // Head into our first iteration of idling while waiting for changes coming
-    // in locally (from quill) or from the server.
-    this._becomeIdle();
+    this.s_becomeEnabled();
+    this.q_start();
   }
 
   /**

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -144,6 +144,19 @@ export default class StateMachine {
   }
 
   /**
+   * Causes the instance to be in a new state.
+   *
+   * @param {string} stateName The name of the new state.
+   */
+  set state(stateName) {
+    TString.check(stateName);
+
+    // Rather than recapitulate the logic of changing state, just call through
+    // to the appropriate `s_*` method.
+    this[`s_${stateName}`]();
+  }
+
+  /**
    * Adds to this instance two methods per event name, named `q_<name>` and
    * `p_<name>`, each of which takes any number of arguments and enqueues an
    * event with the associated name and the given arguments. `q_*` methods

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.13
+version = 1.2.14


### PR DESCRIPTION
So that clients of `BodyClient` don't have to bake in deep knowledge of the class, this PR introduces two new states, `becomeEnabled` and `becomeDisabled`, which instances transition through to indicate moments when the controlled Quill instance should become enabled and disabled (respectively). So, as a client of the class, one can now write something like:

```
await bodyClient.when_becomeDisabled();
quill.disable();
[... whatever else is needed by the higher layer to react to disabling ...]
```

Similarly for enabling.
