### PR TITLE
New `BaseCache` base class for weak-lru caching.

### DIFF
--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -34,7 +34,7 @@ export default class FileCache extends BaseCache {
 
   /** @override */
   _impl_isValidId(id_unused) {
-    // **TODO:** Consider plumbing through the real ID syntax checker.
+    // **TODO:** Consider plumbing through an actual ID syntax checker.
     return true;
   }
 }

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -2,128 +2,39 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import weak from 'weak';
-
-import { Logger } from '@bayou/see-all';
-import { TString } from '@bayou/typecheck';
-import { CommonBase, Errors } from '@bayou/util-common';
+import { BaseCache } from '@bayou/weak-lru-cache';
 
 import BaseFile from './BaseFile';
 
+/** {Int} Maximum size of the LRU cache. */
+const MAX_LRU_CACHE_SIZE = 10;
 
 /**
- * Cache of active instances of {@link BaseFile}, built by using a `Map` with
- * weakly-held values.
+ * Cache of active instances of {@link BaseFile}.
  */
-export default class FileCache extends CommonBase {
+export default class FileCache extends BaseCache {
   /**
    * Constructs an instance.
    *
    * @param {Logger} log Logger instance to use.
    */
   constructor(log) {
-    super();
-
-    /**
-     * {Map<string, Weak<BaseFile>>} The cache, as a map from file IDs to
-     * weak file references.
-     */
-    this._cache = new Map();
-
-    /** {Logger} Logger instance to use. */
-    this._log = Logger.check(log).withAddedContext('cache');
-
-    Object.freeze(this);
+    super(log, MAX_LRU_CACHE_SIZE);
   }
 
-  /**
-   * Gets the file instance associated with the given ID, if any. Returns `null`
-   * if there is no such instance.
-   *
-   * @param {string} fileId The file ID to look up.
-   * @param {boolean} [quiet = false] If `true`, suppress log spew. (This is
-   *   meant for intra-class usage.)
-   * @returns {BaseFile|null} The corresponding file instance, or `null` if no
-   *   such instance is active.
-   */
-  getOrNull(fileId, quiet = false) {
-    TString.check(fileId);
-
-    const fileRef = this._cache.get(fileId);
-
-    if (!fileRef) {
-      if (!quiet) {
-        this._log.event.notCached(fileId);
-      }
-
-      return null;
-    }
-
-    if (weak.isDead(fileRef)) {
-      // We don't bother removing the dead entry, because in all likelihood the
-      // very next thing that will happen is that the calling code is going to
-      // re-instantiate the file and add it.
-
-      if (!quiet) {
-        this._log.event.foundDead(fileId);
-      }
-
-      return null;
-    }
-
-    // We've seen cases where a weakly-referenced object gets collected
-    // and replaced with an instance of a different class. If this check
-    // throws an error, that's what's going on here. (This is evidence of
-    // a bug in Node or in the `weak` package.)
-    const result = BaseFile.check(weak.get(fileRef));
-
-    if (!quiet) {
-      this._log.event.retrieved(fileId);
-    }
-
-    return result;
+  /** @override */
+  get _impl_cachedClass() {
+    return BaseFile;
   }
 
-  /**
-   * Adds the given file instance to the cache. It is an error to add an
-   * instance with an ID that is already represented in the cache (by a live
-   * object).
-   *
-   * @param {BaseFile} file File to add to the cache.
-   */
-  add(file) {
-    BaseFile.check(file);
-
-    const id      = file.id;
-    const already = this.getOrNull(id, true);
-
-    if (already !== null) {
-      throw Errors.badUse(`ID already present in cache: ${id}`);
-    }
-
-    const fileRef = weak(file, this._fileReaper(id));
-
-    this._cache.set(id, fileRef);
-    this._log.event.added(id);
+  /** @override */
+  _impl_idFromObject(file) {
+    return file.id;
   }
 
-  /**
-   * Constructs and returns a post-mortem finalizer (reaper) for a weak
-   * reference on the file with the given ID.
-   *
-   * @param {string} fileId ID of the file in question.
-   * @returns {function} Appropriately-constructed post-mortem finalizer.
-   */
-  _fileReaper(fileId) {
-    return () => {
-      this._log.event.reaped(fileId);
-
-      // Clear the cache entry, but only if it hasn't already been replaced with
-      // a new live reference. (Without the check, we'd have a concurrency
-      // hazard.)
-      if (this.getOrNull(fileId, true) === null) {
-        this._cache.delete(fileId);
-      }
-    };
+  /** @override */
+  _impl_isValidId(id_unused) {
+    // **TODO:** Consider plumbing through the real ID syntax checker.
+    return true;
   }
 }

--- a/local-modules/@bayou/file-store/package.json
+++ b/local-modules/@bayou/file-store/package.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "@bayou/codec": "local",
-    "@bayou/deps-util-server": "local",
     "@bayou/file-store-ot": "local",
     "@bayou/promise-util": "local",
     "@bayou/typecheck": "local",
-    "@bayou/util-common": "local"
+    "@bayou/util-common": "local",
+    "@bayou/weak-lru-cache": "local"
   }
 }

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -238,13 +238,13 @@ export default class BaseCache extends CommonBase {
       cache.push(obj);
 
       if (!quiet) {
-        this._log.lruAdded(id);
+        this._log.event.lruAdded(id);
       }
 
       while (cache.length > this._maxLruSize) {
         const dropped = cache.shift();
         if (!quiet) {
-          this._log.lruDropped(this._idFromObject(dropped));
+          this._log.event.lruDropped(this._idFromObject(dropped));
         }
       }
     } else {
@@ -252,7 +252,7 @@ export default class BaseCache extends CommonBase {
       cache.push(obj);
 
       if (!quiet) {
-        this._log.lruPromoted(id);
+        this._log.event.lruPromoted(id);
       }
     }
   }

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -1,0 +1,279 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import weak from 'weak';
+
+import { BaseLogger } from '@bayou/see-all';
+import { TBoolean, TFunction, TInt, TString } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+/**
+ * Weak-reference based cache, with LRU-based additional cache retention. This
+ * class manages a map from string identifiers to associated objects, with those
+ * objects (a) held via weak references, such that they can be found again so
+ * long as they're being kept alive by other means, and (b) held strongly in an
+ * LRU cache, so as to avoid overzealous collection of objects during transient
+ * disuse.
+ *
+ * This is an abstract base class. Subclasses must fill in a handful of methods
+ * and synthetic properties to get a well-behaved instance.
+ */
+export default class BaseCache extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseLogger} log Logger instance to use.
+   * @param {Int} maxLruSize Maximum number of elements to keep in the LRU
+   *   cache.
+   */
+  constructor(log, maxLruSize) {
+    super();
+
+    /** {BaseLogger} Logger instance to use. */
+    this._log = BaseLogger.check(log).withAddedContext('cache');
+
+    /** {Int} Maximum number of elements to keep in the LRU cache. */
+    this._maxLruSize = TInt.nonNegative(maxLruSize);
+
+    /**
+     * {class} Class (constructor function) for objects to be stored in this
+     * instance.
+     */
+    this._cachedClass = TFunction.checkClass(this._impl_cachedClass);
+
+    /**
+     * {Map<string, Weak>} The weak-reference cache, specifically, a map from
+     * IDs to weak references to associated objects.
+     */
+    this._weakCache = new Map();
+
+    /**
+     * {array<object>} The LRU cache, with the least-recently used entries at
+     * smaller indices in the array and the most-recently used entry at the end.
+     */
+    this._lruCache = [];
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Gets the instance associated with the given ID, if any. Returns `null`
+   * if there is no such instance. If found, moves the instance to the front
+   * of the LRU cache (that is, marks it as the _most_ recently used instance).
+   *
+   * @param {string} id The ID to look up.
+   * @param {boolean} [quiet = false] If `true`, suppress log spew. (This is
+   *   meant for intra-class usage.)
+   * @returns {object|null} The corresponding instance, or `null` if no such
+   *   instance is active.
+   */
+  getOrNull(id, quiet = false) {
+    this._checkId(id);
+
+    const ref = this._weakCache.get(id);
+
+    if (!ref) {
+      if (!quiet) {
+        this._log.event.notCached(id);
+      }
+
+      return null;
+    }
+
+    const result = weak.get(ref);
+
+    if (!result) {
+      // `result` is `undefined`, which is to say, `ref` is a dead weak
+      // reference. We don't bother removing the dead entry from `_weakCache`,
+      // because in all likelihood the very next thing that will happen is that
+      // the calling code is going to re-instantiate the associated object and
+      // add it back. Also, a dead reference doesn't take up much space in
+      // memory.
+
+      if (!quiet) {
+        this._log.event.foundDead(id);
+      }
+
+      return null;
+    }
+
+    // We've seen cases where a weakly-referenced object gets collected and
+    // replaced with an instance of a different class. If this check throws an
+    // error, that's what's going on here. (This is evidence of a bug in Node or
+    // in the `weak` package.)
+    this._cachedClass.check(result);
+
+    this._mru(id, result, quiet);
+
+    if (!quiet) {
+      this._log.event.retrieved(id);
+    }
+
+    return result;
+  }
+
+  /**
+   * Adds the given instance to the cache, both as a weak reference and strongly
+   * at the head of the LRU cache (that is, as the _most_ recently referenced
+   * object). It is an error to add an instance with an ID that is already
+   * represented as a live cache entry.
+   *
+   * @param {object} obj Object to add to the cache.
+   */
+  add(obj) {
+    const id      = this._idFromObject(obj);
+    const already = this.getOrNull(id, true);
+
+    if (already !== null) {
+      throw Errors.badUse(`ID already present in cache: ${id}`);
+    }
+
+    const ref = weak(obj, this._objectReaper(id));
+
+    this._weakCache.set(id, ref);
+    this._mru(id, obj);
+
+    this._log.event.added(id);
+  }
+
+  /**
+   * Indicates that the given object &mdash; which should be cached by this
+   * instance &mdash; is still in active use. This moves the object to the
+   * most-recently-used position in the LRU cache.
+   *
+   * @param {object} obj Object to mark as recently used.
+   */
+  stillUsing(obj) {
+    const id = this._idFromObject(obj);
+
+    this._mru(id, obj);
+  }
+
+  /**
+   * {class} Class (constructor function) for objects to be stored in instances
+   * of this class.
+   *
+   * @abstract
+   */
+  get _impl_cachedClass() {
+    return this._mustOverride();
+  }
+
+  /**
+   * Gets the ID to use with the given cacheable object. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   * @param {object} obj A cacheable object.
+   * @returns {string} The ID to use to represent `obj`.
+   */
+  _impl_idFromObject(obj) {
+    return this._mustOverride(obj);
+  }
+
+  /**
+   * Checks to see if an ID is valid for use with this instance. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   * @param {string} id The ID to check. Guaranteed to be a string by this
+   *   class.
+   * @returns {boolean} `true` if `id` is valid, or `false` if not.
+   */
+  _impl_isValidId(id) {
+    return this._mustOverride(id);
+  }
+
+  /**
+   * Validates an ID to be used with this instance. Returns `id` if valid.
+   * Throws an error if not.
+   *
+   * @param {string} id The ID to check. Guaranteed to be a string by this
+   *   class.
+   * @returns {string} `id` if it is valid.
+   * @throws {Error} Thrown if `id` is invalid.
+   */
+  _checkId(id) {
+    TString.check(id);
+
+    const valid = TBoolean.check(this._impl_isValidId(id));
+
+    if (valid) {
+      return id;
+    }
+
+    throw Errors.badValue(id, String, 'ID syntax');
+  }
+
+  /**
+   * Gets the ID to use with the given cacheable object.
+   *
+   * @param {object} obj A cacheable object.
+   * @returns {string} The ID to use to represent `obj`.
+   */
+  _idFromObject(obj) {
+    this._cachedClass.check(obj);
+
+    const id = this._impl_idFromObject(obj);
+
+    return this._checkId(id);
+  }
+
+  /**
+   * Makes the given object be in the _most_ recently used position in the LRU
+   * cache, adding it if it was not already present or moving it if it was. If
+   * the addition of the object would make the LRU cache too big, trims it.
+   *
+   * @param {string} id The ID of the object in question.
+   * @param {object} obj Object to mark as _most_ recently used.
+   * @param {boolean} quiet If `true`, suppress log spew. (This is meant for
+   *   intra-class usage.)
+   */
+  _mru(id, obj, quiet) {
+    const cache   = this._lruCache;
+    const foundAt = cache.indexOf(obj);
+
+    if (foundAt === -1) {
+      cache.push(obj);
+
+      if (!quiet) {
+        this._log.lruAdded(id);
+      }
+
+      while (cache.length > this._maxLruSize) {
+        const dropped = cache.shift();
+        if (!quiet) {
+          this._log.lruDropped(this._idFromObject(dropped));
+        }
+      }
+    } else {
+      cache.splice(foundAt, 1);
+      cache.push(obj);
+
+      if (!quiet) {
+        this._log.lruPromoted(id);
+      }
+    }
+  }
+
+  /**
+   * Constructs and returns a post-mortem finalizer (reaper) for a weak
+   * reference on the object with the given ID.
+   *
+   * @param {string} id ID in question.
+   * @returns {function} Appropriately-constructed post-mortem finalizer.
+   */
+  _objectReaper(id) {
+    return () => {
+      this._log.event.reaped(id);
+
+      // Clear the cache entry, but only if it hasn't already been replaced with
+      // a new live reference. (Without the check, we'd have a concurrency
+      // hazard.)
+      if (this.getOrNull(id, true) === null) {
+        this._weakCache.delete(id);
+      }
+    };
+  }
+}

--- a/local-modules/@bayou/weak-lru-cache/index.js
+++ b/local-modules/@bayou/weak-lru-cache/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import WeakLruCache from './WeakLruCache';
+import BaseCache from './BaseCache';
 
-export { WeakLruCache };
+export { BaseCache };

--- a/local-modules/@bayou/weak-lru-cache/index.js
+++ b/local-modules/@bayou/weak-lru-cache/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import WeakLruCache from './WeakLruCache';
+
+export { WeakLruCache };

--- a/local-modules/@bayou/weak-lru-cache/package.json
+++ b/local-modules/@bayou/weak-lru-cache/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@bayou/deps-util-server": "local",
+    "@bayou/see-all": "local",
+    "@bayou/typecheck": "local",
+    "@bayou/util-common": "local"
+  }
+}

