### PR TITLE
A lot of timeout plumbing in service of a reordered validity check.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -268,17 +268,17 @@ export default class BaseControl extends BaseDataManager {
    * but has been kept `async` and takes an (unused) timeout in anticipation
    * of a future state where it will deal with data that it has to page in.
    *
-   * @param {Int|null} [timeoutMsec_unused = null] Maximum amount of time to
-   *   allow in this call, in msec. This value will be silently clamped to the
-   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
-   *   maximum allowed value.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {Int} The instantaneously-current revision number.
    */
-  async currentRevNum(timeoutMsec_unused = null) {
+  async currentRevNum(timeoutMsec = null) {
     const { file, codec }   = this.fileCodec;
     const clazz             = this.constructor;
     const revNumStoragePath = clazz.revisionNumberPath;
-    const fileSnapshot      = await file.getSnapshot();
+    const fileSnapshot      = await file.getSnapshot(null, timeoutMsec);
 
     fileSnapshot.checkPathPresent(revNumStoragePath);
 

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -298,9 +298,13 @@ export default class BaseControl extends BaseDataManager {
    * @param {Int} revNum The revision number of the change. The result is the
    *   change which produced that revision. E.g., `0` is a request for the first
    *   change (the change from the empty document).
+   * @param {Int|null} [timeoutMsec_unused = null] Maximum amount of time to
+   *   allow in this call, in msec. This value will be silently clamped to the
+   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {BodyChange} The requested change.
    */
-  async getChange(revNum) {
+  async getChange(revNum, timeoutMsec_unused = null) {
     RevisionNumber.check(revNum); // So we know we can `+1` without weirdness.
     const changes = await this._getChangeRange(revNum, revNum + 1, true);
 
@@ -381,11 +385,15 @@ export default class BaseControl extends BaseDataManager {
    *   a document delta. When `true`, `baseDelta` must be passed as a document
    *   delta. In addition, _some_ subclasses operate differently when asked to
    *   produce a document vs. not.
+   * @param {Int|null} [timeoutMsec_unused = null] Maximum amount of time to
+   *   allow in this call, in msec. This value will be silently clamped to the
+   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {BaseDelta} The composed result consisting of `baseDelta` composed
    *   with the deltas of revisions `startInclusive` through but not including
    *  `endExclusive`.
    */
-  async getComposedChanges(baseDelta, startInclusive, endExclusive, wantDocument) {
+  async getComposedChanges(baseDelta, startInclusive, endExclusive, wantDocument, timeoutMsec_unused = null) {
     const clazz = this.constructor;
 
     clazz.deltaClass.check(baseDelta);

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -350,7 +350,7 @@ export default class BaseControl extends BaseDataManager {
    */
   async getChangeAfter(baseRevNum, timeoutMsec = null) {
     timeoutMsec = Timeouts.clamp(timeoutMsec);
-    let currentRevNum = await this.currentRevNum();
+    let currentRevNum = await this.currentRevNum(timeoutMsec);
     RevisionNumber.maxInc(baseRevNum, currentRevNum);
 
     if (currentRevNum === baseRevNum) {
@@ -753,7 +753,7 @@ export default class BaseControl extends BaseDataManager {
         timedOut();
       }
 
-      const currentRevNum = await this.currentRevNum();
+      const currentRevNum = await this.currentRevNum(timeoutTime - now);
       if (currentRevNum >= revNum) {
         // No more need to wait or, if this is the first iteration, no need to
         // wait at all.

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -508,7 +508,7 @@ export default class BaseControl extends BaseDataManager {
 
     this.log.event.gettingSnapshot(revNum);
 
-    const result = await this._impl_getSnapshot(revNum);
+    const result = await this._impl_getSnapshot(revNum, timeoutMsec);
 
     if (result === null) {
       this.log.event.snapshotNotAvailable(revNum);
@@ -820,13 +820,17 @@ export default class BaseControl extends BaseDataManager {
    * @abstract
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BaseSnapshot|null} Snapshot of the indicated revision. Must
    *   either be an instance of the concrete snapshot type appropriate for this
    *   instance or `null`. `null` specifically indicates that `revNum` is a
    *   revision older than what this instance can provide.
    */
-  async _impl_getSnapshot(revNum) {
-    return this._mustOverride(revNum);
+  async _impl_getSnapshot(revNum, timeoutMsec = null) {
+    return this._mustOverride(revNum, timeoutMsec);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -492,11 +492,15 @@ export default class BaseControl extends BaseDataManager {
    *   the asynchronous nature of the system, when passed as `null` the
    *   resulting revision might already have been superseded by the time it is
    *   returned to the caller.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BaseSnapshot} Snapshot of the indicated revision. Always an
    *   instance of the concrete snapshot type appropriate for this instance.
    */
-  async getSnapshot(revNum = null) {
-    const currentRevNum = await this.currentRevNum();
+  async getSnapshot(revNum = null, timeoutMsec = null) {
+    const currentRevNum = await this.currentRevNum(timeoutMsec);
 
     if (revNum === null) {
       this.log.info(`Getting most recent snapshot with revNum ${currentRevNum}`);

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1005,6 +1005,30 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * Checks the validity of a (possibly empty) range of revision numbers, where
+   * both arguments must be syntactically correct revision numbers, where the
+   * second must be no less than the first, and where the second must correspond
+   * to a revision (change record) that exists in the document part or be no
+   * more than one revision number beyond the end.
+   *
+   * @param {Int} startInclusive First revision number (inclusive).
+   * @param {Int} endExclusive Last revision number (exclusive).
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
+   * @throws {Error} Thrown if the constraints as described above are violated.
+   */
+  async _checkRevNumRange(startInclusive, endExclusive, timeoutMsec = null) {
+    RevisionNumber.check(startInclusive);
+    RevisionNumber.min(endExclusive, startInclusive);
+
+    const currentRevNum = await this.currentRevNum(timeoutMsec);
+
+    RevisionNumber.maxInc(endExclusive, currentRevNum + 1);
+  }
+
+  /**
    * Reads a sequential chunk of changes. It is an error to request a change
    * beyond the current revision; it is valid for either `startInclusive` or
    * `endExclusive` to be `currentRevNum() + 1` but no greater. If

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -535,14 +535,14 @@ export default class BaseControl extends BaseDataManager {
    *   read.
    * @param {Int} endExclusive End change number (exclusive) of changes to read.
    *   Must be `>= startInclusive`.
-   * @param {Int|null} [timeoutMsec_unused = null] Maximum amount of time to
-   *   allow in this call, in msec. This value will be silently clamped to the
-   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
-   *   maximum allowed value.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {array<Int>} Array of the revision numbers of existing changes, in
    *   order by revision number.
    */
-  async listChangeRange(startInclusive, endExclusive, timeoutMsec_unused = null) {
+  async listChangeRange(startInclusive, endExclusive, timeoutMsec = null) {
     RevisionNumber.check(startInclusive);
     RevisionNumber.min(endExclusive, startInclusive);
 
@@ -551,7 +551,7 @@ export default class BaseControl extends BaseDataManager {
       return [];
     }
 
-    const snapshot = await this.fileCodec.file.getSnapshot();
+    const snapshot = await this.fileCodec.file.getSnapshot(null, timeoutMsec);
     const prefix   = this.constructor.changePathPrefix;
     const paths    = snapshot.getPathRange(prefix, startInclusive, endExclusive);
     const result   = [];
@@ -573,18 +573,18 @@ export default class BaseControl extends BaseDataManager {
    * but has been kept `async` and takes an (unused) timeout in anticipation
    * of a future state where it will deal with data that it has to page in.
    *
-   * @param {Int|null} [timeoutMsec_unused = null] Maximum amount of time to
-   *   allow in this call, in msec. This value will be silently clamped to the
-   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
-   *   maximum allowed value.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BaseSnapshot|null} The stored snapshot, or `null` if no snapshot
    *   was ever stored.
    */
-  async readStoredSnapshotOrNull(timeoutMsec_unused = null) {
+  async readStoredSnapshotOrNull(timeoutMsec = null) {
     const clazz                 = this.constructor;
     const storedSnapshotPath    = clazz.storedSnapshotPath;
     const { file, codec }       = this.fileCodec;
-    const fileSnapshot          = await file.getSnapshot();
+    const fileSnapshot          = await file.getSnapshot(null, timeoutMsec);
     const encodedStoredSnapshot = fileSnapshot.getOrNull(storedSnapshotPath);
 
     if (encodedStoredSnapshot === null) {

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -214,7 +214,7 @@ export default class BaseControl extends BaseDataManager {
       FileOp.op_writePath(revisionPath, codec.encodeJsonBuffer(revNum))
     ];
 
-    const snapshot   = await file.getSnapshot();
+    const snapshot   = await file.getSnapshot(null, timeoutMsec);
     const fileChange = new FileChange(snapshot.revNum + 1, fileOps);
 
     try {
@@ -658,7 +658,7 @@ export default class BaseControl extends BaseDataManager {
     // Snapshot of the base revision. The `getSnapshot()` call effectively
     // validates `change.revNum` as a legit value for the current document
     // state.
-    const baseSnapshot = await this.getSnapshot(baseRevNum);
+    const baseSnapshot = await this.getSnapshot(baseRevNum, timeoutMsec);
 
     // Compose the implied expected result. This has the effect of validating
     // the contents of `delta`.
@@ -987,9 +987,7 @@ export default class BaseControl extends BaseDataManager {
 
     this.log.event.attemptUpdate(change.revNum, baseSnapshot.revNum, expectedSnapshot.revNum);
 
-    // **TODO:** Consider whether we should make this call have an explicit
-    // timeout. (It would require adding an argument to the method.)
-    const currentSnapshot = await this.getSnapshot();
+    const currentSnapshot = await this.getSnapshot(null, timeoutMsec);
 
     const changeToAppend = (baseSnapshot.revNum === currentSnapshot.revNum)
       ? change
@@ -1012,7 +1010,7 @@ export default class BaseControl extends BaseDataManager {
         // the change as-is. No correction!
         return new changeClass(change.revNum, deltaClass.EMPTY);
       } else {
-        const resultSnapshot = await this.getSnapshot(changeToAppend.revNum);
+        const resultSnapshot = await this.getSnapshot(changeToAppend.revNum, timeoutMsec);
         const correction     = expectedSnapshot.diff(resultSnapshot);
 
         this.log.event.updateSucceeded(change.revNum, baseSnapshot.revNum, expectedSnapshot.revNum);

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1061,12 +1061,16 @@ export default class BaseControl extends BaseDataManager {
    * @param {boolean} allowMissing Whether (`true`) or not (`false`) to allow
    *   there to be missing changes from the range. If `false`, the result is
    *   always an array of length `endExclusive - startInclusive`.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to
+   *   allow in this call, in msec. This value will be silently clamped to the
+   *   allowable range as defined by {@link Timeouts}. `null` is treated as the
+   *   maximum allowed value.
    * @returns {array<BaseChange>} Array of changes, in order by revision number.
    */
-  async _getChangeRange(startInclusive, endExclusive, allowMissing) {
+  async _getChangeRange(startInclusive, endExclusive, allowMissing, timeoutMsec) {
     TBoolean.check(allowMissing);
 
-    await this._checkRevNumRange(startInclusive, endExclusive);
+    await this._checkRevNumRange(startInclusive, endExclusive, timeoutMsec);
 
     if (startInclusive === endExclusive) {
       // Per docs, this is valid and has an empty result.
@@ -1080,7 +1084,7 @@ export default class BaseControl extends BaseDataManager {
     const clazz           = this.constructor;
     const result          = [];
     const { file, codec } = this.fileCodec;
-    const snapshot        = await file.getSnapshot();
+    const snapshot        = await file.getSnapshot(null, timeoutMsec);
     const prefix          = this.constructor.changePathPrefix;
     const data            = snapshot.getPathRange(prefix, startInclusive, endExclusive);
 

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -854,6 +854,20 @@ export default class BaseControl extends BaseDataManager {
   }
 
   /**
+   * Subclass-specific change validation. Subclasses must override this method.
+   *
+   * @abstract
+   * @param {BaseChange} change Change to apply.
+   * @param {BaseSnapshot} baseSnapshot The base snapshot the change is being
+   *   applied to.
+   * @throws {Error} Thrown if `change` is not valid as a change to
+   *   `baseSnapshot`.
+   */
+  _impl_validateChange(change, baseSnapshot) {
+    this._mustOverride(change, baseSnapshot);
+  }
+
+  /**
    * Subclass-specific implementation of {@link #validationStatus}. This works
    * for all concrete subclasses of this class. (It builds in knowledge of the
    * difference between durable and ephemeral parts, because it's easier to
@@ -1196,20 +1210,6 @@ export default class BaseControl extends BaseDataManager {
     await this._appendChangeWithRetry(fileChange, timeoutMsec);
 
     this.log.info('Wrote stored snapshot for revision:', snapshot.revNum);
-  }
-
-  /**
-   * Subclass-specific change validation. Subclasses must override this method.
-   *
-   * @abstract
-   * @param {BaseChange} change Change to apply.
-   * @param {BaseSnapshot} baseSnapshot The base snapshot the change is being
-   *   applied to.
-   * @throws {Error} Thrown if `change` is not valid as a change to
-   *   `baseSnapshot`.
-   */
-  _impl_validateChange(change, baseSnapshot) {
-    this._mustOverride(change, baseSnapshot);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -60,11 +60,15 @@ export default class BodyControl extends DurableControl {
    *
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BodySnapshot} Snapshot of the indicated revision. Though the
    *   superclass allows it, this method never returns `null`.
    */
-  async _impl_getSnapshot(revNum) {
-    return this._snapshots.getSnapshot(revNum);
+  async _impl_getSnapshot(revNum, timeoutMsec = null) {
+    return this._snapshots.getSnapshot(revNum, timeoutMsec);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -118,13 +118,17 @@ export default class CaretControl extends EphemeralControl {
    *
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {CaretSnapshot|null} Snapshot of the indicated revision, or
    *   `null` to indicate that the revision is not available.
    */
-  async _impl_getSnapshot(revNum) {
+  async _impl_getSnapshot(revNum, timeoutMsec = null) {
     this._maybeRemoveIdleCarets();
 
-    return this._snapshots.getSnapshot(revNum);
+    return this._snapshots.getSnapshot(revNum, timeoutMsec);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/PropertyControl.js
+++ b/local-modules/@bayou/doc-server/PropertyControl.js
@@ -41,11 +41,15 @@ export default class PropertyControl extends DurableControl {
    *
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {PropertySnapshot|null} Snapshot of the indicated revision, or
    *   `null` to indicate that the revision is not available.
    */
-  async _impl_getSnapshot(revNum) {
-    return this._snapshots.getSnapshot(revNum);
+  async _impl_getSnapshot(revNum, timeoutMsec = null) {
+    return this._snapshots.getSnapshot(revNum, timeoutMsec);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/SnapshotManager.js
+++ b/local-modules/@bayou/doc-server/SnapshotManager.js
@@ -64,9 +64,13 @@ export default class SnapshotManager extends CommonBase {
    *
    * @param {Int} revNum Which revision to get. Guaranteed to be a revision
    *   number for the instantaneously-current revision or earlier.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
    * @returns {BaseSnapshot} Snapshot of the indicated revision.
    */
-  async getSnapshot(revNum) {
+  async getSnapshot(revNum, timeoutMsec) {
     if (this._snapshots.size === 0) {
       // The cache doesn't have anything in it yet.
       if (this._storedSnapshotRetrieved === null) {
@@ -77,7 +81,7 @@ export default class SnapshotManager extends CommonBase {
         // used to satisfy this call. At the same time (well, right after), also
         // set up an entry for revision 0 if in fact change 0 exists.
         this._storedSnapshotRetrieved = (async () => {
-          const storedSnapshot = await this._control.readStoredSnapshotOrNull();
+          const storedSnapshot = await this._control.readStoredSnapshotOrNull(timeoutMsec);
 
           if (storedSnapshot !== null) {
             this._snapshots.set(storedSnapshot.revNum, storedSnapshot);

--- a/local-modules/@bayou/doc-server/mocks/MockControl.js
+++ b/local-modules/@bayou/doc-server/mocks/MockControl.js
@@ -15,7 +15,7 @@ export default class MockControl extends DurableControl {
     this.revNum = 0;
   }
 
-  _impl_getSnapshot(revNum) {
+  _impl_getSnapshot(revNum, timeoutMsec_unused) {
     return new MockSnapshot(revNum, [['snap', revNum]]);
   }
 

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -198,7 +198,7 @@ export default class BaseFile extends CommonBase {
    * @returns {FileChange} The requested change.
    */
   async getChange(revNum, timeoutMsec) {
-    const currentRevNum = await this.currentRevNum();
+    const currentRevNum = await this.currentRevNum(timeoutMsec);
 
     RevisionNumber.maxInc(revNum, currentRevNum);
 
@@ -230,7 +230,7 @@ export default class BaseFile extends CommonBase {
    * @returns {FileSnapshot} Snapshot of the indicated revision.
    */
   async getSnapshot(revNum = null, timeoutMsec = null) {
-    const currentRevNum = await this.currentRevNum();
+    const currentRevNum = await this.currentRevNum(timeoutMsec);
 
     revNum = (revNum === null)
       ? currentRevNum


### PR DESCRIPTION
The main point of this PR is to make it so that `BaseControl._getChangeRange()` does its validity checking up-front instead of possibly being in the middle of the operation when it fails. This is being done so as to help narrow down why we are seeing "Missing change in requested range" errors unexpectedly. My expectation with this PR is _not_ that crashes will be reduced, but _maybe_ that the error we get will be different.

The main change of this PR involved adding a requirement to call `currentRevNum()`, which is `async`, up-front in `_getChangeRange()`, and this triggered a more urgent need to respect timeouts throughout the call chain, and _that_ ended up "infecting" a lot of adjacent code with timeouts as well (e.g., it wasn't code that was in the direct call path, but it was calling some of the same methods). I tried to leave everything in a reasonably consistent state, in terms of how timeouts are passed and used; however, note that we have a long-standing problem that in many cases we will reüse the same timeout value for multiple calls in a row where we should really be "burning down" an overarching timeout. Fixing that problem will have to wait for another day (or maybe never).
