### PR TITLE
Detect bad `BodySnapshot` contents, and reject them in some cases.

### DIFF
--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -191,8 +191,13 @@ export default class BodyDelta extends BaseDelta {
     // The following check _just_ catches these sorts of problems, providing a
     // reasonably apt error message, so as to avoid confusing any of the higher
     // layers.
+    //
+    // **TODO:** This rejects document composition results that fail the
+    // stricter test defined by `endsWithNewlineOrIsEmpty()`. See discussion in
+    // that method about including its tests in `_impl_isDocument()` which would
+    // remove the need for explicitly performing this test here.
 
-    if (wantDocument && !result.isDocument()) {
+    if (wantDocument && !(result.isDocument() && result.endsWithNewlineOrIsEmpty())) {
       // **TODO:** Remove this logging once we track down why we're seeing this
       // error.
       log.event.badComposeOrig(this, other, result);

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -77,6 +77,42 @@ export default class BodyDelta extends BaseDelta {
   }
 
   /**
+   * Indicates whether this instance is ends with a newline character as a text
+   * insertion, _or_ if it is a totally empty instance (no ops).
+   *
+   * **Note:** A document delta is supposed to end with a newline, but this
+   * has not been enforced before. As things stand, it is not possible to
+   * consider completely empty (no ops) instances as being non-document,
+   * because the value {@link #EMPTY} is set up by the superclass and is always
+   * necessarily a no-op instance, and that in turn becomes the basis for
+   * {@link BodySnapshot#EMPTY}. However, so long as there is at least one op,
+   * it _may_ be reasonable to treat an instance of this class as non-document
+   * if the last op isn't a text insertion that ends with a newline. Rather than
+   * just implement that check in {@link #_impl_isDocument} and return `false`
+   * if it fails, we provide this method for use at call sites where a document
+   * is expected, so that those sites can log the would-be failure. Based on log
+   * analysis, we can get a sense of the scope of the problem, and based on that
+   * data decide whether or not to tighten the actual constraint in
+   * {@link #_impl_isDocument}.
+   *
+   * @returns {boolean} `true` if this instance meets the defined constraints,
+   *   or `false` if not.
+   */
+  endsWithNewlineOrIsEmpty() {
+    const ops = this.ops;
+
+    if (ops.length === 0) {
+      return true;
+    }
+
+    const lastOp = ops[ops.length - 1];
+    const props  = lastOp.props;
+
+    return (props.opName === BodyOp.CODE_text)
+      && props.text.endsWith('\n');
+  }
+
+  /**
    * Produces a Quill `Delta` (per se) with the same contents as this instance.
    *
    * @returns {Delta} A Quill `Delta` with the same contents as `this`.
@@ -175,6 +211,9 @@ export default class BodyDelta extends BaseDelta {
    *   `false` if not.
    */
   _impl_isDocument() {
+    // **TODO:** See note in `endsWithNewlineOrIsEmpty()` about possible changes
+    // to this method.
+
     for (const op of this.ops) {
       if (!op.isInsert()) {
         return false;

--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -3,10 +3,16 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseSnapshot } from '@bayou/ot-common';
+import { Logger } from '@bayou/see-all';
 import { Errors } from '@bayou/util-common';
 
 import BodyChange from './BodyChange';
 
+/**
+ * {Logger} Logger for this module. **Note:** Just used for some temporary
+ * debugging stuff.
+ */
+const log = new Logger('body-snapshot');
 
 /**
  * Snapshot of main document body contents.
@@ -23,6 +29,17 @@ export default class BodySnapshot extends BaseSnapshot {
    */
   constructor(revNum, contents) {
     super(revNum, contents);
+
+    // Check for the more strict document requirement, but only log a failure.
+    // **TODO:** See documentation of `endsWithNewlineOrIsEmpty()` for
+    // discussion about making `BodyDelta.isDocument()` check for this, in which
+    // case this test becomes moot and can be removed.
+    if (!this.contents.endsWithNewlineOrIsEmpty()) {
+      const ops    = contents.ops;
+      const length = ops.length;
+      log.event.strictDocumentViolation(length, ops[length - 1]);
+    }
+
     Object.freeze(this);
   }
 

--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -35,7 +35,7 @@ export default class BodySnapshot extends BaseSnapshot {
     // discussion about making `BodyDelta.isDocument()` check for this, in which
     // case this test becomes moot and can be removed.
     if (!this.contents.endsWithNewlineOrIsEmpty()) {
-      const ops    = contents.ops;
+      const ops    = this.contents.ops;
       const length = ops.length;
       log.event.strictDocumentViolation(length, ops[length - 1]);
     }

--- a/local-modules/@bayou/doc-common/tests/test_BodyChange.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyChange.js
@@ -13,15 +13,15 @@ describe('@bayou/doc-common/BodyChange', () => {
   describe('.FIRST', () => {
     const first = BodyChange.FIRST;
 
-    it('should be an instance of `BodyChange`', () => {
+    it('is an instance of `BodyChange`', () => {
       assert.instanceOf(first, BodyChange);
     });
 
-    it('should be a frozen object', () => {
+    it('is a frozen object', () => {
       assert.isFrozen(first);
     });
 
-    it('should have the expected properties', () => {
+    it('has the expected properties', () => {
       assert.deepEqual(first.delta, BodyDelta.EMPTY);
       assert.strictEqual(first.revNum, 0);
       assert.isNull(first.authorId);
@@ -30,12 +30,12 @@ describe('@bayou/doc-common/BodyChange', () => {
   });
 
   describe('constructor()', () => {
-    it('should produce a frozen instance', () => {
+    it('produces a frozen instance', () => {
       const result = new BodyChange(0, BodyDelta.EMPTY);
       assert.isFrozen(result);
     });
 
-    it('should accept valid arguments, which should be reflected in the accessors', () => {
+    it('accepts valid arguments, which are reflected in the accessors', () => {
       function test(...args) {
         const [revNum, delta, timestamp = null, authorId = null] = args;
         const result = new BodyChange(...args);
@@ -53,14 +53,14 @@ describe('@bayou/doc-common/BodyChange', () => {
       test(242, BodyDelta.EMPTY,                      null, 'florp9019');
     });
 
-    it('should accept an array for the `delta`, which should get passed to the `BodyDelta` constructor', () => {
+    it('accepts an array for the `delta`, which get passed to the `BodyDelta` constructor', () => {
       const ops    = [BodyOp.op_retain(100)];
       const result = new BodyChange(0, ops);
 
       assert.deepEqual(result.delta.ops, ops);
     });
 
-    it('should reject invalid arguments', () => {
+    it('rejects invalid arguments', () => {
       function test(...args) {
         assert.throws(() => new BodyChange(...args));
       }

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -15,29 +15,29 @@ describe('@bayou/doc-common/BodyDelta', () => {
   describe('.EMPTY', () => {
     const EMPTY = BodyDelta.EMPTY;
 
-    it('should be an instance of `BodyDelta`', () => {
+    it('is an instance of `BodyDelta`', () => {
       assert.instanceOf(EMPTY, BodyDelta);
     });
 
-    it('should be a frozen object', () => {
+    it('is a frozen object', () => {
       assert.isFrozen(EMPTY);
     });
 
-    it('should have an empty `ops`', () => {
+    it('has an empty `ops`', () => {
       assert.strictEqual(EMPTY.ops.length, 0);
     });
 
-    it('should have a frozen `ops`', () => {
+    it('has a frozen `ops`', () => {
       assert.isFrozen(EMPTY.ops);
     });
 
-    it('should be `.isEmpty()`', () => {
+    it('returns `true` for `.isEmpty()`', () => {
       assert.isTrue(EMPTY.isEmpty());
     });
   });
 
   describe('fromQuillForm()', () => {
-    it('should return an instance with appropriately-converted `ops`', () => {
+    it('returns an instance with appropriately-converted `ops`', () => {
       const ops        = [{ insert: 'foo' }, { retain: 10 }, { insert: 'bar', attributes: { bold: true } }];
       const quillDelta = new Text.Delta(ops);
       const result     = BodyDelta.fromQuillForm(quillDelta);
@@ -49,7 +49,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ]);
     });
 
-    it('should reject non-quill-delta arguments', () => {
+    it('rejects non-quill-delta arguments', () => {
       function test(v) {
         assert.throws(() => { BodyDelta.fromQuillForm(v); });
       }
@@ -63,7 +63,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       test(BodyDelta.EMPTY);
     });
 
-    it('should reject arguments that are instances of the wrong `Delta` class', () => {
+    it('rejects arguments that are instances of the wrong `Delta` class', () => {
       // This test confirms that the code properly detects when there's more
       // than one class named `Delta` in the system and the one _not_ used by
       // this module is passed in here. Historically speaking, the check has
@@ -103,7 +103,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should succeed for: ${inspect(v)}`, () => {
+        it(`succeeds for: ${inspect(v)}`, () => {
           new BodyDelta(v);
         });
       }
@@ -126,7 +126,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should fail for: ${inspect(v)}`, () => {
+        it(`fails for: ${inspect(v)}`, () => {
           assert.throws(() => new BodyDelta(v));
         });
       }
@@ -134,7 +134,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
   });
 
   describe('compose()', () => {
-    it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
+    it('returns an empty result from `EMPTY.compose(EMPTY)`', () => {
       const result1 = BodyDelta.EMPTY.compose(BodyDelta.EMPTY, false);
       assert.instanceOf(result1, BodyDelta);
       assert.deepEqual(result1.ops, []);
@@ -144,7 +144,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       assert.deepEqual(result2.ops, []);
     });
 
-    it('should reject calls when `other` is not an instance of the class', () => {
+    it('rejects calls when `other` is not an instance of the class', () => {
       const delta = BodyDelta.EMPTY;
       const other = 'blort';
       assert.throws(() => delta.compose(other, true));
@@ -152,25 +152,25 @@ describe('@bayou/doc-common/BodyDelta', () => {
   });
 
   describe('diff()', () => {
-    it('should return an empty result from `EMPTY.diff(EMPTY)`', () => {
+    it('returns an empty result from `EMPTY.diff(EMPTY)`', () => {
       const result = BodyDelta.EMPTY.diff(BodyDelta.EMPTY);
       assert.instanceOf(result, BodyDelta);
       assert.deepEqual(result.ops, []);
     });
 
-    it('should reject calls when `this` is not a document', () => {
+    it('rejects calls when `this` is not a document', () => {
       const delta = new BodyDelta([BodyOp.op_retain(10)]);
       const other = BodyDelta.EMPTY;
       assert.throws(() => delta.diff(other));
     });
 
-    it('should reject calls when `other` is not a document', () => {
+    it('rejects calls when `other` is not a document', () => {
       const delta = BodyDelta.EMPTY;
       const other = new BodyDelta([BodyOp.op_retain(10)]);
       assert.throws(() => delta.diff(other));
     });
 
-    it('should reject calls when `other` is not an instance of the class', () => {
+    it('rejects calls when `other` is not an instance of the class', () => {
       const delta = BodyDelta.EMPTY;
       const other = 'blort';
       assert.throws(() => delta.diff(other));
@@ -186,19 +186,19 @@ describe('@bayou/doc-common/BodyDelta', () => {
       newDoc  = new BodyDelta(newDoc);
 
       describe(label, () => {
-        it('should produce the expected composition', () => {
+        it('produces the expected composition', () => {
           const result = origDoc.compose(change, true);
           assert.instanceOf(result, BodyDelta);
           assert.deepEqual(result.ops, newDoc.ops);
         });
 
-        it('should produce the expected diff', () => {
+        it('produces the expected diff', () => {
           const result = origDoc.diff(newDoc);
           assert.instanceOf(result, BodyDelta);
           assert.deepEqual(result.ops, change.ops);
         });
 
-        it('should produce the new document when composing the orig document with the diff', () => {
+        it('produces the new document when composing the orig document with the diff', () => {
           const diff   = origDoc.diff(newDoc);
           const result = origDoc.compose(diff, true);
           assert.instanceOf(result, BodyDelta);
@@ -295,7 +295,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       function test(ops) {
         const delta = new BodyDelta(ops);
         assert.isTrue(delta.equals(delta));
@@ -306,7 +306,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       test([BodyOp.op_text('aaa'), BodyOp.op_text('bbb')]);
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(ops) {
         const d1 = new BodyDelta(ops);
         const d2 = new BodyDelta(ops);
@@ -319,7 +319,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       test([BodyOp.op_text('aaa'), BodyOp.op_text('bbb')]);
     });
 
-    it('should return `true` when equal ops are not also `===`', () => {
+    it('returns `true` when equal ops are not also `===`', () => {
       const ops1 = [BodyOp.op_text('aaa'), BodyOp.op_text('bbb')];
       const ops2 = [BodyOp.op_text('aaa'), BodyOp.op_text('bbb')];
       const d1 = new BodyDelta(ops1);
@@ -329,7 +329,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       assert.isTrue(d2.equals(d1));
     });
 
-    it('should return `false` when array lengths differ', () => {
+    it('returns `false` when array lengths differ', () => {
       const op1 = BodyOp.op_text('aaa');
       const op2 = BodyOp.op_text('bbb');
       const d1 = new BodyDelta([op1]);
@@ -339,7 +339,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       assert.isFalse(d2.equals(d1));
     });
 
-    it('should return `false` when corresponding ops differ', () => {
+    it('returns `false` when corresponding ops differ', () => {
       function test(ops1, ops2) {
         const d1 = new BodyDelta(ops1);
         const d2 = new BodyDelta(ops2);
@@ -364,7 +364,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       test([op1, op2, op3, op4, op5], [op1, op2, op3, op4, op1]);
     });
 
-    it('should return `false` when passed a non-instance or an instance of a different class', () => {
+    it('returns `false` when passed a non-instance or an instance of a different class', () => {
       const delta = new BodyDelta([]);
 
       assert.isFalse(delta.equals(undefined));
@@ -388,7 +388,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
+        it(`returns \`true\` for: ${inspect(v)}`, () => {
           assert.isTrue(new BodyDelta(v).isDocument());
         });
       }
@@ -405,7 +405,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`false\` for: ${inspect(v)}`, () => {
+        it(`returns \`false\` for: ${inspect(v)}`, () => {
           assert.isFalse(new BodyDelta(v).isDocument());
         });
       }
@@ -420,7 +420,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`true\` for: ${inspect(v)}`, () => {
+        it(`returns \`true\` for: ${inspect(v)}`, () => {
           assert.isTrue(v.isEmpty());
         });
       }
@@ -434,7 +434,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
       ];
 
       for (const v of values) {
-        it(`should return \`false\` for: ${inspect(v)}`, () => {
+        it(`returns \`false\` for: ${inspect(v)}`, () => {
           const delta = new BodyDelta(v);
           assert.isFalse(delta.isEmpty());
         });
@@ -443,7 +443,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
   });
 
   describe('toQuillForm()', () => {
-    it('should produce `Delta` instances with appropriately-converted ops', () => {
+    it('produces `Delta` instances with appropriately-converted ops', () => {
       function test(ops) {
         const delta  = new BodyDelta(ops);
         const result = delta.toQuillForm();
@@ -473,7 +473,7 @@ describe('@bayou/doc-common/BodyDelta', () => {
   });
 
   describe('transform()', () => {
-    it('should return an empty result from `EMPTY.transform(EMPTY, *)`', () => {
+    it('returns an empty result from `EMPTY.transform(EMPTY, *)`', () => {
       const result1 = BodyDelta.EMPTY.transform(BodyDelta.EMPTY, false);
       assert.instanceOf(result1, BodyDelta);
       assert.deepEqual(result1.ops, []);
@@ -483,18 +483,18 @@ describe('@bayou/doc-common/BodyDelta', () => {
       assert.deepEqual(result2.ops, []);
     });
 
-    it('should reject calls when `other` is not an instance of the class', () => {
+    it('rejects calls when `other` is not an instance of the class', () => {
       const delta = BodyDelta.EMPTY;
       const other = 'blort';
       assert.throws(() => delta.transform(other, true));
     });
 
-    it('should reject calls when `thisIsFirst` is not a boolean', () => {
+    it('rejects calls when `thisIsFirst` is not a boolean', () => {
       const delta = BodyDelta.EMPTY;
       assert.throws(() => delta.transform(delta, 'blort'));
     });
 
-    it('should produce the expected transformations', () => {
+    it('produces the expected transformations', () => {
       function test(d1, d2, expectedTrue, expectedFalse = expectedTrue) {
         d1 = new BodyDelta(d1);
         d2 = new BodyDelta(d2);

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -207,33 +207,37 @@ describe('@bayou/doc-common/BodyDelta', () => {
       });
     }
 
-    test('full replacement',
-      [BodyOp.op_text('111')],
+    test('full replacement (except for required end-of-delta newline)',
+      [BodyOp.op_text('111\n')],
       [BodyOp.op_text('222'), BodyOp.op_delete(3)],
-      [BodyOp.op_text('222')]);
+      [BodyOp.op_text('222\n')]);
     test('insert at start',
-      [BodyOp.op_text('111')],
+      [BodyOp.op_text('111\n')],
       [BodyOp.op_text('222')],
-      [BodyOp.op_text('222111')]);
+      [BodyOp.op_text('222111\n')]);
     test('append at end',
-      [BodyOp.op_text('111')],
+      [BodyOp.op_text('111\n')],
+      [BodyOp.op_retain(4), BodyOp.op_text('222\n')],
+      [BodyOp.op_text('111\n222\n')]);
+    test('append just before end',
+      [BodyOp.op_text('111\n')],
       [BodyOp.op_retain(3), BodyOp.op_text('222')],
-      [BodyOp.op_text('111222')]);
+      [BodyOp.op_text('111222\n')]);
     test('surround',
-      [BodyOp.op_text('111')],
-      [BodyOp.op_text('222'), BodyOp.op_retain(3), BodyOp.op_text('333')],
-      [BodyOp.op_text('222111333')]);
+      [BodyOp.op_text('111\n')],
+      [BodyOp.op_text('222'), BodyOp.op_retain(4), BodyOp.op_text('333\n')],
+      [BodyOp.op_text('222111\n333\n')]);
     test('replace one middle bit',
-      [BodyOp.op_text('Drink more Slurm.')],
+      [BodyOp.op_text('Drink more Slurm.\n')],
       [BodyOp.op_retain(6), BodyOp.op_text('LESS'), BodyOp.op_delete(4)],
-      [BodyOp.op_text('Drink LESS Slurm.')]);
+      [BodyOp.op_text('Drink LESS Slurm.\n')]);
     test('replace two middle bits',
-      [BodyOp.op_text('[[hello]] [[goodbye]]')],
+      [BodyOp.op_text('[[hello]] [[goodbye]]\n')],
       [
         BodyOp.op_retain(2), BodyOp.op_text('YO'), BodyOp.op_delete(5), BodyOp.op_retain(5),
         BodyOp.op_text('LATER'), BodyOp.op_delete(7)
       ],
-      [BodyOp.op_text('[[YO]] [[LATER]]')]);
+      [BodyOp.op_text('[[YO]] [[LATER]]\n')]);
   });
 
   describe('endsWithNewlineOrIsEmpty()', () => {

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -236,6 +236,64 @@ describe('@bayou/doc-common/BodyDelta', () => {
       [BodyOp.op_text('[[YO]] [[LATER]]')]);
   });
 
+  describe('endsWithNewlineOrIsEmpty()', () => {
+    it('returns `true` for `EMPTY`', () => {
+      assert.isTrue(BodyDelta.EMPTY.endsWithNewlineOrIsEmpty());
+    });
+
+    it('returns `true` for instances that have a text final op with a newline at the end', () => {
+      function test(...ops) {
+        const delta = new BodyDelta(ops);
+        assert.isTrue(delta.endsWithNewlineOrIsEmpty());
+      }
+
+      test(BodyOp.op_text('\n'));
+      test(BodyOp.op_text('x\n'));
+      test(BodyOp.op_text('xyz\n'));
+      test(BodyOp.op_text('x\ny\nz\n'));
+
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('\n'));
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\n'));
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('xyz\n'));
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\ny\nz\n'));
+
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('\n'));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\n'));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('xyz\n'));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\ny\nz\n'));
+    });
+
+    it('returns `false` for instances that have a text final op without a newline at the end', () => {
+      function test(...ops) {
+        const delta = new BodyDelta(ops);
+        assert.isFalse(delta.endsWithNewlineOrIsEmpty());
+      }
+
+      test(BodyOp.op_text('x'));
+      test(BodyOp.op_text('xyz'));
+      test(BodyOp.op_text('x\ny\nz'));
+
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x'));
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('xyz'));
+      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\ny\nz'));
+
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x'));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('xyz'));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\ny\nz'));
+    });
+
+    it('returns `false` for instances that do not have a text final op', () => {
+      function test(...ops) {
+        const delta = new BodyDelta(ops);
+        assert.isFalse(delta.endsWithNewlineOrIsEmpty());
+      }
+
+      test(BodyOp.op_embed('florp', 914));
+      test(BodyOp.op_text('Boop!'), BodyOp.op_embed('florp', 914));
+      test(BodyOp.op_embed('florp', 914), BodyOp.op_embed('florp', 914));
+    });
+  });
+
   describe('equals()', () => {
     it('should return `true` when passed itself', () => {
       function test(ops) {

--- a/local-modules/@bayou/doc-common/tests/test_BodyOp.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyOp.js
@@ -19,7 +19,7 @@ describe('@bayou/doc-common/BodyOp', () => {
   describe('fromQuillForm()', () => {
     describe('invalid arguments', () => {
       function test(v) {
-        it(`should reject: ${inspect(v)}`, () => {
+        it(`rejects: ${inspect(v)}`, () => {
           assert.throws(() => BodyOp.fromQuillForm(v));
         });
       }
@@ -90,7 +90,7 @@ describe('@bayou/doc-common/BodyOp', () => {
 
   describe('fromQuillForm() / toQuillForm()', () => {
     function test(quillOp, bodyOp) {
-      it(`should handle op: ${inspect(bodyOp)}`, () => {
+      it(`handles op: ${inspect(bodyOp)}`, () => {
         const bodyResult = BodyOp.fromQuillForm(quillOp);
 
         assert.instanceOf(bodyResult, BodyOp);
@@ -126,14 +126,14 @@ describe('@bayou/doc-common/BodyOp', () => {
   });
 
   describe('op_delete()', () => {
-    it('should produce a value with expected payload', () => {
+    it('produces a value with expected payload', () => {
       const result = BodyOp.op_delete(123);
       assert.deepEqual(result.payload, new Functor('delete', 123));
     });
   });
 
   describe('op_embed()', () => {
-    it('should produce a value with expected payload', () => {
+    it('produces a value with expected payload', () => {
       const attrib = { bold: true };
 
       const result1 = BodyOp.op_embed('blort', { x: 10 });
@@ -143,7 +143,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       assert.deepEqual(result2.payload, new Functor('embed', 'florp', ['like'], attrib));
     });
 
-    it('should reject a non-identifier `type`', () => {
+    it('rejects a non-identifier `type`', () => {
       assert.throws(() => BodyOp.op_embed('', 1));
       assert.throws(() => BodyOp.op_embed('*', 1));
       assert.throws(() => BodyOp.op_embed(null, 1));
@@ -152,14 +152,14 @@ describe('@bayou/doc-common/BodyOp', () => {
       assert.throws(() => BodyOp.op_embed({ florp: 'like' }, 1));
     });
 
-    it('should reject a non-data `value`', () => {
+    it('rejects a non-data `value`', () => {
       assert.throws(() => BodyOp.op_embed('x', new Map()));
       assert.throws(() => BodyOp.op_embed('x', { get x() { return 10; } }));
     });
   });
 
   describe('op_retain()', () => {
-    it('should produce a value with expected payload', () => {
+    it('produces a value with expected payload', () => {
       const attrib = { header: 1 };
 
       const result1 = BodyOp.op_retain(123);
@@ -171,7 +171,7 @@ describe('@bayou/doc-common/BodyOp', () => {
   });
 
   describe('op_text()', () => {
-    it('should produce a value with expected payload', () => {
+    it('produces a value with expected payload', () => {
       const attrib = { italic: true, bold: null };
 
       const result1 = BodyOp.op_text('florp');
@@ -184,7 +184,7 @@ describe('@bayou/doc-common/BodyOp', () => {
 
   describe('.props', () => {
     function test(op, expected) {
-      it(`should provide expected bindings for: ${op}`, () => {
+      it(`provides expected bindings for: ${op}`, () => {
         const result = op.props;
         assert.isFrozen(result);
         assert.deepEqual(result, expected);
@@ -206,12 +206,12 @@ describe('@bayou/doc-common/BodyOp', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       const op = BodyOp.op_text('florp');
       assert.isTrue(op.equals(op));
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(method, ...args) {
         const op1 = BodyOp[method](...args);
         const op2 = BodyOp[method](...args);
@@ -229,7 +229,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       test('op_retain', 100, { header: 3 });
     });
 
-    it('should return `false` when type or any field differs', () => {
+    it('returns `false` when type or any field differs', () => {
       function test(op1, op2) {
         assert.isFalse(op1.equals(op2));
         assert.isFalse(op2.equals(op1));
@@ -252,7 +252,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       test(BodyOp.op_retain(1, at1),     BodyOp.op_retain(1, at2));
     });
 
-    it('should return `false` when passed a non-instance', () => {
+    it('returns `false` when passed a non-instance', () => {
       const op = BodyOp.op_text('zorch');
 
       assert.isFalse(op.equals(undefined));
@@ -264,7 +264,7 @@ describe('@bayou/doc-common/BodyOp', () => {
   });
 
   describe('isInsert()', () => {
-    it('should return `true` for inserts', () => {
+    it('returns `true` for inserts', () => {
       function test(v) {
         assert.isTrue(v.isInsert());
       }
@@ -275,7 +275,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       test(BodyOp.op_text('foo', { bold: true }));
     });
 
-    it('should return `false` for non-inserts', () => {
+    it('returns `false` for non-inserts', () => {
       function test(v) {
         assert.isFalse(v.isInsert());
       }
@@ -297,7 +297,7 @@ describe('@bayou/doc-common/BodyOp', () => {
 
     describe('text op', () => {
       describe('when `textOnly` is true', () => {
-        it('should return length of plaintext', () => {
+        it('returns length of plaintext', () => {
           const opLength = PLAIN_TEXT_OP.getLength(true);
 
           assert.strictEqual(opLength, PLAIN_TEXT_LENGTH);
@@ -305,7 +305,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       });
 
       describe('when `textOnly` is false', () => {
-        it('should return length of plaintext', () => {
+        it('returns length of plaintext', () => {
           const opLength = PLAIN_TEXT_OP.getLength(false);
 
           assert.strictEqual(opLength, PLAIN_TEXT_LENGTH);
@@ -313,13 +313,13 @@ describe('@bayou/doc-common/BodyOp', () => {
       });
 
       describe('when `textOnly` is not set', () => {
-        it('should return length of plaintext', () => {
+        it('returns length of plaintext', () => {
           const opLength = PLAIN_TEXT_OP.getLength();
 
           assert.strictEqual(opLength, PLAIN_TEXT_LENGTH);
         });
 
-        it('should return length of text with special chars', () => {
+        it('returns length of text with special chars', () => {
           const opLength = EMOJI_TEXT_OP.getLength();
 
           assert.strictEqual(opLength, EMOJI_TEXT_LENGTH);
@@ -329,7 +329,7 @@ describe('@bayou/doc-common/BodyOp', () => {
 
     describe('embed op', () => {
       describe('when `textOnly` is true', () => {
-        it('should return 0', () => {
+        it('returns `0`', () => {
           const opLength = EMBED_OP.getLength(true);
 
           assert.strictEqual(opLength, 0);
@@ -337,7 +337,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       });
 
       describe('when `textOnly` is false', () => {
-        it('should return 1', () => {
+        it('returns `1`', () => {
           const opLength = EMBED_OP.getLength(false);
 
           assert.strictEqual(opLength, 1);
@@ -345,7 +345,7 @@ describe('@bayou/doc-common/BodyOp', () => {
       });
 
       describe('when `textOnly` is not set', () => {
-        it('should return 1', () => {
+        it('returns `1`', () => {
           const opLength = EMBED_OP.getLength();
 
           assert.strictEqual(opLength, 1);

--- a/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
@@ -13,9 +13,9 @@ import { BodyOp, BodySnapshot } from '@bayou/doc-common';
 // special characters, such as emojis.
 const splitter = new GraphemeSplitter();
 
-const PLAIN_TEXT = 'plain text';
+const PLAIN_TEXT = 'plain text\n';
 const PLAIN_TEXT_LENGTH = PLAIN_TEXT.length;
-const EMOJI_TEXT = '😀 smile!';
+const EMOJI_TEXT = '😀 smile!\n';
 const EMOJI_TEXT_LENGTH = splitter.countGraphemes(EMOJI_TEXT);
 
 const PLAIN_TEXT_OP = BodyOp.op_text(PLAIN_TEXT);

--- a/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
@@ -8,26 +8,23 @@ import GraphemeSplitter from 'grapheme-splitter';
 
 import { BodyOp, BodySnapshot } from '@bayou/doc-common';
 
-// Instance of the grapheme splitter library
-// used to properly count the length of
-// special characters, such as emojis.
+// Instance of the grapheme splitter library used to properly count the length
+// of special characters, such as emojis.
 const splitter = new GraphemeSplitter();
 
-const PLAIN_TEXT = 'plain text\n';
+const PLAIN_TEXT        = 'plain text\n';
 const PLAIN_TEXT_LENGTH = PLAIN_TEXT.length;
-const EMOJI_TEXT = '😀 smile!\n';
+const EMOJI_TEXT        = '😀 smile!\n';
 const EMOJI_TEXT_LENGTH = splitter.countGraphemes(EMOJI_TEXT);
 
 const PLAIN_TEXT_OP = BodyOp.op_text(PLAIN_TEXT);
 const EMOJI_TEXT_OP = BodyOp.op_text(EMOJI_TEXT);
-const EMBED_OP = BodyOp.op_embed('x', 1);
+const EMBED_OP      = BodyOp.op_embed('x', 1);
 
-const EMPTY_BODY_SNAPSHOT = new BodySnapshot(0, []);
+const EMPTY_BODY_SNAPSHOT      = new BodySnapshot(0, []);
 const PLAIN_TEXT_BODY_SNAPSHOT = new BodySnapshot(0, [PLAIN_TEXT_OP]);
-const EMOJI_BODY_SNAPSHOT = new BodySnapshot(0, [EMOJI_TEXT_OP]);
-const MIXED_BODY_SNAPSHOT = new BodySnapshot(0, [PLAIN_TEXT_OP, EMOJI_TEXT_OP]);
-
-const EMBED_BODY_SNAPSHOT = new BodySnapshot(0, [EMBED_OP]);
+const EMOJI_BODY_SNAPSHOT      = new BodySnapshot(0, [EMOJI_TEXT_OP]);
+const MIXED_BODY_SNAPSHOT      = new BodySnapshot(0, [PLAIN_TEXT_OP, EMOJI_TEXT_OP]);
 const EMBED_TEXT_BODY_SNAPSHOT = new BodySnapshot(0, [EMBED_OP, EMOJI_TEXT_OP]);
 
 describe('@bayou/doc-common/BodySnapshot', () => {
@@ -56,13 +53,10 @@ describe('@bayou/doc-common/BodySnapshot', () => {
       assert.strictEqual(bodySnapshotLength, PLAIN_TEXT_LENGTH + EMOJI_TEXT_LENGTH);
     });
 
-    it('should return 1 for body with one embed', () => {
-      const bodySnapshotLength = EMBED_BODY_SNAPSHOT.length;
-
-      assert.strictEqual(bodySnapshotLength, 1);
-    });
-
     it('should return 1 + text length for body with one embed and text', () => {
+      // **Note:** We can't test an embed-only snapshot, because those are (or
+      // should soon be) invalid, because they can't possibly end with a
+      // newline.
       const bodySnapshotLength = EMBED_TEXT_BODY_SNAPSHOT.length;
 
       assert.strictEqual(bodySnapshotLength, 1 + EMOJI_TEXT_LENGTH);

--- a/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodySnapshot.js
@@ -29,31 +29,31 @@ const EMBED_TEXT_BODY_SNAPSHOT = new BodySnapshot(0, [EMBED_OP, EMOJI_TEXT_OP]);
 
 describe('@bayou/doc-common/BodySnapshot', () => {
   describe('.length', () => {
-    it('should return 0 for empty body', () => {
+    it('returns `0` for empty body', () => {
       const bodySnapshotLength = EMPTY_BODY_SNAPSHOT.length;
 
       assert.strictEqual(bodySnapshotLength, 0);
     });
 
-    it('should return length of plain text for plain text body', () => {
+    it('returns length of plain text for plain text body', () => {
       const bodySnapshotLength = PLAIN_TEXT_BODY_SNAPSHOT.length;
 
       assert.strictEqual(bodySnapshotLength, PLAIN_TEXT_LENGTH);
     });
 
-    it('should return length of special text for special text body', () => {
+    it('returns length of special text for special text body', () => {
       const bodySnapshotLength = EMOJI_BODY_SNAPSHOT.length;
 
       assert.strictEqual(bodySnapshotLength, EMOJI_TEXT_LENGTH);
     });
 
-    it('should return length of total text for mixed text body', () => {
+    it('returns length of total text for mixed text body', () => {
       const bodySnapshotLength = MIXED_BODY_SNAPSHOT.length;
 
       assert.strictEqual(bodySnapshotLength, PLAIN_TEXT_LENGTH + EMOJI_TEXT_LENGTH);
     });
 
-    it('should return 1 + text length for body with one embed and text', () => {
+    it('returns `1 + text.length` for body with one embed and text', () => {
       // **Note:** We can't test an embed-only snapshot, because those are (or
       // should soon be) invalid, because they can't possibly end with a
       // newline.


### PR DESCRIPTION
We've known for a while that Quill sometimes doesn't follow its own contract with regards to maintaining the invariant that document bodies (are supposed to) end with a newline. We've had a check in the bridge code for a while that detects and complains about this issue, but it is still possible for us to end up in a situation where the FE sends a change to the BE which, if composed, becomes a snapshot which violates the constraint, and it does so (in the status quo) without the problem being detected until a subsequent document load (that is, in a different session), at which point it's too late because the DB now has a corrupt file.

This PR is meant to "surgically" reject the construction of (these sorts of) bad snapshots in contexts where they are (in effect) gating the writing of bad changes to the DB, while still being a bit more laissez faire about `BodySnapshot` construction in general. This is done by adding a check to `BodyDelta.compose()`. However, the `BodySnapshot` constructor now logs a complaint if it does happen to be making such a bad instance; the idea is that we can analyze the logs to determine if it's practical to actually tighten the constraint in the constructor (in which case we could drop the extra check in `BodyDelta.compose()` and simplify a couple other bits).
