### PR TITLE
Make weakref-based caching code more self-similar.

### DIFF
--- a/local-modules/@bayou/deps-util-server/README.md
+++ b/local-modules/@bayou/deps-util-server/README.md
@@ -3,6 +3,3 @@
 
 This module just serves as a single location to hold external dependencies
 for general utility functionality which applies just to the server environment.
-
-**TODO:** Remove the explicit `nan` dependency, once we can count on building
-with a stable version of Node 10.

--- a/local-modules/@bayou/deps-util-server/package.json
+++ b/local-modules/@bayou/deps-util-server/package.json
@@ -6,7 +6,6 @@
     "is-running": "^2.1.0",
     "memory-fs": "^0.4.1",
     "minimist": "^1.2.0",
-    "nan": "2.11.1",
     "source-map-support": "^0.5.6",
     "weak": "^1.0.1"
   }

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -75,7 +75,11 @@ export default class DocServer extends Singleton {
         if (!weak.isDead(already)) {
           const result = weak.get(already);
           result.log.event.foundInCache();
-          return result;
+
+          // We've seen cases where a weakly-referenced object gets collected
+          // and replaced with an instance of a different class. If this check
+          // throws an error, that's what's going on here.
+          return FileComplex.check(result);
         }
         // The weak reference is dead. We'll fall through and construct a new
         // result.

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -78,7 +78,8 @@ export default class DocServer extends Singleton {
 
           // We've seen cases where a weakly-referenced object gets collected
           // and replaced with an instance of a different class. If this check
-          // throws an error, that's what's going on here.
+          // throws an error, that's what's going on here. (This is evidence of
+          // a bug in Node or in the `weak` package.)
           return FileComplex.check(result);
         }
         // The weak reference is dead. We'll fall through and construct a new

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -73,14 +73,14 @@ export default class DocServer extends Singleton {
       } else {
         // It's a weak reference. If not dead, it refers to a `FileComplex`.
         if (!weak.isDead(already)) {
-          const result = weak.get(already);
-          result.log.event.foundInCache();
-
           // We've seen cases where a weakly-referenced object gets collected
           // and replaced with an instance of a different class. If this check
           // throws an error, that's what's going on here. (This is evidence of
           // a bug in Node or in the `weak` package.)
-          return FileComplex.check(result);
+          const result = FileComplex.check(weak.get(already));
+
+          result.log.event.foundInCache();
+          return result;
         }
         // The weak reference is dead. We'll fall through and construct a new
         // result.

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -83,7 +83,7 @@ export default class DocServer extends Singleton {
         }
         // The weak reference is dead. We'll fall through and construct a new
         // result.
-        log.withAddedContext(documentId).info('Cached complex was gc\'ed.');
+        log.withAddedContext(documentId).event.foundDead();
       }
     }
 

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -138,7 +138,7 @@ export default class FileComplex extends BaseComplexMember {
     // author matches, we create and return the corresponding object.
 
     const caretSnapshot = await this.caretControl.getSnapshot();
-    const foundCaret = caretSnapshot.getOrNull(caretId);
+    const foundCaret    = caretSnapshot.getOrNull(caretId);
 
     if (foundCaret === null) {
       throw Errors.badId(caretId);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -105,12 +105,23 @@ export default class FileComplex extends BaseComplexMember {
     CaretId.check(caretId);
 
     const foundWeak = this._sessions.get(caretId);
-    if ((foundWeak !== undefined) && !weak.isDead(foundWeak)) {
-      const foundSession = weak.get(foundWeak);
-      if (foundSession instanceof DocSession) {
-        // There is already a `DocSession` for the given session ID.
+
+    if (foundWeak) {
+      // Found in cache.
+      if (weak.isDead(foundWeak)) {
+        // ...but it's since been reaped. Fall through and search for the caret
+        // in the snapshot for same.
+        this.log.event.foundDead(authorId, caretId);
+      } else {
+        // We've seen cases where a weakly-referenced object gets collected
+        // and replaced with an instance of a different class. If this check
+        // throws an error, that's what's going on here. (This is evidence of
+        // a bug in Node or in the `weak` package.)
+        const foundSession = DocSession.check(weak.get(foundWeak));
+
         if (authorId === foundSession.getAuthorId()) {
-          // ...and the author ID matches. Bingo!
+          // We found a pre-existing session for the caret, and the author ID
+          // matches. Bingo!
           return foundSession;
         } else {
           // Existing caret but wrong author ID for it. Log it (could be useful

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -908,7 +908,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.deepEqual(gotBase, new MockSnapshot(6, [new MockOp('x', 6)]));
       assert.strictEqual(gotChange, change);
       assert.deepEqual(gotExpected,
-        new MockSnapshot(7, [new MockOp('composedDoc'), new MockOp('y')]));
+        new MockSnapshot(7, [new MockOp('composedDoc', 1), new MockOp('y')]));
       assert.isNumber(gotTimeout);
 
       assert.instanceOf(result, MockChange);

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -121,7 +121,7 @@ export default class FileCache extends CommonBase {
       // Clear the cache entry, but only if it hasn't already been replaced with
       // a new live reference. (Without the check, we'd have a concurrency
       // hazard.)
-      if (this.getOrNull(fileId) === null) {
+      if (this.getOrNull(fileId, true) === null) {
         this._cache.delete(fileId);
       }
     };

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -71,13 +71,16 @@ export default class FileCache extends CommonBase {
       return null;
     }
 
-    const result = BaseFile.check(weak.get(fileRef));
+    const result = weak.get(fileRef);
 
     if (!quiet) {
       this._log.event.retrieved(fileId);
     }
 
-    return result;
+    // We've seen cases where a weakly-referenced object gets collected
+    // and replaced with an instance of a different class. If this check
+    // throws an error, that's what's going on here.
+    return BaseFile.check(result);
   }
 
   /**

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -79,7 +79,8 @@ export default class FileCache extends CommonBase {
 
     // We've seen cases where a weakly-referenced object gets collected
     // and replaced with an instance of a different class. If this check
-    // throws an error, that's what's going on here.
+    // throws an error, that's what's going on here. (This is evidence of
+    // a bug in Node or in the `weak` package.)
     return BaseFile.check(result);
   }
 

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -65,7 +65,7 @@ export default class FileCache extends CommonBase {
       // re-instantiate the file and add it.
 
       if (!quiet) {
-        this._log.event.dead(fileId);
+        this._log.event.foundDead(fileId);
       }
 
       return null;

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -71,17 +71,17 @@ export default class FileCache extends CommonBase {
       return null;
     }
 
-    const result = weak.get(fileRef);
+    // We've seen cases where a weakly-referenced object gets collected
+    // and replaced with an instance of a different class. If this check
+    // throws an error, that's what's going on here. (This is evidence of
+    // a bug in Node or in the `weak` package.)
+    const result = BaseFile.check(weak.get(fileRef));
 
     if (!quiet) {
       this._log.event.retrieved(fileId);
     }
 
-    // We've seen cases where a weakly-referenced object gets collected
-    // and replaced with an instance of a different class. If this check
-    // throws an error, that's what's going on here. (This is evidence of
-    // a bug in Node or in the `weak` package.)
-    return BaseFile.check(result);
+    return result;
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -39,7 +39,7 @@ export default class BaseOp extends CommonBase {
    * on an instance of this class.
    *
    * **Note:** This depends on the set of `CODE_*` properties being correct for
-   * the concrete subclass class.
+   * the concrete subclass.
    *
    * @param {string} name Potential opcode name.
    * @returns {boolean} `true` if `name` is valid for use as an opcode name on

--- a/local-modules/@bayou/ot-common/BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/BaseSnapshot.js
@@ -134,20 +134,44 @@ export default class BaseSnapshot extends CommonBase {
    * `revNum` as this instance, this method returns `this`. Otherwise, this
    * method returns a new instance.
    *
+   * **Note:** This method is `async` because composing many changes can be
+   * CPU-intensive, and as such it can be a bad idea to perform an invocation of
+   * this method without having it be able to yield (allow other code to run) in
+   * the middle of the operation. The second argument of the method controls
+   * the yielding behavior.
+   *
    * @param {array<BaseChange>} changes Changes to compose on top of this
    *   instance. Each array element must be an instance of the `changeClass` as
    *   defined by the subclass.
+   * @param {Int} [maxChangesPerIteration = 1] The number of changes that are to
+   *   be composed without yielding to other computation. (See note above.)
+   * @param {function} [yieldFunction = () => {}] Function call and `await` on
+   *   the result of, at each iteration. Clients of this method are advised to
+   *   insert a short delay in the function's behavior, to help avoid CPU
+   *   starvation. The function is passed `start` and `end` arguments with
+   *   semantics similar to `Array.slice()`, indicating which elements of
+   *   `changes` are _about to be_ processed.
    * @returns {BaseSnapshot} New instance consisting of the composition of
    *   this instance with all of the `changes`. Will be a direct instance of the
    *   same class as `this`.
    */
-  composeAll(changes) {
+  async composeAll(changes, maxChangesPerIteration = 1, yieldFunction = () => { /*empty*/ }) {
     TArray.check(changes);
 
     let result = this;
 
-    for (const c of changes) {
-      result = result.compose(c);
+    for (let i = 0; i < changes.length; i += maxChangesPerIteration) {
+      const startAt = i;
+      const endAt   = Math.min(i + maxChangesPerIteration, changes.length);
+      const chunk   = changes.slice(i, i + maxChangesPerIteration);
+
+      await yieldFunction(startAt, endAt);
+
+      // **TODO:** Make it possible for this to have a more efficient
+      // implementation in subclasses.
+      for (const c of chunk) {
+        result = result.compose(c);
+      }
     }
 
     return result;

--- a/local-modules/@bayou/ot-common/mocks/MockDelta.js
+++ b/local-modules/@bayou/ot-common/mocks/MockDelta.js
@@ -29,16 +29,17 @@ export default class MockDelta extends BaseDelta {
   }
 
   _impl_compose(other, wantDocument) {
-    let resultName = wantDocument ? 'composedDoc' : 'composedNotDoc';
-    const op0 = this.ops[0];
+    const resultName = wantDocument ? 'composedDoc' : 'composedNotDoc';
+    let   resultArg  = 1;
+    const op0        = this.ops[0];
 
     if (op0 && op0.name.startsWith(resultName)) {
-      // The first op gets a `_` suffix on its name for each additional
-      // composition.
-      resultName = op0.name + '_';
+      // The first op gets an argument which is a running tally of how many
+      // times composition happened.
+      resultArg = op0.arg0 + 1;
     }
 
-    return new MockDelta([new MockOp(resultName), ...other.ops]);
+    return new MockDelta([new MockOp(resultName, resultArg), ...other.ops]);
   }
 
   _impl_isDocument() {

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -9,8 +9,6 @@ import { BaseOp } from '@bayou/ot-common';
  */
 export default class MockOp extends BaseOp {
   static get CODE_composedDoc()    { return 'composedDoc';    }
-  static get CODE_composedDoc_()   { return 'composedDoc_';   }
-  static get CODE_composedDoc__()  { return 'composedDoc__';  }
   static get CODE_composedNotDoc() { return 'composedNotDoc'; }
   static get CODE_diffDelta()      { return 'diffDelta';      }
   static get CODE_notDocument()    { return 'notDocument';    }
@@ -22,6 +20,10 @@ export default class MockOp extends BaseOp {
 
   get name() {
     return this.payload.name;
+  }
+
+  get arg0() {
+    return this.payload.args[0];
   }
 
   static _impl_isValidPayload() {

--- a/local-modules/@bayou/ot-common/tests/test_BaseChange.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseChange.js
@@ -31,15 +31,15 @@ describe('@bayou/ot-common/BaseChange', () => {
   describe('.FIRST', () => {
     const first = MockChange.FIRST;
 
-    it('should be an instance of the subclass', () => {
+    it('is an instance of the subclass', () => {
       assert.instanceOf(first, MockChange);
     });
 
-    it('should be a frozen object', () => {
+    it('is a frozen object', () => {
       assert.isFrozen(first);
     });
 
-    it('should have the expected properties', () => {
+    it('has the expected properties', () => {
       assert.deepEqual(first.delta, MockDelta.EMPTY);
       assert.strictEqual(first.revNum, 0);
       assert.isNull(first.authorId);
@@ -48,12 +48,12 @@ describe('@bayou/ot-common/BaseChange', () => {
   });
 
   describe('constructor()', () => {
-    it('should produce a frozen instance', () => {
+    it('produces a frozen instance', () => {
       const result = new MockChange(0, MockDelta.EMPTY);
       assert.isFrozen(result);
     });
 
-    it('should accept valid arguments, which should be reflected in the accessors', () => {
+    it('accepts valid arguments, which should be reflected in the accessors', () => {
       function test(...args) {
         assertFields(new MockChange(...args), ...args);
       }
@@ -69,18 +69,18 @@ describe('@bayou/ot-common/BaseChange', () => {
       test(242, MockDelta.EMPTY,   Timestamp.MAX_VALUE, 'florp9019');
     });
 
-    it('should accept a valid `delta` array, which should get passed to the delta constructor', () => {
+    it('accepts a valid `delta` array, which should get passed to the delta constructor', () => {
       const array  = MockDelta.VALID_OPS;
       const result = new MockChange(0, array);
 
       assert.deepEqual(result.delta.ops, array);
     });
 
-    it('should reject an invalid `delta` array, via the delta constructor', () => {
+    it('rejects an invalid `delta` array, via the delta constructor', () => {
       assert.throws(() => { new MockChange(0, MockDelta.INVALID_OPS); });
     });
 
-    it('should reject invalid arguments', () => {
+    it('rejects invalid arguments', () => {
       function test(...args) {
         assert.throws(() => new MockChange(...args));
       }
@@ -121,7 +121,7 @@ describe('@bayou/ot-common/BaseChange', () => {
       const orig = new MockChange(...args);
 
       describe(`${methodName}()`, () => {
-        it('should produce a new instance with the expected fields', () => {
+        it('produces a new instance with the expected fields', () => {
           const result     = orig[methodName](newValue);
           const expectArgs = args.slice();
 
@@ -129,12 +129,12 @@ describe('@bayou/ot-common/BaseChange', () => {
           assertFields(result, ...expectArgs);
         });
 
-        it('should return `this` if the given argument is the same as what is in the instance', () => {
+        it('returns `this` if the given argument is the same as what is in the instance', () => {
           const result = orig[methodName](args[argIndex]);
           assert.strictEqual(result, orig);
         });
 
-        it('should reject invalid arguments', () => {
+        it('rejects invalid arguments', () => {
           function reject(v) {
             assert.throws(() => orig[methodName](v));
           }

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -28,23 +28,23 @@ describe('@bayou/ot-common/BaseDelta', () => {
   describe('.EMPTY', () => {
     const EMPTY = MockDelta.EMPTY;
 
-    it('should be an instance of the subclass', () => {
+    it('is an instance of the subclass', () => {
       assert.instanceOf(EMPTY, MockDelta);
     });
 
-    it('should be a frozen object', () => {
+    it('is a frozen object', () => {
       assert.isFrozen(EMPTY);
     });
 
-    it('should have an empty `ops`', () => {
+    it('has an empty `ops`', () => {
       assert.lengthOf(EMPTY.ops, 0);
     });
 
-    it('should have a frozen `ops`', () => {
+    it('has a frozen `ops`', () => {
       assert.isFrozen(EMPTY.ops);
     });
 
-    it('should be `.isEmpty()`', () => {
+    it('is `.isEmpty()`', () => {
       assert.isTrue(EMPTY.isEmpty());
     });
   });
@@ -62,7 +62,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should succeed for: ${inspect(v)}`, () => {
+        it(`succeeds for: ${inspect(v)}`, () => {
           new MockDelta(v);
         });
       }
@@ -87,13 +87,13 @@ describe('@bayou/ot-common/BaseDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should fail for: ${inspect(v)}`, () => {
+        it(`fails for: ${inspect(v)}`, () => {
           assert.throws(() => new MockDelta(v));
         });
       }
     });
 
-    it('should convert array-of-array arguments into constructed ops', () => {
+    it('converts array-of-array arguments into constructed ops', () => {
       function test(...argses) {
         const ops = argses.map(a => new MockOp(...a));
         const result = new MockDelta(argses);
@@ -114,7 +114,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
   });
 
   describe('compose()', () => {
-    it('should call through to the impl when given valid arguments', () => {
+    it('calls through to the impl when given valid arguments', () => {
       function test(ops1, ops2, wantDocument, expectOps) {
         const d1     = new MockDelta(ops1);
         const d2     = new MockDelta(ops2);
@@ -126,11 +126,11 @@ describe('@bayou/ot-common/BaseDelta', () => {
         assert.deepEqual(result.ops, expectOps);
       }
 
-      test([], [['x']], false, [['composedNotDoc'], ['x']]);
-      test([], [['x']], true,  [['composedDoc'], ['x']]);
+      test([], [['x']], false, [['composedNotDoc', 1], ['x']]);
+      test([], [['x']], true,  [['composedDoc',    1], ['x']]);
     });
 
-    it('should reject invalid `other` arguments', () => {
+    it('rejects invalid `other` arguments', () => {
       function test(value) {
         const delta = MockDelta.EMPTY;
         assert.throws(() => { delta.compose(value, false); }, /badValue/);
@@ -144,7 +144,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       test(new Map());
     });
 
-    it('should reject non-boolean `wantDocument` arguments', () => {
+    it('rejects non-boolean `wantDocument` arguments', () => {
       function test(value) {
         const delta = MockDelta.EMPTY;
         assert.throws(() => { delta.compose(delta, value); }, /badValue/);
@@ -157,21 +157,21 @@ describe('@bayou/ot-common/BaseDelta', () => {
       test('blort');
     });
 
-    it('should reject a non-document `this` when `wantDocument` is `true`', () => {
+    it('rejects a non-document `this` when `wantDocument` is `true`', () => {
       const delta = new MockDelta([['notDocument']]);
       assert.throws(() => { delta.compose(MockDelta.EMPTY, true); }, /badUse/);
     });
   });
 
   describe('deconstruct()', () => {
-    it('should return a data value', () => {
+    it('returns a data value', () => {
       const delta  = new MockDelta([['x', 1, 2, 3, [4, 5, 6]], ['y', { x: ['y'] }]]);
       const result = delta.deconstruct();
 
       assert.isTrue(DataUtil.isData(result));
     });
 
-    it('should return an array of length one, which contains an array-of-arrays', () => {
+    it('returns an array of length one, which contains an array-of-arrays', () => {
       const delta  = new MockDelta([['x', 1], ['y', [1, 2]]]);
       const result = delta.deconstruct();
 
@@ -184,7 +184,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       }
     });
 
-    it('should return a value which successfully round-trips from and to a constructor argument', () => {
+    it('returns a value which successfully round-trips from and to a constructor argument', () => {
       function test(arg) {
         const delta1 = new MockDelta(arg);
         const result = delta1.deconstruct();
@@ -205,7 +205,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       function test(ops) {
         const delta = new MockDelta(ops);
         assert.isTrue(delta.equals(delta));
@@ -216,7 +216,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       test(MockDelta.NOT_DOCUMENT_OPS);
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(ops) {
         const d1 = new MockDelta(ops);
         const d2 = new MockDelta(ops);
@@ -231,7 +231,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       test([['x'], ['y', 1, 2, 3]]);
     });
 
-    it('should return `true` when equal ops are not also `===`', () => {
+    it('returns `true` when equal ops are not also `===`', () => {
       const ops1 = [new MockOp('x'), new MockOp('y')];
       const ops2 = [new MockOp('x'), new MockOp('y')];
       const d1 = new MockDelta(ops1);
@@ -241,7 +241,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       assert.isTrue(d2.equals(d1));
     });
 
-    it('should return `false` when array lengths differ', () => {
+    it('returns `false` when array lengths differ', () => {
       const op1 = new MockOp('x');
       const op2 = new MockOp('y');
       const d1 = new MockDelta([op1]);
@@ -251,7 +251,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       assert.isFalse(d2.equals(d1));
     });
 
-    it('should return `false` when corresponding ops differ', () => {
+    it('returns `false` when corresponding ops differ', () => {
       function test(ops1, ops2) {
         const d1 = new MockDelta(ops1);
         const d2 = new MockDelta(ops2);
@@ -276,7 +276,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       test([op1, op2, op3, op4, op5], [op1, op2, op3, op4, op1]);
     });
 
-    it('should return `false` when passed a non-instance or an instance of a different class', () => {
+    it('returns `false` when passed a non-instance or an instance of a different class', () => {
       const delta = new MockDelta([]);
 
       assert.isFalse(delta.equals(undefined));
@@ -298,14 +298,16 @@ describe('@bayou/ot-common/BaseDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
+        it(`returns \`true\` for: ${inspect(v)}`, () => {
           assert.isTrue(new MockDelta(v).isDocument());
         });
       }
     });
 
     describe('`false` cases', () => {
-      assert.isFalse(new MockDelta(MockDelta.NOT_DOCUMENT_OPS).isDocument());
+      it('returns `false` when appropriate', () => {
+        assert.isFalse(new MockDelta(MockDelta.NOT_DOCUMENT_OPS).isDocument());
+      });
     });
   });
 
@@ -317,7 +319,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
+        it(`returns \`true\` for: ${inspect(v)}`, () => {
           assert.isTrue(v.isEmpty());
         });
       }
@@ -330,7 +332,7 @@ describe('@bayou/ot-common/BaseDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`false\` for: ${inspect(v)}`, () => {
+        it(`returns \`false\` for: ${inspect(v)}`, () => {
           const delta = new MockDelta(v);
           assert.isFalse(delta.isEmpty());
         });

--- a/local-modules/@bayou/ot-common/tests/test_BaseOp.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseOp.js
@@ -12,23 +12,23 @@ import { MockOp } from '@bayou/ot-common/mocks';
 
 describe('@bayou/ot-common/BaseOp', () => {
   describe('constructor()', () => {
-    it('should accept a string `name argument', () => {
+    it('accepts a string `name argument', () => {
       const result = new MockOp('x');
       assert.strictEqual(result.payload.name, 'x');
     });
 
-    it('should accept at least ten arguments after the name', () => {
+    it('accepts at least ten arguments after the name', () => {
       const result = new MockOp('x', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
       assert.strictEqual(result.payload.args.length, 10);
     });
 
-    it('should produce a frozen instance with a frozen payload', () => {
+    it('produces a frozen instance with a frozen payload', () => {
       const op = new MockOp('x');
       assert.isFrozen(op);
       assert.isFrozen(op.payload);
     });
 
-    it('should have all frozen payload arguments even when given non-frozen ones', () => {
+    it('has all frozen payload arguments even when given non-frozen ones', () => {
       function test(...args) {
         const op      = new MockOp('x', ...args);
         const gotArgs = op.payload.args;
@@ -56,7 +56,7 @@ describe('@bayou/ot-common/BaseOp', () => {
       test({ a: { b: { c: 30 } }, d: [[[[['like']]]]] });
     });
 
-    it('should reject payloads with arguments that are neither frozen nor deep-freezable data', () => {
+    it('rejects payloads with arguments that are neither frozen nor deep-freezable data', () => {
       function test(...args) {
         assert.throws(() => new MockOp('x', ...args));
       }
@@ -75,7 +75,7 @@ describe('@bayou/ot-common/BaseOp', () => {
       //test(new Functor('x', 1, 2, new Set()));
     });
 
-    it('should reject non-string first arguments', () => {
+    it('rejects non-string first arguments', () => {
       function test(v) {
         assert.throws(() => new MockOp(v));
       }
@@ -88,7 +88,7 @@ describe('@bayou/ot-common/BaseOp', () => {
   });
 
   describe('.payload', () => {
-    it('should be a functor based on the constructor arguments', () => {
+    it('is a functor based on the constructor arguments', () => {
       const payload = new Functor('x', 1, 2, 3);
       const op = new MockOp(payload.name, ...payload.args);
 
@@ -97,7 +97,7 @@ describe('@bayou/ot-common/BaseOp', () => {
   });
 
   describe('deconstruct()', () => {
-    it('should return an array data value', () => {
+    it('returns an array data value', () => {
       const op     = new MockOp('x', ['florp', 'like'], { timeline: 'sideways' });
       const result = op.deconstruct();
 
@@ -105,7 +105,7 @@ describe('@bayou/ot-common/BaseOp', () => {
       assert.isTrue(DataUtil.isData(result));
     });
 
-    it('should return a value which successfully round-trips from and to constructor arguments', () => {
+    it('returns a value which successfully round-trips from and to constructor arguments', () => {
       function test(...args) {
         const op1    = new MockOp(...args);
         const result = op1.deconstruct();

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -35,7 +35,7 @@ class AnotherSnapshot extends BaseSnapshot {
 
 describe('@bayou/ot-common/BaseSnapshot', () => {
   describe('.EMPTY', () => {
-    it('should be an empty instance', () => {
+    it('is an empty instance', () => {
       const EMPTY = MockSnapshot.EMPTY;
 
       assert.strictEqual(EMPTY.revNum, 0);
@@ -45,7 +45,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('constructor()', () => {
-    it('should accept an array of ops for the contents', () => {
+    it('accepts an array of ops for the contents', () => {
       function test(value) {
         new MockSnapshot(0, value);
       }
@@ -54,7 +54,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(MockDelta.VALID_OPS);
     });
 
-    it('should accept valid revision numbers', () => {
+    it('accepts valid revision numbers', () => {
       function test(value) {
         new MockSnapshot(value, MockDelta.EMPTY);
       }
@@ -64,7 +64,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(999999);
     });
 
-    it('should accept a valid delta', () => {
+    it('accepts a valid delta', () => {
       function test(ops) {
         const delta = new MockDelta(ops);
         new MockSnapshot(0, delta);
@@ -74,24 +74,24 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(MockDelta.VALID_OPS);
     });
 
-    it('should produce a frozen instance', () => {
+    it('produces a frozen instance', () => {
       const snap = new MockSnapshot(0, MockDelta.VALID_OPS);
       assert.isFrozen(snap);
     });
 
-    it('should reject an invalid array', () => {
+    it('rejects an invalid array', () => {
       assert.throws(() => { new MockSnapshot(0, MockDelta.INVALID_OPS); });
       assert.throws(() => { new MockSnapshot(0, MockDelta.NOT_DOCUMENT_OPS); });
     });
 
-    it('should reject a non-document delta', () => {
+    it('rejects a non-document delta', () => {
       // This is a valid delta for which `isDocument()` is `false`.
       const badDelta = new MockDelta(MockDelta.NOT_DOCUMENT_OPS);
 
       assert.throws(() => { new MockSnapshot(0, badDelta); });
     });
 
-    it('should reject invalid revision numbers', () => {
+    it('rejects invalid revision numbers', () => {
       function test(value) {
         assert.throws(() => { new MockSnapshot(value, MockDelta.EMPTY); });
       }
@@ -108,7 +108,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('should call through to the delta and wrap the result in a new instance', () => {
+    it('calls through to the delta and wrap the result in a new instance', () => {
       const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(20, [new MockOp('y')]);
       const result = snap.compose(change);
@@ -118,10 +118,10 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composedDoc'), new MockOp('y')]);
+        [new MockOp('composedDoc', 1), new MockOp('y')]);
     });
 
-    it('should return `this` given a same-`revNum` empty-`delta` change', () => {
+    it('returns `this` given a same-`revNum` empty-`delta` change', () => {
       const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(10, []);
       const result = snap.compose(change);
@@ -129,14 +129,14 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.strictEqual(result, snap);
     });
 
-    it('should reject instances of the wrong change class', () => {
+    it('rejects instances of the wrong change class', () => {
       const snap   = new MockSnapshot(10, []);
       const change = new AnotherChange(0, []);
 
       assert.throws(() => { snap.compose(change); });
     });
 
-    it('should reject non-change arguments', () => {
+    it('rejects non-change arguments', () => {
       const snap = new MockSnapshot(10, []);
 
       function test(v) {
@@ -157,63 +157,153 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('composeAll()', () => {
-    it('should call through to the delta and wrap the result in a new instance', () => {
+    it('calls through to the delta and wraps the result in a new instance', async () => {
       const snap    = new MockSnapshot(10, [new MockOp('x')]);
       const change1 = new MockChange(21, [new MockOp('y')]);
       const change2 = new MockChange(22, [new MockOp('z')]);
-      const result = snap.composeAll([change1, change2]);
+      const result  = await snap.composeAll([change1, change2]);
 
       assert.instanceOf(result, MockSnapshot);
       assert.strictEqual(result.revNum, 22);
       assert.instanceOf(result.contents, MockDelta);
 
       assert.deepEqual(result.contents.ops,
-        [new MockOp('composedDoc_'), new MockOp('z')]);
+        [new MockOp('composedDoc', 2), new MockOp('z')]);
     });
 
-    it('should return `this` given same-`revNum` empty-`delta` changes', () => {
+    it('returns `this` given same-`revNum` empty-`delta` changes', async () => {
       const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(10, []);
-      const result = snap.composeAll([change, change, change, change]);
+      const result = await snap.composeAll([change, change, change, change]);
 
       assert.strictEqual(result, snap);
     });
 
-    it('should reject instances of the wrong change class', () => {
-      const snap   = new MockSnapshot(10, []);
-      const change = new AnotherChange(0, []);
+    it('calls the `yieldFunction` the appropriate number of times and with the expected arguments', async () => {
+      const snap    = new MockSnapshot(10, [new MockOp('x')]);
+      const allChanges = [];
 
-      assert.throws(() => { snap.composeAll([change]); });
-    });
-
-    it('should reject non-change array elements', () => {
-      const snap = new MockSnapshot(10, []);
-
-      function test(v) {
-        assert.throws(() => { snap.compose([v]); });
+      for (let i = 0; i < 100; i++) {
+        allChanges.push(new MockChange(i + 100, [new MockOp('yes', i), new MockOp('x', i)]));
       }
 
-      test(undefined);
-      test(null);
-      test(false);
-      test('blort');
-      test([]);
-      test(['florp']);
-      test({ x: 10 });
-      test(new Map());
-      test(MockDelta.EMPTY);
-      test(MockSnapshot.EMPTY);
+      async function test(max, total = allChanges.length) {
+        const label     = `max ${max}, total ${total}`;
+        const asserts   = [];
+        const changes   = allChanges.slice(0, total);
+        let callCount   = 0;
+        let expectStart = 0;
+
+        const yfunc = async (start, end) => {
+          callCount++;
+
+          // Required so as to capture this iteration's values for use in the
+          // closure below.
+          const cc = callCount;
+          const s  = expectStart;
+
+          asserts.push(() => {
+            const e = Math.min(s + max, changes.length);
+            assert.strictEqual(start, s, `${label}, count ${cc}`);
+            assert.strictEqual(end,   e, `${label}, count ${cc}`);
+          });
+
+          expectStart += max;
+        };
+
+        const result = await snap.composeAll(changes, max, yfunc);
+        assert.strictEqual(callCount, Math.ceil(changes.length / max), label);
+
+        const lastChange = changes[changes.length - 1];
+        const expectOps  = [new MockOp('composedDoc', total), ...lastChange.delta.ops];
+        assert.deepEqual(result, new MockSnapshot(lastChange.revNum, expectOps), label);
+
+        // What's going on here: We don't want to throw assertion errors inside
+        // the middle of the call to `composeAll()`, so we build up an array of
+        // assertion closures as we go, and run through them all here, after the
+        // call to the method under test is complete.
+        for (const a of asserts) {
+          a();
+        }
+      }
+
+      await test(1);
+      await test(1, 1);
+      await test(1, 2);
+      await test(1, 17);
+      await test(1, 90);
+      await test(2);
+      await test(2, 1);
+      await test(2, 2);
+      await test(2, 5);
+      await test(2, 80);
+      await test(2, 99);
+      await test(10);
+      await test(10, 1);
+      await test(10, 9);
+      await test(10, 95);
+      await test(31);
+      await test(31, 25);
+      await test(67);
+      await test(67, 98);
+      await test(100);
+      await test(100, 52);
     });
 
-    it('should reject non-array arguments', () => {
-      const snap   = new MockSnapshot(10, []);
+    it('rejects instances of the wrong change class', async () => {
+      const snap = new MockSnapshot(10, []);
+      const good = new MockChange(0, []);
+      const bad  = new AnotherChange(0, []);
 
-      assert.throws(() => { snap.composeAll(123); });
+      await assert.isRejected(snap.composeAll([bad]), /badValue/);
+      await assert.isRejected(snap.composeAll([bad, good]), /badValue/);
+      await assert.isRejected(snap.composeAll([good, bad]), /badValue/);
+    });
+
+    it('rejects non-change array elements', async () => {
+      const snap   = new MockSnapshot(10, []);
+      const change = new MockChange(10, []);
+
+      async function test(v) {
+        await assert.isRejected(snap.composeAll([v]), /badValue/);
+        await assert.isRejected(snap.composeAll([v, change]), /badValue/);
+        await assert.isRejected(snap.composeAll([change, v]), /badValue/);
+      }
+
+      await test(undefined);
+      await test(null);
+      await test(false);
+      await test(123);
+      await test('blort');
+      await test([]);
+      await test(['florp']);
+      await test({ x: 10 });
+      await test(new Map());
+      await test(MockDelta.EMPTY);
+      await test(MockSnapshot.EMPTY);
+    });
+
+    it('rejects non-array arguments', async () => {
+      const snap = new MockSnapshot(10, []);
+
+      async function test(v) {
+        await assert.isRejected(snap.composeAll(v), /badValue/);
+      }
+
+      await test(undefined);
+      await test(null);
+      await test(false);
+      await test(123);
+      await test('blort');
+      await test({ x: 10 });
+      await test(new Map());
+      await test(MockDelta.EMPTY);
+      await test(MockSnapshot.EMPTY);
     });
   });
 
   describe('diff()', () => {
-    it('should call through to the impl and wrap the result in a timeless authorless change', () => {
+    it('calls through to the impl and wrap the result in a timeless authorless change', () => {
       const oldSnap = new MockSnapshot(10, []);
       const newSnap = new MockSnapshot(20, [new MockOp('x')]);
       const result  = oldSnap.diff(newSnap);
@@ -228,7 +318,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
         [new MockOp('diffDelta'), new MockOp('x')]);
     });
 
-    it('should return an empty change when given an argument with identical contents', () => {
+    it('returns an empty change when given an argument with identical contents', () => {
       function test(s1, s2) {
         const result = s1.diff(s2);
 
@@ -249,14 +339,14 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(snap3, snap2);
     });
 
-    it('should reject instances of the wrong snapshot class', () => {
+    it('rejects instances of the wrong snapshot class', () => {
       const oldSnap = new MockSnapshot(10, []);
       const newSnap = new AnotherSnapshot(20, []);
 
       assert.throws(() => { oldSnap.diff(newSnap); });
     });
 
-    it('should reject non-snapshot arguments', () => {
+    it('rejects non-snapshot arguments', () => {
       const oldSnap = new MockSnapshot(10, []);
 
       function test(v) {
@@ -274,7 +364,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       function test(...args) {
         const snap = new MockSnapshot(...args);
         assert.isTrue(snap.equals(snap), inspect(snap));
@@ -287,7 +377,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(914, MockDelta.VALID_OPS);
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(...args) {
         const snap1 = new MockSnapshot(...args);
         const snap2 = new MockSnapshot(...args);
@@ -303,7 +393,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       test(914, MockDelta.VALID_OPS);
     });
 
-    it('should return `true` when equal property values are not also `===`', () => {
+    it('returns `true` when equal property values are not also `===`', () => {
       // This validates that the base class calls `.equals()` on the delta.
       const snap1 = new MockSnapshot(37, MockDelta.VALID_OPS);
       const snap2 = new MockSnapshot(37, MockDelta.VALID_OPS);
@@ -312,7 +402,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.isTrue(snap2.equals(snap1));
     });
 
-    it('should return `false` when `revNum`s differ', () => {
+    it('returns `false` when `revNum`s differ', () => {
       const snap1 = new MockSnapshot(123, MockDelta.EMPTY);
       const snap2 = new MockSnapshot(456, MockDelta.EMPTY);
 
@@ -320,7 +410,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
 
-    it('should return `false` when deltas are not equal', () => {
+    it('returns `false` when deltas are not equal', () => {
       const snap1 = new MockSnapshot(123, [new MockOp('x')]);
       const snap2 = new MockSnapshot(123, [new MockOp('y')]);
 
@@ -328,7 +418,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
 
-    it('should return `false` when passed a non-snapshot', () => {
+    it('returns `false` when passed a non-snapshot', () => {
       const snap = MockSnapshot.EMPTY;
 
       assert.isFalse(snap.equals(undefined));
@@ -342,13 +432,13 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('withContents()', () => {
-    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+    it('returns `this` if the given `contents` is `===` to the snapshot\'s', () => {
       const snap = new MockSnapshot(123, MockDelta.EMPTY);
 
       assert.strictEqual(snap.withContents(MockDelta.EMPTY), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `contents`', () => {
+    it('returns an appropriately-constructed instance given a different `contents`', () => {
       const delta  = new MockDelta([new MockOp('x')]);
       const snap   = new MockSnapshot(123, [new MockOp('y')]);
       const result = snap.withContents(delta);
@@ -357,7 +447,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `contents`', () => {
+    it('rejects an invalid `contents`', () => {
       const snap = new MockSnapshot(123, []);
 
       assert.throws(() => snap.withContents('blortch'));
@@ -366,13 +456,13 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('withRevNum()', () => {
-    it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
+    it('returns `this` if the given `revNum` is the same as in the snapshot', () => {
       const snap = new MockSnapshot(123, MockDelta.EMPTY);
 
       assert.strictEqual(snap.withRevNum(123), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `revNum`', () => {
+    it('returns an appropriately-constructed instance given a different `revNum`', () => {
       const delta  = new MockDelta(MockDelta.VALID_OPS);
       const snap   = new MockSnapshot(123, delta);
       const result = snap.withRevNum(456);
@@ -381,7 +471,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `revNum`', () => {
+    it('rejects an invalid `revNum`', () => {
       const snap = new MockSnapshot(123, []);
 
       assert.throws(() => snap.withRevNum('blortch'));

--- a/local-modules/@bayou/ot-common/tests/test_RevisionNumber.js
+++ b/local-modules/@bayou/ot-common/tests/test_RevisionNumber.js
@@ -50,7 +50,7 @@ function rejectNonNumbers(name, ...args) {
 
 describe('@bayou/ot-common/RevisionNumber', () => {
   describe('check()', () => {
-    it('should accept non-negative integers', () => {
+    it('accepts non-negative integers', () => {
       function test(value) {
         assert.strictEqual(RevisionNumber.check(value), value);
       }
@@ -64,17 +64,17 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(900090009);
     });
 
-    it('should reject other numbers', () => {
+    it('rejects other numbers', () => {
       rejectBadNumbers('check');
     });
 
-    it('should reject non-numbers', () => {
+    it('rejects non-numbers', () => {
       rejectNonNumbers('check');
     });
   });
 
   describe('maxExc()', () => {
-    it('should accept non-negative integers up to the specified limit', () => {
+    it('accepts non-negative integers up to the specified limit', () => {
       function test(value, limit) {
         assert.strictEqual(RevisionNumber.maxExc(value, limit), value);
       }
@@ -87,7 +87,7 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(37, 39);
     });
 
-    it('should reject non-negative integers beyond the specified limit', () => {
+    it('rejects non-negative integers beyond the specified limit', () => {
       function test(value, limit) {
         assert.throws(() => RevisionNumber.maxExc(value, limit), /^badValue/);
       }
@@ -99,17 +99,17 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(100, 99);
     });
 
-    it('should reject other numbers', () => {
+    it('rejects other numbers', () => {
       rejectBadNumbers('maxExc', 10);
     });
 
-    it('should reject non-numbers', () => {
+    it('rejects non-numbers', () => {
       rejectNonNumbers('maxExc', 10);
     });
   });
 
   describe('maxInc()', () => {
-    it('should accept non-negative integers up to the specified limit', () => {
+    it('accepts non-negative integers up to the specified limit', () => {
       function test(value, limit) {
         assert.strictEqual(RevisionNumber.maxInc(value, limit), value);
       }
@@ -126,7 +126,7 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(37, 37);
     });
 
-    it('should reject non-negative integers beyond the specified limit', () => {
+    it('rejects non-negative integers beyond the specified limit', () => {
       function test(value, limit) {
         assert.throws(() => RevisionNumber.maxInc(value, limit), /^badValue/);
       }
@@ -138,17 +138,17 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(100, 98);
     });
 
-    it('should reject other numbers', () => {
+    it('rejects other numbers', () => {
       rejectBadNumbers('maxInc', 10);
     });
 
-    it('should reject non-numbers', () => {
+    it('rejects non-numbers', () => {
       rejectNonNumbers('maxInc', 10);
     });
   });
 
   describe('min()', () => {
-    it('should accept non-negative integers at or beyond the specified limit', () => {
+    it('accepts non-negative integers at or beyond the specified limit', () => {
       function test(value, limit) {
         assert.strictEqual(RevisionNumber.min(value, limit), value);
       }
@@ -175,17 +175,17 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(100, 10000);
     });
 
-    it('should reject other numbers', () => {
+    it('rejects other numbers', () => {
       rejectBadNumbers('min', 10);
     });
 
-    it('should reject non-numbers', () => {
+    it('rejects non-numbers', () => {
       rejectNonNumbers('min', 10);
     });
   });
 
   describe('orNeg1()', () => {
-    it('should accept non-negative integers', () => {
+    it('accepts non-negative integers', () => {
       function test(value) {
         assert.strictEqual(RevisionNumber.orNeg1(value), value);
       }
@@ -199,11 +199,11 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(900090009);
     });
 
-    it('should accept `-1`', () => {
+    it('accepts `-1`', () => {
       assert.strictEqual(RevisionNumber.orNeg1(-1), -1);
     });
 
-    it('should reject other numbers', () => {
+    it('rejects other numbers', () => {
       function test(value) {
         assert.throws(() => RevisionNumber.orNeg1(value), /^badValue/);
       }
@@ -216,7 +216,7 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(NaN);
     });
 
-    it('should reject non-numbers', () => {
+    it('rejects non-numbers', () => {
       rejectNonNumbers('orNeg1');
     });
   });

--- a/local-modules/@bayou/ot-common/tests/test_Timestamp.js
+++ b/local-modules/@bayou/ot-common/tests/test_Timestamp.js
@@ -15,39 +15,39 @@ const SEC_2040_JAN_01 = Math.floor(new Date(2040, 1, 1, 0, 0, 0, 0).valueOf() / 
 
 describe('@bayou/ot-common/Timestamp', () => {
   describe('.MAX_VALUE', () => {
-    it('should be an instance of the class', () => {
+    it('is an instance of the class', () => {
       assert.instanceOf(Timestamp.MAX_VALUE, Timestamp);
     });
 
-    it('should be larger than `MIN_VALUE`', () => {
+    it('is larger than `MIN_VALUE`', () => {
       assert.strictEqual(Timestamp.MAX_VALUE.compareTo(Timestamp.MIN_VALUE), 1);
     });
 
-    it('should have the largest allowed `usecs`', () => {
+    it('has the largest allowed `usecs`', () => {
       assert.strictEqual(Timestamp.MAX_VALUE.usecs, 999999);
     });
   });
 
   describe('.MIN_VALUE', () => {
-    it('should be an instance of the class', () => {
+    it('is an instance of the class', () => {
       assert.instanceOf(Timestamp.MIN_VALUE, Timestamp);
     });
 
-    it('should be smaller than `MAX_VALUE`', () => {
+    it('is smaller than `MAX_VALUE`', () => {
       assert.strictEqual(Timestamp.MIN_VALUE.compareTo(Timestamp.MAX_VALUE), -1);
     });
 
-    it('should have `0` for `usecs`', () => {
+    it('has `0` for `usecs`', () => {
       assert.strictEqual(Timestamp.MIN_VALUE.usecs, 0);
     });
   });
 
   describe('check()', () => {
-    it('should reject `null`', () => {
+    it('rejects `null`', () => {
       assert.throws(() => Timestamp.check(null));
     });
 
-    it('should reject non-instances', () => {
+    it('rejects non-instances', () => {
       assert.throws(() => Timestamp.check(37));
       assert.throws(() => Timestamp.check('x'));
       assert.throws(() => Timestamp.check(false));
@@ -55,14 +55,14 @@ describe('@bayou/ot-common/Timestamp', () => {
       assert.throws(() => Timestamp.check(new Map()));
     });
 
-    it('should accept an instance', () => {
+    it('accepts an instance', () => {
       const value = new Timestamp(SEC_2010_JAN_01, 0);
       assert.strictEqual(Timestamp.check(value), value);
     });
   });
 
   describe('fromMsec()', () => {
-    it('should produce an instance with the expected fields', () => {
+    it('produces an instance with the expected fields', () => {
       function test(v) {
         const sec  = Math.floor(v / 1000);
         const usec = Math.floor((v - (sec * 1000)) * 1000);
@@ -80,7 +80,7 @@ describe('@bayou/ot-common/Timestamp', () => {
   });
 
   describe('fromUsec()', () => {
-    it('should produce an instance with the expected fields', () => {
+    it('produces an instance with the expected fields', () => {
       function test(v) {
         const sec  = Math.floor(v / 1000000);
         const usec = v - (sec * 1000000);
@@ -98,11 +98,11 @@ describe('@bayou/ot-common/Timestamp', () => {
   });
 
   describe('orNull()', () => {
-    it('should accept `null`', () => {
+    it('accepts `null`', () => {
       assert.isNull(Timestamp.orNull(null));
     });
 
-    it('should reject non-instances', () => {
+    it('rejects non-instances', () => {
       assert.throws(() => Timestamp.orNull(37));
       assert.throws(() => Timestamp.orNull('x'));
       assert.throws(() => Timestamp.orNull(false));
@@ -110,14 +110,14 @@ describe('@bayou/ot-common/Timestamp', () => {
       assert.throws(() => Timestamp.orNull(new Map()));
     });
 
-    it('should accept an instance', () => {
+    it('accepts an instance', () => {
       const value = new Timestamp(SEC_2010_JAN_01, 0);
       assert.strictEqual(Timestamp.orNull(value), value);
     });
   });
 
   describe('constructor()', () => {
-    it('should accept two in-range integers and reflect those values in the corresponding fields', () => {
+    it('accepts two in-range integers and reflect those values in the corresponding fields', () => {
       function test(secs, usecs) {
         const result = new Timestamp(secs, usecs);
         assert.strictEqual(result.secs, secs);
@@ -131,7 +131,7 @@ describe('@bayou/ot-common/Timestamp', () => {
   });
 
   describe('toString()', () => {
-    it('should convert as expected', () => {
+    it('converts as expected', () => {
       function test(secs, usecs) {
         const result = new Timestamp(secs, usecs);
 


### PR DESCRIPTION
There are three different weakref-based caches in the system. This PR makes the code for them a bit more similar to each other. A future PR will probably factor out a common class, and — I hope — be able to be structured such that that class can be unit tested (unlike all these current bits, which are a bit more entwined with their immediate environs). This will also ultimately make it possible for us to either tweak or eliminate our usage of the `weak` package consistently in one place.
