### PR TITLE
Logging, on a few fronts.

### DIFF
--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -68,7 +68,7 @@ export default class ApiLog extends CommonBase {
       details.result = response.result;
     }
 
-    this._log.event.apiReturned(details);
+    this._logCompletedCall(details);
   }
 
   /**
@@ -103,8 +103,23 @@ export default class ApiLog extends CommonBase {
       error:     response.originalError
     };
 
+    this._logCompletedCall(details);
+  }
+
+  /**
+   * Performs end-of-call logging.
+   *
+   * @param {object} details Ad-hoc object with call details.
+   */
+  _logCompletedCall(details) {
+    const durationMsec = details.endTime - details.startTime;
+    const ok           = details.ok;
+
     // **TODO:** This will ultimately need to redact some information beyond
     // what `msg.logInfo` might have done.
     this._log.event.apiReturned(details);
+
+    // Log just the success and elapsed time as a metric.
+    this._log.metric.apiCall({ ok, durationMsec });
   }
 }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -129,6 +129,8 @@ export default class ApiLog extends CommonBase {
    * @param {object} details Ad-hoc object with call details.
    */
   _logCompletedCall(details) {
+    const msg          = details.msg;
+    const method       = msg ? msg.payload.name : '<unknown>';
     const durationMsec = details.endTime - details.startTime;
     const ok           = details.ok;
 
@@ -136,9 +138,9 @@ export default class ApiLog extends CommonBase {
 
     this._log.event.apiReturned(details);
 
-    // Log just the success and elapsed time as a metric, for easy downstream
-    // consumption.
-    this._log.metric.apiCall({ ok, durationMsec });
+    // For easy downstream, log a metric of just the method name, success flag,
+    // and elapsed time.
+    this._log.metric.apiCall({ ok, durationMsec, method });
   }
 
   /**

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -58,7 +58,7 @@ export default class ApiLog extends CommonBase {
     // Details to log. **TODO:** This will ultimately need to redact some
     // information in the response.
 
-    details.endTime = Date.now();
+    details.endTime = this._now();
 
     if (response.error) {
       details.ok     = false;
@@ -105,7 +105,7 @@ export default class ApiLog extends CommonBase {
    * @returns {object} Ad-hoc details object.
    */
   _initialDetails(msg) {
-    const now = Date.now();
+    const now = this._now();
 
     return {
       msg:       msg ? msg.logInfo : null,
@@ -131,5 +131,17 @@ export default class ApiLog extends CommonBase {
 
     // Log just the success and elapsed time as a metric.
     this._log.metric.apiCall({ ok, durationMsec });
+  }
+
+  /**
+   * Gets the current time, in the usual Unix Epoch msec form.
+   *
+   * **Note:** This method exists so as to make this class a little easier to
+   * test.
+   *
+   * @returns {Int} The current time in msec since the Unix Epoch.
+   */
+  _now() {
+    return Date.now();
   }
 }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -392,7 +392,7 @@ export default class Application extends CommonBase {
         }
       }
 
-      log.event.activeConnections(connections.size);
+      log.metric.activeConnections(connections.size);
     }
   }
 }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -44,10 +44,6 @@ export default class BootInfo extends CommonBase {
     /** {Int} Count of how many times this build has been booted. */
     this._bootCount = this._determineBootCount();
 
-    // **TODO:** Add other bits that are specific to this boot. Notably, we
-    // have discussed trying to count how many times a given build has been
-    // booted, and here is probably a reasonable place to have that.
-
     Object.freeze(this);
   }
 

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -39,8 +39,14 @@ export default class BootInfo extends CommonBase {
    */
   get info() {
     return {
-      time:     this._bootTimeString,
-      timeMsec: this._bootTime
+      time:       this._bootTimeString,
+      timeMsec:   this._bootTime,
+      uptimeMsec: this.uptimeMsec
     };
+  }
+
+  /** {Int} The length of time this server has been running, in msec. */
+  get uptimeMsec() {
+    return Date.now() - this._bootTime;
   }
 }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -2,8 +2,17 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { LogRecord } from '@bayou/see-all';
+import fs from 'fs';
+import path from 'path';
+
+import { Logger, LogRecord } from '@bayou/see-all';
+import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
+
+import Dirs from './Dirs';
+
+/** {Logger} Logger for this class. */
+const log = new Logger('boot-info');
 
 /**
  * Information about the booting of this server.
@@ -11,17 +20,29 @@ import { CommonBase } from '@bayou/util-common';
 export default class BootInfo extends CommonBase {
   /**
    * Constructs an instance.
+   *
+   * @param {string} buildId The build ID of this server's build (used to figure
+   *   out how many times this same build has been booted).
    */
