### PR TITLE
Add shutdown count metric.

### DIFF
--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -45,6 +45,8 @@ export default class BootInfo extends CommonBase {
     this._bootCount = this._determineBootCount();
 
     Object.freeze(this);
+
+    this._logBoot();
   }
 
   /** {Int}  Count of how many times this build has been booted. */
@@ -107,5 +109,13 @@ export default class BootInfo extends CommonBase {
     fs.writeFileSync(this._bootCountPath, newText, { encoding: 'utf8' });
 
     return bootCount;
+  }
+
+  /**
+   * Logs the `boot` metric.
+   */
+  _logBoot() {
+    const { bootCount, buildId } = this;
+    log.metric.boot({ buildId, bootCount });
   }
 }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -41,12 +41,18 @@ export default class BootInfo extends CommonBase {
     /** {string} Path for the boot count file. */
     this._bootCountPath = path.resolve(Dirs.theOne.CONTROL_DIR, 'boot-count.txt');
 
-    /** {Int} Count of how many times this build has been booted. */
-    this._bootCount = this._determineBootCount();
+    const { bootCount, shutdownCount } = this._determineCounts();
 
-    Object.freeze(this);
+    /** {Int} Count of how many times this build has been booted. */
+    this._bootCount = bootCount;
+
+    /** {Int} Count of how many times this build has been shut down cleanly. */
+    this._shutdownCount = shutdownCount;
+
+    Object.seal(this);
 
     this._logBoot();
+    this._writeFile();
   }
 
   /** {Int}  Count of how many times this build has been booted. */
@@ -68,11 +74,17 @@ export default class BootInfo extends CommonBase {
    */
   get info() {
     return {
-      bootCount:  this._bootCount,
-      time:       this._bootTimeString,
-      timeMsec:   this._bootTime,
-      uptimeMsec: this.uptimeMsec
+      bootCount:     this._bootCount,
+      shutdownCount: this._shutdownCount,
+      time:          this._bootTimeString,
+      timeMsec:      this._bootTime,
+      uptimeMsec:    this.uptimeMsec
     };
+  }
+
+  /** {Int} Count of how many times this build has been shut down cleanly. */
+  get shutdownCount() {
+    return this._shutdownCount;
   }
 
   /** {Int} The length of time this server has been running, in msec. */
@@ -81,22 +93,34 @@ export default class BootInfo extends CommonBase {
   }
 
   /**
-   * Returns the number of times that this build (by ID) has been started on
-   * this server. It does this by reading the build ID file (if present) and
-   * (re)writing it (to update the statistic).
-   *
-   * @returns {Int} The number of times this build has booted.
+   * Increments the shutdown count, and writes the resulting modified info to
+   * the boot info file.
    */
-  _determineBootCount() {
-    const buildId = this._buildId;
-    let bootCount = 1;
+  incrementShutdownCount() {
+    this._shutdownCount++;
+    this._writeFile();
+  }
+
+  /**
+   * Returns the number of times that this build (by ID) has been started and
+   * shut down on this server. It does this by reading the build ID file (if
+   * present) and (re)writing it (to update the statistic).
+   *
+   * @returns {object} Ad-hoc plain object mapping `bootCount` and
+   *   `shutdownCount`, each an integer.
+   */
+  _determineCounts() {
+    const buildId     = this._buildId;
+    let bootCount     = 1;
+    let shutdownCount = 0;
 
     try {
       const text = fs.readFileSync(this._bootCountPath, { encoding: 'utf8' });
       const obj  = JSON.parse(text);
 
       if (obj.buildId === buildId) {
-        bootCount = obj.bootCount + 1;
+        bootCount     = (obj.bootCount || 0) + 1;
+        shutdownCount = obj.shutdownCount || 0;
       }
     } catch (e) {
       // `ENOENT` is "file not found." Anything else is logworthy.
@@ -105,17 +129,23 @@ export default class BootInfo extends CommonBase {
       }
     }
 
-    const newText = `${JSON.stringify({ bootCount, buildId }, null, 2)}\n`;
-    fs.writeFileSync(this._bootCountPath, newText, { encoding: 'utf8' });
-
-    return bootCount;
+    return { bootCount, shutdownCount };
   }
 
   /**
    * Logs the `boot` metric.
    */
   _logBoot() {
-    const { bootCount, buildId } = this;
-    log.metric.boot({ buildId, bootCount });
+    const { bootCount, buildId, shutdownCount } = this;
+    log.metric.boot({ buildId, bootCount, shutdownCount });
+  }
+
+  /**
+   * Writes the boot info file.
+   */
+  _writeFile() {
+    const { buildId, bootCount, shutdownCount } = this;
+    const text = `${JSON.stringify({ buildId, bootCount, shutdownCount }, null, 2)}\n`;
+    fs.writeFileSync(this._bootCountPath, text, { encoding: 'utf8' });
   }
 }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -47,6 +47,16 @@ export default class BootInfo extends CommonBase {
     Object.freeze(this);
   }
 
+  /** {Int}  Count of how many times this build has been booted. */
+  get bootCount() {
+    return this._bootCount;
+  }
+
+  /** {string} The build ID. */
+  get buildId() {
+    return this._buildId;
+  }
+
   /**
    * {object} Ad-hoc object with the info from this instance.
    *

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -46,7 +46,7 @@ export default class ServerEnv extends Singleton {
     this._pidFile = new PidFile();
 
     /** {ShutdownManager} The shutdown manager. */
-    this._shutdownManager = new ShutdownManager();
+    this._shutdownManager = new ShutdownManager(this._bootInfo);
 
     Object.freeze(this);
   }
