### PR TITLE
Handle `BodyClient` vs. `Quill` revision skew vis-a-vis change events.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -773,7 +773,6 @@ export default class BodyClient extends StateMachine {
       // situation arises, in case it is a harbinger of some other nascent new
       // problem.
       if (this._isQuillChangePending()) {
-        // **TODO:** Log in such a way that the server sees it.
         const thisSnap   = this._snapshot;
         const quillDelta = BodyDelta.fromQuillForm(this._quill.getContents());
         const quillSnap  = new BodySnapshot(thisSnap.revNum + 1, quillDelta);

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -1193,22 +1193,23 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
-   * Updates `_snapshot` to be the given revision by applying the indicated
-   * change to the current revision, and tells the attached Quill instance to
-   * update itself accordingly.
+   * Updates {@link #_snapshot} to be the given revision by applying the
+   * indicated change to the current revision, and tells the attached `Quill`
+   * instance to update itself accordingly.
    *
    * This is only valid to call when the revision of the document that Quill has
-   * is the same as what is represented in `_snapshot` _or_ if `quillDelta` is
-   * passed as an empty delta. That is, this is only valid when Quill's revision
-   * of the document doesn't need to be updated. If that isn't the case, then
-   * this method will throw an error.
+   * is the same as what is represented in {@link #_snapshot} _or_ if
+   * `quillDelta` is passed as an empty delta. That is, this is only valid when
+   * the `Quill` instance's revision of the document doesn't need to be updated.
+   * If that isn't the case, then this method will throw an error.
    *
-   * @param {BodyChange} change Change from the current `_snapshot` contents.
-   * @param {BodyDelta} [quillDelta = change.delta] Delta from Quill's
-   *   current state, which is expected to preserve any state that Quill has
-   *   that isn't yet represented in `_snapshot`. This must be used in cases
-   *   where Quill's state has progressed ahead of `_snapshot` due to local
-   *   activity.
+   * @param {BodyChange} change Change from the current {@link #_snapshot}
+   *   contents.
+   * @param {BodyDelta} [quillDelta = change.delta] Delta from the `Quill`
+   *   instance's current state, which is expected to preserve any state that
+   *   Quill has that isn't yet represented in {@link #_snapshot}. This must be
+   *   used in cases where the `Quill` instance state has progressed ahead of
+   *   {@link #_snapshot} due to local activity.
    */
   _updateWithChange(change, quillDelta = change.delta) {
     const needQuillUpdate = !quillDelta.isEmpty();

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -777,7 +777,9 @@ export default class BodyClient extends StateMachine {
         const thisSnap   = this._snapshot;
         const quillDelta = BodyDelta.fromQuillForm(this._quill.getContents());
         const quillSnap  = new BodySnapshot(thisSnap.revNum + 1, quillDelta);
-        this.log.event.quillChangePending(thisSnap.diff(quillSnap));
+        const diff       = thisSnap.diff(quillSnap);
+        this.log.event.quillChangePending(diff);
+        this._sessionProxy.logEvent('quillChangePending', diff); // Log it on the server too.
       } else {
         this._updateWithChange(result);
       }

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -47,6 +47,9 @@ export default class DocSession extends CommonBase {
 
     /** {PropertyControl} The underlying property (metadata) controller. */
     this._propertyControl = fileComplex.propertyControl;
+
+    /** {Logger} Logger to use to relay events coming from the client. */
+    this._clientLog = this._fileComplex.fileAccess.log.withAddedContext('client');
   }
 
   /**
@@ -333,5 +336,19 @@ export default class DocSession extends CommonBase {
    */
   getFileId() {
     return this._fileComplex.fileAccess.file.id;
+  }
+
+  /**
+   * Causes an event (which will come from the client) to be logged here on the
+   * server. This is useful for tactical debugging, moreso than intended for
+   * long-term use.
+   *
+   * **TODO:** Consider removing this.
+   *
+   * @param {string} name The event name to log.
+   * @param {...*} args Arbitrary arguments to log.
+   */
+  logEvent(name, ...args) {
+    this._clientLog.event[name](...args);
   }
 }

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.3.1
+version = 1.3.2


### PR DESCRIPTION
This PR changes the logic in `BodyClient` when handling changes coming from the server, so that it only tries to apply them if the `BodyClient` snapshot is up-to-date with respect to the _synchronous_ `Quill` instance state. The problem that this solves is that, whenever the user makes an edit, the `Quill` state gets updated promptly, and then `Quill` emits an event. That event necessarily gets handled _asynchronously_ by `BodyClient`. Furthermore, between the moment of the `Quill` change and the time that the corresponding event is received, it is possible for there to be a _server_-originated event which gets interposed. This ordering of "local change -> server event -> local event" was not anticipated by the original code. Now, it _is_.

More specifically, in the case in question, `BodyClient` now does nothing other than ignore the event (other than to log the situation for further analysis). Of necessity when this arises, there is _already_ a `Quill` event that is about to be consumed, so `BodyClient` just goes back to "idling" and that `Quill` event will just come a-rollin' on in.

Per parenthetical above, rather than just silently drop the event, we now log it so that it is visible both in client and server logs. The reason for logging is because — even though this was totally a bug in `BodyClient` — the problem only just started showing up, and it behooves us to try to understand why.

This PR includes a product version bump, because the fix is in a bridge module, and so the client code will need to pick it up.
