### PR TITLE
Minor "code tidiness" pass.

### DIFF
--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -56,13 +56,11 @@ export default class BodySnapshot extends BaseSnapshot {
   }
 
   /**
-   * Implementation of {@link validateChange}, which
-   * will perform semantic validation checks on a body change
-   * in the context of a snapshot.
+   * Implementation as required by the superclass.
    *
-   * @param {BodyChange} change The change being validated.
-   * @throws {Error} A validation error if semantic validation
-   *   performed on a given change fails.
+   * @param {BodyChange} change The change to be validated in the context of
+   *   `this`.
+   * @throws {Error} Thrown if `change` is not valid to compose with `this`.
    */
   _impl_validateChange(change) {
     const ops = change.delta.ops;

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -269,9 +269,15 @@ export default class CaretSnapshot extends BaseSnapshot {
     return new CaretDelta(resultOps);
   }
 
-  // TODO: implement caret snapshot specific validation
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {CaretChange} change The change to be validated in the context of
+   *   `this`.
+   * @throws {Error} Thrown if `change` is not valid to compose with `this`.
+   */
   _impl_validateChange() {
-    return true;
+    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/doc-common/PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/PropertySnapshot.js
@@ -233,9 +233,15 @@ export default class PropertySnapshot extends BaseSnapshot {
     return new PropertyDelta(resultOps);
   }
 
-  // TODO: implement property snapshot specific validation
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {PropertyChange} change The change to be validated in the context of
+   *   `this`.
+   * @throws {Error} Thrown if `change` is not valid to compose with `this`.
+   */
   _impl_validateChange() {
-    return true;
+    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1167,14 +1167,17 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
-   * Subclass-specific implementation of {@link #validateChange}. Subclasses
-   * must override this to perform validation.
-   * @param {BaseChange} change Change to apply.
-   * @returns {boolean} `true` if valid, otherwise throws and error.
+   * Subclass-specific change validation. Subclasses must override this method.
+   *
    * @abstract
+   * @param {BaseChange} change Change to apply.
+   * @param {BaseSnapshot} baseSnapshot The base snapshot the change is being
+   *   applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
    */
-  _impl_validateChange(change) {
-    return this._mustOverride(change);
+  _impl_validateChange(change, baseSnapshot) {
+    this._mustOverride(change, baseSnapshot);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -86,12 +86,13 @@ export default class BodyControl extends DurableControl {
   }
 
   /**
-   * Subclass-specific implementation of {@link #validateChange}. This
-   * class implements semantic validation for an OT change in the Body.
-   * @param {BodyChange} change The change to apply.
-   * @param {BodySnapshot} baseSnapshot The base snapshot the change
-   *   is being applied to.
-   * @throws {Error} A validation error if any semantic validation fails.
+   * Implementation as required by the superclass.
+   *
+   * @param {BodyChange} change Change to apply.
+   * @param {BodySnapshot} baseSnapshot The base snapshot the change is being
+   *   applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
    */
   _impl_validateChange(change, baseSnapshot) {
     // TODO: Add semantic validation for:

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -29,6 +29,23 @@ export default class BodyControl extends DurableControl {
     Object.seal(this);
   }
 
+  // TODO: Add queuing logic to only export HTML once in a while,
+  // using a timer for now. In the future, use external job queue.
+  /**
+   * Queues up an HTML export of the current body snapshot.
+   *
+   * @param {RevisionNumber} revNum The revision number of the body snapshot to
+   *   convert to HTML.
+   * @param {string} documentId The document ID.
+   */
+  async queueHtmlExport(revNum, documentId) {
+    RevisionNumber.check(revNum);
+    Storage.dataStore.checkDocumentIdSyntax(documentId);
+
+    const snapshot = await this._impl_getSnapshot(revNum);
+    await HtmlExport.exportHtml(snapshot, documentId);
+  }
+
   /**
    * Subclass-specific implementation of `afterInit()`.
    */
@@ -103,23 +120,6 @@ export default class BodyControl extends DurableControl {
     // `change` in the context of the snapshot
     // it is being applied to.
     baseSnapshot.validateChange(change);
-  }
-
-  // TODO: Add queuing logic to only export HTML once in a while,
-  // using a timer for now. In the future, use external job queue.
-  /**
-   * Queues up an HTML export of the current body snapshot.
-   *
-   * @param {RevisionNumber} revNum The revision number of the body snapshot to
-   *   convert to HTML.
-   * @param {string} documentId The document ID.
-   */
-  async queueHtmlExport(revNum, documentId) {
-    RevisionNumber.check(revNum);
-    Storage.dataStore.checkDocumentIdSyntax(documentId);
-
-    const snapshot = await this._impl_getSnapshot(revNum);
-    await HtmlExport.exportHtml(snapshot, documentId);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -169,6 +169,19 @@ export default class CaretControl extends EphemeralControl {
   }
 
   /**
+   * Implementation as required by the superclass.
+   *
+   * @param {CaretChange} change_unused Change to apply.
+   * @param {CaretSnapshot} baseSnapshot_unused The base snapshot the change is
+   *   being applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
+   */
+  _impl_validateChange(change_unused, baseSnapshot_unused) {
+    // **TODO:** Implement this!
+  }
+
+  /**
    * Perform idle caret cleanup, but only if it's been long enough since the
    * last time that was done. If in fact cleanup is performed, it happens
    * _asynchronously_ with respect to the call to this method.
@@ -233,19 +246,6 @@ export default class CaretControl extends EphemeralControl {
     }
 
     this.log.event.removedIdle(removedCount);
-  }
-
-  /**
-   * Implementation as required by the superclass.
-   *
-   * @param {CaretChange} change_unused Change to apply.
-   * @param {CaretSnapshot} baseSnapshot_unused The base snapshot the change is
-   *   being applied to.
-   * @throws {Error} Thrown if `change` is not valid as a change to
-   *   `baseSnapshot`.
-   */
-  _impl_validateChange(change_unused, baseSnapshot_unused) {
-    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -235,9 +235,17 @@ export default class CaretControl extends EphemeralControl {
     this.log.event.removedIdle(removedCount);
   }
 
-  // TODO: Implement validateChange for Caret Control
-  _impl_validateChange() {
-    return true;
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {CaretChange} change_unused Change to apply.
+   * @param {CaretSnapshot} baseSnapshot_unused The base snapshot the change is
+   *   being applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
+   */
+  _impl_validateChange(change_unused, baseSnapshot_unused) {
+    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/doc-server/PropertyControl.js
+++ b/local-modules/@bayou/doc-server/PropertyControl.js
@@ -86,9 +86,17 @@ export default class PropertyControl extends DurableControl {
     return finalChange;
   }
 
-  // TODO: Implement validateChange for Property Control
-  _impl_validateChange() {
-    return true;
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {PropertyChange} change_unused Change to apply.
+   * @param {PropertySnapshot} baseSnapshot_unused The base snapshot the change
+   *   is being applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
+   */
+  _impl_validateChange(change_unused, baseSnapshot_unused) {
+    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -355,7 +355,7 @@ export default class FileSnapshot extends BaseSnapshot {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {CaretChange} change The change to be validated in the context of
+   * @param {FileChange} change The change to be validated in the context of
    *   `this`.
    * @throws {Error} Thrown if `change` is not valid to compose with `this`.
    */

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -352,9 +352,15 @@ export default class FileSnapshot extends BaseSnapshot {
     return new FileDelta(resultOps);
   }
 
-  // TODO: implement file snapshot specific validation
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @param {CaretChange} change The change to be validated in the context of
+   *   `this`.
+   * @throws {Error} Thrown if `change` is not valid to compose with `this`.
+   */
   _impl_validateChange() {
-    return true;
+    // **TODO:** Implement this!
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/BaseSnapshot.js
@@ -226,13 +226,14 @@ export default class BaseSnapshot extends CommonBase {
    * Semantic validation for an OT change in the context of this snapshot.
    * Each subclass implements its own version of the semantic validation.
    *
-   * @param {BodyChange} change The change to apply.
-   * @returns {boolean} `true` if valid change, otherwise throws an error.
+   * @param {BaseChange} change The change to apply.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
    */
   validateChange(change) {
     this.constructor.changeClass.check(change);
 
-    return this._impl_validateChange(change);
+    this._impl_validateChange(change);
   }
 
   /**
@@ -283,17 +284,17 @@ export default class BaseSnapshot extends CommonBase {
   }
 
   /**
-   * The abstract implementation of {@link #validateChange}. This
-   * class implements semantic validation for an OT change in the context
-   * of this snapshot. Should be implemented by all subclasses.
+   * Main implementation of {@link #validateChange}, as defined by the subclass.
+   * This method should return without error if `change` is valid to compose
+   * with `this`, or throw an error if invalid.
    *
    * @abstract
-   * @param {BodyChange} change The change to be validated in the context
-   *   of this snapshot.
-   * @returns {boolean} `true` if valid change, otherwise throws an error.
+   * @param {BaseChange} change The change to be validated in the context of
+   *   `this`.
+   * @throws {Error} Thrown if `change` is not valid to compose with `this`.
    */
   _impl_validateChange(change) {
-    return this._mustOverride(change);
+    this._mustOverride(change);
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/BaseSnapshot.js
@@ -255,8 +255,9 @@ export default class BaseSnapshot extends CommonBase {
   /**
    * Semantic validation for an OT change in the context of this snapshot.
    * Each subclass implements its own version of the semantic validation.
+   *
    * @param {BodyChange} change The change to apply.
-   * @returns {boolean} `true` if valid change, otherwise throws and error.
+   * @returns {boolean} `true` if valid change, otherwise throws an error.
    */
   validateChange(change) {
     this.constructor.changeClass.check(change);
@@ -268,10 +269,11 @@ export default class BaseSnapshot extends CommonBase {
    * The abstract implementation of {@link #validateChange}. This
    * class implements semantic validation for an OT change in the context
    * of this snapshot. Should be implemented by all subclasses.
+   *
+   * @abstract
    * @param {BodyChange} change The change to be validated in the context
    *   of this snapshot.
-   * @returns {boolean} `true` if valid change, otherwise throws and error.
-   * @abstract
+   * @returns {boolean} `true` if valid change, otherwise throws an error.
    */
   _impl_validateChange(change) {
     return this._mustOverride(change);

--- a/local-modules/@bayou/ot-common/BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/BaseSnapshot.js
@@ -223,6 +223,19 @@ export default class BaseSnapshot extends CommonBase {
   }
 
   /**
+   * Semantic validation for an OT change in the context of this snapshot.
+   * Each subclass implements its own version of the semantic validation.
+   *
+   * @param {BodyChange} change The change to apply.
+   * @returns {boolean} `true` if valid change, otherwise throws an error.
+   */
+  validateChange(change) {
+    this.constructor.changeClass.check(change);
+
+    return this._impl_validateChange(change);
+  }
+
+  /**
    * Returns an instance just like this one except with the content set as
    * given. This will return `this` if `content` is strictly equal (`===`) to
    * `this.content`.
@@ -253,33 +266,6 @@ export default class BaseSnapshot extends CommonBase {
   }
 
   /**
-   * Semantic validation for an OT change in the context of this snapshot.
-   * Each subclass implements its own version of the semantic validation.
-   *
-   * @param {BodyChange} change The change to apply.
-   * @returns {boolean} `true` if valid change, otherwise throws an error.
-   */
-  validateChange(change) {
-    this.constructor.changeClass.check(change);
-
-    return this._impl_validateChange(change);
-  }
-
-  /**
-   * The abstract implementation of {@link #validateChange}. This
-   * class implements semantic validation for an OT change in the context
-   * of this snapshot. Should be implemented by all subclasses.
-   *
-   * @abstract
-   * @param {BodyChange} change The change to be validated in the context
-   *   of this snapshot.
-   * @returns {boolean} `true` if valid change, otherwise throws an error.
-   */
-  _impl_validateChange(change) {
-    return this._mustOverride(change);
-  }
-
-  /**
    * Main implementation of {@link #diff}, as defined by the subclass. Takes a
    * snapshot of the same class, and produces a delta (not a change)
    * representing the difference.
@@ -294,6 +280,20 @@ export default class BaseSnapshot extends CommonBase {
    */
   _impl_diffAsDelta(newerSnapshot) {
     return this._mustOverride(newerSnapshot);
+  }
+
+  /**
+   * The abstract implementation of {@link #validateChange}. This
+   * class implements semantic validation for an OT change in the context
+   * of this snapshot. Should be implemented by all subclasses.
+   *
+   * @abstract
+   * @param {BodyChange} change The change to be validated in the context
+   *   of this snapshot.
+   * @returns {boolean} `true` if valid change, otherwise throws an error.
+   */
+  _impl_validateChange(change) {
+    return this._mustOverride(change);
   }
 
   /**


### PR DESCRIPTION
This PR fixes up the various "validation" methods to be more self-consistent and consistent with respect to the rest of the system, in terms of arguments taken, code comments, and sort position with respect to other methods in each file.

There are no actual semantic changes in this PR.