### PR TITLE
Metrics logging

### DIFF
--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -115,7 +115,7 @@ export default class DocServer extends Singleton {
 
         const endTime = Date.now();
         result.log.event.madeComplex(...((fileId === documentId) ? [] : [fileId]));
-        result.log.event.initTimeMsec(endTime - startTime);
+        result.log.metric.initTimeMsec(endTime - startTime);
 
         return result;
       } catch (e) {

--- a/local-modules/@bayou/see-all-server/tests/test_RecentSink.js
+++ b/local-modules/@bayou/see-all-server/tests/test_RecentSink.js
@@ -13,7 +13,7 @@ const LOG_TAG = new LogTag('blort-tag');
 
 describe('@bayou/see-all-server/RecentSink', () => {
   describe('log()', () => {
-    it('should log a regular item as given', () => {
+    it('logs a regular item as given', () => {
       const sink   = new RecentSink(1);
       const record = LogRecord.forMessage(90909, 'yay-stack', LOG_TAG, 'error', 'bar', 'baz');
 
@@ -24,7 +24,7 @@ describe('@bayou/see-all-server/RecentSink', () => {
       assert.strictEqual(contents[0], record);
     });
 
-    it('should log a time record as given', () => {
+    it('logs a time record as given', () => {
       const sink = new RecentSink(1);
       const lr   = LogRecord.forTime(80808);
 
@@ -37,7 +37,7 @@ describe('@bayou/see-all-server/RecentSink', () => {
   });
 
   describe('.contents', () => {
-    it('should contain all logged items assuming no `time` has been logged', () => {
+    it('contains all logged items assuming no `time` has been logged', () => {
       const sink = new RecentSink(1);
       const NUM_LINES = 10;
 
@@ -58,7 +58,7 @@ describe('@bayou/see-all-server/RecentSink', () => {
       }
     });
 
-    it('should only contain new-enough items if `time` was just logged', () => {
+    it('only contains new-enough items if `time` was just logged', () => {
       function timeForLine(line) {
         return 12345 + (line * 100);
       }
@@ -87,7 +87,7 @@ describe('@bayou/see-all-server/RecentSink', () => {
   });
 
   describe('.htmlContents', () => {
-    it('should return the logged lines as HTML', () => {
+    it('returns the logged lines as HTML', () => {
       const sink = new RecentSink(1);
       const NUM_LINES = 10;
 

--- a/local-modules/@bayou/see-all/BaseLogger.js
+++ b/local-modules/@bayou/see-all/BaseLogger.js
@@ -11,10 +11,9 @@ import LogRecord from './LogRecord';
 import LogStream from './LogStream';
 import LogTag from './LogTag';
 
-
 /**
- * Base class for loggers. Subclasses must implement `_impl_logEvent()` and
- * `_impl_logMessage()`.
+ * Base class for loggers. Subclasses must implement a handful of `_impl_*`
+ * methods.
  */
 export default class BaseLogger extends CommonBase {
   /**
@@ -28,6 +27,12 @@ export default class BaseLogger extends CommonBase {
      * as to enable `this.event.whatever(...)`.
      */
     this._event = LogProxyHandler.makeProxy((...args) => this.logEvent(...args));
+
+    /**
+     * {Proxy} Proxy which uses an instance of {@link LogProxyHandler}, so
+     * as to enable `this.metric.whatever(...)`.
+     */
+    this._metric = LogProxyHandler.makeProxy((...args) => this.logMetric(...args));
   }
 
   /**
@@ -38,6 +43,16 @@ export default class BaseLogger extends CommonBase {
    */
   get event() {
     return this._event;
+  }
+
+  /**
+   * {Proxy} Metric logger. This is a proxy object which synthesizes metrics
+   * logging functions. For any name `someName`, `metric.someName` is a
+   * function that, when called with arguments `(some, args)`, will log a
+   * metric `someName(some, args)`.
+   */
+  get metric() {
+    return this._metric;
   }
 
   /**

--- a/local-modules/@bayou/see-all/BaseLogger.js
+++ b/local-modules/@bayou/see-all/BaseLogger.js
@@ -27,7 +27,7 @@ export default class BaseLogger extends CommonBase {
      * {Proxy} Proxy which uses an instance of {@link LogProxyHandler}, so
      * as to enable `this.event.whatever(...)`.
      */
-    this._event = LogProxyHandler.makeProxy(this);
+    this._event = LogProxyHandler.makeProxy((...args) => this.logEvent(...args));
   }
 
   /**

--- a/local-modules/@bayou/see-all/BaseLogger.js
+++ b/local-modules/@bayou/see-all/BaseLogger.js
@@ -71,6 +71,19 @@ export default class BaseLogger extends CommonBase {
   }
 
   /**
+   * Logs a metric. From the perspective of this class, a metric is just a
+   * structured event with a special name prefix.
+   *
+   * @param {string} name Event name.
+   * @param {...*} args Event payload arguments. Recommended practice for
+   *   metrics is that these arguments be simple atomic data, especially
+   *   numbers and booleans.
+   */
+  logMetric(name, ...args) {
+    this.logEvent(LogRecord.eventNameFromMetricName(name), ...args);
+  }
+
+  /**
    * Logs an ad-hoc message at the `debug` level.
    *
    * @param {...*} message Message to log. See {@link #logMessage} for details.

--- a/local-modules/@bayou/see-all/BaseLogger.js
+++ b/local-modules/@bayou/see-all/BaseLogger.js
@@ -92,7 +92,9 @@ export default class BaseLogger extends CommonBase {
    * @param {string} name Event name.
    * @param {...*} args Event payload arguments. Recommended practice for
    *   metrics is that these arguments be simple atomic data, especially
-   *   numbers and booleans.
+   *   numbers and booleans. For a metric that represents an atomic occurrence
+   *   (with no salient data) to merely be counted / aggregated, it is valid to
+   *   pass no additional arguments.
    */
   logMetric(name, ...args) {
     this.logEvent(LogRecord.eventNameFromMetricName(name), ...args);

--- a/local-modules/@bayou/see-all/BaseLogger.js
+++ b/local-modules/@bayou/see-all/BaseLogger.js
@@ -6,7 +6,7 @@ import { inspect } from 'util';
 
 import { CommonBase, DataUtil, Errors, Functor } from '@bayou/util-common';
 
-import EventProxyHandler from './EventProxyHandler';
+import LogProxyHandler from './LogProxyHandler';
 import LogRecord from './LogRecord';
 import LogStream from './LogStream';
 import LogTag from './LogTag';
@@ -24,10 +24,10 @@ export default class BaseLogger extends CommonBase {
     super();
 
     /**
-     * {Proxy} Proxy which uses an instance of {@link EventProxyHandler}, so
+     * {Proxy} Proxy which uses an instance of {@link LogProxyHandler}, so
      * as to enable `this.event.whatever(...)`.
      */
-    this._event = EventProxyHandler.makeProxy(this);
+    this._event = LogProxyHandler.makeProxy(this);
   }
 
   /**

--- a/local-modules/@bayou/see-all/EventProxyHandler.js
+++ b/local-modules/@bayou/see-all/EventProxyHandler.js
@@ -16,16 +16,6 @@ import BaseLogger from './BaseLogger';
  */
 export default class EventProxyHandler extends MethodCacheProxyHandler {
   /**
-   * Makes a proxy that is handled by an instance of this class.
-   *
-   * @param {BaseLogger} log Logger to call through to.
-   * @returns {Proxy} An appropriately-constructed proxy object.
-   */
-  static makeProxy(log) {
-    return new Proxy(Object.freeze({}), new EventProxyHandler(log));
-  }
-
-  /**
    * Constructs an instance.
    *
    * @param {BaseLogger} log Logger to call through to.

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -2,9 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { TFunction } from '@bayou/typecheck';
 import { MethodCacheProxyHandler } from '@bayou/util-common';
-
-import BaseLogger from './BaseLogger';
 
 /**
  * Proxy handler which provides the illusion of an object with infinitely many
@@ -18,13 +17,15 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
   /**
    * Constructs an instance.
    *
-   * @param {BaseLogger} log Logger to call through to.
+   * @param {function} logFunction Function to call through to to perform
+   *   logging. It must take a string name as the first argument and arbitrary
+   *   additional arguments.
    */
-  constructor(log) {
+  constructor(logFunction) {
     super();
 
-    /** {BaseLogger} Logger to call through to. */
-    this._log = BaseLogger.check(log);
+    /** {function} Function to call through to to perform logging. */
+    this._logFunction = TFunction.checkCallable(logFunction);
 
     Object.freeze(this);
   }
@@ -37,7 +38,7 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
    */
   _impl_methodFor(name) {
     return (...args) => {
-      this._log.logEvent(name, ...args);
+      this._logFunction(name, ...args);
     };
   }
 }

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -14,7 +14,7 @@ import BaseLogger from './BaseLogger';
  * For example, `proxy.blort(1, 2, 3)` will cause a `blort` event to
  * be logged with arguments `[1, 2, 3]`.
  */
-export default class EventProxyHandler extends MethodCacheProxyHandler {
+export default class LogProxyHandler extends MethodCacheProxyHandler {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/see-all/LogRecord.js
+++ b/local-modules/@bayou/see-all/LogRecord.js
@@ -13,6 +13,9 @@ import LogTag from './LogTag';
 const MESSAGE_LEVELS_ARRAY =
   Object.freeze(['debug', 'error', 'warn', 'info', 'detail']);
 
+/** {string} Prefix which distinguishes metric names from other event names. */
+const METRIC_PREFIX = 'metric-';
+
 /**
  * {Set<string>} Set of severity levels for message instances where having a
  * stack trace in the human-oriented output is most desirable.
@@ -120,6 +123,17 @@ export default class LogRecord extends CommonBase {
     }
 
     return level;
+  }
+
+  /**
+   * Makes the event name that corresponds to the given plain metric name.
+   *
+   * @param {string} name The raw metric name.
+   * @returns {string} The corresponding event name.
+   */
+  static eventNameFromMetricName(name) {
+    TString.check(name);
+    return `${METRIC_PREFIX}${name}`;
   }
 
   /**
@@ -307,14 +321,6 @@ export default class LogRecord extends CommonBase {
   }
 
   /**
-   * {Functor} Main log payload. In the case of ad-hoc human-oriented
-   * messages, the functor name is the severity level.
-   */
-  get payload() {
-    return this._payload;
-  }
-
-  /**
    * {string} Unified message string, composed from all of the individual
    * arguments. The form varies based on the sort of record (ad-hoc message vs.
    * structured event vs. timestamp).
@@ -390,6 +396,26 @@ export default class LogRecord extends CommonBase {
     }
 
     return result.join('');
+  }
+
+  /**
+   * {string|null} The plain metric name corresponding to this instance, or
+   * `null` if this instance doesn't represent a metric.
+   */
+  get metricName() {
+    const name = this._payload.name;
+
+    return name.startsWith(METRIC_PREFIX)
+      ? name.slice(METRIC_PREFIX.length)
+      : null;
+  }
+
+  /**
+   * {Functor} Main log payload. In the case of ad-hoc human-oriented
+   * messages, the functor name is the severity level.
+   */
+  get payload() {
+    return this._payload;
   }
 
   /**

--- a/local-modules/@bayou/see-all/tests/test_BaseLogger.js
+++ b/local-modules/@bayou/see-all/tests/test_BaseLogger.js
@@ -67,6 +67,23 @@ describe('@bayou/see-all/BaseLogger', () => {
     }
   });
 
+  describe('logMetric()', () => {
+    it('calls through to `_impl_logEvent()` when given valid arguments', () => {
+      const logger  = new MockLogger();
+      const name    = 'blort';
+      const payload = new Functor(LogRecord.eventNameFromMetricName(name), 1, '2', [3]);
+
+      logger.logMetric(name, ...payload.args);
+
+      assert.deepEqual(logger.record, [['event', [], payload]]);
+    });
+
+    it('rejects invalid payload names', () => {
+      const logger = new MockLogger();
+      assert.throws(() => logger.logMetric('$&*', 1, 2, 3));
+    });
+  });
+
   describe('streamFor()', () => {
     it('returns a stream which operates as expected', () => {
       const logger = new MockLogger();

--- a/local-modules/@bayou/see-all/tests/test_BaseLogger.js
+++ b/local-modules/@bayou/see-all/tests/test_BaseLogger.js
@@ -13,6 +13,18 @@ import { Functor } from '@bayou/util-common';
 // made to `_impl_logEvent()` and `_impl_logMessage()`.
 
 describe('@bayou/see-all/BaseLogger', () => {
+  describe('.metric', () => {
+    it('provides a whatever valid name you want, calling through to `logMetric()` when used', () => {
+      const logger = new MockLogger();
+      const name   = 'zorch';
+      const args   = [1, 2];
+      const expect = new Functor(LogRecord.eventNameFromMetricName(name), ...args);
+      logger.metric[name](...args);
+
+      assert.deepEqual(logger.record, [['event', [], expect]]);
+    });
+  });
+
   describe('logEvent()', () => {
     it('calls through to `_impl_logEvent()` when given valid arguments', () => {
       const logger  = new MockLogger();

--- a/local-modules/@bayou/see-all/tests/test_BaseLogger.js
+++ b/local-modules/@bayou/see-all/tests/test_BaseLogger.js
@@ -13,6 +13,18 @@ import { Functor } from '@bayou/util-common';
 // made to `_impl_logEvent()` and `_impl_logMessage()`.
 
 describe('@bayou/see-all/BaseLogger', () => {
+  describe('.event', () => {
+    it('provides a whatever valid name you want, calling through to `logEvent()` when used', () => {
+      const logger = new MockLogger();
+      const name   = 'whatTheMuffin';
+      const args   = ['x', 'y', 'z'];
+      const expect = new Functor(name, ...args);
+      logger.event[name](...args);
+
+      assert.deepEqual(logger.record, [['event', [], expect]]);
+    });
+  });
+
   describe('.metric', () => {
     it('provides a whatever valid name you want, calling through to `logMetric()` when used', () => {
       const logger = new MockLogger();

--- a/local-modules/@bayou/see-all/tests/test_LogRecord.js
+++ b/local-modules/@bayou/see-all/tests/test_LogRecord.js
@@ -25,6 +25,23 @@ describe('@bayou/see-all/LogRecord', () => {
     });
   });
 
+  describe('eventNameFromMetricName()', () => {
+    it('converts a name as expected', () => {
+      const orig1   = 'boop';
+      const orig2   = 'florp';
+      const result1 = LogRecord.eventNameFromMetricName(orig1);
+      const result2 = LogRecord.eventNameFromMetricName(orig2);
+
+      assert.isTrue(result1.endsWith(orig1));
+      assert.isTrue(result2.endsWith(orig2));
+
+      const prefix1 = result1.slice(0, result1.length - orig1.length);
+      const prefix2 = result2.slice(0, result2.length - orig2.length);
+
+      assert.strictEqual(prefix1, prefix2);
+    });
+  });
+
   describe('checkMessageLevel()', () => {
     it('accepts valid levels', () => {
       function test(level) {
@@ -48,7 +65,7 @@ describe('@bayou/see-all/LogRecord', () => {
     });
   });
 
-  describe('messageString()', () => {
+  describe('.messageString', () => {
     it('operates as expected', () => {
       const LOG_TAG = new LogTag('whee');
 
@@ -84,6 +101,28 @@ describe('@bayou/see-all/LogRecord', () => {
       test('123',       123);
       test('[ 1, 2 ]',  [1, 2]);
       test('{ a: 10 }', { a: 10 });
+    });
+  });
+
+  describe('.metricName', () => {
+    const LOG_TAG = new LogTag('boop');
+
+    it('is `null` for a message', () => {
+      const lr = LogRecord.forMessage(0, 'some-stack-trace', LOG_TAG, 'info', 'woop');
+      assert.isNull(lr.metricName);
+    });
+
+    it('is `null` for a non-metric event', () => {
+      const lr = LogRecord.forEvent(0, 'some-stack-trace', LOG_TAG, new Functor('zorch', 123));
+      assert.isNull(lr.metricName);
+    });
+
+    it('is the expected metric name for a metric event', () => {
+      const name      = 'bloop';
+      const eventName = LogRecord.eventNameFromMetricName(name);
+      const payload   = new Functor(eventName, 123);
+      const lr        = LogRecord.forEvent(0, 'some-stack-trace', LOG_TAG, payload);
+      assert.strictEqual(lr.metricName, name);
     });
   });
 

--- a/local-modules/@bayou/see-all/tests/test_LogStream.js
+++ b/local-modules/@bayou/see-all/tests/test_LogStream.js
@@ -11,7 +11,7 @@ import { MockLogger } from '@bayou/see-all/mocks';
 
 describe('@bayou/see-all/LogStream', () => {
   describe('constructor()', () => {
-    it('should accept valid arguments', () => {
+    it('accepts valid arguments', () => {
       const logger = new MockLogger();
 
       new LogStream(logger, 'info');
@@ -19,11 +19,11 @@ describe('@bayou/see-all/LogStream', () => {
       new LogStream(logger, 'error');
     });
 
-    it('should reject an invalid logger argument', () => {
+    it('rejects an invalid logger argument', () => {
       assert.throws(() => { new LogStream(null, 'info'); });
     });
 
-    it('should reject an invalid `level` argument', () => {
+    it('rejects an invalid `level` argument', () => {
       const logger = new MockLogger();
 
       assert.throws(() => { new LogStream(logger, 'blortch is not a level'); });
@@ -31,7 +31,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('write(string)', () => {
-    it('should call through to the underlying logger', () => {
+    it('calls through to the underlying logger', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'info');
 
@@ -42,7 +42,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('write(string, encoding)', () => {
-    it('should not pay attention to the `encoding` argument', () => {
+    it('does not pay attention to the `encoding` argument', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'debug');
 
@@ -52,7 +52,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('write(string, encoding, callback)', () => {
-    it('should call the callback', async () => {
+    it('calls the callback', async () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'info');
       let gotCallback = false;
@@ -67,7 +67,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('write(buffer)', () => {
-    it('should call through to the underlying logger', () => {
+    it('calls through to the underlying logger', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'error');
 
@@ -77,7 +77,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('write(buffer, encoding)', () => {
-    it('should not pay attention to the `encoding` argument', () => {
+    it('does not pay attention to the `encoding` argument', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'warn');
 
@@ -87,7 +87,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('end(string)', () => {
-    it('should call through to the underlying logger', () => {
+    it('calls through to the underlying logger', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'info');
 
@@ -97,7 +97,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('end(string, encoding)', () => {
-    it('should not pay attention to the `encoding` argument', () => {
+    it('does not pay attention to the `encoding` argument', () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'debug');
 
@@ -107,7 +107,7 @@ describe('@bayou/see-all/LogStream', () => {
   });
 
   describe('end(string, encoding, callback)', () => {
-    it('should *not* call the callback', async () => {
+    it('does *not* call the callback', async () => {
       const logger = new MockLogger();
       const ls = new LogStream(logger, 'info');
       let gotCallback = false;


### PR DESCRIPTION
This PR adds metrics logging in a form that — hopefully — is easy to consume in downstream log-processing machinery.

In the context of this project, metrics logs are just a special case of event logs, except:

* They're known as metrics per se, detectable as such when inspecting log records programmatically.
* When sunk into a file log (including `stdout`) in JSON form, the metric name becomes a top-level property of each record, instead of being buried in the stringified `message`.

To log a metric, the most convenient way is to use the new synthetic property `BaseLogger.metric`, which behaves analogously to `.event`, except it bottoms out in a call to `logMetric()` instead of `logEvent()`. One example use of the new mechanism is included, changing `initTimeMsec` as emitted by `DocServer` from being a plain event to now being a metric.
