### PR TITLE
Logging follow-up.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -202,7 +202,7 @@ export default class Application extends CommonBase {
     // Thwack the `X-Powered-By` header that Express provides by default,
     // replacing it with something that identifies this product.
     app.use((req_unused, res, next) => {
-      res.setHeader('X-Powered-By', ServerEnv.theOne.productInfo.buildId);
+      res.setHeader('X-Powered-By', ServerEnv.theOne.buildInfo.buildId);
       next();
     });
 

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -80,7 +80,7 @@ export default class Monitor extends CommonBase {
     // Thwack the `X-Powered-By` header that Express provides by default,
     // replacing it with something that identifies this product.
     app.use((req_unused, res, next) => {
-      res.setHeader('X-Powered-By', ServerEnv.theOne.productInfo.buildId);
+      res.setHeader('X-Powered-By', ServerEnv.theOne.buildInfo.buildId);
       next();
     });
 
@@ -95,7 +95,7 @@ export default class Monitor extends CommonBase {
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
         boot:    ServerEnv.theOne.bootInfo,
-        build:   ServerEnv.theOne.productInfo,
+        build:   ServerEnv.theOne.buildInfo,
         runtime: ServerEnv.theOne.runtimeInfo
       });
     });

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -94,8 +94,8 @@ export default class Monitor extends CommonBase {
 
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
-        boot:    ServerEnv.theOne.buildInfo,
-        build:   ServerEnv.theOne.productInfo.INFO,
+        boot:    ServerEnv.theOne.bootInfo,
+        build:   ServerEnv.theOne.productInfo,
         runtime: ServerEnv.theOne.runtimeInfo
       });
     });

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -78,7 +78,7 @@ export default class Deployment extends UtilityClass {
    */
   static serverInfo() {
     return {
-      buildId: ServerEnv.theOne.productInfo.buildId,
+      buildId: ServerEnv.theOne.buildInfo.buildId,
       baseUrl: Network.baseUrl
     };
   }

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -42,6 +42,8 @@ export default class DocServer extends Singleton {
      * from getting GC'ed.
      */
     this._complexes = new Map();
+
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/@bayou/env-server/BuildInfo.js
+++ b/local-modules/@bayou/env-server/BuildInfo.js
@@ -36,6 +36,8 @@ export default class BuildInfo extends CommonBase {
 
     /** {object} Info object. */
     this._info = Object.freeze(info);
+
+    Object.freeze(this);
   }
 
   /**

--- a/local-modules/@bayou/env-server/BuildInfo.js
+++ b/local-modules/@bayou/env-server/BuildInfo.js
@@ -13,9 +13,10 @@ import Dirs from './Dirs';
 
 /**
  * Build / product metainformation. This is information about the built product
- * artifact.
+ * artifact, explicitly stored as a file at the top level of the product
+ * artifact directory.
  */
-export default class ProductInfo extends CommonBase {
+export default class BuildInfo extends CommonBase {
   /**
    * Constructs the instance.
    */
@@ -31,7 +32,7 @@ export default class ProductInfo extends CommonBase {
       info[camelCase(key)] = value;
     }
 
-    info.buildId = ProductInfo._makeBuildIdString(info);
+    info.buildId = BuildInfo._makeBuildIdString(info);
 
     /** {object} Info object. */
     this._info = Object.freeze(info);

--- a/local-modules/@bayou/env-server/ProductInfo.js
+++ b/local-modules/@bayou/env-server/ProductInfo.js
@@ -12,7 +12,8 @@ import Dirs from './Dirs';
 
 
 /**
- * Product metainformation.
+ * Build / product metainformation. This is information about the built product
+ * artifact.
  */
 export default class ProductInfo extends CommonBase {
   /**
@@ -32,15 +33,16 @@ export default class ProductInfo extends CommonBase {
 
     info.buildId = ProductInfo._makeBuildIdString(info);
 
-    /** {object} Product info object. */
-    this._productInfo = Object.freeze(info);
+    /** {object} Info object. */
+    this._info = Object.freeze(info);
   }
 
   /**
-   * {object} The product info object, as parsed from `product-info.txt`.
+   * {object} The info object, as parsed from the build / product
+   * metainformation file.
    */
   get info() {
-    return this._productInfo;
+    return this._info;
   }
 
   /**

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -36,7 +36,7 @@ export default class ServerEnv extends Singleton {
     this._bootInfo = new BootInfo();
 
     /** {ProductInfo} Info about the build. */
-    this._productInfo = new ProductInfo();
+    this._buildInfo = new ProductInfo();
 
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();
@@ -59,14 +59,14 @@ export default class ServerEnv extends Singleton {
   }
 
   /**
-   * {object} Ad-hoc object with metainformation about the product (that is,
-   * about the build), intended for logging / debugging.
+   * {object} Ad-hoc object with metainformation about the build (that is, about
+   * the product artifact), intended for logging / debugging.
    *
    * **Note:** This isn't all-caps `*_INFO` because it's not necessarily
    * expected to be a constant value.
    */
-  get productInfo() {
-    return this._productInfo.info;
+  get buildInfo() {
+    return this._buildInfo.info;
   }
 
   /**

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -12,7 +12,7 @@ import { Errors, Singleton } from '@bayou/util-common';
 import BootInfo from './BootInfo';
 import Dirs from './Dirs';
 import PidFile from './PidFile';
-import ProductInfo from './ProductInfo';
+import BuildInfo from './BuildInfo';
 import ShutdownManager from './ShutdownManager';
 
 /** {Logger} Logger. */
@@ -35,8 +35,8 @@ export default class ServerEnv extends Singleton {
     /** {BootInfo} Info about the booting of this server. */
     this._bootInfo = new BootInfo();
 
-    /** {ProductInfo} Info about the build. */
-    this._buildInfo = new ProductInfo();
+    /** {BuildInfo} Info about the build. */
+    this._buildInfo = new BuildInfo();
 
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();

--- a/local-modules/@bayou/env-server/tests/test_BuildInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_BuildInfo.js
@@ -5,18 +5,18 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import ProductInfo from '@bayou/env-server/ProductInfo';
+import BuildInfo from '@bayou/env-server/BuildInfo';
 
-describe('@bayou/env-server/ProductInfo', () => {
+describe('@bayou/env-server/BuildInfo', () => {
   describe('.info', () => {
     it('is a frozen value', () => {
-      const info = new ProductInfo().info;
+      const info = new BuildInfo().info;
 
       assert.isFrozen(info);
     });
 
     it('is an object full of the expected product info', () => {
-      const info = new ProductInfo().info;
+      const info = new BuildInfo().info;
       const requiredKeys = [
         'buildDate', 'buildId', 'buildNumber', 'commitId', 'commitDate', 'name', 'nodeVersion', 'version'
       ];

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -260,7 +260,7 @@ export default class Action extends CommonBase {
     // A little spew to identify the build and our environment.
 
     log.metric.boot();
-    log.event.buildInfo(ServerEnv.theOne.productInfo);
+    log.event.buildInfo(ServerEnv.theOne.buildInfo);
     log.event.runtimeInfo(ServerEnv.theOne.runtimeInfo);
     log.event.bootInfo(ServerEnv.theOne.bootInfo);
 


### PR DESCRIPTION
I messed up the monitor `/info` endpoint in the last PR, which can arguably be attributed to me getting confused about the terms `buildInfo` and `productInfo`, which refer to the same thing. This PR makes the name of these be consistently the former (capitalized in the case of a class name), and fixes the spot I messed up.