### PR TITLE
`FileDelta` comments and tests.

### DIFF
--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -112,6 +112,9 @@ export default class FileDelta extends BaseDelta {
         case FileOp.CODE_deletePathPrefix: {
           const prefix = opProps.path;
 
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
           for (const id of data.keys()) {
             if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
               data.delete(id);
@@ -210,6 +213,9 @@ export default class FileDelta extends BaseDelta {
         case FileOp.CODE_deletePathPrefix: {
           const prefix = opProps.path;
 
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
           for (const id of data.keys()) {
             if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
               data.delete(id);

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -165,8 +165,24 @@ export default class FileDelta extends BaseDelta {
    * @returns {FileDelta} Composed result.
    */
   _composeNonDocument(other) {
-    const data  = new Map();   // Single-target ops (writes and deletes).
-    const deletes = new Set(); // Multi-target deletes.
+    // Single-target ops (writes and deletes).
+    const data = new Map();
+
+    // Multi-target deletes. Unlike single-target deletes, which can be
+    // correctly handled in the `data` map including possibly getting
+    // overwritten by subsequent ops, multi-target deletes cannot in general
+    // get overwritten, as their existence can affect subsequent uses of the
+    // result in other `compose()` operations. **Note:** This implementation
+    // does not necessarily produce a "canonical" or maximally compact result,
+    // because (a) it does not try to remove redundancies from within the
+    // deletes other than recognizing `deleteAll` as mooting the whole set
+    // (e.g., `deletePathRange('/x', 1, 6)` and `deletePathRange('x/', 4, 10)`
+    // would ideally combine to `deletePathRange('/x', 1, 10)`); and (b) it does
+    // not trim / remove delete operations that intersect with subsequent writes
+    // (e.g., `deletePathRange('/x', 1, 10)` followed by `writePath('/x/1')`
+    // would ideally trim the resulting delete to
+    // `deletePathRange('/x', 2, 10)`).
+    const deletes = new Set();
 
     // Add / replace the ops, first from `this` and then from `other`, as a
     // mapping from the storage ID.
@@ -192,10 +208,6 @@ export default class FileDelta extends BaseDelta {
         }
 
         case FileOp.CODE_deletePathPrefix: {
-          // Delete any references in `data` to the prefix, but also remember
-          // the op (because it could end up affecting a subsequent
-          // `compose()`).
-
           const prefix = opProps.path;
 
           for (const id of data.keys()) {
@@ -210,10 +222,6 @@ export default class FileDelta extends BaseDelta {
         }
 
         case FileOp.CODE_deletePathRange: {
-          // Delete any references in `data` to the range, but also remember
-          // the op (because it could end up affecting a subsequent
-          // `compose()`).
-
           const { path: prefix, startInclusive, endExclusive } = opProps;
 
           // **TODO:** This isn't necessarily the most efficient way to achieve

--- a/local-modules/@bayou/file-store-ot/tests/test_FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/tests/test_FileDelta.js
@@ -137,8 +137,23 @@ describe('@bayou/file-store-ot/FileDelta', () => {
         const d2     = new FileDelta([op2, op3, op4]);
         const result = d1.compose(d2, false);
 
-        // Order of operations matters!
+        // Order of operations matters (so `deepEqual` and not `sameMembers`).
         assert.deepEqual(result.ops, [op3, op4]);
+      });
+
+      it('does not represent `delete*` ops that are mooted by a `deleteAll`', () => {
+        const op1    = FileOp.op_deleteBlob(FrozenBuffer.coerce('222'));
+        const op2    = FileOp.op_deletePath('/aaa');
+        const op3    = FileOp.op_deletePathPrefix('/x/y');
+        const op4    = FileOp.op_deletePathRange('/florp/like', 10, 20);
+        const op5    = FileOp.op_deleteAll();
+        const op6    = FileOp.op_deletePath('/xyz');
+        const d1     = new FileDelta([op1, op2, op3]);
+        const d2     = new FileDelta([op4, op5, op6]);
+        const result = d1.compose(d2, false);
+
+        // Order of operations matters (so `deepEqual` and not `sameMembers`).
+        assert.deepEqual(result.ops, [op5, op6]);
       });
 
       it('handles `deleteBlob` ops', () => {
@@ -438,8 +453,24 @@ describe('@bayou/file-store-ot/FileDelta', () => {
         const d4     = new FileDelta([op7]);
         const result = d1.composeAll([d2, d3, d4], false);
 
-        // Order of operations matters!
+        // Order of operations matters (so `deepEqual` and not `sameMembers`).
         assert.deepEqual(result.ops, [op5, op6, op7]);
+      });
+
+      it('does not represent `delete*` ops that are mooted by a `deleteAll`', () => {
+        const op1    = FileOp.op_deleteBlob(FrozenBuffer.coerce('222'));
+        const op2    = FileOp.op_deletePath('/aaa');
+        const op3    = FileOp.op_deletePathPrefix('/x/y');
+        const op4    = FileOp.op_deletePathRange('/florp/like', 10, 20);
+        const op5    = FileOp.op_deleteAll();
+        const op6    = FileOp.op_deletePath('/xyz');
+        const d1     = new FileDelta([op1, op2]);
+        const d2     = new FileDelta([op3, op4]);
+        const d3     = new FileDelta([op5, op6]);
+        const result = d1.composeAll([d2, d3], false);
+
+        // Order of operations matters (so `deepEqual` and not `sameMembers`).
+        assert.deepEqual(result.ops, [op5, op6]);
       });
 
       it('handles `deleteBlob` ops', () => {


### PR DESCRIPTION
In advance of major surgery on the file, this PR clarifies the implementation of `compose*()` in `FileDelta`, and adds a handful more tests. No non-test non-comment code changes in this PR.