--- a/scripts/build
+++ b/scripts/build
@@ -382,7 +382,10 @@ function build-server {
     # Copy everything else over to the final `server` directory as-is. We use
     # the `--update` option to avoid clobbering those Babel-compiled files we
     # just went through all the trouble to make.
-    rsync-archive --delete --update "${fromDir}/" "${toDir}" || return 1
+    echo 'server: Copying final code...'
+    rsync-archive --delete --update "${fromDir}/" "${toDir}" \
+        || return 1
+    echo 'server: Copying final code... done.'
 }
 
 # Builds the client code.
@@ -393,8 +396,10 @@ function build-client {
     do-install client "${mainClient}" || return 1
 
     # Copy the built result into the final output.
+    echo 'client: Copying final code...'
     rsync-archive --delete "${outDir}/client/" "${toDir}" \
-    || return 1
+        || return 1
+    echo 'client: Copying final code... done'
 }
 
 # Builds the compiler (transpiler) code.

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -116,12 +116,12 @@ function publishable-module-names {
 # `rsync`. This is salient at some of the use sites.
 function rsync-archive {
     # **Note:** We use checksum-based checking, because the default time-and-
-    # size method is counterproductive. Specifically, a time-and-size check can
-    # will cause a failure to copy when two non-identical files happen to match
-    # in both size and timestamp, which does happen in practice specifically
-    # when running a build on a freshly checked-out source tree, wherein many
-    # many files have the same timestamps, which means that only the sizes come
-    # into play for the comparisons. And it's very easy to have a file size
+    # size method is counterproductive. Specifically, a time-and-size check will
+    # cause a failure to copy when two non-identical files happen to match in
+    # both size and timestamp, which does happen in practice specifically when
+    # running a build on a freshly checked-out source tree, wherein many many
+    # files have the same timestamps, which means that only the sizes come into
+    # play for the comparisons. And it's very easy to have a file size
     # coincidence.)
     #
     # **Note:** An earlier version of this code used `--ignore-times` instead

--- a/scripts/lib/include-build.sh
+++ b/scripts/lib/include-build.sh
@@ -115,14 +115,21 @@ function publishable-module-names {
 # **Note:** Trailing slashes on source directory names are significant to
 # `rsync`. This is salient at some of the use sites.
 function rsync-archive {
-    # **Note:** We turn off file-sameness checking, which is irrelevant for this
-    # use and is furthermore counterproductive, in that it can cause a failure
-    # to copy when two non-identical files happen to match in both size and
-    # timestamp. (This has happened in practice. When running a build on a
-    # freshly checked-out source tree, many many files have the same timestamps,
-    # so only the file sizes come into play, and it's very easy to have a file
-    # size coincidence.)
-    rsync --archive --ignore-times "$@"
+    # **Note:** We use checksum-based checking, because the default time-and-
+    # size method is counterproductive. Specifically, a time-and-size check can
+    # will cause a failure to copy when two non-identical files happen to match
+    # in both size and timestamp, which does happen in practice specifically
+    # when running a build on a freshly checked-out source tree, wherein many
+    # many files have the same timestamps, which means that only the sizes come
+    # into play for the comparisons. And it's very easy to have a file size
+    # coincidence.)
+    #
+    # **Note:** An earlier version of this code used `--ignore-times` instead
+    # of `--checksum`. The former worked equally well for this use case, except
+    # because it would always write the target files (even if identical), it
+    # would take significantly more time in the no-op case. (Specifically, some
+    # virus checkers can seriously degrade write performance.)
+    rsync --archive --checksum "$@"
 }
 
 # Sets up the build output directory, including cleaning it out or creating it,


### PR DESCRIPTION
This PR introduces a new class `BaseCache`, which implements a weak-reference based cache that also includes an LRU component to keep the most-recently referenced items alive via strong reference. This class is meant to replace — become the base class used for — the three preëxisting weakref-based caches in the system. And in fact it's used in this PR to replace one of them, specifically `FileCache` which was in fact used as the basis for the new base class.

The use of an LRU component is new to this code (that is, it wasn't part of `FileCache`), and it's introduced on the theory that we will get to avoid some unnecessary churn by allowing a handful (settable value, currently 10) of cached instances to be spared the fate of GC based on recency of usage. This alone will probably help alleviate — but not totally eliminate — the crashes we see due to bad `weak` module behavior, though probably not with this PR (because we'll have to use the same tactic in the other caches… coming soon!).

**Bonus:** I noticed that my build time slowed down considerably, seemingly with no change in code, specifically in the step which merged/copied the server code into `out/final/server`. My best theory is that our virus checker started doing more work on file writes, and this build step is a ***huge*** file write operation. I switched the build to only copy changed files (`rsync --checksum`), and it seems to have helped a lot. See the code comment in the build script for the gory details.