### PR TITLE
Add overridable method `BaseDelta._impl_composeAll()`.

### DIFF
--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -169,7 +169,7 @@ export default class BaseDelta extends CommonBase {
       return this;
     }
 
-    const result = (deltas.lenth === 1)
+    const result = (deltas.length === 1)
       ? this._impl_compose(deltas[0], wantDocument)
       : this._impl_composeAll(deltas, wantDocument);
 
@@ -300,7 +300,6 @@ export default class BaseDelta extends CommonBase {
    * must fill this in. If `wantDocument` is passed as `true`, `this` is
    * guaranteed to be a document delta.
    *
-   * @abstract
    * @param {array<BaseDelta>} deltas Instances to compose on top of this
    *   instance. This is guaranteed to be an array consisting of instances of
    *   the same concrete class as `this`.

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -173,13 +173,7 @@ export default class BaseDelta extends CommonBase {
       ? this._impl_compose(deltas[0], wantDocument)
       : this._impl_composeAll(deltas, wantDocument);
 
-    this.constructor.check(result);
-
-    if (wantDocument && !result.isDocument()) {
-      // This indicates a bug in the subclass.
-      throw Errors.wtf('Non-document return value when passed `true` for `wantDocument`.');
-    }
-
+    this._checkResult(result, wantDocument);
     return result;
   }
 
@@ -314,13 +308,7 @@ export default class BaseDelta extends CommonBase {
 
     for (const d of deltas) {
       result = result._impl_compose(d, wantDocument);
-
-      this.constructor.check(result);
-
-      if (wantDocument && !result.isDocument()) {
-        // This indicates a bug in the subclass.
-        throw Errors.wtf('Non-document return value when passed `true` for `wantDocument`.');
-      }
+      this._checkResult(result, wantDocument);
     }
 
     return result;
@@ -335,6 +323,23 @@ export default class BaseDelta extends CommonBase {
    */
   _impl_isDocument() {
     return this._mustOverride();
+  }
+
+  /**
+   * Helper for validation of subclass behavior, which checks that the given
+   * value is an instance of the class, and optionally that it is a document
+   * delta. Throws an error if the check(s) fail.
+   *
+   * @param {*} result (Alleged) instance.
+   * @param {boolean} wantDocument Whether `result` must be a document delta.
+   */
+  _checkResult(result, wantDocument) {
+    this.constructor.check(result);
+
+    if (wantDocument && !result.isDocument()) {
+      // This indicates a bug in the subclass.
+      throw Errors.wtf('Non-document return value when passed `true` for `wantDocument`.');
+    }
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -307,8 +307,16 @@ export default class BaseDelta extends CommonBase {
     let result = this;
 
     for (const d of deltas) {
+      if (result !== this) {
+        // No need to check the incoming `this`, as the caller (in this class)
+        // guarantees validity. Somewhat similarly, we do the check here at the
+        // top of the loop instead of after the re-assignment of `result` below,
+        // because the caller will always check the final result, and so a
+        // post-assignment check here would _also_ be redundant.
+        this._checkResult(result, wantDocument);
+      }
+
       result = result._impl_compose(d, wantDocument);
-      this._checkResult(result, wantDocument);
     }
 
     return result;


### PR DESCRIPTION
This PR adds a new method `BaseDelta._impl_composeAll()`, which can be overridden to provide a subclass-specific implementation of `composeAll()`. This method gets a default implementation which is (more or less) the former guts of `BaseDelta.composeAll()`, and that latter method now has the smarts to call either `_impl_composeAll()` or `_impl_compose()` or neither, depending on the number of `deltas` it's being asked to operate on.

Without actually overriding the new method, there should be no change in semantics or efficiency compared to the state of affairs before this PR.
