### PR TITLE
Boot info logging. `server-env` self-consistency.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -11,7 +11,7 @@ import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
-import { Dirs, ProductInfo, ServerEnv } from '@bayou/env-server';
+import { Dirs, ServerEnv } from '@bayou/env-server';
 import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, PropertyIterable } from '@bayou/util-common';
@@ -202,7 +202,7 @@ export default class Application extends CommonBase {
     // Thwack the `X-Powered-By` header that Express provides by default,
     // replacing it with something that identifies this product.
     app.use((req_unused, res, next) => {
-      res.setHeader('X-Powered-By', ProductInfo.theOne.INFO.buildId);
+      res.setHeader('X-Powered-By', ServerEnv.theOne.productInfo.buildId);
       next();
     });
 

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -5,7 +5,7 @@
 import express from 'express';
 import http from 'http';
 
-import { ProductInfo, ServerEnv } from '@bayou/env-server';
+import { ServerEnv } from '@bayou/env-server';
 import { Logger } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
@@ -80,7 +80,7 @@ export default class Monitor extends CommonBase {
     // Thwack the `X-Powered-By` header that Express provides by default,
     // replacing it with something that identifies this product.
     app.use((req_unused, res, next) => {
-      res.setHeader('X-Powered-By', ProductInfo.theOne.INFO.buildId);
+      res.setHeader('X-Powered-By', ServerEnv.theOne.productInfo.buildId);
       next();
     });
 
@@ -95,7 +95,7 @@ export default class Monitor extends CommonBase {
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
         boot:    ServerEnv.theOne.buildInfo,
-        build:   ProductInfo.theOne.INFO,
+        build:   ServerEnv.theOne.productInfo.INFO,
         runtime: ServerEnv.theOne.runtimeInfo
       });
     });

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -94,8 +94,9 @@ export default class Monitor extends CommonBase {
 
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
+        boot:    ServerEnv.theOne.buildInfo,
         build:   ProductInfo.theOne.INFO,
-        runtime: ServerEnv.theOne.info
+        runtime: ServerEnv.theOne.runtimeInfo
       });
     });
 

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -5,7 +5,7 @@
 import path from 'path';
 
 import { Assets } from '@bayou/assets-client';
-import { ProductInfo } from '@bayou/env-server';
+import { ServerEnv } from '@bayou/env-server';
 import { UtilityClass } from '@bayou/util-common';
 
 import Network from './Network';
@@ -78,7 +78,7 @@ export default class Deployment extends UtilityClass {
    */
   static serverInfo() {
     return {
-      buildId: ProductInfo.theOne.INFO.buildId,
+      buildId: ServerEnv.theOne.productInfo.buildId,
       baseUrl: Network.baseUrl
     };
   }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -1,0 +1,40 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { LogRecord } from '@bayou/see-all';
+import { CommonBase } from '@bayou/util-common';
+
+/**
+ * Information about the booting of this server.
+ */
+export default class BootInfo extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    const bootTime = Date.now();
+
+    /** {Int} Time (Unix-epoch msec) when the server booted. */
+    this._bootTime = bootTime;
+
+    /** {string} String form of the boot time. */
+    this._bootTimeString = LogRecord.forTime(bootTime).timeStrings.join(' / ');
+
+    // **TODO:** Add other bits that are specific to this boot. Notably, we
+    // have discussed trying to count how many times a given build has been
+    // booted, and here is probably a reasonable place to have that.
+
+    Object.freeze(this);
+  }
+
+  /** {object} Ad-hoc object with the info from this instance. */
+  get info() {
+    return {
+      time:     this._bootTimeString,
+      timeMsec: this._bootTime
+    };
+  }
+}

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -30,7 +30,13 @@ export default class BootInfo extends CommonBase {
     Object.freeze(this);
   }
 
