### PR TITLE
Get `FileDelta` to compose more than one delta at a time.

### DIFF
--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -34,7 +34,7 @@ const MAX_PARALLEL_FS_CALLS = 20;
  * CPU-bound for an extended period of time. That is, we want to be a good
  * cooperative-multitasking citizen.
  */
-const MAX_ATOMIC_COMPOSED_CHANGES = 50;
+const MAX_ATOMIC_COMPOSED_CHANGES = 1000;
 
 /**
  * File implementation that stores everything in the locally-accessible

--- a/local-modules/@bayou/file-store-ot/FileChange.js
+++ b/local-modules/@bayou/file-store-ot/FileChange.js
@@ -15,6 +15,7 @@ export default class FileChange extends BaseChange {
   /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class.
+   * @override
    */
   static get _impl_deltaClass() {
     return FileDelta;

--- a/local-modules/@bayou/file-store-ot/FileChange.js
+++ b/local-modules/@bayou/file-store-ot/FileChange.js
@@ -12,11 +12,7 @@ import FileDelta from './FileDelta';
  * of {@link FileDelta}.
  */
 export default class FileChange extends BaseChange {
-  /**
-   * {class} Class (constructor function) of delta objects to be used with
-   * instances of this class.
-   * @override
-   */
+  /** @override */
   static get _impl_deltaClass() {
     return FileDelta;
   }

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -29,9 +29,13 @@ export default class FileDelta extends BaseDelta {
    * @returns {FileDelta} Composed result.
    */
   _impl_compose(other, wantDocument) {
-    return wantDocument
-      ? this._composeDocument(other)
-      : this._composeNonDocument(other);
+    const opMap     = new Map();
+    const deleteSet = wantDocument ? null : new Set;
+
+    FileDelta._composeOne(opMap, deleteSet, this);
+    FileDelta._composeOne(opMap, deleteSet, other);
+
+    return FileDelta._composeResult(opMap, deleteSet);
   }
 
   /**
@@ -79,197 +83,150 @@ export default class FileDelta extends BaseDelta {
   }
 
   /**
-   * Helper for {@link #_impl_compose} which handles the case of `wantDocument
-   * === true`.
-   *
-   * @param {FileDelta} other Delta to compose with this instance.
-   * @returns {FileDelta} Composed result.
-   */
-  _composeDocument(other) {
-    const data = new Map();
-
-    // Add / replace the ops, first from `this` and then from `other`, as a
-    // mapping from the storage ID.
-    for (const op of [...this.ops, ...other.ops]) {
-      const opProps = op.props;
-
-      switch (opProps.opName) {
-        case FileOp.CODE_deleteAll: {
-          data.clear();
-          break;
-        }
-
-        case FileOp.CODE_deleteBlob: {
-          data.delete(opProps.hash);
-          break;
-        }
-
-        case FileOp.CODE_deletePath: {
-          data.delete(opProps.path);
-          break;
-        }
-
-        case FileOp.CODE_deletePathPrefix: {
-          const prefix = opProps.path;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (const id of data.keys()) {
-            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
-              data.delete(id);
-            }
-          }
-
-          break;
-        }
-
-        case FileOp.CODE_deletePathRange: {
-          const { path: prefix, startInclusive, endExclusive } = opProps;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (let n = startInclusive; n < endExclusive; n++) {
-            data.delete(`${prefix}/${n}`);
-          }
-
-          break;
-        }
-
-        case FileOp.CODE_writeBlob: {
-          data.set(opProps.blob.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_writePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
-        }
-      }
-    }
-
-    // Convert the map to an array of ops, and construct the result therefrom.
-    return new FileDelta([...data.values()]);
-  }
-
-  /**
-   * Helper for {@link #_impl_compose} which handles the case of `wantDocument
-   * === false`. Notably, in this case, the result has to include any `delete*`
-   * operations from `this` and `other` which could possibly have an effect
-   * should the result be used as the argument to a subsequent call to
-   * `compose()`.
-   *
-   * @param {FileDelta} other Delta to compose with this instance.
-   * @returns {FileDelta} Composed result.
-   */
-  _composeNonDocument(other) {
-    // Single-target ops (writes and deletes).
-    const data = new Map();
-
-    // Multi-target deletes. Unlike single-target deletes, which can be
-    // correctly handled in the `data` map including possibly getting
-    // overwritten by subsequent ops, multi-target deletes cannot in general
-    // get overwritten, as their existence can affect subsequent uses of the
-    // result in other `compose()` operations. **Note:** This implementation
-    // does not necessarily produce a "canonical" or maximally compact result,
-    // because (a) it does not try to remove redundancies from within the
-    // deletes other than recognizing `deleteAll` as mooting the whole set
-    // (e.g., `deletePathRange('/x', 1, 6)` and `deletePathRange('x/', 4, 10)`
-    // would ideally combine to `deletePathRange('/x', 1, 10)`); and (b) it does
-    // not trim / remove delete operations that intersect with subsequent writes
-    // (e.g., `deletePathRange('/x', 1, 10)` followed by `writePath('/x/1')`
-    // would ideally trim the resulting delete to
-    // `deletePathRange('/x', 2, 10)`).
-    const deletes = new Set();
-
-    // Add / replace the ops, first from `this` and then from `other`, as a
-    // mapping from the storage ID.
-    for (const op of [...this.ops, ...other.ops]) {
-      const opProps = op.props;
-
-      switch (opProps.opName) {
-        case FileOp.CODE_deleteAll: {
-          data.clear();
-          deletes.clear();
-          deletes.add(op);
-          break;
-        }
-
-        case FileOp.CODE_deleteBlob: {
-          data.set(opProps.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_deletePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        case FileOp.CODE_deletePathPrefix: {
-          const prefix = opProps.path;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (const id of data.keys()) {
-            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
-              data.delete(id);
-            }
-          }
-
-          deletes.add(op);
-
-          break;
-        }
-
-        case FileOp.CODE_deletePathRange: {
-          const { path: prefix, startInclusive, endExclusive } = opProps;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (let n = startInclusive; n < endExclusive; n++) {
-            data.delete(`${prefix}/${n}`);
-          }
-
-          deletes.add(op);
-
-          break;
-        }
-
-        case FileOp.CODE_writeBlob: {
-          data.set(opProps.blob.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_writePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
-        }
-      }
-    }
-
-    // Convert the map to an array of ops, and construct the result therefrom.
-
-    const ops = [...deletes.values(), ...data.values()];
-
-    return new FileDelta(ops);
-  }
-
-  /**
    * {class} Class (constructor function) of operation objects to be used with
    * instances of this class.
    */
   static get _impl_opClass() {
     return FileOp;
+  }
+
+  /**
+   * Helper for {@link #_impl_compose} and {@link #_impl_composeAll} which
+   * performs one composition of a delta on top of a running composition result,
+   * said running result which takes the form of a map from IDs to ops and an
+   * optional set of multi-target delete operations (which is `null` for
+   * document composes and required for non-document composes).
+   *
+   * **Note:** The deal with the `deletes` set is that multi-target deletes, in
+   * general, cannot be dropped from a composition result because they will have
+   * an effect when the composition result is itself used as the argument to
+   * a later compose operation. (Single-target deletes can always be dropped if
+   * they are "overwritten" by a later write operation with the exact same ID.)
+   *
+   * **Note the Second:** This implementation does not necessarily produce a
+   * "canonical" or maximally compact result with regards to multi-target delete
+   * operations, because (a) it does not try to remove redundancies from within
+   * the deletes other than recognizing `deleteAll` as mooting the whole set
+   * (e.g., `deletePathRange('/x', 1, 6)` and `deletePathRange('x/', 4, 10)`
+   * would ideally combine to `deletePathRange('/x', 1, 10)`); and (b) it does
+   * not trim / remove delete operations that intersect with subsequent writes
+   * (e.g., `deletePathRange('/x', 1, 10)` followed by `writePath('/x/1')`
+   * would ideally trim the resulting delete to
+   * `deletePathRange('/x', 2, 10)`).
+   *
+   * @param {Map<string, FileOp>} opMap Map from IDs to corresponding file
+   *   operations, representing the result of composition in progress. This
+   *   method modifies the value.
+   * @param {Set<FileOp>|null} deleteSet Set of multi-target delete operations,
+   *   representing the result of composition in progress. This method modifies
+   *   the value. If `null`, deletes are not tracked at all, either through
+   *   this argument (of course) but also via `opMap`.
+   * @param {FileDelta} delta Delta to compose with this running result as
+   *   represented in the previous two arguments.
+   */
+  static _composeOne(opMap, deleteSet, delta) {
+    const trackDeletes = (deleteSet !== null);
+
+    for (const op of delta.ops) {
+      const opProps = op.props;
+
+      switch (opProps.opName) {
+        case FileOp.CODE_deleteAll: {
+          opMap.clear();
+          if (trackDeletes) {
+            deleteSet.clear();
+            deleteSet.add(op);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deleteBlob: {
+          if (trackDeletes) {
+            opMap.set(opProps.hash, op);
+          } else {
+            opMap.delete(opProps.hash);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deletePath: {
+          if (trackDeletes) {
+            opMap.set(opProps.path, op);
+          } else {
+            opMap.delete(opProps.path);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deletePathPrefix: {
+          const prefix = opProps.path;
+
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
+          for (const id of opMap.keys()) {
+            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
+              opMap.delete(id);
+            }
+          }
+
+          if (trackDeletes) {
+            deleteSet.add(op);
+          }
+
+          break;
+        }
+
+        case FileOp.CODE_deletePathRange: {
+          const { path: prefix, startInclusive, endExclusive } = opProps;
+
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
+          for (let n = startInclusive; n < endExclusive; n++) {
+            opMap.delete(`${prefix}/${n}`);
+          }
+
+          if (trackDeletes) {
+            deleteSet.add(op);
+          }
+
+          break;
+        }
+
+        case FileOp.CODE_writeBlob: {
+          opMap.set(opProps.blob.hash, op);
+          break;
+        }
+
+        case FileOp.CODE_writePath: {
+          opMap.set(opProps.path, op);
+          break;
+        }
+
+        default: {
+          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper for {@link #_impl_compose} and {@link #_impl_composeAll} which
+   * produces a final result from the op map and delete set that were used for
+   * a series of calls to {@link #_composeOne}.
+   *
+   * @param {Map<string, FileOp>} opMap Operatrion map used to build up a
+   *   composition result.
+   * @param {Set<FileOp>|null} deleteSet Set of multi-target delete operations,
+   *   used to build up a composition result.
+   * @returns {FileDelta} Final composition result.
+   */
+  static _composeResult(opMap, deleteSet) {
+    const ops = (deleteSet === null)
+      ? [...opMap.values()]
+      : [...deleteSet.values(), ...opMap.values()];
+
+    return new FileDelta(ops);
   }
 }

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -40,6 +40,27 @@ export default class FileDelta extends BaseDelta {
   }
 
   /**
+   * Implementation as suggested by the superclass.
+   *
+   * @override
+   * @param {array<FileDelta>} deltas Instances to compose on top of this one.
+   * @param {boolean} wantDocument Whether the result of the operation should be
+   *   a document delta.
+   * @returns {FileDelta} Composed result.
+   */
+  _impl_composeAll(deltas, wantDocument) {
+    const opMap     = new Map();
+    const deleteSet = wantDocument ? null : new Set;
+
+    FileDelta._composeOne(opMap, deleteSet, this);
+    for (const d of deltas) {
+      FileDelta._composeOne(opMap, deleteSet, d);
+    }
+
+    return FileDelta._composeResult(opMap, deleteSet);
+  }
+
+  /**
    * Implementation as required by the superclass.
    *
    * @override

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -84,11 +84,7 @@ export default class FileDelta extends BaseDelta {
     return true;
   }
 
-  /**
-   * {class} Class (constructor function) of operation objects to be used with
-   * instances of this class.
-   * @override
-   */
+  /** @override */
   static get _impl_opClass() {
     return FileOp;
   }

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -21,8 +21,9 @@ import StoragePath from './StoragePath';
  */
 export default class FileDelta extends BaseDelta {
   /**
-   * Main implementation of {@link #compose}.
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileDelta} other Delta to compose with this instance.
    * @param {boolean} wantDocument Whether the result of the operation should be
    *   a document delta.
@@ -39,8 +40,9 @@ export default class FileDelta extends BaseDelta {
   }
 
   /**
-   * Main implementation of {@link #isDocument}.
+   * Implementation as required by the superclass.
    *
+   * @override
    * @returns {boolean} `true` if this instance can be used as a document or
    *   `false` if not.
    */
@@ -85,6 +87,7 @@ export default class FileDelta extends BaseDelta {
   /**
    * {class} Class (constructor function) of operation objects to be used with
    * instances of this class.
+   * @override
    */
   static get _impl_opClass() {
     return FileOp;

--- a/local-modules/@bayou/file-store-ot/FileOp.js
+++ b/local-modules/@bayou/file-store-ot/FileOp.js
@@ -210,8 +210,9 @@ export default class FileOp extends BaseOp {
   }
 
   /**
-   * Subclass-specific implementation of {@link #isValidPayload}.
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {Functor} payload_unused The would-be payload for an instance.
    * @returns {boolean} `true` if `payload` is valid, or `false` if not.
    */

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -315,9 +315,9 @@ export default class FileSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Main implementation of {@link #diff}, which produces a delta (not a
-   * change).
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileSnapshot} newerSnapshot Snapshot to take the difference from.
    * @returns {FileDelta} Delta which represents the difference between
    *   `newerSnapshot` and this instance.
@@ -355,6 +355,7 @@ export default class FileSnapshot extends BaseSnapshot {
   /**
    * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileChange} change The change to be validated in the context of
    *   `this`.
    * @throws {Error} Thrown if `change` is not valid to compose with `this`.
@@ -366,6 +367,7 @@ export default class FileSnapshot extends BaseSnapshot {
   /**
    * {class} Class (constructor function) of change objects to be used with
    * instances of this class.
+   * @override
    */
   static get _impl_changeClass() {
     return FileChange;

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -364,11 +364,7 @@ export default class FileSnapshot extends BaseSnapshot {
     // **TODO:** Implement this!
   }
 
-  /**
-   * {class} Class (constructor function) of change objects to be used with
-   * instances of this class.
-   * @override
-   */
+  /** @override */
   static get _impl_changeClass() {
     return FileChange;
   }


### PR DESCRIPTION
After quite a series of prefactors, cleanups, and test expansion, this is the main event…

This PR adds an implementation of `FileDelta._impl_composeAll()`, which produces a composed result of multiple instances in a single step. This is as opposed to the default implementation which it overrides, which produces an intermediate delta instance per instance composed.

_*This speeds up composition operations a lot*_, changing them from being O(N*M) on N == the total number of operations and M == the number of deltas composed, to being O(N) on the total number of operations across all deltas.

On the calling side of this method, there is still an O(N²)-ish thing going on, but with what (at first blush) appears to be an acceptably small constant factor for now. Specifically, when putting together the initial snapshot of a file during file load, the changes are divided into chunks of a fixed number of changes each, and each of those is composed using a `composeAll()`. Before this PR, that chunk size was set to 50, because once you hit ~5000 changes total, each of those 50-size compose steps would take something like 0.5sec. But as of this PR, the chunk size is set to 1000 and each step seems to take more like 100msec or less.

As part of implementing this, I did one more refactor in `FileDelta`, so as to avoid re-duplicating (quadruplicating?) some already-duplicative code.
