### PR TITLE
Only become "unrecovered" after a minimum amount of time.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -14,7 +14,7 @@ import DocSession from './DocSession';
 
 /**
  * {Int} Minimum amount of time (in msec) to wait (and continue to retry
- * connections) before deciding that an instance is in an "unrecoverable" error
+ * connecting) before deciding that an instance is in an "unrecoverable" error
  * state.
  */
 const ERROR_STATE_MIN_TIME_MSEC = 45 * 1000; // 45 seconds.

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -13,6 +13,12 @@ import { Errors, Functor, InfoError } from '@bayou/util-common';
 import DocSession from './DocSession';
 
 /**
+ * {Int} Minimum amount of time to wait (and continue to retry connections)
+ * before deciding that an instance is in an "unrecoverable" error state.
+ */
+const ERROR_STATE_MIN_TIME_MSEC = 45 * 1000; // 45 seconds.
+
+/**
  * {Int} Amount of time in msec over which errors are counted, in order to
  * determine that an instance is in an "unrecoverable" error state.
  */
@@ -1098,7 +1104,7 @@ export default class BodyClient extends StateMachine {
    * a new one for the current moment in time.
    */
   _addErrorStamp() {
-    const now = Date.now();
+    const now     = Date.now();
     const agedOut = now - ERROR_WINDOW_MSEC;
 
     this._errorStamps = this._errorStamps.filter(value => (value >= agedOut));
@@ -1190,15 +1196,26 @@ export default class BodyClient extends StateMachine {
    * @returns {boolean} `true` iff the instance is unrecoverably errored.
    */
   _isUnrecoverablyErrored() {
-    const errorCount      = this._errorStamps.length;
-    const errorsPerMinute = (errorCount / ERROR_WINDOW_MSEC) * 60 * 1000;
+    const stamps       = this._errorStamps;
+    const total        = stamps.length;
+    const perMinuteRaw = (total / ERROR_WINDOW_MSEC) * 60 * 1000;
+    const perMinute    = Math.round(perMinuteRaw * 100) / 100;
 
-    this.log.event.errorWindow({
-      total:     errorCount,
-      perMinute: Math.round(errorsPerMinute * 100) / 100
-    });
+    if (total === 0) {
+      // Shouldn't happen, but might as well just avoid weird math below in case
+      // it does.
+      return false;
+    }
 
-    return errorsPerMinute >= ERROR_MAX_PER_MINUTE;
+    const startTime = stamps[0];
+    const endTime   = stamps[total - 1];
+    const period    = endTime - startTime;
+    const periodSec = Math.floor(period / 1000);
+
+    this.log.event.errorWindow({ periodSec, total, perMinute });
+
+    return (perMinute >= ERROR_MAX_PER_MINUTE)
+      && (period >= ERROR_STATE_MIN_TIME_MSEC);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -13,13 +13,14 @@ import { Errors, Functor, InfoError } from '@bayou/util-common';
 import DocSession from './DocSession';
 
 /**
- * {Int} Minimum amount of time to wait (and continue to retry connections)
- * before deciding that an instance is in an "unrecoverable" error state.
+ * {Int} Minimum amount of time (in msec) to wait (and continue to retry
+ * connections) before deciding that an instance is in an "unrecoverable" error
+ * state.
  */
 const ERROR_STATE_MIN_TIME_MSEC = 45 * 1000; // 45 seconds.
 
 /**
- * {Int} Amount of time in msec over which errors are counted, in order to
+ * {Int} Amount of time (in msec) over which errors are counted, in order to
  * determine that an instance is in an "unrecoverable" error state.
  */
 const ERROR_WINDOW_MSEC = 3 * 60 * 1000; // Three minutes.

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -28,7 +28,7 @@ const ERROR_WINDOW_MSEC = 3 * 60 * 1000; // Three minutes.
  * {number} Error rate, expressed in errors per minute, above which constitutes
  * sufficient evidence that the instance is in an "unrecoverable" error state.
  */
-const ERROR_MAX_PER_MINUTE = 2.25;
+const ERROR_MAX_PER_MINUTE = 3.00;
 
 /**
  * {Int} How long to wait (in msec) after receiving a local change (to allow

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.3.2
+version = 1.3.3


### PR DESCRIPTION
This PR adds to the `BodyClient` connection recovery system an explicit time-based trigger which must pass before the client considers its state to be "unrecoverably errored." As set up, it will not go into that ultimate error state until at least 45 seconds have passed. I also bumped up the required error rate per minute for going into that state.

This all is done based on our actual experience in production of what currently happens when we push a new version of the server code. Specifically, these new conditions are meant to make it so that, at least in the typical case, a client which becomes disconnected due to server upgrade will be able to successfully connect _before_ hitting the "unrecoverable" condition.