### PR TITLE
Fix a couple of `file-store` things. Prepare for the future!

### DIFF
--- a/local-modules/@bayou/doc-server/FileBootstrap.js
+++ b/local-modules/@bayou/doc-server/FileBootstrap.js
@@ -227,7 +227,7 @@ export default class FileBootstrap extends BaseDataManager {
 
     // `revNum` is `1` because a newly-created body always has an empty
     // change for revision `0`.
-    const change = new BodyChange(1, firstText, Timestamp.now());
+    const change  = new BodyChange(1, firstText, Timestamp.now());
     const initOps = this.initOps;
 
     await this.file.create();
@@ -237,7 +237,7 @@ export default class FileBootstrap extends BaseDataManager {
     // future, we will presumably replace the entire notion of conveying
     // information through appending notes in the document itself, and this
     // entire code block will disappear.
-    const currentRevNum = this.file.currentSnapshot.revNum;
+    const currentRevNum     = await this.file.currentRevNum();
     const initialFileChange = new FileChange(currentRevNum + 1, initOps);
     await this.file.appendChange(initialFileChange, FILE_CREATE_TIMEOUT_MSEC);
     await this.afterInit();

--- a/local-modules/@bayou/doc-server/SchemaHandler.js
+++ b/local-modules/@bayou/doc-server/SchemaHandler.js
@@ -57,7 +57,7 @@ export default class SchemaHandler extends BaseDataManager {
    */
   async _impl_validationStatus() {
     const { file, codec } = this.fileCodec;
-    const snapshot = file.currentSnapshot;
+    const snapshot        = await file.getSnapshot();
     let schemaVersion;
 
     try {

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -179,9 +179,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       let actualFileChange;
 
       // TODO: Replace with stub
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(snapshotRevNum, [['yes']])
-      });
+      file.getSnapshot = () => new MockSnapshot(snapshotRevNum, [['yes']]);
 
       // TODO: Replace with stub
       file.appendChange = (changeToAppend) => {
@@ -221,9 +219,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       };
 
       // TODO: Replace with stub
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [['x', 1]])
-      });
+      file.getSnapshot = () => new MockSnapshot(100, [['x', 1]]);
 
       async function test(timeout, expect, msg) {
         await assert.isRejected(control.appendChange(change, timeout), /to_be_expected/, `${msg} rejection check`);
@@ -257,9 +253,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [['yes']])
-      });
+      file.getSnapshot = () => new MockSnapshot(100, [['yes']]);
 
       // TODO: Replace with spy
       let storeSnapshotCalled = false;
@@ -277,9 +271,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [['yes']])
-      });
+      file.getSnapshot = () => new MockSnapshot(100, [['yes']]);
 
       control._maybeWriteStoredSnapshot = (revNum_unused) => {
         throw new Error('Should not have been called');
@@ -303,9 +295,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       const control    = new MockControl(fileAccess, 'boop');
       const change     = new MockChange(99, [['x', 'f'], ['y', 'b']]);
 
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new MockSnapshot(100, [['x']])
-      });
+      file.getSnapshot = () => new MockSnapshot(100, [['x']]);
 
       control._maybeWriteStoredSnapshot = (revNum_unused) => {
         throw new Error('Should not have been called');
@@ -368,9 +358,7 @@ describe('@bayou/doc-server/BaseControl', () => {
 
       const fileOp = FileOp.op_writePath('/mock_control/revision_number', CODEC.encodeJsonBuffer(expectedRevNum));
 
-      Object.defineProperty(file, 'currentSnapshot', {
-        get: () => new FileSnapshot(90909, [fileOp])
-      });
+      file.getSnapshot = () => new FileSnapshot(90909, [fileOp]);
 
       await assert.eventually.strictEqual(control.currentRevNum(), expectedRevNum);
     });
@@ -382,9 +370,7 @@ describe('@bayou/doc-server/BaseControl', () => {
         const control    = new MockControl(fileAccess, 'boop');
 
         // TODO: Replace with stub
-        Object.defineProperty(file, 'currentSnapshot', {
-          get: () => new MockSnapshot(revNum, [[`snap_blort_${revNum}`]])
-        });
+        file.getSnapshot = () => new MockSnapshot(revNum, [[`snap_blort_${revNum}`]]);
 
         await assert.isRejected(control.currentRevNum(), /^badValue/);
       }


### PR DESCRIPTION
This PR is another increment of work on `file-store`. The main thing this achieves is removing the unsafe synthetic property `.currentSnapshot` from the concrete subclass of `BaseFile`. The original call sites now use either `currentRevNum()` or `getSnapshot()`, both of which have a safe API (`async` and with timeout behavior). Internally to the implementation, there is now a private `_getCurrentSnapshot()` which is pretty much the same implementation as the old `.currentSnapshot`, except (a) it's private and (b) it's `async`, which means we are in a position to make the implementation less bad (which I'll do in a future PR).