### PR TITLE
Fill in new `file-store` methods, and use them just a little.

### DIFF
--- a/local-modules/@bayou/app-setup/ServerUtil.js
+++ b/local-modules/@bayou/app-setup/ServerUtil.js
@@ -99,7 +99,7 @@ export default class ServerUtil extends UtilityClass {
    * @param {string|null} head HTML head text if any, or `null` to not include
    *   a `<head>` section.
    * @param {string} body HTML body text.
-   * @param {int} [statusCode = 200] The response status code.
+   * @param {Int} [statusCode = 200] The response status code.
    */
   static sendHtmlResponse(res, head, body, statusCode = 200) {
     head = (head === null)
@@ -118,7 +118,7 @@ export default class ServerUtil extends UtilityClass {
    * @param {http.ServerResponse} res The response object representing the
    *   connection to send to.
    * @param {object} body The body of the response, as a JSON-encodable object.
-   * @param {int} [statusCode = 200] The response status code.
+   * @param {Int} [statusCode = 200] The response status code.
    */
   static sendJsonResponse(res, body, statusCode = 200) {
     const text = `${JSON.stringify(body, null, 2)}\n`;
@@ -132,7 +132,7 @@ export default class ServerUtil extends UtilityClass {
    * @param {http.ServerResponse} res The response object representing the
    *   connection to send to.
    * @param {string} body The body of the response, as a string.
-   * @param {int} [statusCode = 200] The response status code.
+   * @param {Int} [statusCode = 200] The response status code.
    */
   static sendPlainTextResponse(res, body, statusCode = 200) {
     ServerUtil.sendTextResponse(res, body, 'text/plain', statusCode);
@@ -146,7 +146,7 @@ export default class ServerUtil extends UtilityClass {
    * @param {string} body The body of the response, as a string.
    * @param {string} contentType The content type, _without_ a charset. (The
    *   charset is always set to be `utf-8`.)
-   * @param {int} statusCode The response status code.
+   * @param {Int} statusCode The response status code.
    */
   static sendTextResponse(res, body, contentType, statusCode) {
     res

--- a/local-modules/@bayou/client-bundle/ClientBundle.js
+++ b/local-modules/@bayou/client-bundle/ClientBundle.js
@@ -144,9 +144,10 @@ export default class ClientBundle extends Singleton {
     const bundles = this._currentBundles;
 
     if (bundles.size === 0) {
-      // This request came in before bundles have ever been built. Instead of
-      // trying to get too fancy, we just wait a second and retry (and maybe
-      // retry again, etc.).
+      // This request came in before bundles have ever been built, but we know
+      // by virtue of being here that they are in the process of being built.
+      // Instead of trying to get too fancy, we just wait a second and recheck
+      // (and maybe recheck yet again, etc.).
       this._log.event.waitingForBundles();
       while (bundles.size === 0) {
         await Delay.resolve(1000);

--- a/local-modules/@bayou/client-bundle/ClientBundle.js
+++ b/local-modules/@bayou/client-bundle/ClientBundle.js
@@ -5,6 +5,7 @@
 import memory_fs from 'memory-fs';
 import webpack from 'webpack';
 
+import { Delay } from '@bayou/promise-util';
 import { Singleton } from '@bayou/util-common';
 
 import WebpackConfig from './WebpackConfig';
@@ -139,15 +140,18 @@ export default class ClientBundle extends Singleton {
    * @param {function} next Function to call to execute the next handler in the
    *   chain.
    */
-  _requestHandler(req, res, next) {
+  async _requestHandler(req, res, next) {
     const bundles = this._currentBundles;
 
     if (bundles.size === 0) {
       // This request came in before bundles have ever been built. Instead of
-      // trying to get too fancy, we just wait a second and retry (which itself
-      // might end up waiting some more).
-      setTimeout(() => { this._requestHandler(req, res, next); }, 1000);
-      return;
+      // trying to get too fancy, we just wait a second and retry (and maybe
+      // retry again, etc.).
+      this._log.event.waitingForBundles();
+      while (bundles.size === 0) {
+        await Delay.resolve(1000);
+      }
+      this._log.event.doneWaitingForBundles();
     }
 
     const name = req.params.name;

--- a/local-modules/@bayou/client-bundle/package.json
+++ b/local-modules/@bayou/client-bundle/package.json
@@ -3,6 +3,7 @@
     "@bayou/deps-compiler": "local",
     "@bayou/deps-util-server": "local",
     "@bayou/env-server": "local",
+    "@bayou/promise-util": "local",
     "@bayou/see-all": "local",
     "@bayou/testing-server": "local",
     "@bayou/util-common": "local"

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -101,7 +101,7 @@ export default class BodyClient extends StateMachine {
    *   (`true`) or not (`false`) this instance should automatically manage the
    *   "enabled" state of `quill`. If `false`, it is up to clients of this class
    *   to use `quill.enable()` and `quill.disable()`.
-   * @param {int} [pollingDelayMsec = 0] Delay in msecs to wait before
+   * @param {Int} [pollingDelayMsec = 0] Delay in msecs to wait before
    *   transitioning from `wantInputAfterDelay` to `wantInput`.
    */
   constructor(quill, docSession, manageEnabledState = true, pollingDelayMsec = 0) {
@@ -119,7 +119,7 @@ export default class BodyClient extends StateMachine {
      */
     this._manageEnabledState = manageEnabledState;
 
-    /** {int} Delay between polling for changes, 0 by default. */
+    /** {Int} Delay between polling for changes, 0 by default. */
     this._pollingDelayMsec = pollingDelayMsec;
 
     /**
@@ -293,7 +293,7 @@ export default class BodyClient extends StateMachine {
   /**
    * Validates a `wantInputAfterDelay` event.
    *
-   * @param {int} delayMsec Msec to wait before firing `wantInput`.
+   * @param {Int} delayMsec Msec to wait before firing `wantInput`.
    */
   _check_wantInputAfterDelay(delayMsec) {
     TInt.nonNegative(delayMsec);
@@ -844,7 +844,7 @@ export default class BodyClient extends StateMachine {
    * after a configured delay, which will make requests both to the server and
    * to the local Quill instance.
    *
-   * @param {int} delayMsec Msec to wait before firing `wantInput`.
+   * @param {Int} delayMsec Msec to wait before firing `wantInput`.
    */
   async _handle_idle_wantInputAfterDelay(delayMsec) {
     // Fire off the next iteration of requesting server changes, after a delay.

--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -27,7 +27,7 @@ export default class BodySnapshot extends BaseSnapshot {
   }
 
   /**
-   * {int} The length of this document, where the count is made
+   * {Int} The length of this document, where the count is made
    * up of text and embeds. An embed has a length of 1.
    */
   get length() {
@@ -89,7 +89,7 @@ export default class BodySnapshot extends BaseSnapshot {
    * Checks to make sure that the given retain OP's count
    * does not exceed the document body length
    * @param {BodyOp} retainOp A retain Op.
-   * @param {int} bodyLength The maximum length that can be retained.
+   * @param {Int} bodyLength The maximum length that can be retained.
    * @throws {Error} A validation error if any semantic validation fails
    *   on given `retain` op.
    */

--- a/local-modules/@bayou/doc-server/FileBootstrap.js
+++ b/local-modules/@bayou/doc-server/FileBootstrap.js
@@ -36,7 +36,7 @@ const RECOVERY_NOTE = new BodyDelta([
   ['text', '(Recreated document due to allegedly-recoverable corruption.)\n']
 ]);
 
-/** {int} Timeout for file creation, in msec. */
+/** {Int} Timeout for file creation, in msec. */
 const FILE_CREATE_TIMEOUT_MSEC = 10000;
 
 /**

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -345,11 +345,17 @@ export default class LocalFile extends BaseFile {
       throw Errors.fileNotFound(this.id);
     }
 
-    // It's a wait transaction, so we need to be prepared to loop / retry
-    // (until satisfaction or timeout).
+    // It's a wait transaction, so we need to be prepared to loop / retry (until
+    // satisfaction or timeout).
     for (;;) {
+      // **TODO:** Similar to the TODO above, `getSnapshot()` does timeout
+      // stuff, and we ought to be able to pass in the timeout-in-progress here.
+      // For now, we just make the call time out after 1000msec as a fixed
+      // value, which (a) is typically much smaller than the outer timeout, and
+      // (b) shouldn't ever actually get triggered in practice.
+      const snapshot = await this.getSnapshot(null, 1000);
 
-      if (this.currentSnapshot.checkPathIsNot(storagePath, hash)) {
+      if (snapshot.checkPathIsNot(storagePath, hash)) {
         // Wait condition was satisfied. If the op has a `path` then that's the
         // storage ID result; otherwise it's its `hash`. (There are no other
         // possibilities.)

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -348,6 +348,10 @@ export default class LocalFile extends BaseFile {
     // It's a wait transaction, so we need to be prepared to loop / retry (until
     // satisfaction or timeout).
     for (;;) {
+      if (timeout) {
+        throw Errors.timedOut(clampedTimeoutMsec);
+      }
+
       // **TODO:** Similar to the TODO above, `getSnapshot()` does timeout
       // stuff, and we ought to be able to pass in the timeout-in-progress here.
       // For now, we just make the call time out after 1000msec as a fixed
@@ -367,9 +371,6 @@ export default class LocalFile extends BaseFile {
       // (that is, wait for _any_ change to the file) or for timeout to occur.
       this._changeCondition.value = false;
       await Promise.race([this._changeCondition.whenTrue(), timeoutProm]);
-      if (timeout) {
-        throw Errors.timedOut(clampedTimeoutMsec);
-      }
 
       // Have to re-check for file existence, as the file could have been
       // deleted while we were waiting.

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -300,8 +300,11 @@ export default class LocalFile extends BaseFile {
    *   available.
    */
   async _impl_getSnapshot(revNum, timeoutMsec) {
-    // **TODO:** Fill this in.
-    return this._mustOverride(revNum, timeoutMsec);
+    // **TODO:** This should probably be set up to work when `revNum` is
+    // something other than the current revision.
+    await this._readStorageIfNecessary(timeoutMsec);
+    const current = this.currentSnapshot;
+    return (current.revNum === revNum) ? current : null;
   }
 
   /**

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -17,8 +17,32 @@ describe('@bayou/file-store-local/LocalFile', () => {
     });
   });
 
-  // **TODO:** Need to test `appendChange()`. See other TODO below for an
-  // example that should be extracted into a test here (and fixed).
+  describe('appendChange()', () => {
+    it('loses the append race on an existing revision number', async () => {
+      const file  = await TempFiles.makeAndCreateFile();
+      const value = FrozenBuffer.coerce('x');
+
+      // This should lose the race (return `false`) because `create()` writes
+      // change #0.
+      assert.isFalse(await file.appendChange(FileChange.FIRST));
+
+      // Append change #1 twice. First should succeed. Second should lose.
+
+      const change1 = new FileChange(1, [FileOp.op_writePath('/x', value)]);
+      assert.isTrue(await file.appendChange(change1));
+      assert.isFalse(await file.appendChange(change1));
+    });
+
+    it('fails with an error when given a `revNum` more than one past the end', async () => {
+      const file  = await TempFiles.makeAndCreateFile();
+      const value = FrozenBuffer.coerce('x');
+
+      for (let revNum = 2; revNum < 1000; revNum = (revNum * 2) + 123) {
+        const change = new FileChange(revNum, [FileOp.op_writePath('/x', value)]);
+        await assert.isRejected(file.appendChange(change), /badValue/, `revNum ${revNum}`);
+      }
+    });
+  });
 
   describe('create()', () => {
     it('causes a non-existent file to come into existence', async () => {
@@ -32,6 +56,22 @@ describe('@bayou/file-store-local/LocalFile', () => {
       await TempFiles.doneWithFile(file);
     });
 
+    it('causes a non-existent file to have one change with the expected contents', async () => {
+      const file = TempFiles.makeFile();
+
+      await file.create();
+
+      const revNum = await file.currentRevNum();
+      assert.strictEqual(revNum, 0);
+
+      const snap = await file.getSnapshot(0);
+      assert.strictEqual(snap.size, 0);
+
+      // **TODO:** Should try to `getChange(0)`, when that becomes possible.
+
+      await TempFiles.doneWithFile(file);
+    });
+
     it('does nothing if called on a non-empty file', async () => {
       const file        = await TempFiles.makeAndCreateFile();
       const storagePath = '/abc';
@@ -40,8 +80,6 @@ describe('@bayou/file-store-local/LocalFile', () => {
       // Baseline setup / assumption.
 
       const change1 = new FileChange(1, [FileOp.op_writePath(storagePath, value)]);
-      // **TODO:** Adding this line should fail, but doesn't!!
-      // await file.appendChange(FileChange.FIRST);
       await file.appendChange(change1);
 
       assert.isTrue(await file.exists());

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -45,7 +45,9 @@ describe('@bayou/file-store-local/LocalFile', () => {
       await file.appendChange(change1);
 
       assert.isTrue(await file.exists());
-      assert.doesNotThrow(() => file.currentSnapshot.checkPathIs(storagePath, value));
+
+      const snap1 = await file.getSnapshot();
+      assert.doesNotThrow(() => snap1.checkPathIs(storagePath, value));
 
       // The real test.
 
@@ -53,8 +55,12 @@ describe('@bayou/file-store-local/LocalFile', () => {
 
       // Ensure the file exists and that the path that was written is still
       // there.
+
       assert.isTrue(await file.exists());
-      assert.doesNotThrow(() => file.currentSnapshot.checkPathIs(storagePath, value));
+
+      const snap2 = await file.getSnapshot();
+
+      assert.doesNotThrow(() => snap2.checkPathIs(storagePath, value));
 
       await TempFiles.doneWithFile(file);
     });

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -159,7 +159,9 @@ export default class BaseFile extends CommonBase {
    * @returns {boolean} Success flag. `true` indicates that the change was
    *   appended, and `false` indicates that the operation failed due to a lost
    *   append race.
-   * @throws {Error} Thrown for failures _other than_ lost append race.
+   * @throws {Error} Thrown for failures _other than_ lost append race. In the
+   *   case of `fileChange` having a too-large `revNum`, this is a `badValue`
+   *   error.
    */
   async appendChange(fileChange, timeoutMsec = null) {
     FileChange.check(fileChange);

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { StorageId, StoragePath, FileChange } from '@bayou/file-store-ot';
-import { FileSnapshot, RevisionNumber } from '@bayou/ot-common';
+import { FileSnapshot, StorageId, StoragePath, FileChange } from '@bayou/file-store-ot';
+import { RevisionNumber } from '@bayou/ot-common';
 import { TBoolean, TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 

--- a/local-modules/@bayou/testing-common/BaseReporter.js
+++ b/local-modules/@bayou/testing-common/BaseReporter.js
@@ -82,7 +82,7 @@ export default class BaseReporter extends CommonBase {
    * specified filter matches no tests), then the runner emits no events, and so
    * nothing else on this class will get called.
    *
-   * @param {int} failures The number of test failures.
+   * @param {Int} failures The number of test failures.
    * @param {function|undefined} fn Optional function to call with `failures` as
    *   an argument.
    */


### PR DESCRIPTION
This PR fills in the implementations of the new methods added to `BaseFile` (in the concrete subclass), and starts to use them in a class-internal sort of way. A later PR will change use sites of `BaseFile.currentSnapshot` (which is to a first approximation "unsafe" to use because it is synchronous and can be quite CPU-heavy) to instead use `BaseFile.getSnapshot()` (which is safe by virtue of being an `async` method that takes a timeout).

As a "semi-bonus," this PR makes the use of timeouts a bit more consistent throughout the affected classes. However, this brings the nascent issue of dealing with "timeouts-within-timeouts-within…" more to the forefront. It's very clear that we need to do some work to get timeouts to be integrated in a sensible and painless way, instead of copy-pasting obscure boilerplate (and leaving TODOs about other deficiencies that aren't easily remedied in place).

**Bonuses:**
* Made `ClientBundle._requestHandler()` be promise-based (somewhat more modern code; avoids direct use of `setTimeout()`.
* Nit-pickily fixed the typename `Int` as used in annotations. (Arguably lowercase `int` makes more sense, and arguably we should switch to it, but right now we specify `Int` in our conventions.)