### PR TITLE
"Transaction" verbiage rework, and one actual change.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -729,7 +729,7 @@ export default class BaseControl extends BaseDataManager {
     const timedOut = () => {
       // Log a message -- it's at least somewhat notable, though it does occur
       // regularly -- and throw `timedOut` with the original timeout value. (If
-      // called as a result of catching a timeout from a file transaction the
+      // called as a result of catching a timeout from a file operation the
       // timeout value in the error might not be the original `timeoutMsec`.)
 
       // TODO: Make log message more descriptive, have timeoutMsec be the
@@ -1019,8 +1019,8 @@ export default class BaseControl extends BaseDataManager {
    * even if a non-zero number of changes were requested.
    *
    * **Note:** The point of the max count limit is that we want to avoid
-   * creating a transaction which could run afoul of a limit on the amount of
-   * data returned by any one transaction.
+   * performing an operation which could run so long as to clog Node's top-level
+   * event dispatch loop.
    *
    * @param {Int} startInclusive Start change number (inclusive) of changes to
    *   read.

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -26,7 +26,7 @@ const MAX_UPDATE_RETRY_MSEC = 15 * 1000;
  * changes. (The idea is to avoid doing so much processing that the main Node
  * event loop chokes up.)
  */
-const MAX_CHANGE_READS_PER_ITERATION = 20;
+const MAX_CHANGE_READS_PER_ITERATION = 1000;
 
 /**
  * {Int} Maximum number of changes to compose in order to produce a result from

--- a/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
@@ -14,7 +14,7 @@ import { MockLogger } from '@bayou/see-all/mocks';
 
 describe('@bayou/doc-server/BaseComplexMember', () => {
   describe('constructor()', () => {
-    it('should accept a `FileAccess` and reflect it in the getters', () => {
+    it('accepts a `FileAccess` and reflects it in the getters', () => {
       const codec  = appCommon_TheModule.modelCodec;
       const file   = new MockFile('blort');
       const fa     = new FileAccess(codec, 'x', file);
@@ -29,12 +29,12 @@ describe('@bayou/doc-server/BaseComplexMember', () => {
       assert.notStrictEqual(result.log, fa.log);
     });
 
-    it('should reject non-`FileAccess` arguments', () => {
+    it('rejects non-`FileAccess` arguments', () => {
       assert.throws(() => new BaseComplexMember(null,      'boop'));
       assert.throws(() => new BaseComplexMember({ x: 10 }, 'boop'));
     });
 
-    it('should use the `logLabel` to create an appropriate `log`', () => {
+    it('uses the `logLabel` to create an appropriate `log`', () => {
       const codec  = appCommon_TheModule.modelCodec;
       const log    = new MockLogger();
       const fa     = new FileAccess(codec, 'x', new MockFile('file-id'), log);

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -28,33 +28,33 @@ describe('@bayou/doc-server/BaseControl', () => {
   const FILE_ACCESS = new FileAccess(CODEC, 'doc-xyz', new MockFile('blort'));
 
   describe('.changeClass', () => {
-    it('should reflect the subclass\'s implementation', () => {
+    it('reflects the subclass\'s implementation', () => {
       const result = MockControl.changeClass;
       assert.strictEqual(result, MockSnapshot.changeClass);
     });
   });
 
   describe('.changePathPrefix', () => {
-    it('should reflect the subclass\'s implementation', () => {
+    it('reflects the subclass\'s implementation', () => {
       const result = MockControl.changePathPrefix;
       assert.strictEqual(result, '/mock_control/change');
     });
   });
 
   describe('.deltaClass', () => {
-    it('should reflect the subclass\'s implementation', () => {
+    it('reflects the subclass\'s implementation', () => {
       const result = MockControl.deltaClass;
       assert.strictEqual(result, MockSnapshot.deltaClass);
     });
   });
 
   describe('.pathPrefix', () => {
-    it('should reflect the subclass\'s implementation', () => {
+    it('reflects the subclass\'s implementation', () => {
       const result = MockControl.pathPrefix;
       assert.strictEqual(result, '/mock_control');
     });
 
-    it('should reject an improper subclass choice', () => {
+    it('rejects an improper subclass choice', () => {
       class HasBadPrefix extends DurableControl {
         static get _impl_pathPrefix() {
           return '//invalid/path_string!';
@@ -64,7 +64,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.throws(() => HasBadPrefix.pathPrefix);
     });
 
-    it('should only ever ask the subclass once', () => {
+    it('only ever asks the subclass once', () => {
       class GoodControl extends DurableControl {
         static get _impl_pathPrefix() {
           this.count++;
@@ -84,12 +84,12 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('.snapshotClass', () => {
-    it('should reflect the subclass\'s implementation', () => {
+    it('reflects the subclass\'s implementation', () => {
       const result = MockControl.snapshotClass;
       assert.strictEqual(result, MockSnapshot);
     });
 
-    it('should reject an improper subclass choice', () => {
+    it('rejects an improper subclass choice', () => {
       class HasBadSnapshot extends DurableControl {
         static get _impl_snapshotClass() {
           return Object;
@@ -99,7 +99,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.throws(() => HasBadSnapshot.snapshotClass);
     });
 
-    it('should only ever ask the subclass once', () => {
+    it('only ever asks the subclass once', () => {
       class GoodControl extends DurableControl {
         static get _impl_snapshotClass() {
           this.count++;
@@ -119,7 +119,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('pathForChange()', () => {
-    it('should return an appropriate path given a valid argument', () => {
+    it('returns an appropriate path given a valid argument', () => {
       function test(value) {
         const expect = `${MockControl.pathPrefix}/change/${value}`;
         assert.strictEqual(MockControl.pathForChange(value), expect);
@@ -131,7 +131,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       test(100000914);
     });
 
-    it('should reject invalid arguments', () => {
+    it('rejects invalid arguments', () => {
       function test(value) {
         assert.throws(() => MockControl.pathForChange(value), /badValue/);
       }
@@ -147,7 +147,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('constructor()', () => {
-    it('should accept a `FileAccess` and reflect it in the inherited getters', () => {
+    it('accepts a `FileAccess` and reflect it in the inherited getters', () => {
       const fa     = FILE_ACCESS;
       const result = new MockControl(fa, 'boop');
 
@@ -160,14 +160,14 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.notStrictEqual(result.log, fa.log);
     });
 
-    it('should reject non-`FileAccess` arguments', () => {
+    it('rejects non-`FileAccess` arguments', () => {
       assert.throws(() => new MockControl(null,      'boop'));
       assert.throws(() => new MockControl({ x: 10 }, 'boop'));
     });
   });
 
   describe('appendChange()', () => {
-    it('should perform an appropriate operation given a valid change', async () => {
+    it('performs an appropriate operation given a valid change', async () => {
       const file = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control = new MockControl(fileAccess, 'boop');
@@ -202,7 +202,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.strictEqual(revNumWritePathOp.props.path, `/mock_control/revision_number`);
     });
 
-    it('should provide a default for `null` and clamp an out-of-range (but otherwise valid) timeout', async () => {
+    it('provides a default for `null` and clamps an out-of-range (but otherwise valid) timeout', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -247,7 +247,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       }
     });
 
-    it('should call the snapshot maybe-writer and html exporter, and return `true` if the operation succeeds', async () => {
+    it('calls the snapshot maybe-writer and html exporter, and returns `true` if the operation succeeds', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -265,7 +265,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.isTrue(storeSnapshotCalled);
     });
 
-    it('should return `false` if the operation fails due to a precondition failure', async () => {
+    it('returns `false` if the operation fails due to a precondition failure', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -289,7 +289,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(fileStoreOt_Errors.pathNotAbsent('/mock_control/change/99'));
     });
 
-    it('should rethrow any error other than a precondition failure and timeout', async () => {
+    it('rethrows any error other than a precondition failure and timeout', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -313,7 +313,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(Errors.badValue('foo', 'bar'));
     });
 
-    it('should reject an empty change', async () => {
+    it('rejects an empty change', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -322,7 +322,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.appendChange(change), /badValue/);
     });
 
-    it('should reject a change of the wrong type', async () => {
+    it('rejects a change of the wrong type', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -330,7 +330,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.appendChange('not_a_change'), /badValue/);
     });
 
-    it('should reject an invalid timeout value', async () => {
+    it('rejects an invalid timeout value', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -350,7 +350,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('currentRevNum()', () => {
-    it('should use the result of the operation it performed', async () => {
+    it('uses the result of the operation it performed', async () => {
       const file           = new MockFile('blort');
       const fileAccess     = new FileAccess(CODEC, 'doc-1', file);
       const control        = new MockControl(fileAccess, 'boop');
@@ -363,7 +363,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.eventually.strictEqual(control.currentRevNum(), expectedRevNum);
     });
 
-    it('should reject improper subclass results', async () => {
+    it('rejects improper subclass results', async () => {
       async function test(revNum) {
         const file       = new MockFile('blort');
         const fileAccess = new FileAccess(CODEC, 'doc-1', file);
@@ -399,7 +399,7 @@ describe('@bayou/doc-server/BaseControl', () => {
         return changeResult;
       };
 
-      it('should pass appropriate arguments to `_getChangeRange()`', async () => {
+      it('passes appropriate arguments to `_getChangeRange()`', async () => {
         async function test(n) {
           await control.getChange(n);
           assert.strictEqual(gotStart, n);
@@ -412,19 +412,19 @@ describe('@bayou/doc-server/BaseControl', () => {
         await test(914);
       });
 
-      it('should return the first element of the return value from `_getChangeRange()`', async () => {
+      it('returns the first element of the return value from `_getChangeRange()`', async () => {
         changeResult = ['foomp'];
         const result = await control.getChange(123);
         assert.strictEqual(result, 'foomp');
       });
 
-      it('should convert an empty result from `_getChangeRange()` a `revisionNotAvailable` error', async () => {
+      it('converts an empty result from `_getChangeRange()` a `revisionNotAvailable` error', async () => {
         changeResult = [];
         await assert.isRejected(control.getChange(1), /^revisionNotAvailable/);
       });
     });
 
-    it('should promptly reject blatantly invalid `revNum` values', async () => {
+    it('promptly rejects blatantly invalid `revNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control._getChangeRange = async (start_unused, end_unused, allow_unused) => {
         throw new Error('This should not have been called.');
@@ -444,7 +444,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('getChangeAfter()', () => {
-    it('should call through to `currentRevNum()` before anything else', async () => {
+    it('calls through to `currentRevNum()` before anything else', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         throw new Error('Oy!');
@@ -459,7 +459,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.getChangeAfter(0), /^Oy!/);
     });
 
-    it('should check the validity of `baseRevNum` against the response from `currentRevNum()`', async () => {
+    it('checks the validity of `baseRevNum` against the response from `currentRevNum()`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -474,7 +474,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.getChangeAfter(11), /^badValue/);
     });
 
-    it('should reject blatantly invalid `baseRevNum` values', async () => {
+    it('rejects blatantly invalid `baseRevNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -499,7 +499,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test([10]);
     });
 
-    it('should appropriately clamp `timeoutMsec` values', async () => {
+    it('appropriately clamps `timeoutMsec` values', async () => {
       let gotTimeout = null;
 
       const control = new MockControl(FILE_ACCESS, 'boop');
@@ -529,7 +529,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       }
     });
 
-    it('should not call through to `whenRevNum()` if the requested revision is not the current one', async () => {
+    it('does not call through to `whenRevNum()` if the requested revision is not the current one', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -545,7 +545,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.strictEqual(result, 'diff 5 10');
     });
 
-    it('should call through to `whenRevNum()` if the requested revision is the current one', async () => {
+    it('calls through to `whenRevNum()` if the requested revision is the current one', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       let   rev     = 10;
       control.currentRevNum = async () => {
@@ -567,7 +567,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('getDiff()', () => {
-    it('should reject bad arguments', async () => {
+    it('rejects bad arguments', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
 
       async function test(base, newer) {
@@ -599,7 +599,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(914, 10);
     });
 
-    it('should produce a result in one of the two specified ways', async () => {
+    it('produces a result in one of the two specified ways', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       let reqBase, reqNewer;
 
@@ -660,7 +660,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('getSnapshot()', () => {
-    it('should call through to `currentRevNum()` before anything else', async () => {
+    it('calls through to `currentRevNum()` before anything else', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         throw new Error('Oy!');
@@ -673,7 +673,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.getSnapshot(), /^Oy!/);
     });
 
-    it('should check the validity of a non-`null` `revNum` against the response from `currentRevNum()`', async () => {
+    it('checks the validity of a non-`null` `revNum` against the response from `currentRevNum()`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -685,7 +685,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.getSnapshot(11), /^badValue/);
     });
 
-    it('should reject blatantly invalid `revNum` values', async () => {
+    it('rejects blatantly invalid `revNum` values', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -706,7 +706,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test([10]);
     });
 
-    it('should return back a valid non-`null` subclass response', async () => {
+    it('returns back a valid non-`null` subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -721,7 +721,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.deepEqual(result.contents.ops, [new MockOp('x', 5)]);
     });
 
-    it('should use the returned `currentRevNum` when `revNum` is passed asa `null`', async () => {
+    it('uses the returned `currentRevNum` when `revNum` is passed asa `null`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 37;
@@ -736,7 +736,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.deepEqual(result.contents.ops, [new MockOp('x', 37)]);
     });
 
-    it('should convert a `null` subclass response to a `revisionNotAvailable` error', async () => {
+    it('converts a `null` subclass response to a `revisionNotAvailable` error', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -748,7 +748,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.getSnapshot(1), /^revisionNotAvailable/);
     });
 
-    it('should reject a non-snapshot subclass response', async () => {
+    it('rejects a non-snapshot subclass response', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -770,7 +770,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('update()', () => {
-    it('should reject non-change first arguments', async () => {
+    it('rejects non-change first arguments', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
@@ -793,7 +793,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(['boop']);
     });
 
-    it('should reject change arguments with invalid fields', async () => {
+    it('rejects change arguments with invalid fields', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
@@ -816,7 +816,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(new MockChange(1, []));
     });
 
-    it('should reject an invalid timeout value', async () => {
+    it('rejects an invalid timeout value', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         throw new Error('This should not have been called.');
@@ -842,7 +842,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test({ florp: 12 });
     });
 
-    it('should reject a too-large `revNum` in valid nontrivial cases', async () => {
+    it('rejects a too-large `revNum` in valid nontrivial cases', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -858,7 +858,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.update(change), /^badValue/);
     });
 
-    it('should call through to `_attemptUpdate()` given an empty change', async () => {
+    it('calls through to `_attemptUpdate()` given an empty change', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       control.currentRevNum = async () => {
         return 10;
@@ -875,7 +875,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.isRejected(control.update(change), /expected/);
     });
 
-    it('should call through to `_attemptUpdate()` in valid nontrivial cases', async () => {
+    it('calls through to `_attemptUpdate()` in valid nontrivial cases', async () => {
       const control   = new MockControl(FILE_ACCESS, 'boop');
       const current   = new MockSnapshot(10, [new MockOp('x', 10)]);
       let callCount   = 0;
@@ -915,7 +915,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.deepEqual(result, new MockChange(14, [new MockOp('yes')]));
     });
 
-    it('should retry the `_attemptUpdate()` call if it returns `null`', async () => {
+    it('retries the `_attemptUpdate()` call if it returns `null`', async () => {
       const control = new MockControl(FILE_ACCESS, 'boop');
       let callCount = 0;
 
@@ -943,7 +943,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('whenRevNum()', () => {
-    it('should return promptly if the revision is already available', async () => {
+    it('returns promptly if the revision is already available', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -247,7 +247,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       }
     });
 
-    it('should call the snapshot maybe-writer and html exporter, and return `true` if the transaction succeeds', async () => {
+    it('should call the snapshot maybe-writer and html exporter, and return `true` if the operation succeeds', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -265,7 +265,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       assert.isTrue(storeSnapshotCalled);
     });
 
-    it('should return `false` if the transaction fails due to a precondition failure', async () => {
+    it('should return `false` if the operation fails due to a precondition failure', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -289,7 +289,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await test(fileStoreOt_Errors.pathNotAbsent('/mock_control/change/99'));
     });
 
-    it('should rethrow any transaction error other than a precondition failure and timeout', async () => {
+    it('should rethrow any error other than a precondition failure and timeout', async () => {
       const file       = new MockFile('blort');
       const fileAccess = new FileAccess(CODEC, 'doc-1', file);
       const control    = new MockControl(fileAccess, 'boop');
@@ -350,7 +350,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('currentRevNum()', () => {
-    it('should use the result of the transaction it performed', async () => {
+    it('should use the result of the operation it performed', async () => {
       const file           = new MockFile('blort');
       const fileAccess     = new FileAccess(CODEC, 'doc-1', file);
       const control        = new MockControl(fileAccess, 'boop');
@@ -363,7 +363,7 @@ describe('@bayou/doc-server/BaseControl', () => {
       await assert.eventually.strictEqual(control.currentRevNum(), expectedRevNum);
     });
 
-    it('should reject improper transaction results', async () => {
+    it('should reject improper subclass results', async () => {
       async function test(revNum) {
         const file       = new MockFile('blort');
         const fileAccess = new FileAccess(CODEC, 'doc-1', file);

--- a/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
@@ -14,7 +14,7 @@ const FILE_ACCESS = new FileAccess(appCommon_TheModule.modelCodec, 'doc-123', ne
 
 describe('@bayou/doc-server/BaseDataManager', () => {
   describe('afterInit()', () => {
-    it('should call through to the impl', async () => {
+    it('calls through to the impl', async () => {
       const dm = new BaseDataManager(FILE_ACCESS, 'boop');
 
       let callCount = 0;
@@ -28,7 +28,7 @@ describe('@bayou/doc-server/BaseDataManager', () => {
       assert.isUndefined(result);
     });
 
-    it('should throw whatever error is thrown by the impl', async () => {
+    it('throws whatever error is thrown by the impl', async () => {
       const dm = new BaseDataManager(FILE_ACCESS, 'boop');
       dm._impl_afterInit = async () => {
         throw new Error('oy');
@@ -39,7 +39,7 @@ describe('@bayou/doc-server/BaseDataManager', () => {
   });
 
   describe('validationStatus()', () => {
-    it('should call through to the impl', async () => {
+    it('calls through to the impl', async () => {
       const dm = new BaseDataManager(FILE_ACCESS, 'boop');
 
       let callCount = 0;
@@ -53,7 +53,7 @@ describe('@bayou/doc-server/BaseDataManager', () => {
       assert.strictEqual(result, ValidationStatus.STATUS_ok);
     });
 
-    it('should throw whatever error is thrown by the impl', async () => {
+    it('throws whatever error is thrown by the impl', async () => {
       const dm = new BaseDataManager(FILE_ACCESS, 'boop');
       dm._impl_validationStatus = async () => {
         throw new Error('oy');
@@ -62,7 +62,7 @@ describe('@bayou/doc-server/BaseDataManager', () => {
       await assert.isRejected(dm.validationStatus(), /^oy$/);
     });
 
-    it('should reject bogus impl return values', async () => {
+    it('rejects bogus impl return values', async () => {
       const dm = new BaseDataManager(FILE_ACCESS, 'boop');
       dm._impl_validationStatus = async () => {
         return ['not actually a validation status'];

--- a/local-modules/@bayou/doc-server/tests/test_BodyDeltaHtml.js
+++ b/local-modules/@bayou/doc-server/tests/test_BodyDeltaHtml.js
@@ -32,7 +32,7 @@ function testHtml(ops, expectedHtml) {
 
 describe('@bayou/doc-server/BodyDeltaHtml', () => {
   describe('toHtmlForm()', () => {
-    it('should produce HTML string', () => {
+    it('produces an HTML string', () => {
       testHtml([], '');
       testHtml([BodyOp.op_embed('image', 'https://www.fakeimage.com')],
         '<p><img class="ql-image" src="https://www.fakeimage.com"/></p>');
@@ -44,15 +44,15 @@ describe('@bayou/doc-server/BodyDeltaHtml', () => {
       testHtml([BodyOp.op_text('bold text', { bold: true })], '<p><strong>bold text</strong></p>');
     });
 
-    it('should produce expected HTML string of a valid custom op', () => {
+    it('produces the expected HTML string of a valid custom op', () => {
       testHtml([BodyOp.op_embed('customTest')], `<p>${expectedCustomOpHtml}</p>`);
     });
 
-    it('should produce expected HTML string when invalid custom op', () => {
+    it('produces the expected HTML string when given an invalid custom op', () => {
       testHtml([BodyOp.op_embed('unregisteredCustomOp')], `<p>${expectedUnfoundCustomOpHtml}</p>`);
     });
 
-    it('should produce non-altered url', () => {
+    it('produces a non-altered url', () => {
       const unsafeLink = 'test.com';
       testHtml([BodyOp.op_text('unsafe link', { link: unsafeLink })], `<p><a href="${unsafeLink}" target="_blank">unsafe link</a></p>`);
     });

--- a/local-modules/@bayou/doc-server/tests/test_DurableControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_DurableControl.js
@@ -12,7 +12,7 @@ describe('@bayou/doc-server/DurableControl', () => {
   class SomeControl extends DurableControl { /*empty*/ }
 
   describe('.ephemeral', () => {
-    it('should be `false`', () => {
+    it('is `false`', () => {
       assert.isFalse(SomeControl.ephemeral);
     });
   });

--- a/local-modules/@bayou/doc-server/tests/test_EphemeralControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_EphemeralControl.js
@@ -12,7 +12,7 @@ describe('@bayou/doc-server/EphemeralControl', () => {
   class SomeControl extends EphemeralControl { /*empty*/ }
 
   describe('.ephemeral', () => {
-    it('should be `true`', () => {
+    it('is `true`', () => {
       assert.isTrue(SomeControl.ephemeral);
     });
   });

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -154,7 +154,8 @@ export default class LocalFile extends BaseFile {
    * completed and settled in the filesystem.
    *
    * **Note:** This method wouldn't be necessary if {@link #_impl_create},
-   * {@link #_impl_transact}, etc. were all more realistically transactional.
+   * {@link #_impl_appendChange}, etc. were all more realistically
+   * transactional.
    */
   async flush() {
     await this._flushPendingStorage();
@@ -356,7 +357,7 @@ export default class LocalFile extends BaseFile {
       throw Errors.fileNotFound(this.id);
     }
 
-    // It's a wait transaction, so we need to be prepared to loop / retry (until
+    // Set up a loop, because we need to be prepared to wait and retry (until
     // satisfaction or timeout).
     for (;;) {
       if (timeout) {
@@ -639,8 +640,8 @@ export default class LocalFile extends BaseFile {
     this._storageToWrite  = new Map();
     this._storageIsDirty  = false;
 
-    // This wakes up wait transactions, if any, which can then go about figuring
-    // out if they're satisfied.
+    // This wakes up change waiters, if any, which can then go about figuring
+    // out if their actual conditions are satisfied.
     this._changeCondition.value = true;
 
     return true;

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -34,7 +34,7 @@ const MAX_PARALLEL_FS_CALLS = 20;
  * CPU-bound for an extended period of time. That is, we want to be a good
  * cooperative-multitasking citizen.
  */
-const MAX_ATOMIC_COMPOSED_CHANGES = 50;
+const MAX_ATOMIC_COMPOSED_CHANGES = 1000;
 
 /**
  * File implementation that stores everything in the locally-accessible

--- a/local-modules/@bayou/file-store-ot/FileChange.js
+++ b/local-modules/@bayou/file-store-ot/FileChange.js
@@ -12,10 +12,7 @@ import FileDelta from './FileDelta';
  * of {@link FileDelta}.
  */
 export default class FileChange extends BaseChange {
-  /**
-   * {class} Class (constructor function) of delta objects to be used with
-   * instances of this class.
-   */
+  /** @override */
   static get _impl_deltaClass() {
     return FileDelta;
   }

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -21,22 +21,49 @@ import StoragePath from './StoragePath';
  */
 export default class FileDelta extends BaseDelta {
   /**
-   * Main implementation of {@link #compose}.
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileDelta} other Delta to compose with this instance.
    * @param {boolean} wantDocument Whether the result of the operation should be
    *   a document delta.
    * @returns {FileDelta} Composed result.
    */
   _impl_compose(other, wantDocument) {
-    return wantDocument
-      ? this._composeDocument(other)
-      : this._composeNonDocument(other);
+    const opMap     = new Map();
+    const deleteSet = wantDocument ? null : new Set;
+
+    FileDelta._composeOne(opMap, deleteSet, this);
+    FileDelta._composeOne(opMap, deleteSet, other);
+
+    return FileDelta._composeResult(opMap, deleteSet);
   }
 
   /**
-   * Main implementation of {@link #isDocument}.
+   * Implementation as suggested by the superclass.
    *
+   * @override
+   * @param {array<FileDelta>} deltas Instances to compose on top of this one.
+   * @param {boolean} wantDocument Whether the result of the operation should be
+   *   a document delta.
+   * @returns {FileDelta} Composed result.
+   */
+  _impl_composeAll(deltas, wantDocument) {
+    const opMap     = new Map();
+    const deleteSet = wantDocument ? null : new Set;
+
+    FileDelta._composeOne(opMap, deleteSet, this);
+    for (const d of deltas) {
+      FileDelta._composeOne(opMap, deleteSet, d);
+    }
+
+    return FileDelta._composeResult(opMap, deleteSet);
+  }
+
+  /**
+   * Implementation as required by the superclass.
+   *
+   * @override
    * @returns {boolean} `true` if this instance can be used as a document or
    *   `false` if not.
    */
@@ -78,198 +105,148 @@ export default class FileDelta extends BaseDelta {
     return true;
   }
 
-  /**
-   * Helper for {@link #_impl_compose} which handles the case of `wantDocument
-   * === true`.
-   *
-   * @param {FileDelta} other Delta to compose with this instance.
-   * @returns {FileDelta} Composed result.
-   */
-  _composeDocument(other) {
-    const data = new Map();
-
-    // Add / replace the ops, first from `this` and then from `other`, as a
-    // mapping from the storage ID.
-    for (const op of [...this.ops, ...other.ops]) {
-      const opProps = op.props;
-
-      switch (opProps.opName) {
-        case FileOp.CODE_deleteAll: {
-          data.clear();
-          break;
-        }
-
-        case FileOp.CODE_deleteBlob: {
-          data.delete(opProps.hash);
-          break;
-        }
-
-        case FileOp.CODE_deletePath: {
-          data.delete(opProps.path);
-          break;
-        }
-
-        case FileOp.CODE_deletePathPrefix: {
-          const prefix = opProps.path;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (const id of data.keys()) {
-            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
-              data.delete(id);
-            }
-          }
-
-          break;
-        }
-
-        case FileOp.CODE_deletePathRange: {
-          const { path: prefix, startInclusive, endExclusive } = opProps;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (let n = startInclusive; n < endExclusive; n++) {
-            data.delete(`${prefix}/${n}`);
-          }
-
-          break;
-        }
-
-        case FileOp.CODE_writeBlob: {
-          data.set(opProps.blob.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_writePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
-        }
-      }
-    }
-
-    // Convert the map to an array of ops, and construct the result therefrom.
-    return new FileDelta([...data.values()]);
-  }
-
-  /**
-   * Helper for {@link #_impl_compose} which handles the case of `wantDocument
-   * === false`. Notably, in this case, the result has to include any `delete*`
-   * operations from `this` and `other` which could possibly have an effect
-   * should the result be used as the argument to a subsequent call to
-   * `compose()`.
-   *
-   * @param {FileDelta} other Delta to compose with this instance.
-   * @returns {FileDelta} Composed result.
-   */
-  _composeNonDocument(other) {
-    // Single-target ops (writes and deletes).
-    const data = new Map();
-
-    // Multi-target deletes. Unlike single-target deletes, which can be
-    // correctly handled in the `data` map including possibly getting
-    // overwritten by subsequent ops, multi-target deletes cannot in general
-    // get overwritten, as their existence can affect subsequent uses of the
-    // result in other `compose()` operations. **Note:** This implementation
-    // does not necessarily produce a "canonical" or maximally compact result,
-    // because (a) it does not try to remove redundancies from within the
-    // deletes other than recognizing `deleteAll` as mooting the whole set
-    // (e.g., `deletePathRange('/x', 1, 6)` and `deletePathRange('x/', 4, 10)`
-    // would ideally combine to `deletePathRange('/x', 1, 10)`); and (b) it does
-    // not trim / remove delete operations that intersect with subsequent writes
-    // (e.g., `deletePathRange('/x', 1, 10)` followed by `writePath('/x/1')`
-    // would ideally trim the resulting delete to
-    // `deletePathRange('/x', 2, 10)`).
-    const deletes = new Set();
-
-    // Add / replace the ops, first from `this` and then from `other`, as a
-    // mapping from the storage ID.
-    for (const op of [...this.ops, ...other.ops]) {
-      const opProps = op.props;
-
-      switch (opProps.opName) {
-        case FileOp.CODE_deleteAll: {
-          data.clear();
-          deletes.clear();
-          deletes.add(op);
-          break;
-        }
-
-        case FileOp.CODE_deleteBlob: {
-          data.set(opProps.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_deletePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        case FileOp.CODE_deletePathPrefix: {
-          const prefix = opProps.path;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (const id of data.keys()) {
-            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
-              data.delete(id);
-            }
-          }
-
-          deletes.add(op);
-
-          break;
-        }
-
-        case FileOp.CODE_deletePathRange: {
-          const { path: prefix, startInclusive, endExclusive } = opProps;
-
-          // **TODO:** This isn't necessarily the most efficient way to achieve
-          // the desired result. Consider a cleverer solution, should this turn
-          // out to be a performance issue.
-          for (let n = startInclusive; n < endExclusive; n++) {
-            data.delete(`${prefix}/${n}`);
-          }
-
-          deletes.add(op);
-
-          break;
-        }
-
-        case FileOp.CODE_writeBlob: {
-          data.set(opProps.blob.hash, op);
-          break;
-        }
-
-        case FileOp.CODE_writePath: {
-          data.set(opProps.path, op);
-          break;
-        }
-
-        default: {
-          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
-        }
-      }
-    }
-
-    // Convert the map to an array of ops, and construct the result therefrom.
-
-    const ops = [...deletes.values(), ...data.values()];
-
-    return new FileDelta(ops);
-  }
-
-  /**
-   * {class} Class (constructor function) of operation objects to be used with
-   * instances of this class.
-   */
+  /** @override */
   static get _impl_opClass() {
     return FileOp;
+  }
+
+  /**
+   * Helper for {@link #_impl_compose} and {@link #_impl_composeAll} which
+   * performs one composition of a delta on top of a running composition result,
+   * said running result which takes the form of a map from IDs to ops and an
+   * optional set of multi-target delete operations (which is `null` for
+   * document composes and required for non-document composes).
+   *
+   * **Note:** The deal with the `deletes` set is that multi-target deletes, in
+   * general, cannot be dropped from a composition result because they will have
+   * an effect when the composition result is itself used as the argument to
+   * a later compose operation. (Single-target deletes can always be dropped if
+   * they are "overwritten" by a later write operation with the exact same ID.)
+   *
+   * **Note the Second:** This implementation does not necessarily produce a
+   * "canonical" or maximally compact result with regards to multi-target delete
+   * operations, because (a) it does not try to remove redundancies from within
+   * the deletes other than recognizing `deleteAll` as mooting the whole set
+   * (e.g., `deletePathRange('/x', 1, 6)` and `deletePathRange('x/', 4, 10)`
+   * would ideally combine to `deletePathRange('/x', 1, 10)`); and (b) it does
+   * not trim / remove delete operations that intersect with subsequent writes
+   * (e.g., `deletePathRange('/x', 1, 10)` followed by `writePath('/x/1')`
+   * would ideally trim the resulting delete to
+   * `deletePathRange('/x', 2, 10)`).
+   *
+   * @param {Map<string, FileOp>} opMap Map from IDs to corresponding file
+   *   operations, representing the result of composition in progress. This
+   *   method modifies the value.
+   * @param {Set<FileOp>|null} deleteSet Set of multi-target delete operations,
+   *   representing the result of composition in progress. This method modifies
+   *   the value. If `null`, deletes are not tracked at all, either through
+   *   this argument (of course) but also via `opMap`.
+   * @param {FileDelta} delta Delta to compose with this running result as
+   *   represented in the previous two arguments.
+   */
+  static _composeOne(opMap, deleteSet, delta) {
+    const trackDeletes = (deleteSet !== null);
+
+    for (const op of delta.ops) {
+      const opProps = op.props;
+
+      switch (opProps.opName) {
+        case FileOp.CODE_deleteAll: {
+          opMap.clear();
+          if (trackDeletes) {
+            deleteSet.clear();
+            deleteSet.add(op);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deleteBlob: {
+          if (trackDeletes) {
+            opMap.set(opProps.hash, op);
+          } else {
+            opMap.delete(opProps.hash);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deletePath: {
+          if (trackDeletes) {
+            opMap.set(opProps.path, op);
+          } else {
+            opMap.delete(opProps.path);
+          }
+          break;
+        }
+
+        case FileOp.CODE_deletePathPrefix: {
+          const prefix = opProps.path;
+
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
+          for (const id of opMap.keys()) {
+            if (StoragePath.isInstance(id) && StoragePath.isPrefixOrSame(prefix, id)) {
+              opMap.delete(id);
+            }
+          }
+
+          if (trackDeletes) {
+            deleteSet.add(op);
+          }
+
+          break;
+        }
+
+        case FileOp.CODE_deletePathRange: {
+          const { path: prefix, startInclusive, endExclusive } = opProps;
+
+          // **TODO:** This isn't necessarily the most efficient way to achieve
+          // the desired result. Consider a cleverer solution, should this turn
+          // out to be a performance issue.
+          for (let n = startInclusive; n < endExclusive; n++) {
+            opMap.delete(`${prefix}/${n}`);
+          }
+
+          if (trackDeletes) {
+            deleteSet.add(op);
+          }
+
+          break;
+        }
+
+        case FileOp.CODE_writeBlob: {
+          opMap.set(opProps.blob.hash, op);
+          break;
+        }
+
+        case FileOp.CODE_writePath: {
+          opMap.set(opProps.path, op);
+          break;
+        }
+
+        default: {
+          throw Errors.wtf(`Weird op name: ${opProps.opName}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper for {@link #_impl_compose} and {@link #_impl_composeAll} which
+   * produces a final result from the op map and delete set that were used for
+   * a series of calls to {@link #_composeOne}.
+   *
+   * @param {Map<string, FileOp>} opMap Operatrion map used to build up a
+   *   composition result.
+   * @param {Set<FileOp>|null} deleteSet Set of multi-target delete operations,
+   *   used to build up a composition result.
+   * @returns {FileDelta} Final composition result.
+   */
+  static _composeResult(opMap, deleteSet) {
+    const ops = (deleteSet === null)
+      ? [...opMap.values()]
+      : [...deleteSet.values(), ...opMap.values()];
+
+    return new FileDelta(ops);
   }
 }

--- a/local-modules/@bayou/file-store-ot/FileOp.js
+++ b/local-modules/@bayou/file-store-ot/FileOp.js
@@ -210,8 +210,9 @@ export default class FileOp extends BaseOp {
   }
 
   /**
-   * Subclass-specific implementation of {@link #isValidPayload}.
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {Functor} payload_unused The would-be payload for an instance.
    * @returns {boolean} `true` if `payload` is valid, or `false` if not.
    */

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -315,9 +315,9 @@ export default class FileSnapshot extends BaseSnapshot {
   }
 
   /**
-   * Main implementation of {@link #diff}, which produces a delta (not a
-   * change).
+   * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileSnapshot} newerSnapshot Snapshot to take the difference from.
    * @returns {FileDelta} Delta which represents the difference between
    *   `newerSnapshot` and this instance.
@@ -355,6 +355,7 @@ export default class FileSnapshot extends BaseSnapshot {
   /**
    * Implementation as required by the superclass.
    *
+   * @override
    * @param {FileChange} change The change to be validated in the context of
    *   `this`.
    * @throws {Error} Thrown if `change` is not valid to compose with `this`.
@@ -363,10 +364,7 @@ export default class FileSnapshot extends BaseSnapshot {
     // **TODO:** Implement this!
   }
 
-  /**
-   * {class} Class (constructor function) of change objects to be used with
-   * instances of this class.
-   */
+  /** @override */
   static get _impl_changeClass() {
     return FileChange;
   }

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -45,8 +45,8 @@ export default class BaseFile extends CommonBase {
 
   /**
    * {Int|null} The maximum value allowed (inclusive) as the duration specified
-   * on `timeout` operations in transactions on this instance, or `null` if
-   * there is no limit. Out-of-range values are clamped to this limit.
+   * as the timeout for methods on this instance, or `null` if there is no
+   * limit. Out-of-range values are clamped to this limit.
    *
    * @abstract
    */
@@ -56,7 +56,7 @@ export default class BaseFile extends CommonBase {
 
   /**
    * {Int|null} The minimum value allowed (inclusive) as the duration specified
-   * on `timeout` operations in transactions on this instance, or `null` if
+   * as the timeout for methods on this instance, or `null` if there is no
    * there is no limit. Out-of-range values are clamped to this limit.
    *
    * @abstract
@@ -103,9 +103,6 @@ export default class BaseFile extends CommonBase {
    * Creates this file if it does not already exist. This does nothing if the
    * file already exists. Immediately after this call returns successfully, the
    * file is guaranteed to exist but might not be empty.
-   *
-   * **Note:** To erase the contents of a file without deleting the file itself,
-   * use the `deleteAll` operation in a transaction.
    */
   async create() {
     await this._impl_create();


### PR DESCRIPTION
This PR started life as me finding the term "transaction" in the code, to see if the surrounding docs (mostly) and code (sometimes) needed an update, with the answer being "yes" most of the time.

In all that, there was one actual code change worth making, related to the recent `FileDelta.composeAll()` work, namely, the maximum number of file changes to operate on in a single iteration inside `BaseControl` was safe to increase from its old value of 20.

**Bonus:** Continued my quest of shedding the tentative voice from unit test `it()` descriptions. (That is, `it('somethings...')` and not `it('should something...')`.)