### PR TITLE
Logging follow-up.

### DIFF
--- a/local-modules/@bayou/deps-ansi-color/package.json
+++ b/local-modules/@bayou/deps-ansi-color/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "ansi-html": "^0.0.7",
     "ansi_up": "^4.0.3",
     "chalk": "^2.4.1",
     "string-length": "^2.0.0",

--- a/local-modules/@bayou/deps-ansi-color/package.json
+++ b/local-modules/@bayou/deps-ansi-color/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "ansi-html": "^0.0.7",
+    "ansi_up": "^4.0.3",
     "chalk": "^2.4.1",
     "string-length": "^2.0.0",
     "strip-ansi": "^4.0.0",

--- a/local-modules/@bayou/see-all-client/ClientSink.js
+++ b/local-modules/@bayou/see-all-client/ClientSink.js
@@ -85,7 +85,7 @@ export default class ClientSink extends BaseSink {
         args.push(label);
 
         switch (metricArgs.length) {
-          case 0:  {                       break; }
+          case 0:  {                             break; }
           case 1:  { formatValue(metricArgs[0]); break; }
           default: { formatValue(metricArgs);    break; }
         }

--- a/local-modules/@bayou/see-all-client/ClientSink.js
+++ b/local-modules/@bayou/see-all-client/ClientSink.js
@@ -71,9 +71,25 @@ export default class ClientSink extends BaseSink {
     }
 
     if (logRecord.isEvent()) {
-      formatStr.push('%c ');
-      args.push('color: #840; font-weight: bold');
-      formatValue(payload);
+      const metricName = logRecord.metricName;
+      if (metricName === null) {
+        formatStr.push('%c ');
+        args.push('color: #840; font-weight: bold');
+        formatValue(payload);
+      } else {
+        const metricArgs = logRecord.payload.args;
+        const label      = `${metricName}${(metricArgs.length === 0) ? '' : ': '}`;
+
+        formatStr.push('%c %s');
+        args.push('color: #503; font-weight: bold');
+        args.push(label);
+
+        switch (metricArgs.length) {
+          case 0:  {                       break; }
+          case 1:  { formatValue(metricArgs[0]); break; }
+          default: { formatValue(metricArgs);    break; }
+        }
+      }
     } else {
       for (const a of payload.args) {
         switch (typeof a) {

--- a/local-modules/@bayou/see-all-server/RecentSink.js
+++ b/local-modules/@bayou/see-all-server/RecentSink.js
@@ -4,7 +4,6 @@
 
 import AnsiUp from 'ansi_up';
 import chalk from 'chalk';
-import { escape } from 'lodash';
 
 import { BaseSink, SeeAll } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
@@ -38,7 +37,6 @@ export default class RecentSink extends BaseSink {
 
     /** {AnsiUp} ANSI-to-HTML converter to use. */
     this._ansiUp = new AnsiUp();
-    this._ansiUp.escape_for_html = false;
 
     /** {array<object>} The log contents. */
     this._log = [];
@@ -137,9 +135,9 @@ export default class RecentSink extends BaseSink {
       default:      { prefix = ck.hex('#888').bold(prefix); break; }
     }
 
-    const prefixHtml  = this._fromAnsi(escape(prefix));
-    const contextHtml = this._fromAnsi(escape(ck.hex('#88f').bold(context)));
-    const bodyHtml    = this._fromAnsi(escape(body));
+    const prefixHtml  = this._fromAnsi(prefix);
+    const contextHtml = this._fromAnsi(ck.hex('#88f').bold(context));
+    const bodyHtml    = this._fromAnsi(body);
 
     return `<tr><td>${prefixHtml}</td><td>${contextHtml}</td><td><pre>${bodyHtml}</pre></td>`;
   }

--- a/local-modules/@bayou/see-all-server/RecentSink.js
+++ b/local-modules/@bayou/see-all-server/RecentSink.js
@@ -4,6 +4,7 @@
 
 import AnsiUp from 'ansi_up';
 import chalk from 'chalk';
+import { inspect } from 'util';
 
 import { BaseSink, SeeAll } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
@@ -108,9 +109,10 @@ export default class RecentSink extends BaseSink {
    * @returns {string} HTML string form for the entry.
    */
   _htmlLine(logRecord) {
-    const ck      = this._chalk;
-    let   prefix  = logRecord.prefixString;
-    const context = logRecord.contextString || '';
+    const ck         = this._chalk;
+    let   prefix     = logRecord.prefixString;
+    const context    = logRecord.contextString || '';
+    const metricName = logRecord.metricName;
     let   body;
 
     if (logRecord.isTime()) {
@@ -118,6 +120,18 @@ export default class RecentSink extends BaseSink {
       const utcString    = ck.blue.bold(utc);
       const localString  = ck.hex('#88f').bold(local);
       body = `${utcString} ${ck.hex('#888').bold('/')} ${localString}`;
+    } else if (metricName !== null) {
+      const args  = logRecord.payload.args;
+      const label = `${metricName}${(args.length === 0) ? '' : ': '}`;
+      let   argString;
+
+      switch (args.length) {
+        case 0:  { argString = '';               break; }
+        case 1:  { argString = inspect(args[0]); break; }
+        default: { argString = inspect(args);    break; }
+      }
+
+      body = `${ck.hex('#503').bold(label)}${argString}`;
     } else {
       // Distill the message (or event) down to a single string, and trim
       // leading and trailing newlines.

--- a/local-modules/@bayou/see-all-server/RecentSink.js
+++ b/local-modules/@bayou/see-all-server/RecentSink.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import ansiHtml from 'ansi-html';
+import AnsiUp from 'ansi_up';
 import chalk from 'chalk';
 import { escape } from 'lodash';
 
@@ -32,11 +32,13 @@ export default class RecentSink extends BaseSink {
     /**
      * {Chalk} Chalk instance to use. We don't just use the global `chalk`, as
      * it gets configured for the observed TTY, and this class wants it to
-     * be at level `1`, which is what the `ansi-html` module supports.
-     * **TODO:** Update this when `ansi-html` gets level `4` support. See
-     * <https://github.com/Tjatse/ansi-html/issues/10>.
+     * be at level `3` for maximum fidelity when converting to HTML.
      */
-    this._chalk = new chalk.constructor({ level: 1 });
+    this._chalk = new chalk.constructor({ level: 3 });
+
+    /** {AnsiUp} ANSI-to-HTML converter to use. */
+    this._ansiUp = new AnsiUp();
+    this._ansiUp.escape_for_html = false;
 
     /** {array<object>} The log contents. */
     this._log = [];
@@ -92,6 +94,16 @@ export default class RecentSink extends BaseSink {
   }
 
   /**
+   * Converts the given ANSI-bearing string to HTML.
+   *
+   * @param {string} s String to convert.
+   * @returns {string} Converted form.
+   */
+  _fromAnsi(s) {
+    return this._ansiUp.ansi_to_html(s);
+  }
+
+  /**
    * Converts the given log line to HTML.
    *
    * @param {LogRecord} logRecord Log record.
@@ -106,28 +118,28 @@ export default class RecentSink extends BaseSink {
     if (logRecord.isTime()) {
       const [utc, local] = logRecord.timeStrings;
       const utcString    = ck.blue.bold(utc);
-      const localString  = ck.blue.dim.bold(local);
-      body = `${utcString} ${ck.dim.bold('/')} ${localString}`;
+      const localString  = ck.hex('#88f').bold(local);
+      body = `${utcString} ${ck.hex('#888').bold('/')} ${localString}`;
     } else {
       // Distill the message (or event) down to a single string, and trim
       // leading and trailing newlines.
       body = logRecord.messageString.replace(/(^\n+)|(\n+$)/g, '');
 
       if (logRecord.isEvent()) {
-        body = ck.dim.bold(body);
+        body = ck.hex('#884').bold(body);
       }
     }
 
     // Color the prefix depending on the event name / severity level.
     switch (logRecord.payload.name) {
-      case 'error': { prefix = ck.red.bold(prefix);    break; }
-      case 'warn':  { prefix = ck.yellow.bold(prefix); break; }
-      default:      { prefix = ck.dim.bold(prefix);    break; }
+      case 'error': { prefix = ck.red.bold(prefix);         break; }
+      case 'warn':  { prefix = ck.yellow.bold(prefix);      break; }
+      default:      { prefix = ck.hex('#888').bold(prefix); break; }
     }
 
-    const prefixHtml  = ansiHtml(escape(prefix));
-    const contextHtml = ansiHtml(escape(ck.blue.dim.bold(context)));
-    const bodyHtml    = ansiHtml(escape(body));
+    const prefixHtml  = this._fromAnsi(escape(prefix));
+    const contextHtml = this._fromAnsi(escape(ck.hex('#88f').bold(context)));
+    const bodyHtml    = this._fromAnsi(escape(body));
 
     return `<tr><td>${prefixHtml}</td><td>${contextHtml}</td><td><pre>${bodyHtml}</pre></td>`;
   }

--- a/local-modules/@bayou/see-all-server/package.json
+++ b/local-modules/@bayou/see-all-server/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@bayou/deps-ansi-color": "local",
-    "@bayou/deps-util-common": "local",
     "@bayou/see-all": "local",
     "@bayou/util-common": "local"
   }

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -259,6 +259,7 @@ export default class Action extends CommonBase {
 
     // A little spew to identify the build and our environment.
 
+    log.metric.boot();
     log.event.buildInfo(ProductInfo.theOne.INFO);
     log.event.runtimeInfo(ServerEnv.theOne.info);
 


### PR DESCRIPTION
This PR is mostly about getting the new metric logs to render reasonably to the various human-oriented places. In addition, I switched us from using `ansi-html` to `ansi_up` for ANSI-to-HTML (control sequence) conversion. And I went ahead and added a no-arg `boot` metric, which will hopefully come in handy. (An intended later PR will have a more fully fleshed out boot-time metric, in replacement of or addition to this one.)