-  constructor() {
+  constructor(buildId) {
     super();
 
     const bootTime = Date.now();
+
+    /** {string} The build ID. */
+    this._buildId = TString.check(buildId);
 
     /** {Int} Time (Unix-epoch msec) when the server booted. */
     this._bootTime = bootTime;
 
     /** {string} String form of the boot time. */
     this._bootTimeString = LogRecord.forTime(bootTime).timeStrings.join(' / ');
+
+    /** {string} Path for the boot count file. */
+    this._bootCountPath = path.resolve(Dirs.theOne.CONTROL_DIR, 'boot-count.txt');
+
+    /** {Int} Count of how many times this build has been booted. */
+    this._bootCount = this._determineBootCount();
 
     // **TODO:** Add other bits that are specific to this boot. Notably, we
     // have discussed trying to count how many times a given build has been
@@ -39,6 +60,7 @@ export default class BootInfo extends CommonBase {
    */
   get info() {
     return {
+      bootCount:  this._bootCount,
       time:       this._bootTimeString,
       timeMsec:   this._bootTime,
       uptimeMsec: this.uptimeMsec
@@ -48,5 +70,36 @@ export default class BootInfo extends CommonBase {
   /** {Int} The length of time this server has been running, in msec. */
   get uptimeMsec() {
     return Date.now() - this._bootTime;
+  }
+
+  /**
+   * Returns the number of times that this build (by ID) has been started on
+   * this server. It does this by reading the build ID file (if present) and
+   * (re)writing it (to update the statistic).
+   *
+   * @returns {Int} The number of times this build has booted.
+   */
+  _determineBootCount() {
+    const buildId = this._buildId;
+    let bootCount = 1;
+
+    try {
+      const text = fs.readFileSync(this._bootCountPath, { encoding: 'utf8' });
+      const obj  = JSON.parse(text);
+
+      if (obj.buildId === buildId) {
+        bootCount = obj.bootCount + 1;
+      }
+    } catch (e) {
+      // `ENOENT` is "file not found." Anything else is logworthy.
+      if (e.code !== 'ENOENT') {
+        log.error('Trouble reading boot-count file.', e);
+      }
+    }
+
+    const newText = `${JSON.stringify({ bootCount, buildId }, null, 2)}\n`;
+    fs.writeFileSync(this._bootCountPath, newText, { encoding: 'utf8' });
+
+    return bootCount;
   }
 }

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -36,11 +36,11 @@ export default class ServerEnv extends Singleton {
     // further.
     Dirs.theOne;
 
-    /** {BootInfo} Info about the booting of this server. */
-    this._bootInfo = new BootInfo();
-
     /** {BuildInfo} Info about the build. */
     this._buildInfo = new BuildInfo();
+
+    /** {BootInfo} Info about the booting of this server. */
+    this._bootInfo = new BootInfo(this._buildInfo.info.buildId);
 
     /** {PidFile} The PID file manager. */
     this._pidFile = new PidFile();

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -6,6 +6,7 @@ import is_running from 'is-running';
 import http from 'http';
 
 import { Network } from '@bayou/config-server';
+import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { Errors, Singleton } from '@bayou/util-common';
 
@@ -14,6 +15,9 @@ import Dirs from './Dirs';
 import PidFile from './PidFile';
 import BuildInfo from './BuildInfo';
 import ShutdownManager from './ShutdownManager';
+
+/** {Int} Frequency of uptime metric logs, in msec per log. */
+const UPTIME_LOG_MSEC = 5 * 60 * 1000; // Five minutes.
 
 /** {Logger} Logger. */
 const log = new Logger('env-server');
@@ -117,6 +121,7 @@ export default class ServerEnv extends Singleton {
     }
 
     this._pidFile.init();
+    this._uptimeLoop();
   }
 
   /**
@@ -197,5 +202,26 @@ export default class ServerEnv extends Singleton {
     }
 
     return result;
+  }
+
+  /**
+   * Runs a loop which repeatedly logs a metric which includes the build ID and
+   * the uptime, with a reasonable delay between each iteration.
+   */
+  async _uptimeLoop() {
+    const buildId = this._buildInfo.info.buildId;
+
+    for (;;) {
+      // Round the current uptime up to a multiple of the desired frequency (ok
+      // ok ok, technically "wavelength"), delay until the time hits, and log
+      // it. We log the "clean" exact value of the multiple, for the sake of
+      // cleanliness, even though by the time the log happens it'll probably be
+      // a few msec beyond the logged uptime value.
+      const uptimeMsec = this._bootInfo.uptimeMsec;
+      const nextLogMsec = Math.round(Math.ceil(uptimeMsec / UPTIME_LOG_MSEC) * UPTIME_LOG_MSEC);
+
+      await Delay.resolve(nextLogMsec - uptimeMsec);
+      log.metric.running({ buildId, uptimeMsec: nextLogMsec });
+    }
   }
 }


### PR DESCRIPTION
This PR adds a handful of new logged metrics and other additions to the logs:

* New metric logged per incoming API call, including the method name, success flag, and duration of the call.
* New metric logged per outgoing webapp callback, including the method name, success flag, and duration of the call.
* Switch the `activeConnections` event to be a metric.
* Regularly (every five minutes right now) log a `running` metric which includes the build ID and the current server uptime.
* Add a new `bootCount` property to the boot info, which indicates how many times a given build of the system has been started on the machine so reporting.
