### PR TITLE
"Top half" of view-only sessions.

### DIFF
--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -51,7 +51,7 @@ export default class TargetMap extends CommonBase {
   /**
    * Creates and binds a proxy for the target with the given ID. Returns the
    * so-created proxy. It is an error to try to add the same `idOrToken` more
-   * than once (except if {@link #clear} is called in the mean time).
+   * than once (except if {@link #clear} is called in the meantime).
    *
    * **Note:** This class doesn't care (or notice) if multiple `BearerToken`s
    * with the same _token_ ID get added, nor if a `BearerToken` gets added whose

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -128,7 +128,7 @@ export default class AuthorAccess extends CommonBase {
 
     // Ensure (to the extent possible) that both salient IDs are valid the
     // moment before we ask for a permission check. (There is a chance that one
-    // or the other could become invalid in the mean time. In those cases, the
+    // or the other could become invalid in the meantime. In those cases, the
     // permission call will properly fail, but nonetheless we're better off
     // trying to get a probably-less-obscure error to happen up front in the
     // usual case.)

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -67,11 +67,13 @@ export default class AuthorAccess extends CommonBase {
 
     CaretId.check(caretId);
 
+    const canEdit = true; // **TODO:** Should be a permission check!
+
     const fileComplex = await DocServer.theOne.getFileComplex(documentId);
 
     let session;
     try {
-      session = await fileComplex.findExistingSession(this._authorId, caretId);
+      session = await fileComplex.findExistingSession(this._authorId, caretId, canEdit);
     } catch (e) {
       if (Errors.is_badId(e)) {
         // Per method header doc, this isn't considered a throwable offense.
@@ -121,13 +123,8 @@ export default class AuthorAccess extends CommonBase {
       throw Errors.fileNotFound(documentId);
     }
 
-    if (!canEdit) {
-      // **TODO:** Support view-only session creation.
-      throw Errors.wtf('View-only sessions not yet supported.');
-    }
-
     const fileComplex = await DocServer.theOne.getFileComplex(documentId);
-    const session     = await fileComplex.makeNewSession(authorId);
+    const session     = await fileComplex.makeNewSession(authorId, canEdit);
     const caretId     = session.getCaretId();
 
     log.event.madeSession({ authorId, documentId, caretId });

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -457,7 +457,7 @@ export default class BodyClient extends StateMachine {
       this._becomeUnrecoverable();
     } else {
       // Wait an appropriate amount of time and then try starting again (unless
-      // the instance got `stop()`ed in the mean time). The `start` event will
+      // the instance got `stop()`ed in the meantime). The `start` event will
       // be received in the `errorWait` state, and as such will be handled
       // differently than a clean start from scratch.
 
@@ -890,7 +890,7 @@ export default class BodyClient extends StateMachine {
         // It's a document modification. Go into state `collecting`, leaving the
         // event chain alone for now. After the prescribed amount of time, the
         // `collecting` handler will hoover up the event with any other edits
-        // that happened in the mean time.
+        // that happened in the meantime.
         (async () => {
           await Delay.resolve(PUSH_DELAY_MSEC);
           this.q_wantToUpdate(baseRevNum);
@@ -1048,7 +1048,7 @@ export default class BodyClient extends StateMachine {
 
     // The hard case, a/k/a "Several people are typing." The server got back
     // to us with a response that included changes we didn't know about, *and*
-    // in the mean time the local user has been busy making changes of their
+    // in the meantime the local user has been busy making changes of their
     // own. We need to "transform" (in OT terms) or "rebase" (in git terms) the
     // the local changes to be on top of the new base document as provided by
     // the server.
@@ -1422,7 +1422,7 @@ export default class BodyClient extends StateMachine {
   _waitThenStop() {
     // **Note:** We do this in an immediate-async block so as to make this
     // method return promptly. Its callers in fact want to be able to proceed
-    // with event processing in the mean time.
+    // with event processing in the meantime.
     (async () => {
       this.log.event.waitingBeforeStopping();
       await Delay.resolve(STOP_POLL_DELAY_MSEC);

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -317,7 +317,8 @@ export default class DocSession extends CommonBase {
       authorId:   this.getAuthorId(),
       caretId:    this.getCaretId(),
       documentId: this.getDocumentId(),
-      fileId:     this.getFileId()
+      fileId:     this.getFileId(),
+      canEdit:    this.canEdit()
     };
 
     // Only include the file ID if it's not the same as the document ID.

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -139,7 +139,7 @@ export default class DocSession extends CommonBase {
    * in which case the client will likely want to use `caret_getSnapshot()` to
    * get back in synch.
    *
-   * **Note:** Caret information and the main document have _separate_ revision
+   * **Note:** Caret information and the document body have _separate_ revision
    * numbers. `CaretSnapshot` instances have information about both revision
    * numbers.
    *

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -179,7 +179,7 @@ export default class FileComplex extends BaseComplexMember {
    * @returns {DocSession} A newly-constructed session.
    */
   _activateSession(authorId, caretId) {
-    const result = new DocSession(this, authorId, caretId);
+    const result = new DocSession(this, authorId, caretId, true); // **TODO:** Not always `true`.
     const fileId = this.file.id;
 
     this._sessions.add(result);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Storage } from '@bayou/config-server';
+import { TBoolean, TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import BaseComplexMember from './BaseComplexMember';
@@ -82,14 +83,19 @@ export default class FileComplex extends BaseComplexMember {
    *
    * @param {string} authorId ID of the author.
    * @param {string} caretId ID of the caret.
+   * @param {boolean} canEdit `true` if the session is to allow changes to be
+   *   made through it, or `false` if not (that is, `false` for a view-only
+   *   session).
    * @returns {DocSession} A session object to control the indicated
    *   pre-existing caret.
    * @throws {InfoError} Thrown with name `badId` specifically if the caret is
    *   not found (including if it exists but is controlled by a different
    *   author).
    */
-  async findExistingSession(authorId, caretId) {
-    const canEdit = true; // **TODO:** Should be an argument.
+  async findExistingSession(authorId, caretId, canEdit) {
+    TString.check(authorId); // Basic type check.
+    TString.check(caretId);  // Basic type check.
+    TBoolean.check(canEdit);
 
     // **Note:** We only need to validate syntax, because if we actually find
     // the session, we can match the author ID and (if it does match) know that
@@ -139,13 +145,19 @@ export default class FileComplex extends BaseComplexMember {
   /**
    * Makes and returns a new session for the document controlled by this
    * instance, which allows the indicated author to control a newly-instantiated
-   * caret.
+   * session. Depending on the value of `canEdit`, the session will (`true`) or
+   * won't (`false`) allow editing operations to happen through it.
    *
    * @param {string} authorId ID for the author.
+   * @param {boolean} canEdit `true` if the session is to allow changes to be
+   *   made through it, or `false` if not (that is, `false` for a view-only
+   *   session).
    * @returns {DocSession} A newly-constructed session.
    */
-  async makeNewSession(authorId) {
-    const canEdit = true; // **TODO:** Should be an argument.
+  async makeNewSession(authorId, canEdit) {
+    TString.check(authorId); // Basic type check.
+    TBoolean.check(canEdit);
+
     const timeoutTime = Date.now() + MAKE_SESSION_TIMEOUT_MSEC;
 
     // This validates the ID with the back end.
@@ -185,6 +197,9 @@ export default class FileComplex extends BaseComplexMember {
    *
    * @param {string} authorId ID of the author.
    * @param {string} caretId ID of the caret.
+   * @param {boolean} canEdit `true` if the session is to allow changes to be
+   *   made through it, or `false` if not (that is, `false` for a view-only
+   *   session).
    * @returns {DocSession} A newly-constructed session.
    */
   _activateSession(authorId, caretId, canEdit) {

--- a/scripts/build
+++ b/scripts/build
@@ -537,7 +537,7 @@ function avoid-simultaneous-builds {
             return 1
         elif [[ ${alreadyPid} != ${lastPid} ]]; then
             echo ''
-            echo 'A different build started running in the mean time.'
+            echo 'A different build started running in the meantime.'
             echo "  pid:       ${alreadyPid}"
             echo ''
         elif (( (${waitSecs} % 20) == 0 )); then


### PR DESCRIPTION
This PR starts to pay more attention to the back-end permission check for document access. More specifically, it now _begins_ to do something sensible for document/author pairs where the permissions are view-only, whereas with the status quo a view-only permission result gets rejected fairly early. As of this PR, it all bottoms out in the (server side) `DocSession` constructor, which now takes a `canEdit` argument… where it will reject attempts to construct with `canEdit === false`. A follow-on PR will fill things in further.

**Bonus:** "Meantime" (no space in the middle) is a word. I've been writing it wrong for a while, it seems.