### PR TITLE
Lint pedantry. Bump version.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,7 @@
         "tabWidth": 8
       }
     ],
+    "new-parens": "error",
     "no-alert": "warn",
     "no-array-constructor": "error",
     "no-empty-function": "error",

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -31,7 +31,7 @@ export default class FileDelta extends BaseDelta {
    */
   _impl_compose(other, wantDocument) {
     const opMap     = new Map();
-    const deleteSet = wantDocument ? null : new Set;
+    const deleteSet = wantDocument ? null : new Set();
 
     FileDelta._composeOne(opMap, deleteSet, this);
     FileDelta._composeOne(opMap, deleteSet, other);
@@ -50,7 +50,7 @@ export default class FileDelta extends BaseDelta {
    */
   _impl_composeAll(deltas, wantDocument) {
     const opMap     = new Map();
-    const deleteSet = wantDocument ? null : new Set;
+    const deleteSet = wantDocument ? null : new Set();
 
     FileDelta._composeOne(opMap, deleteSet, this);
     for (const d of deltas) {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.15
+version = 1.2.16


### PR DESCRIPTION
This PR adds a linter rule we probably should have had on already, and fixes the violations of that rule that I recently introduced.

In addition, this bumps the product version, simply for a general-cadence release (no more-specific motivation). 