### PR TITLE
Clean up `BaseFile` and subclass, and minor expansion.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -479,11 +479,11 @@ export default class BaseControl extends BaseDataManager {
    * request a revision that is _no longer_ available; in this case, the error
    * name is always `revisionNotAvailable`.
    *
-   * @param {Int|null} revNum Which revision to get. If passed as `null`,
-   *   indicates the current (most recent) revision. **Note:** Due to the
-   *   asynchronous nature of the system, when passed as `null` the resulting
-   *   revision might already have been superseded by the time it is returned to
-   *   the caller.
+   * @param {Int|null} [revNum = null] Which revision to get. If passed as
+   *   `null`, indicates the current (most recent) revision. **Note:** Due to
+   *   the asynchronous nature of the system, when passed as `null` the
+   *   resulting revision might already have been superseded by the time it is
+   *   returned to the caller.
    * @returns {BaseSnapshot} Snapshot of the indicated revision. Always an
    *   instance of the concrete snapshot type appropriate for this instance.
    */

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -252,11 +252,11 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec.
    * @returns {Int} The instantaneously current revision number of the file.
    */
-  async _impl_currentRevNum(timeoutMsec = null) {
+  async _impl_currentRevNum(timeoutMsec) {
     await this._readStorageIfNecessaryWithTimeout(timeoutMsec);
 
     return this._currentRevNum;
@@ -295,8 +295,8 @@ export default class LocalFile extends BaseFile {
   * Implementation as required by the superclass.
    *
    * @param {Int} revNum Which revision to get.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec.
    * @returns {FileSnapshot|null} Snapshot of the indicated revision, if
    *   available.
    */

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -284,6 +284,20 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
+  * Implementation as required by the superclass.
+   *
+   * @param {Int} revNum Which revision to get.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec.
+   * @returns {FileSnapshot|null} Snapshot of the indicated revision, if
+   *   available.
+   */
+  async _impl_getSnapshot(revNum, timeoutMsec) {
+    // **TODO:** Fill this in.
+    return this._mustOverride(revNum, timeoutMsec);
+  }
+
+  /**
    * Implementation as required by the superclass.
    *
    * @param {StoragePath} storagePath The storage path to use to get the

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -203,7 +203,7 @@ export default class LocalFile extends BaseFile {
   /**
    * Reads the file storage if it has not yet been loaded by given timeout.
    *
-   * @param {int} timeoutMsec The amount of time before reading storage is
+   * @param {Int|null} timeoutMsec The amount of time before reading storage is
    *   aborted and timeout error thrown.
    */
   async _readStorageIfNecessaryWithTimeout(timeoutMsec) {
@@ -275,10 +275,12 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec.
    * @returns {Int} The instantaneously current revision number of the file.
    */
-  async _impl_currentRevNum() {
-    await this._readStorageIfNecessary();
+  async _impl_currentRevNum(timeoutMsec = null) {
+    await this._readStorageIfNecessaryWithTimeout(timeoutMsec);
 
     return this._currentRevNum;
   }

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -275,6 +275,17 @@ export default class LocalFile extends BaseFile {
   /**
    * Implementation as required by the superclass.
    *
+   * @returns {Int} The instantaneously current revision number of the file.
+   */
+  async _impl_currentRevNum() {
+    await this._readStorageIfNecessary();
+
+    return this._currentRevNum;
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
    * @param {StoragePath} storagePath The storage path to use to get the
    *   data to validate.
    * @param {FrozenBuffer} hash Hash to validate against.

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -197,9 +197,7 @@ export default class LocalFile extends BaseFile {
    * @param {FileChange} fileChange Change to append. Must be an
    *   instance FileChange.
    * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
-   *   in msec. This value will be silently clamped to the allowable range as
-   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
-   *   value.
+   *   in msec.
    * @returns {boolean} Success flag. `true` indicates that the change was
    *   appended, and `false` indicates that the operation failed due to a lost
    *   append race.
@@ -311,10 +309,8 @@ export default class LocalFile extends BaseFile {
    * @param {StoragePath} storagePath The storage path to use to get the
    *   data to validate.
    * @param {FrozenBuffer} hash Hash to validate against.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec.
    * @abstract
    */
   async _impl_whenPathIsNot(storagePath, hash, timeoutMsec) {

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -102,30 +102,12 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Main implementation of `create()`.
-   *
-   * @abstract
-   */
-  async _impl_create() {
-    this._mustOverride();
-  }
-
-  /**
    * Deletes the storage for this file if it exists. This does nothing if the
    * file does not exist. Immediately after this call returns successfully, the
    * file is guaranteed not to exist.
    */
   async delete() {
     await this._impl_delete();
-  }
-
-  /**
-   * Main implementation of `delete()`.
-   *
-   * @abstract
-   */
-  async _impl_delete() {
-    this._mustOverride();
   }
 
   /**
@@ -138,16 +120,6 @@ export default class BaseFile extends CommonBase {
     const result = this._impl_exists();
 
     return TBoolean.check(await result);
-  }
-
-  /**
-   * Main implementation of `exists()`.
-   *
-   * @abstract
-   * @returns {boolean} `true` iff this file exists.
-   */
-  async _impl_exists() {
-    this._mustOverride();
   }
 
   /**
@@ -206,14 +178,14 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Abstract implementation of `appendChange()`.
-   * Appends a new change to the document. On success, this returns `true`.
+   * Subclass-specific implementation of {@link #appendChange}. Appends a new
+   * change to the document. On success, this returns `true`.
    *
    * It is an error to call this method on a file that doesn't exist, in the
-   * sense of the `exists()` method. That is, if `exists()` would return
-   * `false`, then this method will fail.
+   * sense of the method {@link #exists} method. That is, if {@link #exists}
+   * would return `false`, then this method will fail.
    *
-   * Each subclass implements its own version of `appendChange()`.
+   * Subclasses must override this method.
    *
    * @abstract
    * @param {FileChange} fileChange Change to append. Must be an
@@ -232,9 +204,39 @@ export default class BaseFile extends CommonBase {
   }
 
   /**
-   * Abstract implementation of `whenPathIsNot()`
+   * Subclass-specific implementation of {@link #create}. Subclasses must
+   * override this method.
    *
-   * Each subclass implements its own version.
+   * @abstract
+   */
+  async _impl_create() {
+    this._mustOverride();
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #delete}. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   */
+  async _impl_delete() {
+    this._mustOverride();
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #exists}. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   * @returns {boolean} `true` iff this file exists.
+   */
+  async _impl_exists() {
+    this._mustOverride();
+  }
+
+  /**
+   * Subclass-specific implementation of {@link #whenPathIsNot}. Subclasses must
+   * override this method.
    *
    * @param {StoragePath} storagePath The storage path to use to get the
    *   data to validate.
@@ -246,8 +248,6 @@ export default class BaseFile extends CommonBase {
    * @abstract
    */
   async _impl_whenPathIsNot(storagePath, hash, timeoutMsec) {
-    await this._mustOverride(storagePath, hash, timeoutMsec);
-
-    return;
+    this._mustOverride(storagePath, hash, timeoutMsec);
   }
 }

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -274,10 +274,12 @@ export default class BaseFile extends CommonBase {
    * override this method.
    *
    * @abstract
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec.
    * @returns {Int} The instantaneously current revision number of the file.
    */
-  async _impl_currentRevNum() {
-    return this._mustOverride();
+  async _impl_currentRevNum(timeoutMsec) {
+    return this._mustOverride(timeoutMsec);
   }
 
   /**

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -114,8 +114,8 @@ export default class BaseFile extends CommonBase {
    *
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   *   range as defined by {@link #clampTimeoutMsec}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {Int} The instantaneously-current revision number.
    */
   async currentRevNum(timeoutMsec = null) {
@@ -154,8 +154,8 @@ export default class BaseFile extends CommonBase {
    * @param {FileChange} fileChange Change to append.
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   *   range as defined by {@link #clampTimeoutMsec}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {boolean} Success flag. `true` indicates that the change was
    *   appended, and `false` indicates that the operation failed due to a lost
    *   append race.
@@ -184,8 +184,8 @@ export default class BaseFile extends CommonBase {
    *   returned to the caller.
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   *   range as defined by {@link #clampTimeoutMsec}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {FileSnapshot} Snapshot of the indicated revision.
    */
   async getSnapshot(revNum = null, timeoutMsec = null) {
@@ -221,8 +221,8 @@ export default class BaseFile extends CommonBase {
    * @param {FrozenBuffer} hash Hash to validate against.
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   *   range as defined by {@link #clampTimeoutMsec}. `null` is treated as the
+   *   maximum allowed value.
    */
   async whenPathIsNot(storagePath, hash, timeoutMsec) {
     StoragePath.check(storagePath);

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -248,8 +248,8 @@ export default class BaseFile extends CommonBase {
    *   instance of FileChange.
    * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
    *   in msec. This value will be silently clamped to the allowable range as
-   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
-   *   value.
+   *   defined by {@link #clampTimeoutMsec}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {boolean} Success flag. `true` indicates that the change was
    *   appended, and `false` indicates that the operation failed due to a lost
    *   append race.
@@ -276,8 +276,8 @@ export default class BaseFile extends CommonBase {
    * @abstract
    * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
    *   in msec. This value will be silently clamped to the allowable range as
-   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
-   *   value.
+   *   defined by {@link #clampTimeoutMsec}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {Int} The instantaneously current revision number of the file.
    */
   async _impl_currentRevNum(timeoutMsec) {
@@ -314,8 +314,8 @@ export default class BaseFile extends CommonBase {
    *   number for the instantaneously-current revision or earlier.
    * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
    *   in msec. This value will be silently clamped to the allowable range as
-   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
-   *   value.
+   *   defined by {@link #clampTimeoutMsec}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {FileSnapshot|null} Snapshot of the indicated revision. A return
    *   value of `null` specifically indicates that `revNum` is a revision older
    *   than what this instance can provide (and will cause this class to report
@@ -335,9 +335,9 @@ export default class BaseFile extends CommonBase {
    * @param {StoragePath} storagePath The storage path to use to get the
    *   data to validate.
    * @param {FrozenBuffer} hash Hash to validate against.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec. This value will be silently clamped to the allowable range as
+   *   defined by {@link #clampTimeoutMsec}. `null` is treated as the maximum
    *   allowed value.
    */
   async _impl_whenPathIsNot(storagePath, hash, timeoutMsec) {

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -274,8 +274,10 @@ export default class BaseFile extends CommonBase {
    * override this method.
    *
    * @abstract
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec. This value will be silently clamped to the allowable range as
+   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
+   *   value.
    * @returns {Int} The instantaneously current revision number of the file.
    */
   async _impl_currentRevNum(timeoutMsec) {
@@ -310,10 +312,10 @@ export default class BaseFile extends CommonBase {
    * @abstract
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec. This value will be silently clamped to the allowable range as
+   *   defined by {@link Timeouts}. `null` is treated as the maximum allowed
+   *   value.
    * @returns {FileSnapshot|null} Snapshot of the indicated revision. A return
    *   value of `null` specifically indicates that `revNum` is a revision older
    *   than what this instance can provide (and will cause this class to report


### PR DESCRIPTION
In preparation for more serious work on these files, I did a cleanup pass over `file-store.BaseFile` and its concrete subclass. By way of context, `BaseFile` and `LocalFile` are two of our older classes, and they predated the nailing down of some of our conventions. Highlights of the work:

* Sorted methods according to our nominal standard.
* Fixed documentation for nit-picky accuracy and parallel wording / markup to other files.

In addition to the cleanup, I added two new methods to the base class, `currentRevNum()` and `getSnapshot()`, which are defined to do pretty much what you'd expect. Neither method is used by the code yet, and the latter is still just stubbed out (the former was a pretty tiny implementation so NBD to roll it into this PR). I left salient `TODO`s in the code.

**Note to reviewers:** Don't get too stressed by the size of the diffs. It's just that Github doesn't really know how to show code reordering very well. There's actually no change to any preëxisting method bodies in this PR.