### PR TITLE
Use `BaseSnapshot.composeAll()`.

### DIFF
--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -180,7 +180,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
     });
 
     it('calls the `yieldFunction` the appropriate number of times and with the expected arguments', async () => {
-      const snap    = new MockSnapshot(10, [new MockOp('x')]);
+      const snap       = new MockSnapshot(10, [new MockOp('x')]);
       const allChanges = [];
 
       for (let i = 0; i < 100; i++) {

--- a/local-modules/@bayou/testing-server/ServerTests.js
+++ b/local-modules/@bayou/testing-server/ServerTests.js
@@ -42,7 +42,8 @@ export default class ServerTests extends UtilityClass {
     const mocha = new Mocha({
       grep:            testFilter || /./,
       reporter:        CollectingReporter,
-      reporterOptions: { holder: reporterHolder }
+      reporterOptions: { holder: reporterHolder },
+      timeout:         10 * 1000 // Ten seconds.
     });
 
     log.info('Initializing server tests...');


### PR DESCRIPTION
This PR hooks up the `file-store` code which makes snapshots from changes to use the recently-revamped `BaseSnapshot.composeAll()`.