### PR TITLE
Perform initial document load in multiple ticks.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/BaseDataManager.js
@@ -46,7 +46,7 @@ export default class BaseDataManager extends BaseComplexMember {
   async validationStatus() {
     const result = ValidationStatus.check(await this._impl_validationStatus());
 
-    this.log.info(`Validation status: ${result}`);
+    this.log.event.validationStatus(result);
 
     return result;
   }

--- a/local-modules/@bayou/doc-server/FileBootstrap.js
+++ b/local-modules/@bayou/doc-server/FileBootstrap.js
@@ -173,8 +173,10 @@ export default class FileBootstrap extends BaseDataManager {
    * @returns {boolean} `true` once setup and initialization are complete.
    */
   async _init() {
-    this.log.info('Doing bootstrap-time validation...');
+    this.log.event.validatingDocument();
     const status  = await this.validationStatus();
+
+    this.log.event.validatedDocument(); // **Note:** The call to `validationStatus()` logs the result.
 
     if (status === ValidationStatus.STATUS_ok) {
       // All's well.

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -517,7 +517,7 @@ export default class LocalFile extends BaseFile {
       return null;
     }
 
-    this._log.event.composingSnapshot(revNum, base.revNum);
+    this._log.event.makingSnapshot(revNum, base.revNum);
 
     // Compose the result one chunk of changes at a time. See comment on
     // `MAX_ATOMIC_COMPOSED_CHANGES`, above, for discussion. **TODO:** It would


### PR DESCRIPTION
This PR changes `_impl_getSnapshot()` (well, its helper method) so that it will take multiple ticks (Node event dispatches). This is specifically beneficial during the initial load of a file, because at that time the system has no precomputed snapshot, which means it has to compose changes from the beginning of time (of the document), and we know that documents which have been around for a while can have a _lot_ of changes.

The benefit of this reärrangement is that the server can do other things while in the middle of composing the snapshot, such as answer API requests for other documents. Having to do this sort of thing is (arguably) one of the most major downsides of Node development, but in the scheme of things it's not too too terrible.

**Bonus:** Changed a lot of the logging during document and file load to be structured events, and added a new logged event `initTimeMsec` which reports how long initial document load takes for any given document.
