### PR TITLE
`BodyClient` enablement.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -225,6 +225,9 @@ export default class BodyClient extends StateMachine {
    *
    * @see {@link #shouldBeEnabled}
    * @see {@link #whenShouldBeEnabled}
+   *
+   * @returns {boolean} `true` (always), asynchrounously when this instance
+   *   believes the editor should be in a disabled state.
    */
   async whenShouldBeDisabled() {
     return this._shouldBeEnabled.whenFalse();
@@ -238,6 +241,9 @@ export default class BodyClient extends StateMachine {
    *
    * @see {@link #shouldBeEnabled}
    * @see {@link #whenShouldBeDisabled}
+   *
+   * @returns {boolean} `true` (always), asynchrounously when this instance
+   *   believes the editor should be in an enabled state.
    */
   async whenShouldBeEnabled() {
     return this._shouldBeEnabled.whenTrue();

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -532,6 +532,8 @@ export default class BodyClient extends StateMachine {
    * @param {function} stateName The name of the state to transition into.
    */
   _handle_becomeDisabled_nextState(stateName) {
+    this.log.event.becameDisabled();
+
     if (this._manageEnabledState) {
       this._quill.disable();
     }
@@ -549,6 +551,8 @@ export default class BodyClient extends StateMachine {
    * transitions into the `idle` state after handling this event.
    */
   _handle_becomeEnabled_start() {
+    this.log.event.becameEnabled();
+
     if (this._manageEnabledState) {
       this._quill.enable();
 

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -4,7 +4,7 @@
 
 import { ConnectionError } from '@bayou/api-common';
 import { BodyChange, BodyDelta, BodyOp, BodySnapshot } from '@bayou/doc-common';
-import { Delay } from '@bayou/promise-util';
+import { Condition, Delay } from '@bayou/promise-util';
 import { QuillEvents, QuillUtil } from '@bayou/quill-util';
 import { TInt, TString } from '@bayou/typecheck';
 import { StateMachine } from '@bayou/state-machine';
@@ -130,6 +130,14 @@ export default class BodyClient extends StateMachine {
     this._running = false;
 
     /**
+     * {Condition} Whether this instance believes that editing "should" be
+     * enabled. This is based on what has been happening with the server
+     * connection (but is not simply the same as whether a server connection has
+     * been established).
+     */
+    this._shouldBeEnabled = new Condition();
+
+    /**
      * {Proxy|null} Local proxy for accessing the server session. Becomes
      * non-`null` during the handling of the `start` event.
      */
@@ -179,6 +187,20 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
+   * Gets this instance's instantaneously current view on whether editing should
+   * be enabled.
+   *
+   * @see {@link #whenShouldBeDisabled}
+   * @see {@link #whenShouldBeEnabled}
+   *
+   * @returns {boolean} `true` if this instance believes that editing should be
+   *   enabled, or `false` if not.
+   */
+  shouldBeEnabled() {
+    return this._shouldBeEnabled.value;
+  }
+
+  /**
    * Requests that this instance start interacting with its associated editor
    * and API handler. This method does nothing if the client is already in an
    * active state (including being in the middle of starting).
@@ -193,6 +215,32 @@ export default class BodyClient extends StateMachine {
    */
   stop() {
     this.q_stop();
+  }
+
+  /**
+   * As an asynchronous method, returns when editing "should" be disabled, from
+   * the perspective of this instance. This method is useful for users of this
+   * class which manage the editor's enabled state (that is, construct instances
+   * with `manageEnabledState` as `false`).
+   *
+   * @see {@link #shouldBeEnabled}
+   * @see {@link #whenShouldBeEnabled}
+   */
+  async whenShouldBeDisabled() {
+    return this._shouldBeEnabled.whenFalse();
+  }
+
+  /**
+   * As an asynchronous method, returns when editing "should" be enabled, from
+   * the perspective of this instance. This method is useful for users of this
+   * class which manage the editor's enabled state (that is, construct instances
+   * with `manageEnabledState` as `false`).
+   *
+   * @see {@link #shouldBeEnabled}
+   * @see {@link #whenShouldBeDisabled}
+   */
+  async whenShouldBeEnabled() {
+    return this._shouldBeEnabled.whenTrue();
   }
 
   //
@@ -488,6 +536,7 @@ export default class BodyClient extends StateMachine {
       this._quill.disable();
     }
 
+    this._shouldBeEnabled.value = false;
     this.state = stateName;
   }
 
@@ -507,6 +556,8 @@ export default class BodyClient extends StateMachine {
       // rather than make them have to click-to-focus first.
       QuillUtil.editorDiv(this._quill).focus();
     }
+
+    this._shouldBeEnabled.value = true;
 
     // Head into our first post-connection iteration of idling while waiting for
     // changes coming in locally (from Quill) or from the server.

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.3.0
+version = 1.3.1


### PR DESCRIPTION
This PR adds an explicit `Condition` variable to expose `BodyClient`'s idea of whether it thinks editing should be enabled. This gets exposed via three methods, `shouldBeEnabled()` which returns a boolean of the instantaneous value, and `whenShouldBeEnabled()` and `whenShouldBeDisabled()` which return level-triggered promises. These all should be more reliable to use than the `when_*` state transition methods, most specifically because the level-triggered nature of the new methods avoids the hazard of the `BodyClient` instance passing through the target state before the user of the instance has a chance to set up a `when_*`.

The way to use these is as follows: Whenever one wants to track the enabled state, start by using the synchronous `shouldBeEnabled()` call. Then, based on that, take appropriate action (e.g. actually disable the editor) and then issue a `whenShouldBe*()` call on the opposite state.

**Bonus:** Just for good measure, this PR adds a logged event whenever the enabled state changes.