### PR TITLE
Switch to the `weak-napi` module.

### DIFF
--- a/local-modules/@bayou/deps-util-server/package.json
+++ b/local-modules/@bayou/deps-util-server/package.json
@@ -7,6 +7,6 @@
     "memory-fs": "^0.4.1",
     "minimist": "^1.2.0",
     "source-map-support": "^0.5.6",
-    "weak": "^1.0.1"
+    "weak-napi": "^1.0.2"
   }
 }

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import weak from 'weak';
+import weak from 'weak-napi';
 
 import { BaseLogger } from '@bayou/see-all';
 import { TBoolean, TFunction, TInt, TString } from '@bayou/typecheck';

--- a/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
+++ b/local-modules/@bayou/weak-lru-cache/WeakCacheEntry.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import weak from 'weak';
+import weak from 'weak-napi';
 
 import { TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';


### PR DESCRIPTION
...instead of `weak`, which is known to be crashy.