### PR TITLE
`BaseFile.getChange()`.

### DIFF
--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -206,7 +206,7 @@ export default class LocalFile extends BaseFile {
       this._fileShouldExist = true;
 
       // Make the standard empty initial change.
-      const firstChange = new FileChange(0, []);
+      const firstChange = FileChange.FIRST;
       this._changes[0] = firstChange;
       this._storageToWrite.set(0, this._encodeChange(firstChange));
 

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -258,6 +258,20 @@ export default class LocalFile extends BaseFile {
   }
 
   /**
+   * Implementation as required by the superclass.
+   *
+   * @param {Int} revNum Which revision to get.
+   * @param {Int|null} timeoutMsec Maximum amount of time to allow in this call,
+   *   in msec.
+   * @returns {FileChange|null} Change instance corresponding to the indicated
+   *   revision, if available.
+   */
+  async _impl_getChange(revNum, timeoutMsec) {
+    // **TODO:** Implement this!
+    return this._mustOverride(revNum, timeoutMsec);
+  }
+
+  /**
   * Implementation as required by the superclass.
    *
    * @param {Int} revNum Which revision to get.

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -267,8 +267,8 @@ export default class LocalFile extends BaseFile {
    *   revision, if available.
    */
   async _impl_getChange(revNum, timeoutMsec) {
-    // **TODO:** Implement this!
-    return this._mustOverride(revNum, timeoutMsec);
+    await this._readStorageIfNecessary(timeoutMsec);
+    return this._changes[revNum] || null;
   }
 
   /**

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -67,7 +67,8 @@ describe('@bayou/file-store-local/LocalFile', () => {
       const snap = await file.getSnapshot(0);
       assert.strictEqual(snap.size, 0);
 
-      // **TODO:** Should try to `getChange(0)`, when that becomes possible.
+      const change = await file.getChange(0);
+      assert.deepEqual(change, FileChange.FIRST);
 
       await TempFiles.doneWithFile(file);
     });

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -125,7 +125,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
     });
 
     it('returns `true` if the file was created in the filesystem', async () => {
-      const dir = TempFiles.uniquePath();
+      const dir   = TempFiles.uniquePath();
       const file1 = await TempFiles.makeAndCreateFile(dir);
 
       // Baseline assumption: Check that `file1` believes itself to exist.
@@ -139,6 +139,35 @@ describe('@bayou/file-store-local/LocalFile', () => {
       assert.isTrue(await file2.exists());
 
       await TempFiles.doneWithFile(file2);
+    });
+  });
+
+  describe('getChange()', () => {
+    it('successfully gets an existing change', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      const got0 = await file.getChange(0);
+      assert.instanceOf(got0, FileChange);
+      assert.deepEqual(got0, FileChange.FIRST);
+
+      const storagePath = '/boop/beep';
+      const value       = FrozenBuffer.coerce('floop-fleep');
+      const change1     = new FileChange(1, [FileOp.op_writePath(storagePath, value)]);
+      assert.isTrue(await file.appendChange(change1));
+
+      const got1 = await file.getChange(1);
+      assert.instanceOf(got1, FileChange);
+      assert.deepEqual(got1, change1);
+
+      await TempFiles.doneWithFile(file);
+    });
+
+    it('reports an error given a future `revNum`', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      assert.isRejected(file.getChange(1), /badValue/);
+
+      await TempFiles.doneWithFile(file);
     });
   });
 });

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { FileChange, FileOp } from '@bayou/file-store-ot';
+import { FileChange, FileOp, FileSnapshot } from '@bayou/file-store-ot';
 import { FrozenBuffer } from '@bayou/util-common';
 
 import TempFiles from './TempFiles';
@@ -167,6 +167,99 @@ describe('@bayou/file-store-local/LocalFile', () => {
       const file = await TempFiles.makeAndCreateFile();
 
       assert.isRejected(file.getChange(1), /badValue/);
+
+      await TempFiles.doneWithFile(file);
+    });
+  });
+
+  describe('getSnapshot()', () => {
+    it('successfully gets the current snapshot', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      const got0 = await file.getSnapshot(0);
+      assert.instanceOf(got0, FileSnapshot);
+      assert.strictEqual(got0.size, 0);
+
+      const path1   = '/hello/there';
+      const value1  = FrozenBuffer.coerce('yo');
+      const change1 = new FileChange(1, [FileOp.op_writePath(path1, value1)]);
+      assert.isTrue(await file.appendChange(change1));
+
+      const got1 = await file.getSnapshot(1);
+      assert.instanceOf(got1, FileSnapshot);
+      assert.strictEqual(got1.getOrNull(path1), value1);
+
+      const path2   = '/hello_again';
+      const value2  = FrozenBuffer.coerce('yoyo');
+      const change2 = new FileChange(2, [FileOp.op_writePath(path2, value2)]);
+      assert.isTrue(await file.appendChange(change2));
+
+      const got2 = await file.getSnapshot(2);
+      assert.instanceOf(got1, FileSnapshot);
+      assert.strictEqual(got2.getOrNull(path2), value2);
+
+      await TempFiles.doneWithFile(file);
+    });
+
+    it('successfully reflects a path replacement in the current snapshot', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      const path    = '/hello/there';
+      const value1  = FrozenBuffer.coerce('yo');
+      const value2  = FrozenBuffer.coerce('oh-ho!');
+      const change1 = new FileChange(1, [FileOp.op_writePath(path, value1)]);
+      const change2 = new FileChange(2, [FileOp.op_writePath(path, value2)]);
+      assert.isTrue(await file.appendChange(change1));
+      assert.isTrue(await file.appendChange(change2));
+
+      const got2 = await file.getSnapshot(2);
+      assert.instanceOf(got2, FileSnapshot);
+      assert.strictEqual(got2.getOrNull(path), value2);
+
+      await TempFiles.doneWithFile(file);
+    });
+
+    it('successfully reflects a path deletion in the current snapshot', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      const path    = '/hello/there';
+      const value   = FrozenBuffer.coerce('yo');
+      const change1 = new FileChange(1, [FileOp.op_writePath(path, value)]);
+      const change2 = new FileChange(2, [FileOp.op_deletePath(path)]);
+      assert.isTrue(await file.appendChange(change1));
+      assert.isTrue(await file.appendChange(change2));
+
+      const got2 = await file.getSnapshot(2);
+      assert.instanceOf(got2, FileSnapshot);
+      assert.isNull(got2.getOrNull(path));
+
+      await TempFiles.doneWithFile(file);
+    });
+
+    it('successfully reflects all-path deletion in the current snapshot', async () => {
+      const file  = await TempFiles.makeAndCreateFile();
+      const value = FrozenBuffer.coerce('yo');
+
+      for (let i = 1; i <= 10; i++) {
+        const path   = `/x/${i}`;
+        const change = new FileChange(i, [FileOp.op_writePath(path, value)]);
+        assert.isTrue(await file.appendChange(change));
+      }
+
+      const change11 = new FileChange(11, [FileOp.op_deleteAll()]);
+      assert.isTrue(await file.appendChange(change11));
+
+      const got11 = await file.getSnapshot(11);
+      assert.instanceOf(got11, FileSnapshot);
+      assert.strictEqual(got11.size, 0);
+
+      await TempFiles.doneWithFile(file);
+    });
+
+    it('reports an error given a future `revNum`', async () => {
+      const file = await TempFiles.makeAndCreateFile();
+
+      assert.isRejected(file.getSnapshot(1), /badValue/);
 
       await TempFiles.doneWithFile(file);
     });

--- a/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
+++ b/local-modules/@bayou/file-store-local/tests/test_LocalFile.js
@@ -86,7 +86,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
       assert.isTrue(await file.exists());
 
       const snap1 = await file.getSnapshot();
-      assert.doesNotThrow(() => snap1.checkPathIs(storagePath, value));
+      assert.deepEqual(snap1.getOrNull(storagePath), value);
 
       // The real test.
 
@@ -99,7 +99,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
 
       const snap2 = await file.getSnapshot();
 
-      assert.doesNotThrow(() => snap2.checkPathIs(storagePath, value));
+      assert.deepEqual(snap2.getOrNull(storagePath), value);
 
       await TempFiles.doneWithFile(file);
     });
@@ -187,7 +187,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
 
       const got1 = await file.getSnapshot(1);
       assert.instanceOf(got1, FileSnapshot);
-      assert.strictEqual(got1.getOrNull(path1), value1);
+      assert.deepEqual(got1.getOrNull(path1), value1);
 
       const path2   = '/hello_again';
       const value2  = FrozenBuffer.coerce('yoyo');
@@ -196,7 +196,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
 
       const got2 = await file.getSnapshot(2);
       assert.instanceOf(got1, FileSnapshot);
-      assert.strictEqual(got2.getOrNull(path2), value2);
+      assert.deepEqual(got2.getOrNull(path2), value2);
 
       await TempFiles.doneWithFile(file);
     });
@@ -214,7 +214,7 @@ describe('@bayou/file-store-local/LocalFile', () => {
 
       const got2 = await file.getSnapshot(2);
       assert.instanceOf(got2, FileSnapshot);
-      assert.strictEqual(got2.getOrNull(path), value2);
+      assert.deepEqual(got2.getOrNull(path), value2);
 
       await TempFiles.doneWithFile(file);
     });

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -15,6 +15,15 @@ import { CommonBase, Errors } from '@bayou/util-common';
  * The model that this class embodies is that a file is a random-access
  * key-value store with keys having a path-like structure and values being
  * arbitrary binary data.
+ *
+ * **Note:** This class intentionally bears resemblance to
+ * {@link doc-server.BaseControl} in terms of its API. However, it probably
+ * won't be the case that these two classes will become siblings to a baser
+ * base class, because, in the long run, the type managed as a "change" in this
+ * class will not be a subclass of {@link ot-common.BaseChange} (because of the
+ * needs of file GC). That said, it is worth keeping an eye on these classes to
+ * (a) maintain parallel structure where feasible, and (b) see if there turns
+ * out to be any common functionality that really can be factored out.
  */
 export default class BaseFile extends CommonBase {
   /**


### PR DESCRIPTION
This PR — which is way more comments and unit tests than code-per-se — adds `BaseFile.getChange()` and concrete subclass implementations.

**Bonuses:**
* Added unit tests for `LocalFile.getSnapshot()`, and cleaned up other tests.
* A couple other miscellaneous fixes in the code I was touching.

