### PR TITLE
Avoid a GC race in `weak-lru-cache`. 

### DIFF
--- a/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
+++ b/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
@@ -89,20 +89,4 @@ export default class WeakCacheEntry extends CommonBase {
   get weak() {
     return this._weak;
   }
-
-  /**
-   * Indicates whether this entry is "alive." An entry is alive in all cases
-   * _except_ when it holds a weak reference whose referent is dead.
-   *
-   * @returns {boolean} `true` if this entry is alive, or `false` if not.
-   */
-  isAlive() {
-    if (this._weak === null) {
-      return true;
-    }
-
-    const obj = weak.get(this._weak);
-
-    return (obj !== undefined);
-  }
 }


### PR DESCRIPTION
Previously, there was a possibility that `weak-lru-cache` could get confused if a weakly-referenced object it was tracking got GC'ed while in the middle of using the associated weak reference. This PR fixes that. As a "collateral benefit" I fixed a bug in how promise rejections get reported (they were all getting silently swallowed before).
