### PR TITLE
Tighten the constraint on document instances of `BodyDelta`.

### DIFF
--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -230,8 +230,13 @@ export default class BodyDelta extends BaseDelta {
   _impl_isDocument() {
     // **TODO:** See note in `endsWithNewlineOrIsEmpty()` about possible changes
     // to this method.
+    const ops = this.ops;
 
-    for (const op of this.ops) {
+    if (ops.length === 0) {
+      return true;
+    }
+
+    for (const op of ops) {
       if (!op.isInsert()) {
         return false;
       }

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -23,6 +23,18 @@ const log = new Logger('body-delta');
  * and high-level semantics, the _types_ of the arguments and results are not
  * actually the same. The methods `toQuillForm()` and `fromQuillForm()` can be
  * used to convert back and forth as needed.
+ *
+ * As a document delta, instances of this class must either be totally empty (no
+ * ops) or consist only of text insertion and embed ops with the final op always
+ * a text insertion op with text payload that ends with a newline.
+ *
+ * **Note:** It is _arguably_ the case that a completely empty delta shouldn't
+ * be considered a document, because the basic constraint is "ends with
+ * newline." However, making this a requirement is problematic in the current
+ * implementation, specifically because there is a single `EMPTY` instance per
+ * concrete class which is set up by the base class to always be a no-ops
+ * instance, and this `EMPTY` instance is in turn used to make the contents for
+ * a no-ops snapshot.
  */
 export default class BodyDelta extends BaseDelta {
   /**

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -222,18 +222,25 @@ export default class BodyDelta extends BaseDelta {
   }
 
   /**
-   * Main implementation of {@link #isDocument}.
+   * Main implementation of {@link #isDocument}. See the class header comment
+   * for details about the constraints that define document deltas for this
+   * class.
    *
    * @returns {boolean} `true` if this instance can be used as a document or
    *   `false` if not.
    */
   _impl_isDocument() {
-    // **TODO:** See note in `endsWithNewlineOrIsEmpty()` about possible changes
-    // to this method.
     const ops = this.ops;
 
     if (ops.length === 0) {
       return true;
+    }
+
+    const lastOp = ops[ops.length - 1];
+    const props  = lastOp.props;
+
+    if ((props.opName !== BodyOp.CODE_text) || !props.text.endsWith('\n')) {
+      return false;
     }
 
     for (const op of ops) {

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -89,42 +89,6 @@ export default class BodyDelta extends BaseDelta {
   }
 
   /**
-   * Indicates whether this instance is ends with a newline character as a text
-   * insertion, _or_ if it is a totally empty instance (no ops).
-   *
-   * **Note:** A document delta is supposed to end with a newline, but this
-   * has not been enforced before. As things stand, it is not possible to
-   * consider completely empty (no ops) instances as being non-document,
-   * because the value {@link #EMPTY} is set up by the superclass and is always
-   * necessarily a no-op instance, and that in turn becomes the basis for
-   * {@link BodySnapshot#EMPTY}. However, so long as there is at least one op,
-   * it _may_ be reasonable to treat an instance of this class as non-document
-   * if the last op isn't a text insertion that ends with a newline. Rather than
-   * just implement that check in {@link #_impl_isDocument} and return `false`
-   * if it fails, we provide this method for use at call sites where a document
-   * is expected, so that those sites can log the would-be failure. Based on log
-   * analysis, we can get a sense of the scope of the problem, and based on that
-   * data decide whether or not to tighten the actual constraint in
-   * {@link #_impl_isDocument}.
-   *
-   * @returns {boolean} `true` if this instance meets the defined constraints,
-   *   or `false` if not.
-   */
-  endsWithNewlineOrIsEmpty() {
-    const ops = this.ops;
-
-    if (ops.length === 0) {
-      return true;
-    }
-
-    const lastOp = ops[ops.length - 1];
-    const props  = lastOp.props;
-
-    return (props.opName === BodyOp.CODE_text)
-      && props.text.endsWith('\n');
-  }
-
-  /**
    * Produces a Quill `Delta` (per se) with the same contents as this instance.
    *
    * @returns {Delta} A Quill `Delta` with the same contents as `this`.
@@ -203,13 +167,8 @@ export default class BodyDelta extends BaseDelta {
     // The following check _just_ catches these sorts of problems, providing a
     // reasonably apt error message, so as to avoid confusing any of the higher
     // layers.
-    //
-    // **TODO:** This rejects document composition results that fail the
-    // stricter test defined by `endsWithNewlineOrIsEmpty()`. See discussion in
-    // that method about including its tests in `_impl_isDocument()` which would
-    // remove the need for explicitly performing this test here.
 
-    if (wantDocument && !(result.isDocument() && result.endsWithNewlineOrIsEmpty())) {
+    if (wantDocument && !result.isDocument()) {
       // **TODO:** Remove this logging once we track down why we're seeing this
       // error.
       log.event.badComposeOrig(this, other, result);

--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -3,16 +3,9 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BaseSnapshot } from '@bayou/ot-common';
-import { Logger } from '@bayou/see-all';
 import { Errors } from '@bayou/util-common';
 
 import BodyChange from './BodyChange';
-
-/**
- * {Logger} Logger for this module. **Note:** Just used for some temporary
- * debugging stuff.
- */
-const log = new Logger('body-snapshot');
 
 /**
  * Snapshot of main document body contents.
@@ -29,16 +22,6 @@ export default class BodySnapshot extends BaseSnapshot {
    */
   constructor(revNum, contents) {
     super(revNum, contents);
-
-    // Check for the more strict document requirement, but only log a failure.
-    // **TODO:** See documentation of `endsWithNewlineOrIsEmpty()` for
-    // discussion about making `BodyDelta.isDocument()` check for this, in which
-    // case this test becomes moot and can be removed.
-    if (!this.contents.endsWithNewlineOrIsEmpty()) {
-      const ops    = this.contents.ops;
-      const length = ops.length;
-      log.event.strictDocumentViolation(length, ops[length - 1]);
-    }
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -240,64 +240,6 @@ describe('@bayou/doc-common/BodyDelta', () => {
       [BodyOp.op_text('[[YO]] [[LATER]]\n')]);
   });
 
-  describe('endsWithNewlineOrIsEmpty()', () => {
-    it('returns `true` for `EMPTY`', () => {
-      assert.isTrue(BodyDelta.EMPTY.endsWithNewlineOrIsEmpty());
-    });
-
-    it('returns `true` for instances that have a text final op with a newline at the end', () => {
-      function test(...ops) {
-        const delta = new BodyDelta(ops);
-        assert.isTrue(delta.endsWithNewlineOrIsEmpty());
-      }
-
-      test(BodyOp.op_text('\n'));
-      test(BodyOp.op_text('x\n'));
-      test(BodyOp.op_text('xyz\n'));
-      test(BodyOp.op_text('x\ny\nz\n'));
-
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('\n'));
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\n'));
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('xyz\n'));
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\ny\nz\n'));
-
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('\n'));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\n'));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('xyz\n'));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\ny\nz\n'));
-    });
-
-    it('returns `false` for instances that have a text final op without a newline at the end', () => {
-      function test(...ops) {
-        const delta = new BodyDelta(ops);
-        assert.isFalse(delta.endsWithNewlineOrIsEmpty());
-      }
-
-      test(BodyOp.op_text('x'));
-      test(BodyOp.op_text('xyz'));
-      test(BodyOp.op_text('x\ny\nz'));
-
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x'));
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('xyz'));
-      test(BodyOp.op_text('Boop! '), BodyOp.op_text('x\ny\nz'));
-
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x'));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('xyz'));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_text('x\ny\nz'));
-    });
-
-    it('returns `false` for instances that do not have a text final op', () => {
-      function test(...ops) {
-        const delta = new BodyDelta(ops);
-        assert.isFalse(delta.endsWithNewlineOrIsEmpty());
-      }
-
-      test(BodyOp.op_embed('florp', 914));
-      test(BodyOp.op_text('Boop!'), BodyOp.op_embed('florp', 914));
-      test(BodyOp.op_embed('florp', 914), BodyOp.op_embed('florp', 914));
-    });
-  });
-
   describe('equals()', () => {
     it('returns `true` when passed itself', () => {
       function test(ops) {

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -386,10 +386,11 @@ describe('@bayou/doc-common/BodyDelta', () => {
     describe('`true` cases', () => {
       const values = [
         [],
-        [BodyOp.op_text('line 1')],
-        [BodyOp.op_text('line 1'), BodyOp.op_text('\n')],
-        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_text('line 2')],
+        [BodyOp.op_text('line 1\n')],
+        [BodyOp.op_text('line 1', { bold: true }), BodyOp.op_text('\n')],
+        [BodyOp.op_text('line 1', { bold: true }), BodyOp.op_text('\n'), BodyOp.op_text('line 2\n')],
         [BodyOp.op_embed('blort', 123), BodyOp.op_text('\n')],
+        [BodyOp.op_text('woop'), BodyOp.op_embed('blort', 123), BodyOp.op_text('\n')]
       ];
 
       for (const v of values) {
@@ -401,14 +402,22 @@ describe('@bayou/doc-common/BodyDelta', () => {
 
     describe('`false` cases', () => {
       const values = [
+        [BodyOp.op_text('line 1')],      // No final newline.
+        [BodyOp.op_embed('blort', 123)], // No final newline. (Not further noted.)
         [BodyOp.op_retain(37)],
+        [BodyOp.op_retain(37), BodyOp.op_text('\n')],
         [BodyOp.op_delete(914)],
+        [BodyOp.op_delete(914), BodyOp.op_text('\n')],
         [BodyOp.op_retain(37, { bold: true })],
+        [BodyOp.op_retain(37, { bold: true }), BodyOp.op_text('\n')],
         [BodyOp.op_text('line 1'), BodyOp.op_retain(9)],
         [BodyOp.op_text('line 1'), BodyOp.op_retain(14), BodyOp.op_text('\n')],
         [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_retain(23), BodyOp.op_text('line 2')],
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_retain(23), BodyOp.op_text('line 2\n')],
+        [BodyOp.op_embed('blort', 123), BodyOp.op_retain(10)],
         [BodyOp.op_embed('blort', 123), BodyOp.op_retain(10), BodyOp.op_text('\n')],
-        [BodyOp.op_embed('blort', 123), BodyOp.op_delete(123)]
+        [BodyOp.op_embed('blort', 123), BodyOp.op_delete(123)],
+        [BodyOp.op_embed('blort', 123), BodyOp.op_delete(123), BodyOp.op_text('\n')]
       ];
 
       for (const v of values) {

--- a/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_BodyDelta.js
@@ -388,7 +388,8 @@ describe('@bayou/doc-common/BodyDelta', () => {
         [],
         [BodyOp.op_text('line 1')],
         [BodyOp.op_text('line 1'), BodyOp.op_text('\n')],
-        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_text('line 2')]
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_text('line 2')],
+        [BodyOp.op_embed('blort', 123), BodyOp.op_text('\n')],
       ];
 
       for (const v of values) {
@@ -405,7 +406,9 @@ describe('@bayou/doc-common/BodyDelta', () => {
         [BodyOp.op_retain(37, { bold: true })],
         [BodyOp.op_text('line 1'), BodyOp.op_retain(9)],
         [BodyOp.op_text('line 1'), BodyOp.op_retain(14), BodyOp.op_text('\n')],
-        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_retain(23), BodyOp.op_text('line 2')]
+        [BodyOp.op_text('line 1'), BodyOp.op_text('\n'), BodyOp.op_retain(23), BodyOp.op_text('line 2')],
+        [BodyOp.op_embed('blort', 123), BodyOp.op_retain(10), BodyOp.op_text('\n')],
+        [BodyOp.op_embed('blort', 123), BodyOp.op_delete(123)]
       ];
 
       for (const v of values) {


### PR DESCRIPTION
This is a follow-on from my PR yesterday where I partially tightened the constraint on `BodyDelta`, limiting the result of `compose()` with `wantDocument === true` to produce instances which end with a newline character. That PR also logged possible times when the `BodySnapshot` constructor _would_ complain if this constraint were introduced to `BodyDelta._impl_isDocument()`. Based on log analysis, we _do not_ have a problem with large amounts of preëxisting bad data (in this regard) — in fact I saw no logged events indicative of the problem — so I believe it is safe to add this constraint, which will prevent downstream crashes in the FE due to the presumed Quill bug which causes it to try to ultimately produce invalid changes.

So, that's what's going on in this PR: The `isDocument()` constraint is updated, the temporary extra checker method `endsWithNewlineOrIsEmpty()` is removed, and its call sites are also removed.

This fixes ARU-1240.