### PR TITLE
`BodyClient.detach()`

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -201,7 +201,14 @@ export default class BodyClient extends StateMachine {
    * `detached` state nor try to do any further server interaction.
    */
   async detach() {
-    throw Errors.wtf('TODO');
+    // Issue a `stop` event, which should eventually land the instance in the
+    // `detached` state.
+    this.q_stop();
+
+    // **TODO:** Set things up so that we won't leave the `detached` state.
+
+    // Wait until we actually land in the `detached` state.
+    await this.when_detached();
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -117,7 +117,10 @@ export default class BodyClient extends StateMachine {
     /** {Quill} Editor object. */
     this._quill = quill;
 
-    /** {DocSession} Server session control / manager. */
+    /**
+     * {DocSession|null} Server session control / manager, or `null` if this
+     * instance has been told to {@link #detach}.
+     */
     this._docSession = DocSession.check(docSession);
 
     /**
@@ -209,6 +212,10 @@ export default class BodyClient extends StateMachine {
 
     // Wait until we actually land in the `detached` state.
     await this.when_detached();
+
+    // Guarantee that we won't try to fire up server communication again.
+    this._docSession   = null;
+    this._sessionProxy = null;
   }
 
   /**

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -229,7 +229,9 @@ export default class BodyClient extends StateMachine {
 
   /**
    * Requests that this instance stop running. This method does nothing if the
-   * client is already stopped (or in the process of stopping).
+   * client is already stopped (or in the process of stopping). Once stopped,
+   * this instance is in the `detached` state, which is the same state a
+   * newly-constructed instance is in.
    */
   stop() {
     this.q_stop();

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -194,6 +194,17 @@ export default class BodyClient extends StateMachine {
   }
 
   /**
+   * Detaches this instance. When this method (asynchronously) returns, the
+   * instance is guaranteed to be quiescent; specifically, it will not be in the
+   * middle of any server operations, and it will be in the `detached` state.
+   * Furthermore, this will guarantee that the instance will never leave the
+   * `detached` state nor try to do any further server interaction.
+   */
+  async detach() {
+    throw Errors.wtf('TODO');
+  }
+
+  /**
    * Gets this instance's instantaneously current view on whether editing should
    * be enabled.
    *

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.3.3
+version = 1.3.4


### PR DESCRIPTION
It turns out the FE has good reason to make new instances of `BodyClient` from time to time, within a single editing session. But `BodyClient` (and the server) are not particularly prepared for the possibility of two instances to both be looking at the same underlying `Quill` instance; when that happens, we see stuff like multiple identical edits being sent to the server, with the expected comedic hijinks.

This PR gives the FE a useful tool to avoid that scenario: Specifically, the FE _does_ know when it is reïnstantiating `BodyClient`, and it is possible for it to take explicit steps to first disable the instance that is being replaced. And with this PR, there is now a method to call exactly for that purpose, `BodyClient.detach()`. This `async` method will fully shut down and detach the instance from any server, and then make it impossible for the instance to (presumably inadvertently) get started back up. And, as an `async` method it only returns _after_ the detaching is complete.
