### PR TITLE
More `BaseCache` progress with an eye towards `FileComplexCache`.

### DIFF
--- a/local-modules/@bayou/doc-server/DocSessionCache.js
+++ b/local-modules/@bayou/doc-server/DocSessionCache.js
@@ -31,6 +31,13 @@ export default class DocSessionCache extends BaseCache {
   }
 
   /** @override */
+  get _impl_maxRejectionAge() {
+    // Valid value so that the constructor won't complain, but note that this
+    // class isn't used asynchronously, so the actual value shouldn't matter.
+    return 1000;
+  }
+
+  /** @override */
   _impl_idFromObject(session) {
     return session.getCaretId();
   }

--- a/local-modules/@bayou/doc-server/DocSessionCache.js
+++ b/local-modules/@bayou/doc-server/DocSessionCache.js
@@ -7,9 +7,6 @@ import { BaseCache } from '@bayou/weak-lru-cache';
 
 import DocSession from './DocSession';
 
-/** {Int} Maximum size of the LRU cache. */
-const MAX_LRU_CACHE_SIZE = 10;
-
 /**
  * Cache of active instances of {@link DocSession}.
  */
@@ -20,12 +17,17 @@ export default class DocSessionCache extends BaseCache {
    * @param {Logger} log Logger instance to use.
    */
   constructor(log) {
-    super(log, MAX_LRU_CACHE_SIZE);
+    super(log);
   }
 
   /** @override */
   get _impl_cachedClass() {
     return DocSession;
+  }
+
+  /** @override */
+  get _impl_maxLruSize() {
+    return 10;
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/FileComplexCache.js
+++ b/local-modules/@bayou/doc-server/FileComplexCache.js
@@ -7,9 +7,6 @@ import { BaseCache } from '@bayou/weak-lru-cache';
 
 import FileComplex from './FileComplex';
 
-/** {Int} Maximum size of the LRU cache. */
-const MAX_LRU_CACHE_SIZE = 10;
-
 /**
  * Cache of active instances of {@link FileComplex}.
  */
@@ -20,12 +17,17 @@ export default class FileComplexCache extends BaseCache {
    * @param {Logger} log Logger instance to use.
    */
   constructor(log) {
-    super(log, MAX_LRU_CACHE_SIZE);
+    super(log);
   }
 
   /** @override */
   get _impl_cachedClass() {
     return FileComplex;
+  }
+
+  /** @override */
+  get _impl_maxLruSize() {
+    return 10;
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/FileComplexCache.js
+++ b/local-modules/@bayou/doc-server/FileComplexCache.js
@@ -31,6 +31,11 @@ export default class FileComplexCache extends BaseCache {
   }
 
   /** @override */
+  get _impl_maxRejectionAge() {
+    return 10 * 1000; // Ten seconds.
+  }
+
+  /** @override */
   _impl_idFromObject(fileComplex) {
     return fileComplex.fileAccess.documentId;
   }

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -6,9 +6,6 @@ import { BaseCache } from '@bayou/weak-lru-cache';
 
 import BaseFile from './BaseFile';
 
-/** {Int} Maximum size of the LRU cache. */
-const MAX_LRU_CACHE_SIZE = 10;
-
 /**
  * Cache of active instances of {@link BaseFile}.
  */
@@ -19,12 +16,17 @@ export default class FileCache extends BaseCache {
    * @param {Logger} log Logger instance to use.
    */
   constructor(log) {
-    super(log, MAX_LRU_CACHE_SIZE);
+    super(log);
   }
 
   /** @override */
   get _impl_cachedClass() {
     return BaseFile;
+  }
+
+  /** @override */
+  get _impl_maxLruSize() {
+    return 10;
   }
 
   /** @override */

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -30,6 +30,13 @@ export default class FileCache extends BaseCache {
   }
 
   /** @override */
+  get _impl_maxRejectionAge() {
+    // Valid value so that the constructor won't complain, but note that this
+    // class isn't used asynchronously, so the actual value shouldn't matter.
+    return 1000;
+  }
+
+  /** @override */
   _impl_idFromObject(file) {
     return file.id;
   }

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -367,7 +367,13 @@ export default class BaseCache extends CommonBase {
     }
 
     if (log) {
-      this._log.event.retrieved(id);
+      if (entry.error) {
+        this._log.event.retrievedError(id);
+      } else if (entry.promise) {
+        this._log.event.retrievedPromise(id);
+      } else {
+        this._log.event.retrievedObject(id);
+      }
     }
 
     return entry;

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -180,7 +180,7 @@ export default class BaseCache extends CommonBase {
    *   instance is active.
    */
   async getOrNullAfterResolving(id) {
-    return this._getOrNullAfterResolving(id, true);
+    return this._getOrNull(id, true);
   }
 
   /**

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -28,17 +28,15 @@ export default class BaseCache extends CommonBase {
    * Constructs an instance.
    *
    * @param {BaseLogger} log Logger instance to use.
-   * @param {Int} maxLruSize Maximum number of elements to keep in the LRU
-   *   cache.
    */
-  constructor(log, maxLruSize) {
+  constructor(log) {
     super();
 
     /** {BaseLogger} Logger instance to use. */
     this._log = BaseLogger.check(log).withAddedContext('cache');
 
     /** {Int} Maximum number of elements to keep in the LRU cache. */
-    this._maxLruSize = TInt.nonNegative(maxLruSize);
+    this._maxLruSize = TInt.nonNegative(this._impl_maxLruSize);
 
     /** {Int} Maximum age (msec) of rejection entries. */
     this._maxRejectionAge = TInt.nonNegative(this._impl_maxRejectionAge);
@@ -220,6 +218,16 @@ export default class BaseCache extends CommonBase {
    * @abstract
    */
   get _impl_cachedClass() {
+    return this._mustOverride();
+  }
+
+  /**
+   * {Int} Maximum size (in entries) of the LRU cache. This many added object
+   * entries will be explicitly maintained in an alive state by this instance.
+   *
+   * @abstract
+   */
+  get _impl_maxLruSize() {
     return this._mustOverride();
   }
 

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -233,12 +233,12 @@ export default class BaseCache extends CommonBase {
 
   /**
    * {Int} Maximum age (in msec) for a promise rejection cache entry, before it
-   * is discarded (literally, or effectively ignored). This class provides a
-   * default value of ten seconds for this property. Subclasses can choose to
-   * override it.
+   * is discarded (literally, or effectively ignored).
+   *
+   * @abstract
    */
   get _impl_maxRejectionAge() {
-    return 10 * 1000;
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -79,7 +79,7 @@ export default class BaseCache extends CommonBase {
 
     const ref = weak(obj, this._objectReaper(id));
 
-    this._weakCache.set(id, new WeakCacheEntry(id, ref));
+    this._weakCache.set(id, new WeakCacheEntry(this._now(), id, ref));
     this._mru(id, obj);
 
     this._log.event.added(id);
@@ -112,7 +112,7 @@ export default class BaseCache extends CommonBase {
       throw Errors.badUse(`ID already present in cache: ${id}`);
     }
 
-    this._weakCache.set(id, new WeakCacheEntry(id, objPromise));
+    this._weakCache.set(id, new WeakCacheEntry(this._now(), id, objPromise));
 
     this._log.event.resolving(id);
 
@@ -126,7 +126,7 @@ export default class BaseCache extends CommonBase {
       return obj;
     } catch (e) {
       this._log.event.rejected(id, e);
-      this._weakCache.set(id, new WeakCacheEntry(id, e));
+      this._weakCache.set(id, new WeakCacheEntry(this._now(), id, e));
       throw e;
     }
   }
@@ -400,6 +400,18 @@ export default class BaseCache extends CommonBase {
 
       this._log.event.lruPromoted(id);
     }
+  }
+
+  /**
+   * Gets the current time, in the usual Unix Epoch msec form.
+   *
+   * **TODO:** Make this configurable per subclass, especially to help with
+   * testing.
+   *
+   * @returns {Int} The current time in msec since the Unix Epoch.
+   */
+  _now() {
+    return Date.now();
   }
 
   /**

--- a/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
+++ b/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
@@ -4,7 +4,7 @@
 
 import weak from 'weak';
 
-import { TString } from '@bayou/typecheck';
+import { TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
 /**
@@ -14,11 +14,16 @@ export default class WeakCacheEntry extends CommonBase {
   /**
    * Constructs an instance.
    *
+   * @param {Int} createTimeMsec The time (Unix Epoch msec) when this entry was
+   *   created.
    * @param {string} id The entry ID.
    * @param {Weak|Promise|Error} value The entry value.
    */
-  constructor(id, value) {
+  constructor(createTimeMsec, id, value) {
     super();
+
+    /** {Int} The time (Unix Epoch msec) when this entry was created. */
+    this._createTimeMsec = TInt.nonNegative(createTimeMsec);
 
     /** {string} The entry ID. */
     this._id = TString.check(id);
@@ -44,6 +49,11 @@ export default class WeakCacheEntry extends CommonBase {
     this._error = (kind === 'error') ? value : null;
 
     Object.freeze(this);
+  }
+
+  /** {Int} The time (Unix Epoch msec) when this entry was created. */
+  get createTimeMsec() {
+    return this._createTimeMsec;
   }
 
   /** {Error|null} The entry value, if it is an error. */


### PR DESCRIPTION
This PR is another round of work on `BaseCache`, with the aim (as before) of making it suitable for use as the base class of `FileComplexCache`. As of this PR, that class is still unused, but my hope is that the next PR will be the one where I rip out the salient guts of `DocServer`, replacing them with a use of the class. We'll see!

**Bonus:** Made subclass configuration of `BaseCache` more self-consistent.
