### PR TITLE
Get `BodyClient` into `detached` state after `unrecoverableError`.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -370,8 +370,7 @@ export default class BodyClient extends StateMachine {
 
       // Stop the user from trying to do more edits, as they'd get lost, and
       // then hang out in `errorWait` until the above delay completes.
-      this.s_becomeDisabled();
-      this.p_nextState('errorWait');
+      this._becomeDisabled('errorWait');
     }
   }
 
@@ -439,8 +438,7 @@ export default class BodyClient extends StateMachine {
     // any editing. And having disabled editing, we should just go back to being
     // in the `detached` state. In that state, additional incoming events will
     // get ignored, except for `start` which will bring the client back to life.
-    this.s_becomeDisabled();
-    this.p_nextState('detached');
+    this._becomeDisabled('detached');
   }
 
   /**
@@ -1005,8 +1003,7 @@ export default class BodyClient extends StateMachine {
 
     // Stop the user from trying to do more edits, as they'd get lost, and then
     // transition into `detached`.
-    this.s_becomeDisabled();
-    this.p_nextState('detached');
+    this._becomeDisabled('detached');
   }
 
   //
@@ -1023,6 +1020,20 @@ export default class BodyClient extends StateMachine {
 
     this._errorStamps = this._errorStamps.filter(value => (value >= agedOut));
     this._errorStamps.push(now);
+  }
+
+  /**
+   * Sets up the client to transition through the `becomeDisabled` state to
+   * another specified state. This transition is what clients of this class can
+   * listen to, in order for them to trigger the actual disabling of the Quill
+   * instance.
+   *
+   * @param {string} nextState The state to transition to after (briefly) being
+   *   in the `becomeDisabled` state.
+   */
+  _becomeDisabled(nextState) {
+    this.s_becomeDisabled();
+    this.p_nextState(nextState);
   }
 
   /**
@@ -1259,8 +1270,6 @@ export default class BodyClient extends StateMachine {
     // Bounce into the `becomeDisabled` state, to perform the actual acts of
     // disabling, and then return to whatever state we're in now, so as to
     // complete the pending action.
-    const currentState = this.state;
-    this.s_becomeDisabled();
-    this.p_nextState(currentState);
+    this._becomeDisabled(this.state);
   }
 }

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -314,36 +314,10 @@ export default class BodyClient extends StateMachine {
   // Event handlers.
   //
   // These are ordered from most generic to most specific. In particular,
-  // `stateName_eventName` is most specific, `any_eventName` is middle-of-the-
-  // road, and `stateName_any` is most generic (that is, the last form only gets
+  // `stateName_eventName` is most specific, `stateName_any` is middle-of-the-
+  // road, and `any_eventName` is most generic (that is, the last form only gets
   // invoked if neither other form matches).
   //
-
-  /**
-   * In state `errorWait`, handles most events.
-   *
-   * @param {string} name The event name.
-   * @param {...*} args The event arguments.
-   */
-  _handle_errorWait_any(name, ...args) {
-    // This space intentionally left blank (except for logging): We might get
-    // "zombie" events from a connection that's shuffling towards doom. But even
-    // if so, we will already have set up a timer to reset the connection.
-    this.log.event.eventWhenErrorWait(new Functor(name, ...args));
-  }
-
-  /**
-   * In state `unrecoverableError`, handles all events. Specifically, this does
-   * nothing, and no further events can be expected. Client code of this class
-   * can use the transition into this state to perform higher-level error
-   * recovery.
-   *
-   * @param {string} name The event name.
-   * @param {...*} args The event arguments.
-   */
-  _handle_unrecoverableError_any(name, ...args) {
-    this.log.event.eventWhenUnrecoverable(new Functor(name, ...args));
-  }
 
   /**
    * In any state, handles event `apiError`. This is a "normal" occurrence if
@@ -494,6 +468,32 @@ export default class BodyClient extends StateMachine {
    */
   _handle_any_wantInputAfterDelay() {
     // Nothing to do.
+  }
+
+  /**
+   * In state `errorWait`, handles all events.
+   *
+   * @param {string} name The event name.
+   * @param {...*} args The event arguments.
+   */
+  _handle_errorWait_any(name, ...args) {
+    // This space intentionally left blank (except for logging): We might get
+    // "zombie" events from a connection that's shuffling towards doom. But even
+    // if so, we will already have set up a timer to reset the connection.
+    this.log.event.eventWhenErrorWait(new Functor(name, ...args));
+  }
+
+  /**
+   * In state `unrecoverableError`, handles all events. Specifically, this does
+   * nothing, and no further events can be expected. Client code of this class
+   * can use the transition into this state to perform higher-level error
+   * recovery.
+   *
+   * @param {string} name The event name.
+   * @param {...*} args The event arguments.
+   */
+  _handle_unrecoverableError_any(name, ...args) {
+    this.log.event.eventWhenUnrecoverable(new Functor(name, ...args));
   }
 
   /**

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -42,7 +42,8 @@ import { Errors, Functor, PropertyIterable } from '@bayou/util-common';
  *   no more specific handler. In the case of an `any` event name, the event
  *   name itself is prepended to the event arguments. **Note:** If there are
  *   matching handlers for both (state, any-event) and (any-state, event), then
- *   the former "wins."
+ *   the former "wins." That is, `_handle_stateName_any()` takes precedence over
+ *   `_handle_any_eventName()`.
  *
  * Constructing an instance will cause the instance to have two methods added
  * per named event, `q_<name>` and `p_<name>`, each of which takes any number of

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -82,7 +82,9 @@ export default class StateMachine {
     TString.check(initialState);
 
     /** {BaseLogger} Logger to use. */
