### PR TITLE
Clean up the new metrics stuff.

### DIFF
--- a/local-modules/@bayou/app-setup/Metrics.js
+++ b/local-modules/@bayou/app-setup/Metrics.js
@@ -4,17 +4,59 @@
 
 import { collectDefaultMetrics, register, Counter } from 'prom-client';
 
-collectDefaultMetrics({ prefix: 'docs_' });
+import { ServerEnv } from '@bayou/env-server';
+import { CommonBase } from '@bayou/util-common';
 
-const RequestsTotal = new Counter({
-  name: 'docs_requests_total',
-  help: 'counter recording request metadata',
-  labelNames: ['method', 'code'],
-});
+/**
+ * Prometheus- / OpenMetrics-based metrics collection and reporting.
+ */
+export default class Metrics extends CommonBase {
+  /**
+   * Constructs an instance. This also sets up default metrics collection. (As
+   * such, the latter bit means that it's probably a bad idea to instantiate
+   * this class more than once per process.)
+   */
+  constructor() {
+    super();
 
-export function MetricsMiddleware(req, res, next) {
-  next();
-  RequestsTotal.labels(req.method, res.statusCode).inc();
+    // **Note:** OpenMetrics seems to prefer `lower_camel_case` names.
+    const prefix = `${ServerEnv.theOne.buildInfo.name}_`;
+
+    /** {string} Prefix to use for metrics names. */
+    this._prefix = prefix;
+
+    /** {Counter} Counter for total HTTP requests. */
+    this._requestsTotal = new Counter({
+      name:       `${prefix}requests_total`,
+      help:       'Counter of HTTP requests, with method and status code labels',
+      labelNames: ['method', 'code'],
+    });
+
+    collectDefaultMetrics({ prefix });
+
+    Object.freeze(this);
+  }
+
+  /**
+   * {function} Express middleware which hooks up the {@link #_requestsTotal}
+   * counter.
+   */
+  get httpRequestMiddleware() {
+    return (req, res, next) => {
+      next();
+      this._requestsTotal.labels(req.method, res.statusCode).inc();
+    };
+  }
+
+  /**
+   * {prom-client.client.Registry} The registry used by this instance.
+   *
+   * **Note:** As of this writing, it is always the default (global) metrics
+   * registry. It is an instance property (not `static`) for consistency with
+   * the rest of the class and on the assumption that we will want to stop using
+   * the global registry at some point (especially so as to aid in testing).
+   */
+  get register() {
+    return register;
+  }
 }
-
-export { register, RequestsTotal };

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -100,17 +100,17 @@ export default class Monitor extends CommonBase {
       });
     });
 
+    app.get('/metrics', async (req_unused, res) => {
+      const register = mainApplication.metrics.register;
+
+      ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
+    });
+
     const varInfo = mainApplication.varInfo;
     app.get('/var', async (req_unused, res) => {
       const info = await varInfo.get();
 
       ServerUtil.sendJsonResponse(res, info);
-    });
-
-    app.get('/metrics', async (req_unused, res) => {
-      const register = mainApplication.metrics.register;
-
-      ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
     });
   }
 }

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -11,7 +11,6 @@ import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import Application from './Application';
-import { register } from './Metrics';
 import RequestLogger from './RequestLogger';
 import ServerUtil from './ServerUtil';
 
@@ -109,6 +108,8 @@ export default class Monitor extends CommonBase {
     });
 
     app.get('/metrics', async (req_unused, res) => {
+      const register = this._mainApplication.metrics.register;
+
       ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
     });
   }

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -100,9 +100,8 @@ export default class Monitor extends CommonBase {
       });
     });
 
+    const register = mainApplication.metrics.register;
     app.get('/metrics', async (req_unused, res) => {
-      const register = mainApplication.metrics.register;
-
       ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
     });
 

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -108,7 +108,7 @@ export default class Monitor extends CommonBase {
     });
 
     app.get('/metrics', async (req_unused, res) => {
-      const register = this._mainApplication.metrics.register;
+      const register = mainApplication.metrics.register;
 
       ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
     });

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -11,6 +11,10 @@ import Application from './Application';
 /**
  * "Variable" info (like, it varies and isn't just static to the system), which
  * is provided via the internal monitoring server (see {@link Monitor}).
+ *
+ * **TODO:** The stuff collected and reported on here is highly-overlapping
+ * with what is (or ought to be) reported via `/metrics`. Look into combining
+ * these or at least moving as much as is sensible to {@link Metrics}.
  */
 export default class VarInfo extends CommonBase {
   /**

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.2.16
+version = 1.3.0


### PR DESCRIPTION
This PR reworks the new metrics stuff into the project's dominant style, sprinkling a few comments in there along the way.

In addition, this bumps the product version to 1.3.0 — more sentimental than semantical — since it feels like we've kinda crossed a new threshold of late.