### PR TITLE
`async` facilities for `weak-lru-cache`.

### DIFF
--- a/local-modules/@bayou/doc-server/FileComplexCache.js
+++ b/local-modules/@bayou/doc-server/FileComplexCache.js
@@ -1,0 +1,44 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Storage } from '@bayou/config-server';
+import { BaseCache } from '@bayou/weak-lru-cache';
+
+import FileComplex from './FileComplex';
+
+/** {Int} Maximum size of the LRU cache. */
+const MAX_LRU_CACHE_SIZE = 10;
+
+/**
+ * Cache of active instances of {@link FileComplex}.
+ */
+export default class FileComplexCache extends BaseCache {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Logger} log Logger instance to use.
+   */
+  constructor(log) {
+    super(log, MAX_LRU_CACHE_SIZE);
+  }
+
+  /** @override */
+  get _impl_cachedClass() {
+    return FileComplex;
+  }
+
+  /** @override */
+  _impl_idFromObject(fileComplex) {
+    return fileComplex.fileAccess.documentId;
+  }
+
+  /** @override */
+  _impl_isValidId(id) {
+    // **Note:** This is just a surface syntax check of the ID. We don't make a
+    // back-end call to check the ID here (which would have to be `async`),
+    // because that would be a major waste if it turns out we're here in the
+    // process of finding an already-cached object.
+    return Storage.dataStore.isDocumentId(id);
+  }
+}

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -329,12 +329,15 @@ export default class BaseCache extends CommonBase {
   /**
    * Gets the object directly present in the weak cache for the given ID, if
    * any, or returning `null` if there is no entry. If there is an entry which
-   * turns out to be a dead weak reference, this method returns `null`.
+   * turns out to be a dead weak reference, this method also returns `null`.
+   * That is, if this method returns non-`null`, then the entry is guaranteed
+   * _not_ to be a for a dead weak reference.
    *
    * @param {string} id ID in question.
    * @param {boolean} [log = false] If `true`, logs the activity.
-   * @returns {object|null} The object associated with `id` in the weak cache,
-   *   or `null` if there is none.
+   * @returns {WeakCacheEntry|null} The entry associated with `id` in the weak
+   *   cache, or `null` if either there is none or the entry represents a dead
+   *   weak reference.
    */
   _getWeakCacheEntry(id, log = false) {
     this._checkId(id);

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -63,45 +63,6 @@ export default class BaseCache extends CommonBase {
   }
 
   /**
-   * Gets the instance associated with the given ID, if any. Returns `null`
-   * if there is no such instance. If found, moves the instance to the front
-   * of the LRU cache (that is, marks it as the _most_ recently used instance).
-   *
-   * In the case of an ID added via {@link #addAfterResolving} which is not yet
-   * resolved, this method will throw an error.
-   *
-   * @param {string} id The ID to look up.
-   * @returns {object|null} The corresponding instance, or `null` if no such
-   *   instance is active.
-   */
-  getOrNull(id) {
-    const entry  = this._getWeakCacheEntry(id, true);
-
-    if (entry === null) {
-      return null;
-    }
-
-    const result = entry.object;
-
-    if (result !== null) {
-      // We've seen cases where a weakly-referenced object gets collected and
-      // replaced with an instance of a different class. If this check throws an
-      // error, that's what's going on here. (This is evidence of a bug in Node
-      // or in the `weak` package.)
-      this._cachedClass.check(result);
-
-      this._mru(id, result);
-      return result;
-    } else if (entry.error) {
-      throw entry.error;
-    } else if (entry.promise) {
-      throw Errors.badUse(`Cannot synchronously get asynchronously-initializing ID: ${id}`);
-    } else {
-      throw Errors.wtf('Weird cache entry.');
-    }
-  }
-
-  /**
    * Adds the given instance to the cache, both as a weak reference and strongly
    * at the head of the LRU cache (that is, as the _most_ recently referenced
    * object). It is an error to add an instance with an ID that is already
@@ -185,6 +146,45 @@ export default class BaseCache extends CommonBase {
 
     this._weakCache.delete(id);
     this._log.event.clearedRejection(id);
+  }
+
+  /**
+   * Gets the instance associated with the given ID, if any. Returns `null`
+   * if there is no such instance. If found, moves the instance to the front
+   * of the LRU cache (that is, marks it as the _most_ recently used instance).
+   *
+   * In the case of an ID added via {@link #addAfterResolving} which is not yet
+   * resolved, this method will throw an error.
+   *
+   * @param {string} id The ID to look up.
+   * @returns {object|null} The corresponding instance, or `null` if no such
+   *   instance is active.
+   */
+  getOrNull(id) {
+    const entry  = this._getWeakCacheEntry(id, true);
+
+    if (entry === null) {
+      return null;
+    }
+
+    const result = entry.object;
+
+    if (result !== null) {
+      // We've seen cases where a weakly-referenced object gets collected and
+      // replaced with an instance of a different class. If this check throws an
+      // error, that's what's going on here. (This is evidence of a bug in Node
+      // or in the `weak` package.)
+      this._cachedClass.check(result);
+
+      this._mru(id, result);
+      return result;
+    } else if (entry.error) {
+      throw entry.error;
+    } else if (entry.promise) {
+      throw Errors.badUse(`Cannot synchronously get asynchronously-initializing ID: ${id}`);
+    } else {
+      throw Errors.wtf('Weird cache entry.');
+    }
   }
 
   /**

--- a/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
+++ b/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
@@ -1,0 +1,98 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import weak from 'weak';
+
+import { TString } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+/**
+ * Entry for the weak-cache portion of a {@link BaseCache} instance.
+ */
+export default class WeakCacheEntry extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} id The entry ID.
+   * @param {Weak|Promise|Error} value The entry value.
+   */
+  constructor(id, value) {
+    super();
+
+    /** {string} The entry ID. */
+    this._id = TString.check(id);
+
+    let kind;
+    if (value instanceof Promise) {
+      kind = 'promise';
+    } else if (value instanceof Error) {
+      kind = 'error';
+    } else if (weak.isWeakRef(value)) {
+      kind = 'weak';
+    } else {
+      throw Errors.badValue(value, 'Weak|Promise');
+    }
+
+    /** {Weak|null} The entry value, if it is a weak reference. */
+    this._weak = (kind === 'weak') ? value : null;
+
+    /** {Promise|null} The entry value, if it is a promise. */
+    this._promise = (kind === 'promise') ? value : null;
+
+    /** {Error|null} The entry value, if it is an error. */
+    this._error = (kind === 'error') ? value : null;
+
+    Object.freeze(this);
+  }
+
+  /** {Error|null} The entry value, if it is an error. */
+  get error() {
+    return this._error;
+  }
+
+  /** {string} The entry ID. */
+  get id() {
+    return this._id;
+  }
+
+  /**
+   * {object|null} A strong reference to the (otherwise) weakly-held value, if
+   * this entry is a weak reference whose referent is alive.
+   */
+  get object() {
+    if (this._weak === null) {
+      return null;
+    }
+
+    const result = weak.get(this._week);
+
+    return (result === undefined) ? null : result;
+  }
+
+  /** {Promise|null} The entry value, if it is a promise. */
+  get promise() {
+    return this._promise;
+  }
+
+  /** {Weak|null} The entry value, if it is a weak reference. */
+  get weak() {
+    return this._weak;
+  }
+
+  /**
+   * Indicates whether this entry is "alive." An entry is alive in all cases
+   * _except_ when it holds a weak reference whose referent is dead.
+   *
+   * @returns {boolean} `true` if this entry is alive, or `false` if not.
+   */
+  isAlive() {
+    if (this._weak === null) {
+      return true;
+    }
+
+    const obj = weak.get(this._weak);
+
+    return (obj !== undefined);
+  }
+}


### PR DESCRIPTION
This PR adds a bunch of stuff to `weak-lru-cache` so that it can be used in an asynchronous manner, more specifically in a way that matches the existing usage pattern of the ad-hoc cache built into `doc-server.DocServer`. This PR includes the addition of a `FileComplexCache`, which is what will eventually be used inside `DocServer`, but that class won't actually be used to replace the ad-hoc cache in `DocServer` until a later PR.