@@ -217,7 +217,7 @@ export default class ServerEnv extends Singleton {
       // it. We log the "clean" exact value of the multiple, for the sake of
       // cleanliness, even though by the time the log happens it'll probably be
       // a few msec beyond the logged uptime value.
-      const uptimeMsec = this._bootInfo.uptimeMsec;
+      const uptimeMsec  = this._bootInfo.uptimeMsec;
       const nextLogMsec = Math.round(Math.ceil(uptimeMsec / UPTIME_LOG_MSEC) * UPTIME_LOG_MSEC);
 
       await Delay.resolve(nextLogMsec - uptimeMsec);

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -10,6 +10,7 @@ import { Logger } from '@bayou/see-all';
 import { TObject } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
+import BootInfo from './BootInfo';
 import Dirs from './Dirs';
 
 /**
@@ -44,11 +45,16 @@ export default class ShutdownManager extends CommonBase {
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (i.e. reacting to the control files); that stuff
    * happens in {@link #init}.
+   *
+   * @param {BootInfo} bootInfo Associated boot info manager.
    */
-  constructor() {
+  constructor(bootInfo) {
     super();
 
     const CONTROL_PATH = Dirs.theOne.CONTROL_DIR;
+
+    /** {BootInfo} Associated boot info manager. */
+    this._bootInfo = BootInfo.check(bootInfo);
 
     /** {string} Path for the shutdown-command file. */
     this._shutdownPath = path.resolve(CONTROL_PATH, 'shutdown');
@@ -217,6 +223,10 @@ export default class ShutdownManager extends CommonBase {
     if (timedOut) {
       log.event.shutdownTimedOut();
     }
+
+    const bootInfo = this._bootInfo;
+    const { bootCount, buildId, uptimeMsec } = bootInfo;
+    log.metric.shutdown({ buildId, uptimeMsec, bootCount, timedOut });
 
     log.event.shutdownComplete();
     process.exit(0);

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -225,8 +225,10 @@ export default class ShutdownManager extends CommonBase {
     }
 
     const bootInfo = this._bootInfo;
-    const { bootCount, buildId, uptimeMsec } = bootInfo;
-    log.metric.shutdown({ buildId, uptimeMsec, bootCount, timedOut });
+
+    bootInfo.incrementShutdownCount();
+    const { bootCount, buildId, shutdownCount, uptimeMsec } = bootInfo;
+    log.metric.shutdown({ buildId, uptimeMsec, bootCount, shutdownCount, timedOut });
 
     log.event.shutdownComplete();
     process.exit(0);

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -259,7 +259,6 @@ export default class Action extends CommonBase {
 
     // A little spew to identify the build and our environment.
 
-    log.metric.boot();
     log.event.buildInfo(ServerEnv.theOne.buildInfo);
     log.event.runtimeInfo(ServerEnv.theOne.runtimeInfo);
     log.event.bootInfo(ServerEnv.theOne.bootInfo);


### PR DESCRIPTION
This PR adds tracking of number of times a given build got shut down cleanly. It gets reported via a new `shutdown` metric, as well as in the preëxisting `boot` metric (which now has a non-empty payload) and the `bootInfo` event.
