### PR TITLE
`/metrics` monitor endpoint.

### DIFF
--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -102,8 +102,9 @@ export default class Monitor extends CommonBase {
 
     app.get('/metrics', async (req_unused, res) => {
       // **TODO:** Real metrics, driven by the calls to `log.metric.*()` in the
-      // main code. NB: The following is in OpenMetrics format (a/k/a Prometheus
-      // format).
+      // main code. Also note the high degree of overlap with `VarInfo`, which
+      // perhaps should be merged with this (or retired). NB: The following is
+      // in OpenMetrics format (a/k/a Prometheus format).
       ServerUtil.sendPlainTextResponse(res,
         '# TYPE uptimeMsec counter\n' +
         `uptimeMsec ${ServerEnv.theOne.bootInfo.uptimeMsec}\n`);

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -100,6 +100,14 @@ export default class Monitor extends CommonBase {
       });
     });
 
+    app.get('/metrics', async (req_unused, res) => {
+      // **TODO:** Real metrics. NB: The following is in OpenMetrics format
+      // (a/k/a Prometheus format).
+      ServerUtil.sendPlainTextResponse(res,
+        '# TYPE uptimeMsec counter\n' +
+        `uptimeMsec ${ServerEnv.theOne.bootInfo.uptimeMsec}\n`);
+    });
+
     const varInfo = mainApplication.varInfo;
     app.get('/var', async (req_unused, res) => {
       const info = await varInfo.get();

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -101,8 +101,9 @@ export default class Monitor extends CommonBase {
     });
 
     app.get('/metrics', async (req_unused, res) => {
-      // **TODO:** Real metrics. NB: The following is in OpenMetrics format
-      // (a/k/a Prometheus format).
+      // **TODO:** Real metrics, driven by the calls to `log.metric.*()` in the
+      // main code. NB: The following is in OpenMetrics format (a/k/a Prometheus
+      // format).
       ServerUtil.sendPlainTextResponse(res,
         '# TYPE uptimeMsec counter\n' +
         `uptimeMsec ${ServerEnv.theOne.bootInfo.uptimeMsec}\n`);


### PR DESCRIPTION
This PR introduces a new endpoint `/metrics` on the monitor port. It's more or less stubbed out (just one metric, hard-coded) and is just meant to be a MVP-ish placeholder so that downstream can test with it.