### PR TITLE
Fix `BaseCache` and use `FileComplexCache`.

### DIFF
--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -2,14 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import weak from 'weak';
-
 import { TheModule as appCommon_TheModule } from '@bayou/app-common';
 import { Storage } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';
 
 import FileComplex from './FileComplex';
+import FileComplexCache from './FileComplexCache';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('doc-server');
@@ -34,14 +33,10 @@ export default class DocServer extends Singleton {
     this._codec = appCommon_TheModule.fullCodec;
 
     /**
-     * {Map<string, Weak<FileComplex>|Promise<FileComplex>>} Map from document
-     * IDs to either a weak-reference or a promise to a {@link FileComplex}, for
-     * the so-IDed document. During asynchrounous construction, the binding is
-     * to a promise, and once constructed it becomes a weak reference. The weak
-     * reference is made because we don't want its presence here to preclude it
-     * from getting GC'ed.
+     * {FileComplexCache} Cache of {@link FileComplex} instances, mapped from
+     * document IDs.
      */
-    this._complexes = new Map();
+    this._complexes = new FileComplexCache(log);
 
     Object.freeze(this);
   }
@@ -54,46 +49,14 @@ export default class DocServer extends Singleton {
    * @returns {FileComplex} The corresponding `FileComplex`.
    */
   async getFileComplex(documentId) {
-    // **Note:** We don't make an `async` back-end call to check the
-    // `documentId` here, because that would be a waste if it turns out we've
-    // already cached a valid result. Once we determine that we need to
-    // construct a new complex (below), we'll call through to the back-end to
+    // **Note:** We don't make an `async` back-end call to check the full
+    // validity of `documentId` here, because that would be a waste if it turns
+    // out we've already cached a valid result. Once we determine that we need
+    // to construct a new complex (below), we'll call through to the back-end to
     // get a file ID, and that call implicitly validates the document ID.
     Storage.dataStore.checkDocumentIdSyntax(documentId);
 
-    // Look for a cached or in-progress result.
-
-    const already = this._complexes.get(documentId);
-    if (already) {
-      // There's something in the cache. There are two possibilities...
-      if (already instanceof Promise) {
-        // It's a _promise_ for a `FileComplex`. This happens if we got a
-        // request for a file in parallel with it getting constructed.
-        const result = await already;
-        result.log.event.parallelRequest();
-        return result;
-      } else {
-        // It's a weak reference. If not dead, it refers to a `FileComplex`.
-        if (!weak.isDead(already)) {
-          // We've seen cases where a weakly-referenced object gets collected
-          // and replaced with an instance of a different class. If this check
-          // throws an error, that's what's going on here. (This is evidence of
-          // a bug in Node or in the `weak` package.)
-          const result = FileComplex.check(weak.get(already));
-
-          result.log.event.foundInCache();
-          return result;
-        }
-        // The weak reference is dead. We'll fall through and construct a new
-        // result.
-        log.withAddedContext(documentId).event.foundDead();
-      }
-    }
-
-    // Nothing in the cache (except, perhaps, a dead weak reference).
-    // Asynchronously construct the ultimate result, returning a promise to it.
-
-    const resultPromise = (async () => {
+    return this._complexes.resolveOrAdd(documentId, async () => {
       try {
         const startTime = Date.now();
 
@@ -109,12 +72,6 @@ export default class DocServer extends Singleton {
 
         await result.init();
 
-        const resultRef = weak(result, this._complexReaper(documentId));
-
-        // Replace the promise in the cache with a weak reference to the actaul
-        // result.
-        this._complexes.set(documentId, resultRef);
-
         const endTime = Date.now();
         result.log.event.madeComplex(...((fileId === documentId) ? [] : [fileId]));
         result.log.metric.initTimeMsec(endTime - startTime);
@@ -122,40 +79,8 @@ export default class DocServer extends Singleton {
         return result;
       } catch (e) {
         log.error(`Trouble constructing complex ${documentId}.`, e);
-
-        // Remove the promise in the cache, so that we will try again instead of
-        // continuing to report this error.
-        this._complexes.delete(documentId);
-
         throw e; // Becomes the rejection value of the promise.
       }
-    })();
-
-    // Store the the promise for the result in the cache, and return it.
-
-    log.withAddedContext(documentId).event.aboutToMake();
-    this._complexes.set(documentId, resultPromise);
-    return resultPromise;
-  }
-
-  /**
-   * Returns a weak reference callback function for the indicated document ID.
-   *
-   * @param {string} documentId Document ID of the file complex to remove.
-   * @returns {function} An appropriately-constructed function.
-   */
-  _complexReaper(documentId) {
-    // **Note:** This function _used to_ remove the document binding from the
-    // `_complexes` map on the presumption that it was a known-dead weak
-    // reference. That code has been deleted. First of all, the only benefit
-    // would have been that it meant that the weak reference itself could get
-    // GC'ed (and a dead weakref doesn't actually take up significant storage).
-    // Second, and more importantly, this could fail due to a race condition: If
-    // the same document was requested _after_ the old one was GC'ed and
-    // _before_ this reaper was called, the cleanup code here would have
-    // incorrectly removed a perfectly valid binding.
-    return () => {
-      log.event.reaped(documentId);
-    };
+    });
   }
 }

--- a/local-modules/@bayou/doc-server/DocSessionCache.js
+++ b/local-modules/@bayou/doc-server/DocSessionCache.js
@@ -17,7 +17,7 @@ export default class DocSessionCache extends BaseCache {
    * @param {Logger} log Logger instance to use.
    */
   constructor(log) {
-    super(log);
+    super(log.withAddedContext('session'));
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -42,10 +42,10 @@ export default class FileComplex extends BaseComplexMember {
      * {FileBootstrap} Bootstrap handler, and also where the complex members are
      * most directly stored.
      */
-    this._bootstrap = new FileBootstrap(this._fileAccess);
+    this._bootstrap = new FileBootstrap(this.fileAccess);
 
     /** {DocSessionCache} Cache of session instances, mapped from caret IDs. */
-    this._sessions = new DocSessionCache(this.log);
+    this._sessions = new DocSessionCache(this.fileAccess.log);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/package.json
+++ b/local-modules/@bayou/doc-server/package.json
@@ -3,7 +3,6 @@
     "@bayou/app-common": "local",
     "@bayou/codec": "local",
     "@bayou/config-server": "local",
-    "@bayou/deps-util-server": "local",
     "@bayou/doc-common": "local",
     "@bayou/file-store": "local",
     "@bayou/file-store-ot": "local",

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -340,11 +340,11 @@ export default class BaseCache extends CommonBase {
   }
 
   /**
-   * Gets the object directly present in the weak cache for the given ID, if
-   * any, or returning `null` if there is no entry. If there is an entry which
-   * turns out to be a dead weak reference, this method also returns `null`.
-   * That is, if this method returns non-`null`, then the entry is guaranteed
-   * _not_ to be a for a dead weak reference.
+   * Gets the entry in the weak cache for the given ID, if any, or returning
+   * `null` if there is no entry. If there is an entry which turns out to be a
+   * dead weak reference, this method also returns `null`. That is, if this
+   * method returns non-`null`, then the entry is guaranteed _not_ to be a dead
+   * weak reference.
    *
    * @param {string} id ID in question.
    * @param {boolean} [log = false] If `true`, logs the activity.

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -108,7 +108,7 @@ export default class BaseCache extends CommonBase {
    * if there is no such instance. If found, moves the instance to the front
    * of the LRU cache (that is, marks it as the _most_ recently used instance).
    *
-   * In the case of an ID added via {@link #addAfterResolving} which is not yet
+   * In the case of an ID added via {@link #resolveOrAdd} which is not yet
    * resolved, this method will throw an error.
    *
    * @param {string} id The ID to look up.

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -87,23 +87,6 @@ export default class BaseCache extends CommonBase {
   }
 
   /**
-   * Removes a cache entry which indicates a rejected promise. It is an error if
-   * the given ID isn't associated with a promise rejection in the cache.
-   *
-   * @param {string} id ID to remove from the cache.
-   */
-  clearRejection(id) {
-    const entry  = this._getWeakCacheEntry(id);
-
-    if ((entry === null) || (entry.error === null)) {
-      throw Errors.badUse(`ID not rejected: ${id}`);
-    }
-
-    this._weakCache.delete(id);
-    this._log.event.clearedRejection(id);
-  }
-
-  /**
    * Gets the instance associated with the given ID, if any. Returns `null`
    * if there is no such instance. If found, moves the instance to the front
    * of the LRU cache (that is, marks it as the _most_ recently used instance).
@@ -150,9 +133,8 @@ export default class BaseCache extends CommonBase {
    * cache (so, e.g., it is invalid to add another instance with the same ID),
    * except that (synchronous) {@link #getOrNull} will report an error. Should
    * the promise ultimately become rejected (not resolved), it will remain in
-   * the cache indefinitely as such, until and unless it is either cleared out
-   * explicitly via a call to {@link #clearRejection} or it "ages" out per this
-   * instance's configuration for same.
+   * the cache until it "ages" out per this instance's configuration for same
+   * (see {@link #_impl_maxRejectionAge}).
    *
    * @param {string} id The ID of the object.
    * @param {function} objMaker Function which is expected to return a suitable

--- a/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
+++ b/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
@@ -75,7 +75,7 @@ export default class WeakCacheEntry extends CommonBase {
       return null;
     }
 
-    const result = weak.get(this._week);
+    const result = weak.get(this._weak);
 
     return (result === undefined) ? null : result;
   }


### PR DESCRIPTION
This PR (finally) replaces the ad-hoc cache in `DocServer` with a use of `FileComplexCache`, which is a subclass of `weak-lru-cache.BaseCache`. This also includes a couple of fixes and tweaks to `BaseCache`. A future PR will do at least a little more tweakage of `BaseCache` (specifically to avoid a potential GC race).

🎉 With this PR, all three weakref-based caches in the system use the `weak-lru-cache` module. 🎉
