### PR TITLE
Capture "high level" crashes in the boot info.

### DIFF
--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -42,7 +42,7 @@ export default class BootInfo extends CommonBase {
     this._bootTimeString = LogRecord.forTime(bootTime).timeStrings.join(' / ');
 
     /** {string} Path for the boot info file. */
-    this._bootCountPath = path.resolve(Dirs.theOne.CONTROL_DIR, 'boot-count.txt');
+    this._bootInfoPath = path.resolve(Dirs.theOne.CONTROL_DIR, 'boot-info.txt');
 
     /** {object} Plain object of durable boot info. */
     this._info = this._readFileWithDefaults();
@@ -159,7 +159,7 @@ export default class BootInfo extends CommonBase {
     const info    = { buildId, bootCount: 0, errors: '', shutdownCount: 0 };
 
     try {
-      const text = fs.readFileSync(this._bootCountPath, { encoding: 'utf8' });
+      const text = fs.readFileSync(this._bootInfoPath, { encoding: 'utf8' });
       const obj  = JSON.parse(text);
 
       if (obj.buildId === buildId) {
@@ -181,6 +181,6 @@ export default class BootInfo extends CommonBase {
    */
   _writeFile() {
     const text = `${JSON.stringify(this._info, null, 2)}\n`;
-    fs.writeFileSync(this._bootCountPath, text, { encoding: 'utf8' });
+    fs.writeFileSync(this._bootInfoPath, text, { encoding: 'utf8' });
   }
 }

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -205,6 +205,16 @@ export default class ServerEnv extends Singleton {
   }
 
   /**
+   * Records an error which caused server shutdown, for ongoing inclusion in
+   * {@link #bootInfo}.
+   *
+   * @param {string} error Stringified error.
+   */
+  recordError(error) {
+    this._bootInfo.recordError(error);
+  }
+
+  /**
    * Runs a loop which repeatedly logs a metric which includes the build ID and
    * the uptime, with a reasonable delay between each iteration.
    */

--- a/local-modules/@bayou/top-server/TopErrorHandler.js
+++ b/local-modules/@bayou/top-server/TopErrorHandler.js
@@ -21,28 +21,7 @@ export default class TopErrorHandler extends UtilityClass {
    * Sets up error handling.
    */
   static init() {
-    process.on('unhandledRejection', (reason, promise_unused) => {
-      // Write to `stdout` directly first, because logging might be broken.
-      process.stderr.write('Unhandled promise rejection:\n');
-      if (reason instanceof Error) {
-        process.stderr.write(reason.stack);
-      } else {
-        process.stderr.write(inspect(reason));
-      }
-      process.stderr.write('\n');
-
-      if (SeeAll.theOne.canLog()) {
-        log.error('Unhandled promise rejection:', reason);
-      }
-
-      // Give the system a moment, so it has a chance to actually flush the log,
-      // and then exit.
-      (async () => {
-        await Delay.resolve(250); // 0.25 second.
-        process.exit(1);
-      })();
-    });
-
+    process.on('unhandledRejection', TopErrorHandler._unhandledRejection);
     process.on('uncaughtException', TopErrorHandler._uncaughtException);
   }
 

--- a/local-modules/@bayou/top-server/TopErrorHandler.js
+++ b/local-modules/@bayou/top-server/TopErrorHandler.js
@@ -21,18 +21,20 @@ export default class TopErrorHandler extends UtilityClass {
    * Sets up error handling.
    */
   static init() {
-    process.on('unhandledRejection', TopErrorHandler._unhandledRejection);
+    process.on('unhandledRejection', TopErrorHandler._uncaughtRejection);
     process.on('uncaughtException', TopErrorHandler._uncaughtException);
   }
 
   /**
    * Handle either top-level problem, as indicated.
    *
-   * @param {string} label How to label the problem (in the logs).
+   * @param {string} eventName Event name to use for logging the problem.
+   * @param {string} label How to label the problem in a human-oriented `error`
+   *   log.
    * @param {*} problem The "problem" (uncaught exception or rejection reason).
    *   Typically, but not necessarily, an `Error`.
    */
-  static _handleProblem(label, problem) {
+  static _handleProblem(eventName, label, problem) {
     // Write to `stdout` directly first, because logging might be broken.
     process.stderr.write(`${label}:\n`);
     if (problem instanceof Error) {
@@ -44,6 +46,7 @@ export default class TopErrorHandler extends UtilityClass {
 
     if (SeeAll.theOne.canLog()) {
       log.error(`${label}:`, problem);
+      log.event[eventName](problem);
     }
 
     // Give the system a moment, so it has a chance to actually flush the log,
@@ -61,7 +64,7 @@ export default class TopErrorHandler extends UtilityClass {
    *   necessarily, an `Error`.
    */
   static _uncaughtException(error) {
-    TopErrorHandler._handleProblem('Uncaught exception', error);
+    TopErrorHandler._handleProblem('uncaughtException', 'Uncaught exception', error);
   }
 
   /**
@@ -71,7 +74,7 @@ export default class TopErrorHandler extends UtilityClass {
    *   necessarily, an `Error`.
    * @param {Promise} promise_unused The promise that was rejected.
    */
-  static _unhandledRejection(reason, promise_unused) {
-    TopErrorHandler._handleProblem('Unhandled promise rejection', reason);
+  static _uncaughtRejection(reason, promise_unused) {
+    TopErrorHandler._handleProblem('uncaughtRejection', 'Uncaught promise rejection', reason);
   }
 }


### PR DESCRIPTION
This PR hooks up the "uncaught exception" and "unhandled rejection" handlers — top-level Node handlers that react when Node is about to crash due to stuff that is actually detected within the JS runtime — so that they get the text of the problem into the boot info file, such that it is available upon server restart.

So, as of this PR, you can look for the `bootInfo` event or at the `boot` section of the `/info` monitor endpoint, and see a compendium of all the high-level-catchable reasons that the particular build of the product crashed on the machine in question. (NB: It gets truncated at 5000 characters.)