-  /** {object} Ad-hoc object with the info from this instance. */
+  /**
+   * {object} Ad-hoc object with the info from this instance.
+   *
+   * **Note:** This isn't all-caps `INFO` because it's not necessarily expected
+   * to be a constant value in the long term (even though it happens to be so
+   * as of this writing).
+   */
   get info() {
     return {
       time:     this._bootTimeString,

--- a/local-modules/@bayou/env-server/ProductInfo.js
+++ b/local-modules/@bayou/env-server/ProductInfo.js
@@ -6,7 +6,7 @@ import { camelCase } from 'lodash';
 import path from 'path';
 
 import { Proppy } from '@bayou/proppy';
-import { Singleton } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import Dirs from './Dirs';
 
@@ -14,7 +14,7 @@ import Dirs from './Dirs';
 /**
  * Product metainformation.
  */
-export default class ProductInfo extends Singleton {
+export default class ProductInfo extends CommonBase {
   /**
    * Constructs the instance.
    */
@@ -37,9 +37,9 @@ export default class ProductInfo extends Singleton {
   }
 
   /**
-   * The product info object, as parsed from `product-info.txt`.
+   * {object} The product info object, as parsed from `product-info.txt`.
    */
-  get INFO() {
+  get info() {
     return this._productInfo;
   }
 

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -9,6 +9,7 @@ import { Network } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Errors, Singleton } from '@bayou/util-common';
 
+import BootInfo from './BootInfo';
 import Dirs from './Dirs';
 import PidFile from './PidFile';
 import ProductInfo from './ProductInfo';
@@ -26,6 +27,9 @@ export default class ServerEnv extends Singleton {
    */
   constructor() {
     super();
+
+    /** {BootInfo} Info about the booting of this server. */
+    this._bootInfo = new BootInfo();
 
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();
@@ -51,6 +55,7 @@ export default class ServerEnv extends Singleton {
       arch:        process.arch,
       pid:         process.pid,
       ppid:        process.ppid,
+      bootInfo:    this._bootInfo.info,
       directories: {
         product: Dirs.theOne.BASE_DIR,
         var:     Dirs.theOne.VAR_DIR,

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -28,8 +28,15 @@ export default class ServerEnv extends Singleton {
   constructor() {
     super();
 
+    // Make sure that the directories could be determined, before proceeding any
+    // further.
+    Dirs.theOne;
+
     /** {BootInfo} Info about the booting of this server. */
     this._bootInfo = new BootInfo();
+
+    /** {ProductInfo} Info about the build. */
+    this._productInfo = new ProductInfo();
 
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();
@@ -49,6 +56,17 @@ export default class ServerEnv extends Singleton {
    */
   get bootInfo() {
     return this._bootInfo.info;
+  }
+
+  /**
+   * {object} Ad-hoc object with metainformation about the product (that is,
+   * about the build), intended for logging / debugging.
+   *
+   * **Note:** This isn't all-caps `*_INFO` because it's not necessarily
+   * expected to be a constant value.
+   */
+  get productInfo() {
+    return this._productInfo.info;
   }
 
   /**
@@ -80,12 +98,10 @@ export default class ServerEnv extends Singleton {
   }
 
   /**
-   * Initializes this module. This sets up the info for the `Dirs` class, sets
-   * up the PID file, and gathers the product metainfo.
+   * Initializes this module. This does everything that can't be done (or done
+   * safely) synchronously in the constructor.
    */
   async init() {
-    Dirs.theOne;
-
     this._shutdownManager.init();
     if (this._shutdownManager.shouldShutDown()) {
       log.error('Server found shutdown indicator(s) during startup.');
@@ -101,7 +117,6 @@ export default class ServerEnv extends Singleton {
     }
 
     this._pidFile.init();
-    ProductInfo.theOne;
   }
 
   /**

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -66,7 +66,6 @@ export default class ServerEnv extends Singleton {
       arch:        process.arch,
       pid:         process.pid,
       ppid:        process.ppid,
-      bootInfo:    this._bootInfo.info,
       directories: {
         product: Dirs.theOne.BASE_DIR,
         var:     Dirs.theOne.VAR_DIR,

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -41,14 +41,25 @@ export default class ServerEnv extends Singleton {
   }
 
   /**
+   * {object} Ad-hoc object with generally-useful info about the booting of this
+   * server, intended for logging / debugging.
+   *
+   * **Note:** This isn't all-caps `*_INFO` because it's not necessarily
+   * expected to be a constant value.
+   */
+  get bootInfo() {
+    return this._bootInfo.info;
+  }
+
+  /**
    * {object} Ad-hoc object with generally-useful runtime info, intended for
    * logging / debugging.
    *
-   * **Note:** This isn't all-caps `INFO` because it's not a constant value,
+   * **Note:** This isn't all-caps `*_INFO` because it's not a constant value,
    * due to the fact that `process.cwd()` and `process.ppid` could possibly
    * change.
    */
-  get info() {
+  get runtimeInfo() {
     return {
       nodeVersion: process.version.replace(/^v/, ''),
       platform:    process.platform,

--- a/local-modules/@bayou/env-server/index.js
+++ b/local-modules/@bayou/env-server/index.js
@@ -3,7 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import Dirs from './Dirs';
-import ProductInfo from './ProductInfo';
 import ServerEnv from './ServerEnv';
 
-export { Dirs, ProductInfo, ServerEnv };
+export { Dirs, ServerEnv };

--- a/local-modules/@bayou/env-server/tests/test_ProductInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_ProductInfo.js
@@ -5,18 +5,18 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { ProductInfo } from '@bayou/env-server';
+import ProductInfo from '@bayou/env-server/ProductInfo';
 
 describe('@bayou/env-server/ProductInfo', () => {
-  describe('.INFO', () => {
+  describe('.info', () => {
     it('is a frozen value', () => {
-      const info = ProductInfo.theOne.INFO;
+      const info = new ProductInfo().info;
 
       assert.isFrozen(info);
     });
 
     it('is an object full of the expected product info', () => {
-      const info = ProductInfo.theOne.INFO;
+      const info = new ProductInfo().info;
       const requiredKeys = [
         'buildDate', 'buildId', 'buildNumber', 'commitId', 'commitDate', 'name', 'nodeVersion', 'version'
       ];

--- a/local-modules/@bayou/see-all-server/FileSink.js
+++ b/local-modules/@bayou/see-all-server/FileSink.js
@@ -52,11 +52,8 @@ export default class FileSink extends BaseSink {
 
     if (metricName !== null) {
       // Metrics are pulled into the `details` directly with the same key as the
-      // metric name. Additionally, as a human-oriented convenience, if there is
-      // only one payload argument, it is represented directly instead of being
-      // represented as a one-element array.
-      const args = logRecord.payload.args;
-      details[metricName] = (args.length === 1) ? args[0] : args;
+      // metric name.
+      details[metricName] = FileSink._metricArgsFrom(logRecord);
     } else if (logRecord.isTime()) {
       // No need to log timestamp records. Those are only really useful for
       // human-oriented logging, because every log record builds in a timestamp
@@ -87,5 +84,26 @@ export default class FileSink extends BaseSink {
     }
 
     fs.appendFileSync(this._path, string);
+  }
+
+  /**
+   * Gets the arguments to represent in the logs for the given metric-bearing
+   * log record. Specifically, the "raw" arguments are always an array, but
+   * (a) for ease of human consumption, the single argument of a single-argument
+   * array is represented in the result directly, and (b) for minimal downstream
+   * confusion (human and code), a no-argument array gets converted to the
+   * boolean value `true`.
+   *
+   * @param {LogRecord} logRecord The record in question.
+   * @returns {*} The corresponding arguments to represent in the log.
+   */
+  static _metricArgsFrom(logRecord) {
+    const args = logRecord.payload.args;
+
+    switch (args.length) {
+      case 0:  { return true;    }
+      case 1:  { return args[0]; }
+      default: { return args;    }
+    }
   }
 }

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -261,7 +261,8 @@ export default class Action extends CommonBase {
 
     log.metric.boot();
     log.event.buildInfo(ProductInfo.theOne.INFO);
-    log.event.runtimeInfo(ServerEnv.theOne.info);
+    log.event.runtimeInfo(ServerEnv.theOne.runtimeInfo);
+    log.event.bootInfo(ServerEnv.theOne.bootInfo);
 
     /** {Application} The main app server. */
     const theApp = new Application(devRoutes);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -9,7 +9,7 @@ import { Application, Monitor } from '@bayou/app-setup';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
 import { DevMode } from '@bayou/dev-mode';
-import { Dirs, ProductInfo, ServerEnv } from '@bayou/env-server';
+import { Dirs, ServerEnv } from '@bayou/env-server';
 import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { HumanSink, FileSink } from '@bayou/see-all-server';
@@ -260,7 +260,7 @@ export default class Action extends CommonBase {
     // A little spew to identify the build and our environment.
 
     log.metric.boot();
-    log.event.buildInfo(ProductInfo.theOne.INFO);
+    log.event.buildInfo(ServerEnv.theOne.productInfo);
     log.event.runtimeInfo(ServerEnv.theOne.runtimeInfo);
     log.event.bootInfo(ServerEnv.theOne.bootInfo);
 


### PR DESCRIPTION
The main point of this PR is to get the `boot` metric to show up in downstream logs and add some new `bootInfo` which (currently) identifies the moment in time when the server boots as an unambiguous event (and which might eventually hold some additional boot-time info).

In addition, I took the opportunity (since I was in the territory) of making the `server-env` module a bit more self-consistent about how it exports its various bits of data.
