### PR TITLE
Start writing stored snapshots again.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1159,6 +1159,7 @@ export default class BaseControl extends BaseDataManager {
       this.log.event.writingStoredSnapshot(revNum);
 
       const snapshot = await this.getSnapshot(revNum);
+
       await this._writeStoredSnapshot(snapshot);
       this.log.event.wroteStoredSnapshot(revNum);
     } catch (e) {
@@ -1206,7 +1207,8 @@ export default class BaseControl extends BaseDataManager {
       fileOps.push(FileOp.op_deletePathRange(this.constructor.changePathPrefix, 0, deleteBefore));
     }
 
-    const fileChange = new FileChange(snapshot.revNum + 1, fileOps);
+    const fileRevNum = await file.currentRevNum(timeoutMsec);
+    const fileChange = new FileChange(fileRevNum.revNum + 1, fileOps);
     const success    = await file.appendChange(fileChange, timeoutMsec);
 
     // `success === false` indicates a lost append race. Turn it into an

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1166,7 +1166,7 @@ export default class BaseControl extends BaseDataManager {
       // "ephemeral" document parts that don't keep full history, and such parts
       // only ever arrange for earlier changes to be erased after a later
       // snapshot is _known_ to be written.
-      this.log.warn(`Trouble writing stored snapshot for revision: r${revNum}`, e);
+      this.log.event.failedToWriteStoredSnapshot(revNum, e);
     }
 
     this.log.event.wroteStoredSnapshot(revNum);

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1165,9 +1165,7 @@ export default class BaseControl extends BaseDataManager {
       // a best-effort basis. To the extent that they're required, it's only for
       // "ephemeral" document parts that don't keep full history, and such parts
       // only ever arrange for earlier changes to be erased after a later
-      // snapshot is _known_ to be written. (**Note::** As of this writing,
-      // there aren't yet any ephemeral document parts, though the caret info is
-      // slated to become one.)
+      // snapshot is _known_ to be written.
       this.log.warn(`Trouble writing stored snapshot for revision: r${revNum}`, e);
     }
 

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1210,8 +1210,6 @@ export default class BaseControl extends BaseDataManager {
     const fileChange = new FileChange(snapshot.revNum + 1, fileOps);
 
     await file.appendChange(fileChange, timeoutMsec);
-
-    this.log.event.wroteStoredSnapshot(`r${snapshot.revNum}`);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1188,7 +1188,8 @@ export default class BaseControl extends BaseDataManager {
    */
   async _writeStoredSnapshot(snapshot, timeoutMsec = null) {
     const clazz = this.constructor;
-    const path = clazz.storedSnapshotPath;
+    const path  = clazz.storedSnapshotPath;
+    const file  = this.fileCodec.file;
     const codec = this.fileCodec.codec;
 
     clazz.snapshotClass.check(snapshot);
@@ -1210,7 +1211,7 @@ export default class BaseControl extends BaseDataManager {
 
     const fileChange = new FileChange(snapshot.revNum + 1, fileOps);
 
-    await this._appendChangeWithRetry(fileChange, timeoutMsec);
+    await file.appendChange(fileChange, timeoutMsec);
 
     this.log.event.wroteStoredSnapshot(`r${snapshot.revNum}`);
   }

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -40,7 +40,7 @@ const MAX_COMPOSED_CHANGES_FOR_DIFF = 100;
  * snapshots will always have a revision number that is an integral multiple of
  * this value.
  */
-const CHANGES_PER_STORED_SNAPSHOT = 100;
+const CHANGES_PER_STORED_SNAPSHOT = 1000;
 
 /**
  * Base class for document part controllers. There is one instance of each

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1208,7 +1208,7 @@ export default class BaseControl extends BaseDataManager {
     }
 
     const fileRevNum = await file.currentRevNum(timeoutMsec);
-    const fileChange = new FileChange(fileRevNum.revNum + 1, fileOps);
+    const fileChange = new FileChange(fileRevNum + 1, fileOps);
     const success    = await file.appendChange(fileChange, timeoutMsec);
 
     // `success === false` indicates a lost append race. Turn it into an

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -595,7 +595,7 @@ export default class BaseControl extends BaseDataManager {
 
     const storedSnapshot = codec.decodeJsonBuffer(encodedStoredSnapshot);
     clazz.snapshotClass.check(storedSnapshot);
-    this.log.event.gotStoredSnapshot(`r${storedSnapshot.revNum}`);
+    this.log.event.gotStoredSnapshot(storedSnapshot.revNum);
 
     return storedSnapshot;
   }
@@ -1160,6 +1160,7 @@ export default class BaseControl extends BaseDataManager {
 
       const snapshot = await this.getSnapshot(revNum);
       await this._writeStoredSnapshot(snapshot);
+      this.log.event.wroteStoredSnapshot(revNum);
     } catch (e) {
       // Though unfortunate, this isn't tragic: Stored snapshots are created on
       // a best-effort basis. To the extent that they're required, it's only for
@@ -1168,8 +1169,6 @@ export default class BaseControl extends BaseDataManager {
       // snapshot is _known_ to be written.
       this.log.event.failedToWriteStoredSnapshot(revNum, e);
     }
-
-    this.log.event.wroteStoredSnapshot(revNum);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1207,8 +1207,13 @@ export default class BaseControl extends BaseDataManager {
     }
 
     const fileChange = new FileChange(snapshot.revNum + 1, fileOps);
+    const success    = await file.appendChange(fileChange, timeoutMsec);
 
-    await file.appendChange(fileChange, timeoutMsec);
+    // `success === false` indicates a lost append race. Turn it into an
+    // exception here, so that our caller can react appropriately.
+    if (!success) {
+      throw Errors.revisionNotAvailable(fileChange.revNum);
+    }
   }
 
   /**


### PR DESCRIPTION
An earlier PR removed the private method `BaseControl._appendChangeWithRetry()` but missed one spot where it was called. Replacing it with a direct call to `BaseFile.appendChange()` revealed another problem with how the change to store the snapshot was being performed. This PR fixes all that.

In addition to the main fix, I changed the number of changes between writing of stored snapshots to be 1000 instead of 100. The original 100 number was picked so that a multiple-change composition operation wouldn't take too long. In the mean time, I made multiple-change composition much faster, which makes it possible to compose significantly more changes without being too slow. This also makes there be less garbage in the file in need of cleanup. (This is a good thing because we still don't do file GC.)

FYI, here's the server log of the failure (which I noticed while looking at a different issue):

```
[doc W] [blorp caret]           
  Trouble writing stored snapshot for revision: r1100
  TypeError: this._appendChangeWithRetry is not a function
     CaretControl._appendChangeWithRetry [as _writeStoredSnapshot] 
+ (.../@bayou/doc-server/BaseControl.js:1213:16)
     CaretControl._writeStoredSnapshot [as _maybeWriteStoredSnapshot] 
+ (.../@bayou/doc-server/BaseControl.js:1162:18)
```

The commit that got us unhappy was made around 11-feb-2019.