### PR TITLE
Add and use `BaseDelta.composeAll()`.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -408,11 +408,11 @@ export default class BaseControl extends BaseDataManager {
     let result = baseDelta;
     const MAX = MAX_CHANGE_READS_PER_TRANSACTION;
     for (let i = startInclusive; i < endExclusive; i += MAX) {
-      const end = Math.min(i + MAX, endExclusive);
+      const end     = Math.min(i + MAX, endExclusive);
       const changes = await this._getChangeRange(i, end, false);
-      for (const c of changes) {
-        result = result.compose(c.delta, wantDocument);
-      }
+      const deltas  = changes.map(c => c.delta);
+
+      result = result.composeAll(deltas, wantDocument);
     }
 
     return result;

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -126,27 +126,7 @@ export default class BaseDelta extends CommonBase {
    *   same concrete class as `this`.
    */
   compose(other, wantDocument) {
-    this.constructor.check(other);
-    TBoolean.check(wantDocument);
-
-    if (wantDocument && !this.isDocument()) {
-      throw Errors.badUse('`wantDocument === true` on non-document instance.');
-    }
-
-    if (other.isEmpty()) {
-      return this;
-    }
-
-    const result = this._impl_compose(other, wantDocument);
-
-    this.constructor.check(result);
-
-    if (wantDocument && !result.isDocument()) {
-      // This indicates a bug in the subclass.
-      throw Errors.wtf('Non-document return value when passed `true` for `wantDocument`.');
-    }
-
-    return result;
+    return this.composeAll([other], wantDocument);
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -112,9 +112,10 @@ export default class BaseDelta extends CommonBase {
 
   /**
    * Composes another instance on top of this one, to produce a new instance.
-   * This operation works equally whether or not `this` is a document delta. If
-   * `other` is empty (and `this` is an appropriate instance with regards to
-   * `wantDocument`), then this method will return `this`.
+   * This operation works equally whether or not `this` is a document delta.
+   * If `other` is an empty delta, this method still typically returns a new
+   * instance, though subclasses can choose to return `this` if circumstances
+   * warrant it).
    *
    * @param {BaseDelta} other The delta to compose. Must be an instance of the
    *   same concrete class as `this`.
@@ -132,9 +133,9 @@ export default class BaseDelta extends CommonBase {
   /**
    * Composes a sequence of deltas on top of this instance, in order, to
    * produce a new instance. This operation works equally whether or not `this`
-   * is a document delta.If the given array is empty or if it only contains
-   * empty instances, this method returns `this`. Otherwise, this method returns
-   * a new instance.
+   * is a document delta. If the given array is empty, this method returns
+   * `this`. Otherwise, this method typically returns a new instance (though
+   * subclasses can choose to return `this` if circumstances warrant it).
    *
    * **Note:** This method can potentially be CPU-intensive, especially if the
    * `deltas` array has many elements and/or has many ops inside the elements
@@ -170,10 +171,6 @@ export default class BaseDelta extends CommonBase {
     // implementation in subclasses.
     for (const d of deltas) {
       this.constructor.check(d);
-
-      if (d.isEmpty()) {
-        continue;
-      }
 
       result = result._impl_compose(d, wantDocument);
 
@@ -283,9 +280,7 @@ export default class BaseDelta extends CommonBase {
   /**
    * Main implementation of {@link #compose} and {@link #composeAll}. Subclasses
    * must fill this in. If `wantDocument` is passed as `true`, `this` is
-   * guaranteed to be a document delta. As a special case, the public methods
-   * will _not_ call this method with an empty value for `other`, as that is
-   * detected and handled directly (as a no-op).
+   * guaranteed to be a document delta.
    *
    * @abstract
    * @param {BaseDelta} other Delta to compose with this instance. Guaranteed

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -120,7 +120,7 @@ export default class BaseDelta extends CommonBase {
    *   a document delta. _Some_ subclasses operate differently when asked to
    *   produce a document vs. not, and this parameter controls that (potential)
    *   behavior. When `true`, `this` must be passed as a document delta.
-   * @returns {BodyDelta} Result of composition. Is always an instance of the
+   * @returns {BaseDelta} Result of composition. Is always an instance of the
    *   same concrete class as `this`.
    */
   compose(other, wantDocument) {

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -28,7 +28,7 @@ export default class BaseDelta extends CommonBase {
     // **Note:** `this` in the context of a static method is the class, not an
     // instance.
 
-    if (!this._EMPTY) {
+    if (!(this._EMPTY instanceof this)) {
       this._EMPTY = new this([]);
     }
 
@@ -112,7 +112,9 @@ export default class BaseDelta extends CommonBase {
 
   /**
    * Composes another instance on top of this one, to produce a new instance.
-   * This operation works equally whether or not `this` is a document delta.
+   * This operation works equally whether or not `this` is a document delta. If
+   * `other` is empty (and `this` is an appropriate instance with regards to
+   * `wantDocument`), then this method will return `this`.
    *
    * @param {BaseDelta} other The delta to compose. Must be an instance of the
    *   same concrete class as `this`.
@@ -129,6 +131,10 @@ export default class BaseDelta extends CommonBase {
 
     if (wantDocument && !this.isDocument()) {
       throw Errors.badUse('`wantDocument === true` on non-document instance.');
+    }
+
+    if (other.isEmpty()) {
+      return this;
     }
 
     const result = this._impl_compose(other, wantDocument);
@@ -238,7 +244,9 @@ export default class BaseDelta extends CommonBase {
   /**
    * Main implementation of {@link #compose}. Subclasses must fill this in.
    * If `wantDocument` is passed as `true`, `this` is guaranteed to be a
-   * document delta.
+   * document delta. As a special case, {@link #compose} will _not_ call this
+   * method with an empty value for `other`, as that is detected directly
+   * (causing {@link #compose} to return `this`).
    *
    * @abstract
    * @param {BaseDelta} other Delta to compose with this instance. Guaranteed

--- a/local-modules/@bayou/ot-common/mocks/MockDelta.js
+++ b/local-modules/@bayou/ot-common/mocks/MockDelta.js
@@ -39,7 +39,8 @@ export default class MockDelta extends BaseDelta {
       resultArg = op0.arg0 + 1;
     }
 
-    return new MockDelta([new MockOp(resultName, resultArg), ...other.ops]);
+    const thisClass = this.constructor;
+    return new thisClass([new MockOp(resultName, resultArg), ...other.ops]);
   }
 
   _impl_isDocument() {

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -114,6 +114,23 @@ describe('@bayou/ot-common/BaseDelta', () => {
   });
 
   describe('compose()', () => {
+    it('returns `this` when `other` is empty', () => {
+      class TestDelta extends MockDelta {
+        _impl_compose(other_unused, wantDocument_unused) {
+          throw new Error('should not have been called');
+        }
+      }
+
+      const docDelta    = new TestDelta([['x']]);
+      const nondocDelta = new TestDelta(MockDelta.NOT_DOCUMENT_OPS);
+
+      assert.strictEqual(docDelta.compose(TestDelta.EMPTY, true), docDelta);
+      assert.strictEqual(docDelta.compose(new TestDelta([]), true), docDelta);
+
+      assert.strictEqual(nondocDelta.compose(TestDelta.EMPTY, false), nondocDelta);
+      assert.strictEqual(nondocDelta.compose(new TestDelta([]), false), nondocDelta);
+    });
+
     it('calls through to the impl when given valid arguments', () => {
       function test(ops1, ops2, wantDocument, expectOps) {
         const d1     = new MockDelta(ops1);

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -175,8 +175,132 @@ describe('@bayou/ot-common/BaseDelta', () => {
     });
 
     it('rejects a non-document `this` when `wantDocument` is `true`', () => {
-      const delta = new MockDelta([['notDocument']]);
+      const delta = new MockDelta(MockDelta.NOT_DOCUMENT_OPS);
       assert.throws(() => { delta.compose(MockDelta.EMPTY, true); }, /badUse/);
+    });
+  });
+
+  describe('composeAll()', () => {
+    it('returns `this` given an empty `deltas`', () => {
+      const docDelta    = new MockDelta([['x']]);
+      const nondocDelta = new MockDelta(MockDelta.NOT_DOCUMENT_OPS);
+
+      assert.strictEqual(docDelta.composeAll([], true), docDelta);
+      assert.strictEqual(nondocDelta.composeAll([], false), nondocDelta);
+    });
+
+    it('returns `this` when `deltas` is non-empty but all instances are empty', () => {
+      const docDelta    = new MockDelta([['x']]);
+      const nondocDelta = new MockDelta(MockDelta.NOT_DOCUMENT_OPS);
+
+      function test(count) {
+        const deltas = [];
+        for (let i = 0; i < count; i++) {
+          deltas.push(MockDelta.EMPTY);
+        }
+
+        assert.strictEqual(docDelta.composeAll(deltas, true), docDelta);
+        assert.strictEqual(nondocDelta.composeAll(deltas, false), nondocDelta);
+      }
+
+      test(1);
+      test(2);
+      test(10);
+    });
+
+    it('calls through to `compose()` the appropriate number of times returning the expected ultimate result', () => {
+      let callCount = 0;
+
+      class TestDelta extends MockDelta {
+        _impl_compose(...args) {
+          callCount++;
+          return super._impl_compose(...args);
+        }
+      }
+
+      const docDelta    = new TestDelta([['x']]);
+      const nondocDelta = new TestDelta(MockDelta.NOT_DOCUMENT_OPS);
+
+      function test(count, emptyCount = 0) {
+        const deltas = [];
+        for (let i = 0; i < count; i++) {
+          deltas.push(new TestDelta([['yes', i + 101]]));
+        }
+        for (let i = 0, at = 5 % (count-1); i < emptyCount; i++, at = (at + 31) % (count-1)) {
+          deltas[at] = TestDelta.EMPTY;
+        }
+
+        callCount = 0;
+        const docResult = docDelta.composeAll(deltas, true);
+        assert.strictEqual(callCount, count - emptyCount);
+        assert.deepEqual(
+          docResult,
+          new TestDelta([['composedDoc', count - emptyCount], ['yes', count + 100]]));
+
+        callCount = 0;
+        const nondocResult = nondocDelta.composeAll(deltas, false);
+        assert.strictEqual(callCount, count - emptyCount);
+        assert.deepEqual(
+          nondocResult,
+          new TestDelta([['composedNotDoc', count - emptyCount], ['yes', count + 100]]));
+      }
+
+      test(1);
+      test(2);
+      test(10);
+
+      test(2, 1);
+      test(6, 2);
+      test(23, 7);
+    });
+
+    it('rejects instances of the wrong delta class', () => {
+      const delta = new MockDelta([['x']]);
+      const good  = new MockDelta([['yes']]);
+      const bad   = AnotherDelta.EMPTY;
+
+      assert.throws(() => delta.composeAll([bad]), /badValue/);
+      assert.throws(() => delta.composeAll([bad, good]), /badValue/);
+      assert.throws(() => delta.composeAll([good, bad]), /badValue/);
+    });
+
+    it('rejects non-delta array elements', () => {
+      const delta = new MockDelta([['x']]);
+      const other = new MockDelta([['yes']]);
+
+      function test(v) {
+        assert.throws(() => delta.composeAll([v]), /badValue/);
+        assert.throws(() => delta.composeAll([v, other]), /badValue/);
+        assert.throws(() => delta.composeAll([other, v]), /badValue/);
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test(123);
+      test('blort');
+      test([]);
+      test(['florp']);
+      test({ x: 10 });
+      test(new Map());
+      test(new MockOp('x'));
+    });
+
+    it('rejects non-array arguments', () => {
+      const delta = new MockDelta([['x']]);
+
+      function test(v) {
+        assert.throws(() => delta.composeAll(v), /badValue/);
+      }
+
+      test(undefined);
+      test(null);
+      test(false);
+      test(123);
+      test('blort');
+      test({ x: 10 });
+      test(new Map());
+      test(new MockOp('x'));
     });
   });
 

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -171,12 +171,12 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
         [new MockOp('composedDoc', 2), new MockOp('z')]);
     });
 
-    it('returns `this` given same-`revNum` empty-`delta` changes', async () => {
+    it('returns a value equal to `this` given same-`revNum` empty-`delta` changes', async () => {
       const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(10, []);
       const result = await snap.composeAll([change, change, change, change]);
 
-      assert.strictEqual(result, snap);
+      assert.deepEqual(result, snap);
     });
 
     it('calls the `yieldFunction` the appropriate number of times and with the expected arguments', async () => {

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -171,14 +171,6 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
         [new MockOp('composedDoc', 2), new MockOp('z')]);
     });
 
-    it('returns a value equal to `this` given same-`revNum` empty-`delta` changes', async () => {
-      const snap   = new MockSnapshot(10, [new MockOp('x')]);
-      const change = new MockChange(10, []);
-      const result = await snap.composeAll([change, change, change, change]);
-
-      assert.deepEqual(result, snap);
-    });
-
     it('calls the `yieldFunction` the appropriate number of times and with the expected arguments', async () => {
       const snap       = new MockSnapshot(10, [new MockOp('x')]);
       const allChanges = [];


### PR DESCRIPTION
This PR moves the _synchronous_ logic from `BaseSnapshot.composeAll()` into a new method `BaseDelta.composeAll()`, and uses that new method both in `BaseSnapshot` as well as in `BaseControl.getComposedChanges()`.

Very informal testing indicates that the current arrangement cuts about half the time out of the snapshot composition that happens during initial file load. However, that doesn't actually solve the problem — we still have an O(N²) thing going on — and there is still ample opportunity to address it.