-    this._log = (logger === null) ? new Logger('state-machine') : BaseLogger.check(logger);
+    this._log = (logger === null)
+      ? new Logger('state-machine')
+      : BaseLogger.check(logger).withAddedContext('sm');
 
     /** {boolean} Whether to be particularly chatty in the logs. */
     this._verboseLogging = TBoolean.check(verboseLogging);
@@ -259,37 +261,6 @@ export default class StateMachine {
   }
 
   /**
-   * Dispatches the first event on the queue. If the queue is empty, waits for
-   * an event to be enqueued, or for the instance to be shut down.
-   *
-   * @returns {boolean} `true` iff the instance should still be considered
-   *   active; `false` means it is being shut down.
-   */
-  async _dispatchOne() {
-    for (;;) {
-      // Check to see if we're done (either idle or shutting down).
-      if (this._eventQueue === null) {
-        // Shutting down.
-        return false;
-      } else if (this._eventQueue.length === 0) {
-        // Idle.
-        this._anyEventPending.value = false;
-        await this._anyEventPending.whenTrue();
-      } else {
-        // There's an event!
-        break;
-      }
-    }
-
-    // Grab the first event on the queue, and dispatch it.
-    const event = this._eventQueue.shift();
-    await this._dispatchEvent(event);
-
-    // The instance is still active.
-    return true;
-  }
-
-  /**
    * Dispatches the given event.
    *
    * @param {Functor} event The event.
@@ -326,6 +297,37 @@ export default class StateMachine {
     if ((this._eventCount % 25) === 0) {
       log.event.eventsHandled(this._eventCount);
     }
+  }
+
+  /**
+   * Dispatches the first event on the queue. If the queue is empty, waits for
+   * an event to be enqueued, or for the instance to be shut down.
+   *
+   * @returns {boolean} `true` iff the instance should still be considered
+   *   active; `false` means it is being shut down.
+   */
+  async _dispatchOne() {
+    for (;;) {
+      // Check to see if we're done (either idle or shutting down).
+      if (this._eventQueue === null) {
+        // Shutting down.
+        return false;
+      } else if (this._eventQueue.length === 0) {
+        // Idle.
+        this._anyEventPending.value = false;
+        await this._anyEventPending.whenTrue();
+      } else {
+        // There's an event!
+        break;
+      }
+    }
+
+    // Grab the first event on the queue, and dispatch it.
+    const event = this._eventQueue.shift();
+    await this._dispatchEvent(event);
+
+    // The instance is still active.
+    return true;
   }
 
   /**
@@ -428,12 +430,16 @@ export default class StateMachine {
    * the instance has gotten halted (most likely due to an external error).
    */
   async _serviceEventQueue() {
+    this._log.event.running();
+
     for (;;) {
       const stillActive = await this._dispatchOne();
       if (!stillActive) {
         break;
       }
     }
+
+    this._log.event.stopped();
   }
 
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.14
+version = 1.2.15


### PR DESCRIPTION
This PR is meant to make it possible for clients of `BodyClient` to continue to use the same instance after that instance has declared itself to be "unrecoverable." Per docs in the class, the "unrecoverability" is only that the class itself has nothing else to do, but it's a-okay — and encouraged! — for users of the class to perform higher-level recovery as necessary and then reïssue a call to `bodyClient.start()`.

Before this PR, though the aforementioned was the _intent_, the reality was that once an instance landed in the `unrecoverableError` state, there was no way to get it to snap out of its torpor. This PR fixes that problem; instead of staying in `unrecoverableError`, that state becomes transitory (similar to the recently-introduced `becomeDisabled` and `becomeEnabled` states), and once an instance has given up, it lands back in the `detached` state (same as when it was first instantiated), which is exactly where it should be should a benevolent external force fix things — or perhaps just wait a while — and call `start()`.