### PR TITLE
Explicitly track a Node error shutdown count.

### DIFF
--- a/local-modules/@bayou/dev-mode/DevMode.js
+++ b/local-modules/@bayou/dev-mode/DevMode.js
@@ -341,7 +341,7 @@ export default class DevMode extends Singleton {
     // Log a note after everything is ready.
     await clientReady;
     await serverReady;
-    log.info('Now monitoring for changes.');
+    log.event.running();
   }
 
   /**

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -61,10 +61,15 @@ export default class BootInfo extends CommonBase {
    * as of this writing).
    */
   get info() {
+    // **Note:** The `- 1` drops _this_ process's boot from the count.
+    const { bootCount, cleanShutdownCount, errorShutdownCount } = this._info;
+    const crashCount = bootCount - 1 - cleanShutdownCount - errorShutdownCount;
+
     const extras = {
       time:       this._bootTimeString,
       timeMsec:   this._bootTime,
-      uptimeMsec: this.uptimeMsec
+      uptimeMsec: this.uptimeMsec,
+      crashCount
     };
 
     return Object.assign(extras, this._info);

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -123,6 +123,7 @@ export default class BootInfo extends CommonBase {
     }
 
     this._info.errors = errors;
+    this._info.errorShutdownCount++;
 
     this._writeFile();
   }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -80,11 +80,6 @@ export default class BootInfo extends CommonBase {
     return Object.assign(extras, this._info);
   }
 
-  /** {Int} Count of how many times this build has been shut down cleanly. */
-  get shutdownCount() {
-    return this._info.shutdownCount;
-  }
-
   /** {Int} The length of time this server has been running, in msec. */
   get uptimeMsec() {
     return Date.now() - this._bootTime;
@@ -95,7 +90,7 @@ export default class BootInfo extends CommonBase {
    * the boot info file.
    */
   incrementShutdownCount() {
-    this._info.shutdownCount++;
+    this._info.cleanShutdownCount++;
     this._writeFile();
   }
 
@@ -141,8 +136,8 @@ export default class BootInfo extends CommonBase {
    * Logs the `boot` metric.
    */
   _logBoot() {
-    const { bootCount, buildId, shutdownCount } = this;
-    log.metric.boot({ buildId, bootCount, shutdownCount });
+    const { bootCount, buildId, cleanShutdownCount, errorShutdownCount } = this._info;
+    log.metric.boot({ buildId, bootCount, cleanShutdownCount, errorShutdownCount });
   }
 
   /**
@@ -156,7 +151,13 @@ export default class BootInfo extends CommonBase {
    */
   _readFileWithDefaults() {
     const buildId = this._buildId;
-    const info    = { buildId, bootCount: 0, errors: '', shutdownCount: 0 };
+    const info    = {
+      buildId,
+      bootCount: 0,
+      cleanShutdownCount: 0,
+      errorShutdownCount: 0,
+      errors: ''
+    };
 
     try {
       const text = fs.readFileSync(this._bootInfoPath, { encoding: 'utf8' });

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -53,11 +53,6 @@ export default class BootInfo extends CommonBase {
     this._writeFile();
   }
 
-  /** {Int} Count of how many times this build has been booted. */
-  get bootCount() {
-    return this._info.bootCount;
-  }
-
   /** {string} The build ID. */
   get buildId() {
     return this._info.buildId;

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -53,11 +53,6 @@ export default class BootInfo extends CommonBase {
     this._writeFile();
   }
 
-  /** {string} The build ID. */
-  get buildId() {
-    return this._info.buildId;
-  }
-
   /**
    * {object} Ad-hoc object with the info from this instance.
    *

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -98,14 +98,11 @@ export default class BootInfo extends CommonBase {
   recordError(error) {
     TString.check(error);
 
-    if (!error.endsWith('\n')) {
-      error += '\n';
-    }
-
     let   errors    = this._info.errors;
-    const separator = errors.endsWith('\n') ? '' : '\n';
+    const separator = ((errors === '') || errors.endsWith('\n')) ? '' : '\n';
+    const endNl     = error.endsWith('\n') ? '' : '\n';
 
-    errors = `${errors}${separator}${error}`;
+    errors = `${errors}${separator}${error}${endNl}`;
 
     // Truncate to the desired maximum length, by trimming off the initial
     // portion, in units of whole lines.

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -227,8 +227,8 @@ export default class ShutdownManager extends CommonBase {
     const bootInfo = this._bootInfo;
 
     bootInfo.incrementShutdownCount();
-    const { bootCount, buildId, shutdownCount, uptimeMsec } = bootInfo;
-    log.metric.shutdown({ buildId, uptimeMsec, bootCount, shutdownCount, timedOut });
+    const { bootCount, buildId, cleanShutdownCount, errorShutdownCount, uptimeMsec } = bootInfo.info;
+    log.metric.shutdown({ buildId, uptimeMsec, bootCount, cleanShutdownCount, errorShutdownCount, timedOut });
 
     log.event.shutdownComplete();
     process.exit(0);


### PR DESCRIPTION
This PR adds an explicit count of shutdowns due to uncaught errors at the Node level. These are the things that were already recorded in the (string) `errors` field. Adding the count makes it also possible to directly count the number of process-level crashes (hooray for subtraction).

**Bonus:** Converted the one typical log during development startup which _wasn't_ an event to be an event log.