### PR TITLE
Refactoring, renaming, and a couple yak shaves.

### DIFF
--- a/local-modules/@bayou/api-client/TargetHandler.js
+++ b/local-modules/@bayou/api-client/TargetHandler.js
@@ -37,7 +37,7 @@ export default class TargetHandler extends MethodCacheProxyHandler {
   /**
    * Makes a method handler for the given method name.
    *
-   * @param {string} name The method name.
+   * @param {string|Symbol} name The method name.
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -1,0 +1,187 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Storage } from '@bayou/config-server';
+import { CaretId } from '@bayou/doc-common';
+import { TBoolean } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+import FileComplex from './FileComplex';
+
+/**
+ * Base class for the server-side representative of an access session for a
+ * specific document, by a specific author, using a specific caret. Instances
+ * of (concrete subclasses of) this class are exposed across an API boundary,
+ * and as such all public methods are available for client use.
+ */
+export default class BaseSession extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileComplex} fileComplex File complex representing the underlying
+   *   file for this instance to use.
+   * @param {string} authorId The author this instance acts on behalf of.
+   * @param {string} caretId Caret ID for this instance.
+   * @param {boolean} canEdit Whether (`true`) or not (`false`) the instance is
+   *   to allow editing to happen through it. That is, `false` indicates a
+   *   view-only session.
+   */
+  constructor(fileComplex, authorId, caretId, canEdit) {
+    super();
+
+    /** {FileComplex} File complex that this instance is part of. */
+    this._fileComplex = FileComplex.check(fileComplex);
+
+    /** {string} Author ID. */
+    this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
+
+    /** {string} Caret ID. */
+    this._caretId = CaretId.check(caretId);
+
+    /** {boolean} Whether or not this instance allows edits. */
+    this._canEdit = TBoolean.check(canEdit);
+
+    // **TODO:** Remove this restriction!
+    if (!canEdit) {
+      throw Errors.wtf('View-only sessions not yet supported!');
+    }
+
+    /** {BodyControl} The underlying body content controller. */
+    this._bodyControl = fileComplex.bodyControl;
+
+    /** {CaretControl} The underlying caret info controller. */
+    this._caretControl = fileComplex.caretControl;
+
+    /** {PropertyControl} The underlying property (metadata) controller. */
+    this._propertyControl = fileComplex.propertyControl;
+
+    /** {Logger} Logger to use to relay events coming from the client. */
+    this._clientLog = this._fileComplex.fileAccess.log.withAddedContext('client');
+  }
+
+  /**
+   * {BodyControl} The underlying body content controller.
+   *
+   * This is intended for use by subclasses.
+   */
+  get bodyControl() {
+    return this._bodyControl;
+  }
+
+  /** {CaretControl} The underlying caret info controller.
+   *
+   * This is intended for use by subclasses.
+   */
+  get caretControl() {
+    return this._caretControl;
+  }
+
+  /** {PropertyControl} The underlying property (metadata) controller.
+   *
+   * This is intended for use by subclasses.
+   */
+  get propertyControl() {
+    return this._propertyControl;
+  }
+
+  /**
+   * Indicates whether (`true`) or not (`false`) this instance allows editing to
+   * be performed through it.
+   *
+   * **Note:** This is a method and not just a property, specifically so that
+   * clients (via the API) can make this determination.
+   *
+   * @returns {boolean} `true` if this instance allows editing, or `false` if it
+   *   is view-only.
+   */
+  canEdit() {
+    return this._canEdit;
+  }
+
+  /**
+   * Standard (to this project) `deconstruct` method. This method is defined
+   * here just so that instances can be stringified in a reasonable way (e.g.
+   * when logging), and _not_ because they're expected to get transmitted over
+   * an API boundary or stored in a DB.
+   *
+   * @returns {array<*>} "Reconstruction" arguments, suitable for logging.
+   */
+  deconstruct() {
+    return [this.getLogInfo()];
+  }
+
+  /**
+   * Returns a bit of identifying info about this instance, for the purposes of
+   * logging. Specifically, the client will call this method and log the result
+   * during session initiation.
+   *
+   * @returns {object} Succinct identification.
+   */
+  getLogInfo() {
+    const result = {
+      authorId:   this.getAuthorId(),
+      caretId:    this.getCaretId(),
+      documentId: this.getDocumentId(),
+      fileId:     this.getFileId(),
+      canEdit:    this.canEdit()
+    };
+
+    // Only include the file ID if it's not the same as the document ID.
+    if (result.fileId === result.documentId) {
+      delete result.fileId;
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the author ID of the user managed by this session.
+   *
+   * @returns {string} The author ID.
+   */
+  getAuthorId() {
+    return this._authorId;
+  }
+
+  /**
+   * Returns the caret ID of this instance.
+   *
+   * @returns {string} The caret ID.
+   */
+  getCaretId() {
+    return this._caretId;
+  }
+
+  /**
+   * Returns the ID of the document controlled by this instance.
+   *
+   * @returns {string} The document ID.
+   */
+  getDocumentId() {
+    return this._fileComplex.fileAccess.documentId;
+  }
+
+  /**
+   * Returns the ID of the file controlled by this instance.
+   *
+   * @returns {string} The file ID.
+   */
+  getFileId() {
+    return this._fileComplex.fileAccess.file.id;
+  }
+
+  /**
+   * Causes an event (which will come from the client) to be logged here on the
+   * server. This is useful for tactical debugging, moreso than intended for
+   * long-term use.
+   *
+   * **TODO:** Consider removing this.
+   *
+   * @param {string} name The event name to log.
+   * @param {...*} args Arbitrary arguments to log.
+   */
+  logEvent(name, ...args) {
+    this._clientLog.event[name](...args);
+  }
+}

--- a/local-modules/@bayou/doc-server/DocSession.js
+++ b/local-modules/@bayou/doc-server/DocSession.js
@@ -2,13 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Storage } from '@bayou/config-server';
-import { BodyChange, CaretId, PropertyChange } from '@bayou/doc-common';
+import { BodyChange, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
-import { TBoolean } from '@bayou/typecheck';
-import { CommonBase, Errors } from '@bayou/util-common';
 
-import FileComplex from './FileComplex';
+import BaseSession from './BaseSession';
 
 /**
  * Server side representative of an editing session for a specific document,
@@ -19,7 +16,7 @@ import FileComplex from './FileComplex';
  * underlying `*Control` instances, while implicitly adding author ID and/or
  * caret ID as appropriate to methods that perform modifications.
  */
-export default class DocSession extends CommonBase {
+export default class DocSession extends BaseSession {
   /**
    * Constructs an instance.
    *
@@ -32,36 +29,9 @@ export default class DocSession extends CommonBase {
    *   view-only session.
    */
   constructor(fileComplex, authorId, caretId, canEdit) {
-    super();
+    super(fileComplex, authorId, caretId, canEdit);
 
-    /** {FileComplex} File complex that this instance is part of. */
-    this._fileComplex = FileComplex.check(fileComplex);
-
-    /** {string} Author ID. */
-    this._authorId = Storage.dataStore.checkAuthorIdSyntax(authorId);
-
-    /** {string} Caret ID. */
-    this._caretId = CaretId.check(caretId);
-
-    /** {boolean} Whether or not this instance allows edits. */
-    this._canEdit = TBoolean.check(canEdit);
-
-    // **TODO:** Remove this restriction!
-    if (!canEdit) {
-      throw Errors.wtf('View-only sessions not yet supported!');
-    }
-
-    /** {BodyControl} The underlying body content controller. */
-    this._bodyControl = fileComplex.bodyControl;
-
-    /** {CaretControl} The underlying caret info controller. */
-    this._caretControl = fileComplex.caretControl;
-
-    /** {PropertyControl} The underlying property (metadata) controller. */
-    this._propertyControl = fileComplex.propertyControl;
-
-    /** {Logger} Logger to use to relay events coming from the client. */
-    this._clientLog = this._fileComplex.fileAccess.log.withAddedContext('client');
+    Object.freeze(this);
   }
 
   /**
@@ -289,93 +259,5 @@ export default class DocSession extends CommonBase {
     const change = new PropertyChange(baseRevNum + 1, delta, Timestamp.now(), this._authorId);
 
     return this._propertyControl.update(change);
-  }
-
-  /**
-   * Indicates whether (`true`) or not (`false`) this instance allows editing to
-   * be performed through it.
-   *
-   * **Note:** This is a method and not just a property, specifically so that
-   * clients (via the API) can make this determination.
-   *
-   * @returns {boolean} `true` if this instance allows editing, or `false` if it
-   *   is view-only.
-   */
-  canEdit() {
-    return this._canEdit;
-  }
-
-  /**
-   * Returns a bit of identifying info about this instance, for the purposes of
-   * logging. Specifically, the client will call this method and log the result
-   * during session initiation.
-   *
-   * @returns {object} Succinct identification.
-   */
-  getLogInfo() {
-    const result = {
-      authorId:   this.getAuthorId(),
-      caretId:    this.getCaretId(),
-      documentId: this.getDocumentId(),
-      fileId:     this.getFileId(),
-      canEdit:    this.canEdit()
-    };
-
-    // Only include the file ID if it's not the same as the document ID.
-    if (result.fileId === result.documentId) {
-      delete result.fileId;
-    }
-
-    return result;
-  }
-
-  /**
-   * Returns the author ID of the user managed by this session.
-   *
-   * @returns {string} The author ID.
-   */
-  getAuthorId() {
-    return this._authorId;
-  }
-
-  /**
-   * Returns the caret ID of this instance.
-   *
-   * @returns {string} The caret ID.
-   */
-  getCaretId() {
-    return this._caretId;
-  }
-
-  /**
-   * Returns the ID of the document controlled by this instance.
-   *
-   * @returns {string} The document ID.
-   */
-  getDocumentId() {
-    return this._fileComplex.fileAccess.documentId;
-  }
-
-  /**
-   * Returns the ID of the file controlled by this instance.
-   *
-   * @returns {string} The file ID.
-   */
-  getFileId() {
-    return this._fileComplex.fileAccess.file.id;
-  }
-
-  /**
-   * Causes an event (which will come from the client) to be logged here on the
-   * server. This is useful for tactical debugging, moreso than intended for
-   * long-term use.
-   *
-   * **TODO:** Consider removing this.
-   *
-   * @param {string} name The event name to log.
-   * @param {...*} args Arbitrary arguments to log.
-   */
-  logEvent(name, ...args) {
-    this._clientLog.event[name](...args);
   }
 }

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -8,15 +8,14 @@ import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import BaseSession from './BaseSession';
 
 /**
- * Server side representative of an editing session for a specific document,
- * author, and caret. Instances of this class are exposed across the API
- * boundary, and as such all public methods are available for client use.
+ * Server side representative of a session which allows editing (and temporarily
+ * has an affordance for disabling editing to make a view-only session).
  *
  * For access methods, this passes non-mutating methods through to the
  * underlying `*Control` instances, while implicitly adding author ID and/or
  * caret ID as appropriate to methods that perform modifications.
  */
-export default class DocSession extends BaseSession {
+export default class EditSession extends BaseSession {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -7,7 +7,7 @@ import { TBoolean, TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import BaseComplexMember from './BaseComplexMember';
-import DocSession from './DocSession';
+import EditSession from './EditSession';
 import FileAccess from './FileAccess';
 import FileBootstrap from './FileBootstrap';
 import SessionCache from './SessionCache';
@@ -203,7 +203,7 @@ export default class FileComplex extends BaseComplexMember {
    * @returns {BaseSession} A newly-constructed session.
    */
   _activateSession(authorId, caretId, canEdit) {
-    const result = new DocSession(this, authorId, caretId, canEdit);
+    const result = new EditSession(this, authorId, caretId, canEdit);
     const fileId = this.file.id;
 
     this._sessions.add(result);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -79,14 +79,14 @@ export default class FileComplex extends BaseComplexMember {
    * Finds and returns a session to control a pre-existing caret on the document
    * managed by this instance. More specifically, the caret has to exist in the
    * caret part of the file, but there doesn't have to already be a
-   * {@link DocSession} object in this process which represents it.
+   * {@link BaseSession} object in this process which represents it.
    *
    * @param {string} authorId ID of the author.
    * @param {string} caretId ID of the caret.
    * @param {boolean} canEdit `true` if the session is to allow changes to be
    *   made through it, or `false` if not (that is, `false` for a view-only
    *   session).
-   * @returns {DocSession} A session object to control the indicated
+   * @returns {BaseSession} A session object to control the indicated
    *   pre-existing caret.
    * @throws {InfoError} Thrown with name `badId` specifically if the caret is
    *   not found (including if it exists but is controlled by a different
@@ -152,7 +152,7 @@ export default class FileComplex extends BaseComplexMember {
    * @param {boolean} canEdit `true` if the session is to allow changes to be
    *   made through it, or `false` if not (that is, `false` for a view-only
    *   session).
-   * @returns {DocSession} A newly-constructed session.
+   * @returns {BaseSession} A newly-constructed session.
    */
   async makeNewSession(authorId, canEdit) {
     TString.check(authorId); // Basic type check.
@@ -193,14 +193,14 @@ export default class FileComplex extends BaseComplexMember {
 
   /**
    * Helper for {@link #makeNewSession} and {@link #findExistingSession}, which
-   * does the final setup of a new {@link DocSession} instance.
+   * does the final setup of a new session instance.
    *
    * @param {string} authorId ID of the author.
    * @param {string} caretId ID of the caret.
    * @param {boolean} canEdit `true` if the session is to allow changes to be
    *   made through it, or `false` if not (that is, `false` for a view-only
    *   session).
-   * @returns {DocSession} A newly-constructed session.
+   * @returns {BaseSession} A newly-constructed session.
    */
   _activateSession(authorId, caretId, canEdit) {
     const result = new DocSession(this, authorId, caretId, canEdit);

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -8,9 +8,9 @@ import { Errors } from '@bayou/util-common';
 
 import BaseComplexMember from './BaseComplexMember';
 import DocSession from './DocSession';
-import DocSessionCache from './DocSessionCache';
 import FileAccess from './FileAccess';
 import FileBootstrap from './FileBootstrap';
+import SessionCache from './SessionCache';
 
 /**
  * {Int} Maximum amount of time (in msec) to allow for the creation of new
@@ -45,8 +45,8 @@ export default class FileComplex extends BaseComplexMember {
      */
     this._bootstrap = new FileBootstrap(this.fileAccess);
 
-    /** {DocSessionCache} Cache of session instances, mapped from caret IDs. */
-    this._sessions = new DocSessionCache(this.fileAccess.log);
+    /** {SessionCache} Cache of session instances, mapped from caret IDs. */
+    this._sessions = new SessionCache(this.fileAccess.log);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/SessionCache.js
+++ b/local-modules/@bayou/doc-server/SessionCache.js
@@ -10,7 +10,7 @@ import DocSession from './DocSession';
 /**
  * Cache of active instances of {@link DocSession}.
  */
-export default class DocSessionCache extends BaseCache {
+export default class SessionCache extends BaseCache {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/SessionCache.js
+++ b/local-modules/@bayou/doc-server/SessionCache.js
@@ -5,10 +5,10 @@
 import { CaretId } from '@bayou/doc-common';
 import { BaseCache } from '@bayou/weak-lru-cache';
 
-import DocSession from './DocSession';
+import BaseSession from './BaseSession';
 
 /**
- * Cache of active instances of {@link DocSession}.
+ * Cache of active instances of {@link BaseSession}.
  */
 export default class SessionCache extends BaseCache {
   /**
@@ -22,7 +22,7 @@ export default class SessionCache extends BaseCache {
 
   /** @override */
   get _impl_cachedClass() {
-    return DocSession;
+    return BaseSession;
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/index.js
+++ b/local-modules/@bayou/doc-server/index.js
@@ -9,7 +9,7 @@ import BodyControl from './BodyControl';
 import BodyDeltaHtml from './BodyDeltaHtml';
 import CaretControl from './CaretControl';
 import DocServer from './DocServer';
-import DocSession from './DocSession';
+import EditSession from './EditSession';
 import DurableControl from './DurableControl';
 import EphemeralControl from './EphemeralControl';
 import FileAccess from './FileAccess';
@@ -26,7 +26,7 @@ export {
   BodyDeltaHtml,
   CaretControl,
   DocServer,
-  DocSession,
+  EditSession,
   DurableControl,
   EphemeralControl,
   FileAccess,

--- a/local-modules/@bayou/injecty/InjectHandler.js
+++ b/local-modules/@bayou/injecty/InjectHandler.js
@@ -30,7 +30,7 @@ export default class InjectHandler extends BaseProxyHandler {
    * if an attempt is made to store to a given name more than once.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property The property name.
+   * @param {string|Symbol} property The property name.
    * @param {*} value The new property value.
    * @param {object} receiver_unused The original receiver of the request.
    * @returns {boolean} `true`, always.

--- a/local-modules/@bayou/injecty/UseHandler.js
+++ b/local-modules/@bayou/injecty/UseHandler.js
@@ -30,7 +30,7 @@ export default class UseHandler extends BaseProxyHandler {
    * if an attempt is made to get a property name that was never stored to.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property The property name.
+   * @param {string|Symbol} property The property name.
    * @param {object} receiver_unused The original receiver of the request.
    * @returns {*} The property, or `undefined` if there is no such property
    *   defined.

--- a/local-modules/@bayou/promise-util/EmitHandler.js
+++ b/local-modules/@bayou/promise-util/EmitHandler.js
@@ -43,7 +43,7 @@ export default class EmitHandler extends MethodCacheProxyHandler {
   /**
    * Implementation as required by the superclass.
    *
-   * @param {string} name The method name.
+   * @param {string|Symbol} name The method name.
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -37,6 +37,11 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {
+    if (typeof name === 'symbol') {
+      const rawName = name.toString().replace(/^Symbol\(|\)$/g, '');
+      name = `symbol-${rawName}`;
+    }
+
     return (...args) => {
       this._logFunction(name, ...args);
     };

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TFunction } from '@bayou/typecheck';
 import { MethodCacheProxyHandler } from '@bayou/util-common';
 
@@ -37,7 +39,17 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {
-    if (typeof name === 'symbol') {
+    if (name === inspect.custom) {
+      // Very special case: We're being asked for the method for the standard
+      // "custom inspector" function. Return a straightforward implementation.
+      // This makes it possible to call `util.inspect` on a proxy made from an
+      // instance of this class and get a reasonably useful result (instead of
+      // calling through to the `_logFunction` and logging something
+      // inscrutable), which is a case that _has_ arisen in practice (while
+      // debugging).
+      return '[object LogProxy]';
+    } else if (typeof name === 'symbol') {
+      // Make a valid label out of the symbol's name.
       const rawName = name.toString().replace(/^Symbol\(|\)$/g, '');
       name = `symbol-${rawName}`;
     }

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -39,16 +39,7 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {
-    if (name === inspect.custom) {
-      // Very special case: We're being asked for the method for the standard
-      // "custom inspector" function. Return a straightforward implementation.
-      // This makes it possible to call `util.inspect` on a proxy made from an
-      // instance of this class and get a reasonably useful result (instead of
-      // calling through to the `_logFunction` and logging something
-      // inscrutable), which is a case that _has_ arisen in practice (while
-      // debugging).
-      return () => '[object LogProxy]';
-    } else if (typeof name === 'symbol') {
+    if (typeof name === 'symbol') {
       // Make a valid label out of the symbol's name.
       const rawName = name.toString().replace(/^Symbol\(|\)$/g, '');
       name = `symbol-${rawName}`;

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -2,8 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { inspect } from 'util';
-
 import { TFunction } from '@bayou/typecheck';
 import { MethodCacheProxyHandler } from '@bayou/util-common';
 

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -47,7 +47,7 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
       // calling through to the `_logFunction` and logging something
       // inscrutable), which is a case that _has_ arisen in practice (while
       // debugging).
-      return '[object LogProxy]';
+      return () => '[object LogProxy]';
     } else if (typeof name === 'symbol') {
       // Make a valid label out of the symbol's name.
       const rawName = name.toString().replace(/^Symbol\(|\)$/g, '');

--- a/local-modules/@bayou/see-all/LogProxyHandler.js
+++ b/local-modules/@bayou/see-all/LogProxyHandler.js
@@ -33,7 +33,7 @@ export default class LogProxyHandler extends MethodCacheProxyHandler {
   /**
    * Makes a method handler for the given method name.
    *
-   * @param {string} name The method name.
+   * @param {string|Symbol} name The method name.
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -191,12 +191,15 @@ describe('@bayou/typecheck/TString', () => {
       test('A');
       test('_');
       test('-');
+      test('.');
       test('blort');
       test('florp_like');
       test('florp-like');
+      test('florp.like');
       test('x9');
       test('_0123456789_');
       test('-0123456789-');
+      test('.0123456789.');
       test('abcdefghijklmnopqrstuvwxyz');
       test('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
     });

--- a/local-modules/@bayou/util-common/BaseProxyHandler.js
+++ b/local-modules/@bayou/util-common/BaseProxyHandler.js
@@ -86,7 +86,7 @@ export default class BaseProxyHandler extends CommonBase {
    * Standard `Proxy` handler method.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
+   * @param {string|Symbol} property_unused The property name.
    * @param {object} descriptor_unused The property descriptor.
    * @returns {boolean} `false`, always.
    */
@@ -109,7 +109,7 @@ export default class BaseProxyHandler extends CommonBase {
    * Standard `Proxy` handler method.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
+   * @param {string|Symbol} property_unused The property name.
    * @param {object} receiver_unused The original receiver of the request.
    * @returns {undefined} `undefined`, always.
    */
@@ -121,7 +121,7 @@ export default class BaseProxyHandler extends CommonBase {
    * Standard `Proxy` handler method.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
+   * @param {string|Symbol} property_unused The property name.
    */
   getOwnPropertyDescriptor(target_unused, property_unused) {
     throw Errors.badUse('Unsupported proxy operation.');
@@ -155,7 +155,7 @@ export default class BaseProxyHandler extends CommonBase {
    * Standard `Proxy` handler method.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
+   * @param {string|Symbol} property_unused The property name.
    * @returns {boolean} `false`, always.
    */
   has(target_unused, property_unused) {
@@ -196,7 +196,7 @@ export default class BaseProxyHandler extends CommonBase {
    * Standard `Proxy` handler method.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property_unused The property name.
+   * @param {string|Symbol} property_unused The property name.
    * @param {*} value_unused The new property value.
    * @param {object} receiver_unused The original receiver of the request.
    * @returns {boolean} `false`, always.

--- a/local-modules/@bayou/util-common/DeferredLoader.js
+++ b/local-modules/@bayou/util-common/DeferredLoader.js
@@ -51,7 +51,7 @@ export default class DeferredLoader extends BaseProxyHandler {
    *
    * @param {object} target_unused The proxy's target (which is always a frozen
    *   empty object in this case).
-   * @param {string} property Name of the property (or method) to get.
+   * @param {string|Symbol} property Name of the property (or method) to get.
    * @param {object} receiver_unused The original message receiver (which is
    *   always `this` in this case).
    * @returns {*} The value of the named property in the target object.

--- a/local-modules/@bayou/util-common/MethodCacheProxyHandler.js
+++ b/local-modules/@bayou/util-common/MethodCacheProxyHandler.js
@@ -2,6 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { inspect } from 'util';
+
 import { TFunction } from '@bayou/typecheck';
 
 import BaseProxyHandler from './BaseProxyHandler';
@@ -23,13 +25,20 @@ const VERBOTEN_METHODS = new Set([
  * computed methods, along with a subclass hole to be filled in for how to
  * compute those methods in the first place.
  *
- * As a special case, this class refuses to proxy properties named
- * `constructor`, `then`, or `catch`. The former if proxied can confuse the
- * system into thinking what's being proxied is a class. The latter two can
- * confuse the system into thinking that what's being proxied is a promise.
- * (Duck typing FTL!) Though in the larger sense it is okay to proxy these
- * things, the usual case &mdash; and the one supported by this class &mdash; is
- * that what's proxied is just a plain-old-instance filled with normal methods.
+ * As special cases:
+ *
+ * * This class refuses to proxy properties named `constructor`, `then`, or
+ *   `catch`. The former if proxied can confuse the system into thinking what's
+ *   being proxied is a class. The latter two can confuse the system into
+ *   thinking that what's being proxied is a promise. (Duck typing FTL!) Though
+ *   in the larger sense it is okay to proxy these things, the usual case
+ *   &mdash; and the one supported by this class &mdash; is that what's proxied
+ *   is just a plain-old-instance filled with normal methods.
+ *
+ * * This class returns a simple but useful (and non-confusing) implementation
+ *   when asked for the standard "custom inspection" function
+ *   `util.inspect.custom`. This is done instead of letting the subclass make
+ *   what would no doubt turn out to be a confusing handler function.
  *
  * Use this class by making a subclass, filling in the `_impl`, and constructing
  * a `Proxy` with an instance of it as the handler. The "target" of the proxy is
@@ -67,6 +76,15 @@ export default class MethodCacheProxyHandler extends BaseProxyHandler {
     } else if (VERBOTEN_METHODS.has(property)) {
       // This property is on the blacklist of ones to never proxy.
       return undefined;
+    } else if (property === inspect.custom) {
+      // Very special case: We're being asked for the method for the standard
+      // "custom inspector" function. Return a straightforward implementation.
+      // This makes it possible to call `util.inspect` on a proxy made from an
+      // instance of this class and get a reasonably useful result (instead of
+      // calling through to the `_impl` and doing something totally
+      // inscrutable), which is a case that _has_ arisen in practice (while
+      // debugging).
+      return () => '[object Proxy]';
     } else {
       // The property is allowed to be proxied. Set up and cache a handler for
       // it.

--- a/local-modules/@bayou/util-common/MethodCacheProxyHandler.js
+++ b/local-modules/@bayou/util-common/MethodCacheProxyHandler.js
@@ -54,7 +54,7 @@ export default class MethodCacheProxyHandler extends BaseProxyHandler {
    * to generate method handlers that aren't yet cached.
    *
    * @param {object} target_unused The proxy target.
-   * @param {string} property The property name.
+   * @param {string|Symbol} property The property name.
    * @param {object} receiver_unused The original receiver of the request.
    * @returns {*} The property, or `undefined` if there is no such property
    *   defined.
@@ -81,7 +81,7 @@ export default class MethodCacheProxyHandler extends BaseProxyHandler {
    * ultimately get called by client code as a method on a proxy instance.
    *
    * @abstract
-   * @param {string} name The method name.
+   * @param {string|Symbol} name The method name.
    * @returns {function} An appropriately-constructed handler.
    */
   _impl_methodFor(name) {

--- a/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
+++ b/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
@@ -4,6 +4,7 @@
 
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
+import { inspect } from 'util';
 
 import { MethodCacheProxyHandler } from '@bayou/util-common';
 
@@ -65,6 +66,14 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
       const prom = new Promise(() => { /*empty*/ });
       assert.isUndefined(th.get(prom, 'then'));
       assert.isUndefined(th.get(prom, 'catch'));
+    });
+
+    it('returns the expected special-case `inspect.custom` implementation', () => {
+      const handler    = new MethodCacheProxyHandler();
+      const proxy      = new Proxy({}, handler);
+      const customFunc = proxy[inspect.custom];
+
+      assert.strictEqual(customFunc(), '[object Proxy]');
     });
 
     it('should return a function gotten from a call to the `_impl`', () => {

--- a/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
+++ b/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
@@ -68,13 +68,17 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
       assert.isUndefined(th.get(prom, 'catch'));
     });
 
-    it('returns the expected special-case `inspect.custom` implementation', () => {
-      const handler    = new MethodCacheProxyHandler();
-      const proxy      = new Proxy({}, handler);
-      const customFunc = proxy[inspect.custom];
+    // `if` to prevent this test from being active on the browser client,
+    // because the `util.inspect` shim doesn't deal properly with `custom`.
+    if (typeof inspect.custom === 'symbol') {
+      it('returns the expected special-case `inspect.custom` implementation', () => {
+        const handler    = new MethodCacheProxyHandler();
+        const proxy      = new Proxy({}, handler);
+        const customFunc = proxy[inspect.custom];
 
-      assert.strictEqual(customFunc(), '[object Proxy]');
-    });
+        assert.strictEqual(customFunc(), '[object Proxy]');
+      });
+    }
 
     it('returns a function gotten from a call to the `_impl`', () => {
       const handler = new MethodCacheProxyHandler();

--- a/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
+++ b/local-modules/@bayou/util-common/tests/test_MethodCacheProxyHandler.js
@@ -20,13 +20,13 @@ class ThrowingHandler extends MethodCacheProxyHandler {
 
 describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   describe('constructor', () => {
-    it('should construct an instance', () => {
+    it('constructs an instance', () => {
       assert.doesNotThrow(() => new MethodCacheProxyHandler());
     });
   });
 
   describe('apply()', () => {
-    it('should always throw', () => {
+    it('throws', () => {
       const func = () => { throw new Error('should not have been called'); };
       const th = new ThrowingHandler();
       const proxy = new Proxy(func, th);
@@ -35,7 +35,7 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   });
 
   describe('construct()', () => {
-    it('should always throw', () => {
+    it('throws', () => {
       const func = () => { throw new Error('should not have been called'); };
       const th = new ThrowingHandler();
       const proxy = new Proxy(func, th);
@@ -44,21 +44,21 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   });
 
   describe('defineProperty()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const th = new ThrowingHandler();
       assert.isFalse(th.defineProperty({}, 'blort', { value: 123 }));
     });
   });
 
   describe('deleteProperty()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const th = new ThrowingHandler();
       assert.isFalse(th.deleteProperty({ blort: 10 }, 'blort'));
     });
   });
 
   describe('get()', () => {
-    it('should return `undefined` for verboten property names', () => {
+    it('returns `undefined` for verboten property names', () => {
       const th = new ThrowingHandler();
 
       assert.isUndefined(th.get(Map, 'constructor'));
@@ -76,7 +76,7 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
       assert.strictEqual(customFunc(), '[object Proxy]');
     });
 
-    it('should return a function gotten from a call to the `_impl`', () => {
+    it('returns a function gotten from a call to the `_impl`', () => {
       const handler = new MethodCacheProxyHandler();
       const proxy   = new Proxy({}, handler);
 
@@ -90,7 +90,7 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
       assert.strictEqual(result.blorp, 'blorp-bloop');
     });
 
-    it('should return the same function upon a second-or-more call with the same name', () => {
+    it('returns the same function upon a second-or-more call with the same name', () => {
       const handler = new MethodCacheProxyHandler();
       const proxy   = new Proxy({}, handler);
 
@@ -113,14 +113,14 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   });
 
   describe('getOwnPropertyDescriptor()', () => {
-    it('should always throw', () => {
+    it('throws', () => {
       const th = new ThrowingHandler();
       assert.throws(() => th.getOwnPropertyDescriptor({ blort: 123 }, 'blort'));
     });
   });
 
   describe('getPrototypeOf()', () => {
-    it('should return the target\'s prototype', () => {
+    it('returns the target\'s prototype', () => {
       const th = new ThrowingHandler();
       const obj = new Map();
       assert.strictEqual(th.getPrototypeOf(obj), Object.getPrototypeOf(obj));
@@ -128,35 +128,35 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   });
 
   describe('has()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const th = new ThrowingHandler();
       assert.isFalse(th.has({ blort: 10 }, 'blort'));
     });
   });
 
   describe('isExtensible()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const th = new ThrowingHandler();
       assert.isFalse(th.isExtensible({}));
     });
   });
 
   describe('ownKeys()', () => {
-    it('should always return `[]`', () => {
+    it('returns `[]`', () => {
       const th = new ThrowingHandler();
       assert.deepEqual(th.ownKeys({ a: 10, b: 20 }), []);
     });
   });
 
   describe('preventExstensions()', () => {
-    it('should always return `true`', () => {
+    it('returns `true`', () => {
       const th = new ThrowingHandler();
       assert.isTrue(th.preventExtensions({}));
     });
   });
 
   describe('set()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const func = () => { throw new Error('should not have been called'); };
       const th = new ThrowingHandler();
       const proxy = new Proxy(func, th);
@@ -165,7 +165,7 @@ describe('@bayou/util-common/MethodCacheProxyHandler', () => {
   });
 
   describe('setPrototypeOf()', () => {
-    it('should always return `false`', () => {
+    it('returns `false`', () => {
       const th = new ThrowingHandler();
 
       assert.isFalse(th.setPrototypeOf({}, null));

--- a/local-modules/@bayou/util-core/CoreTypecheck.js
+++ b/local-modules/@bayou/util-core/CoreTypecheck.js
@@ -20,7 +20,7 @@ export default class CoreTypecheck extends UtilityClass {
    */
   static checkIdentifier(value) {
     try {
-      return CoreTypecheck.checkString(value, /^[a-zA-Z_][a-zA-Z_0-9]*$/);
+      return CoreTypecheck.checkString(value, /^[_a-zA-Z][_a-zA-Z0-9]*$/);
     } catch (e) {
       // More accurate error.
       throw Errors.badValue(value, String, 'identifier syntax');
@@ -72,14 +72,14 @@ export default class CoreTypecheck extends UtilityClass {
   /**
    * Checks that a value is of type `string` and has the usual form of a
    * "label-like thing" in programming. This is the same as an identifier,
-   * except that dashes are allowed throughout.
+   * except that dashes and periods are allowed throughout.
    *
    * @param {*} value Value to check.
    * @returns {string} `value`.
    */
   static checkLabel(value) {
     try {
-      return CoreTypecheck.checkString(value, /^[-a-zA-Z_][-a-zA-Z_0-9]*$/);
+      return CoreTypecheck.checkString(value, /^[-._a-zA-Z][-._a-zA-Z0-9]*$/);
     } catch (e) {
       // More accurate error.
       throw Errors.badValue(value, String, 'label syntax');

--- a/local-modules/@bayou/util-core/tests/test_CoreTypecheck.js
+++ b/local-modules/@bayou/util-core/tests/test_CoreTypecheck.js
@@ -255,12 +255,15 @@ describe('@bayou/util-core/CoreTypecheck', () => {
       test('A');
       test('_');
       test('-');
+      test('.');
       test('blort');
       test('florp_like');
       test('florp-like');
+      test('florp.like');
       test('x9');
       test('_0123456789_');
       test('-0123456789-');
+      test('.0123456789.');
       test('abcdefghijklmnopqrstuvwxyz');
       test('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
     });


### PR DESCRIPTION
This PR represents all the refactoring that I think is going to be needed to make it possible to separate out a `ViewSession` class from (what used to be) `DocSession`. The main things are that I extracted a base class `BaseSession` out of `DocSession` and then renamed `DocSession` to `EditSession`.

But in the process of debugging this, I ran into a bit of logging weirdness, which led me on the yak shaves of:

* Make `MethodProxyHandler` do something special (and reasonable) so that `util.inspect()` doesn't go all wonky when handed a proxy handled by an instance of it.
* Fix up `LogProxyHandler` to deal with the possibility of symbol-named properties. (Not that this should ever happen in a _non-buggy_ system, but it did help me diagnose a problem.)
* Expanded the syntax of "labels" to include dots (because of the previous item).
