### PR TITLE
Enable view-only sessions.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -5,7 +5,7 @@
 import { Storage } from '@bayou/config-server';
 import { CaretId } from '@bayou/doc-common';
 import { TBoolean } from '@bayou/typecheck';
-import { CommonBase, Errors } from '@bayou/util-common';
+import { CommonBase } from '@bayou/util-common';
 
 import FileComplex from './FileComplex';
 
@@ -38,11 +38,6 @@ export default class BaseSession extends CommonBase {
 
     /** {boolean} Whether or not this instance allows edits. */
     this._canEdit = TBoolean.check(this._impl_canEdit());
-
-    // **TODO:** Remove this restriction!
-    if (!this._canEdit) {
-      throw Errors.wtf('View-only sessions not yet supported!');
-    }
 
     /** {BodyControl} The underlying body content controller. */
     this._bodyControl = fileComplex.bodyControl;

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -23,11 +23,8 @@ export default class BaseSession extends CommonBase {
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
-   * @param {boolean} canEdit Whether (`true`) or not (`false`) the instance is
-   *   to allow editing to happen through it. That is, `false` indicates a
-   *   view-only session.
    */
-  constructor(fileComplex, authorId, caretId, canEdit) {
+  constructor(fileComplex, authorId, caretId) {
     super();
 
     /** {FileComplex} File complex that this instance is part of. */
@@ -40,10 +37,10 @@ export default class BaseSession extends CommonBase {
     this._caretId = CaretId.check(caretId);
 
     /** {boolean} Whether or not this instance allows edits. */
-    this._canEdit = TBoolean.check(canEdit);
+    this._canEdit = TBoolean.check(this._impl_canEdit());
 
     // **TODO:** Remove this restriction!
-    if (!canEdit) {
+    if (!this._canEdit) {
       throw Errors.wtf('View-only sessions not yet supported!');
     }
 
@@ -183,5 +180,18 @@ export default class BaseSession extends CommonBase {
    */
   logEvent(name, ...args) {
     this._clientLog.event[name](...args);
+  }
+
+  /**
+   * Subclass-specific implementation which underlies {@link #canEdit}. This
+   * method is called exactly once during instance construction. Subclasses must
+   * override this method.
+   *
+   * @abstract
+   * @returns {boolean} `true` if the instance allows editing, or `false` if
+   *   not.
+   */
+  _impl_canEdit() {
+    return this._mustOverride();
   }
 }

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -5,17 +5,15 @@
 import { BodyChange, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 
-import BaseSession from './BaseSession';
+import ViewSession from './ViewSession';
 
 /**
- * Server side representative of a session which allows editing (and temporarily
- * has an affordance for disabling editing to make a view-only session).
+ * Server side representative of a session which allows editing.
  *
- * For access methods, this passes non-mutating methods through to the
- * underlying `*Control` instances, while implicitly adding author ID and/or
- * caret ID as appropriate to methods that perform modifications.
+ * See header comment on superclass {@link ViewSession} for a salient design
+ * note.
  */
-export default class EditSession extends BaseSession {
+export default class EditSession extends ViewSession {
   /**
    * Constructs an instance.
    *
@@ -23,50 +21,11 @@ export default class EditSession extends BaseSession {
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
-   * @param {boolean} canEdit_unused About to go away.
    */
-  constructor(fileComplex, authorId, caretId, canEdit_unused) {
+  constructor(fileComplex, authorId, caretId) {
     super(fileComplex, authorId, caretId);
 
     Object.freeze(this);
-  }
-
-  /**
-   * Returns a particular change to the document body. See the equivalent
-   * {@link BodyControl#getChange} for details.
-   *
-   * @param {Int} revNum The revision number of the change.
-   * @returns {BodyChange} The requested change.
-   */
-  async body_getChange(revNum) {
-    return this._bodyControl.getChange(revNum);
-  }
-
-  /**
-   * Gets a change of the document body from the indicated base revision. See
-   * {@link BodyControl#getChangeAfter} for details.
-   *
-   * @param {Int} baseRevNum Revision number for the document.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
-   * @returns {BodyChange} Delta and associated information.
-   */
-  async body_getChangeAfter(baseRevNum, timeoutMsec = null) {
-    return this._bodyControl.getChangeAfter(baseRevNum, timeoutMsec);
-  }
-
-  /**
-   * Returns a snapshot of the full document body contents. See
-   * {@link BodyControl#snapshot} for details.
-   *
-   * @param {Int|null} [revNum = null] Which revision to get. If passed as
-   *   `null`, indicates the latest (most recent) revision.
-   * @returns {BodySnapshot} The requested snapshot.
-   */
-  async body_getSnapshot(revNum = null) {
-    return this._bodyControl.getSnapshot(revNum);
   }
 
   /**
@@ -98,136 +57,6 @@ export default class EditSession extends BaseSession {
     this._bodyControl.queueHtmlExport(bodyChangeResult.revNum, documentId);
 
     return bodyChangeResult;
-  }
-
-  /**
-   * Gets a change of caret information from the indicated base caret revision.
-   * This will throw an error if the indicated caret revision isn't available,
-   * in which case the client will likely want to use `caret_getSnapshot()` to
-   * get back in synch.
-   *
-   * **Note:** Caret information and the document body have _separate_ revision
-   * numbers. `CaretSnapshot` instances have information about both revision
-   * numbers.
-   *
-   * **Note:** Caret information is only maintained ephemerally, so it is
-   * common for it not to be available for other than just a few recent
-   * revisions.
-   *
-   * @param {Int} baseRevNum Revision number for the caret information which
-   *   will form the basis for the result. If `baseRevNum` is the current
-   *   revision number, this method will block until a new revision is
-   *   available.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
-   * @returns {CaretDelta} Delta from the base caret revision to a newer one.
-   *   Applying this result to a `CaretSnapshot` for `baseRevNum` will produce
-   *  an up-to-date snapshot.
-   */
-  async caret_getChangeAfter(baseRevNum, timeoutMsec = null) {
-    return this._caretControl.getChangeAfter(baseRevNum, timeoutMsec);
-  }
-
-  /**
-   * Gets a snapshot of all active caret information. This will throw an error
-   * if the indicated caret revision isn't available.
-   *
-   * **Note:** Caret information is only maintained ephemerally, so it is
-   * common for it not to be available for other than just a few recent
-   * revisions.
-   *
-   * @param {Int|null} [revNum = null] Which caret revision to get. If passed as
-   *   `null`, indicates the latest (most recent) revision.
-   * @returns {CaretSnapshot} Snapshot of all the active carets.
-   */
-  async caret_getSnapshot(revNum = null) {
-    return this._caretControl.getSnapshot(revNum);
-  }
-
-  /**
-   * Informs the system of the client's current caret or text selection extent.
-   * This should be called by clients when they notice user activity that
-   * changes the selection. More specifically, Quill's `selection-change`
-   * events are expected to drive calls to this method. The `index` and `length`
-   * arguments to this method have the same semantics as they have in Quill,
-   * that is, they ultimately refer to an extent within a Quill `Delta`.
-   *
-   * @param {Int} docRevNum The _document_ revision number that this information
-   *   is with respect to.
-   * @param {Int} index Caret position (if no selection per se) or starting
-   *   caret position of the selection.
-   * @param {Int} [length = 0] If non-zero, length of the selection.
-   * @returns {CaretChange} The correction to the implied expected result of
-   *   this operation. The `delta` of this result can be applied to the expected
-   *   result to get the actual result. The `timestamp` and `authorId` of the
-   *   result will always be `null`. The promise resolves sometime after the
-   *   change has been applied to the caret state.
-   */
-  async caret_update(docRevNum, index, length = 0) {
-    const snapshot = await this._caretControl.getSnapshot();
-
-    if (snapshot.getOrNull(this._caretId) === null) {
-      // The caret isn't actually represented in the caret snapshot. This is
-      // unexpected -- the code which sets up a session is supposed to ensure
-      // that the associated caret is represented in the file before the client
-      // ever has a chance to send an update -- but we can recover: We note the
-      // issue as a warning, and store a new caret first, before applying the
-      // update.
-      const newSessionChange =
-        await this._caretControl.changeForNewCaret(this._caretId, this._authorId);
-
-      this._caretControl.log.warn(`Got update for caret \`${this._caretId}\` before it was set up.`);
-
-      // **TODO:** This should possibly have the same kind of race-loss-retry
-      // logic as seen elsewhere in the codebase. However, for now -- and
-      // perhaps forever -- this is probably fine, because this whole situation
-      // isn't ever supposed to happen anyway.
-      await this._caretControl.update(newSessionChange);
-    }
-
-    const change =
-      await this._caretControl.changeForUpdate(this._caretId, docRevNum, index, length);
-    return this._caretControl.update(change);
-  }
-
-  /**
-   * Returns a particular change to the properties (document metadata). See
-   * {@link PropertyControl#getChange} for details.
-   *
-   * @param {Int} revNum The revision number of the change.
-   * @returns {PropertyChange} The requested change.
-   */
-  async property_getChange(revNum) {
-    return this._propertyControl.getChange(revNum);
-  }
-
-  /**
-   * Gets a change of the properties (document metadata) from the indicated base
-   * revision. See {@link PropertyControl#getChangeAfter} for details.
-   *
-   * @param {Int} baseRevNum Revision number for the document.
-   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
-   *   this call, in msec. This value will be silently clamped to the allowable
-   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
-   *   allowed value.
-   * @returns {PropertyChange} Delta and associated information.
-   */
-  async property_getChangeAfter(baseRevNum, timeoutMsec = null) {
-    return this._propertyControl.getChangeAfter(baseRevNum, timeoutMsec);
-  }
-
-  /**
-   * Returns a snapshot of the properties (document metadata). See
-   * {@link PropertyControl#snapshot} for details.
-   *
-   * @param {Int|null} [revNum = null] Which revision to get. If passed as
-   *   `null`, indicates the latest (most recent) revision.
-   * @returns {PropertySnapshot} The requested snapshot.
-   */
-  async property_getSnapshot(revNum = null) {
-    return this._propertyControl.getSnapshot(revNum);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -23,12 +23,10 @@ export default class EditSession extends BaseSession {
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
-   * @param {boolean} canEdit Whether (`true`) or not (`false`) the instance is
-   *   to allow editing to happen through it. That is, `false` indicates a
-   *   view-only session.
+   * @param {boolean} canEdit_unused About to go away.
    */
-  constructor(fileComplex, authorId, caretId, canEdit) {
-    super(fileComplex, authorId, caretId, canEdit);
+  constructor(fileComplex, authorId, caretId, canEdit_unused) {
+    super(fileComplex, authorId, caretId);
 
     Object.freeze(this);
   }
@@ -258,5 +256,14 @@ export default class EditSession extends BaseSession {
     const change = new PropertyChange(baseRevNum + 1, delta, Timestamp.now(), this._authorId);
 
     return this._propertyControl.update(change);
+  }
+
+  /**
+   * Subclass-specific implementation which underlies {@link #canEdit}.
+   *
+   * @returns {boolean} `true`, always.
+   */
+  _impl_canEdit() {
+    return true;
   }
 }

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -11,6 +11,7 @@ import EditSession from './EditSession';
 import FileAccess from './FileAccess';
 import FileBootstrap from './FileBootstrap';
 import SessionCache from './SessionCache';
+import ViewSession from './ViewSession';
 
 /**
  * {Int} Maximum amount of time (in msec) to allow for the creation of new
@@ -203,7 +204,9 @@ export default class FileComplex extends BaseComplexMember {
    * @returns {BaseSession} A newly-constructed session.
    */
   _activateSession(authorId, caretId, canEdit) {
-    const result = new EditSession(this, authorId, caretId, canEdit);
+    const result = canEdit
+      ? new EditSession(this, authorId, caretId)
+      : new ViewSession(this, authorId, caretId);
     const fileId = this.file.id;
 
     this._sessions.add(result);

--- a/local-modules/@bayou/doc-server/ViewSession.js
+++ b/local-modules/@bayou/doc-server/ViewSession.js
@@ -1,0 +1,211 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import BaseSession from './BaseSession';
+
+/**
+ * Server side representative of a session which allows viewing. Instantiated
+ * directly it represents a view-only session, but it also has a subclass,
+ * {@link EditSession}.
+ *
+ * **Note:** Instances of this class _do_ have the ability to affect the caret
+ * associated with their session, which _does_ mean that instances can alter
+ * file contents but _not_ anything durable (such as most notably the body).
+ *
+ * For access methods, this passes non-mutating methods through to the
+ * underlying `*Control` instances, while implicitly adding author ID and/or
+ * caret ID as appropriate to methods that perform modifications.
+ */
+export default class ViewSession extends BaseSession {
+  /**
+   * Constructs an instance.
+   *
+   * @param {FileComplex} fileComplex File complex representing the underlying
+   *   file for this instance to use.
+   * @param {string} authorId The author this instance acts on behalf of.
+   * @param {string} caretId Caret ID for this instance.
+   */
+  constructor(fileComplex, authorId, caretId) {
+    super(fileComplex, authorId, caretId);
+
+    Object.freeze(this);
+  }
+
+  /**
+   * Returns a particular change to the document body. See the equivalent
+   * {@link BodyControl#getChange} for details.
+   *
+   * @param {Int} revNum The revision number of the change.
+   * @returns {BodyChange} The requested change.
+   */
+  async body_getChange(revNum) {
+    return this._bodyControl.getChange(revNum);
+  }
+
+  /**
+   * Gets a change of the document body from the indicated base revision. See
+   * {@link BodyControl#getChangeAfter} for details.
+   *
+   * @param {Int} baseRevNum Revision number for the document.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
+   * @returns {BodyChange} Delta and associated information.
+   */
+  async body_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._bodyControl.getChangeAfter(baseRevNum, timeoutMsec);
+  }
+
+  /**
+   * Returns a snapshot of the full document body contents. See
+   * {@link BodyControl#snapshot} for details.
+   *
+   * @param {Int|null} [revNum = null] Which revision to get. If passed as
+   *   `null`, indicates the latest (most recent) revision.
+   * @returns {BodySnapshot} The requested snapshot.
+   */
+  async body_getSnapshot(revNum = null) {
+    return this._bodyControl.getSnapshot(revNum);
+  }
+
+  /**
+   * Gets a change of caret information from the indicated base caret revision.
+   * This will throw an error if the indicated caret revision isn't available,
+   * in which case the client will likely want to use `caret_getSnapshot()` to
+   * get back in synch.
+   *
+   * **Note:** Caret information and the document body have _separate_ revision
+   * numbers. `CaretSnapshot` instances have information about both revision
+   * numbers.
+   *
+   * **Note:** Caret information is only maintained ephemerally, so it is
+   * common for it not to be available for other than just a few recent
+   * revisions.
+   *
+   * @param {Int} baseRevNum Revision number for the caret information which
+   *   will form the basis for the result. If `baseRevNum` is the current
+   *   revision number, this method will block until a new revision is
+   *   available.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
+   * @returns {CaretDelta} Delta from the base caret revision to a newer one.
+   *   Applying this result to a `CaretSnapshot` for `baseRevNum` will produce
+   *  an up-to-date snapshot.
+   */
+  async caret_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._caretControl.getChangeAfter(baseRevNum, timeoutMsec);
+  }
+
+  /**
+   * Gets a snapshot of all active caret information. This will throw an error
+   * if the indicated caret revision isn't available.
+   *
+   * **Note:** Caret information is only maintained ephemerally, so it is
+   * common for it not to be available for other than just a few recent
+   * revisions.
+   *
+   * @param {Int|null} [revNum = null] Which caret revision to get. If passed as
+   *   `null`, indicates the latest (most recent) revision.
+   * @returns {CaretSnapshot} Snapshot of all the active carets.
+   */
+  async caret_getSnapshot(revNum = null) {
+    return this._caretControl.getSnapshot(revNum);
+  }
+
+  /**
+   * Informs the system of the client's current caret or text selection extent.
+   * This should be called by clients when they notice user activity that
+   * changes the selection. More specifically, Quill's `selection-change`
+   * events are expected to drive calls to this method. The `index` and `length`
+   * arguments to this method have the same semantics as they have in Quill,
+   * that is, they ultimately refer to an extent within a Quill `Delta`.
+   *
+   * @param {Int} docRevNum The _document_ revision number that this information
+   *   is with respect to.
+   * @param {Int} index Caret position (if no selection per se) or starting
+   *   caret position of the selection.
+   * @param {Int} [length = 0] If non-zero, length of the selection.
+   * @returns {CaretChange} The correction to the implied expected result of
+   *   this operation. The `delta` of this result can be applied to the expected
+   *   result to get the actual result. The `timestamp` and `authorId` of the
+   *   result will always be `null`. The promise resolves sometime after the
+   *   change has been applied to the caret state.
+   */
+  async caret_update(docRevNum, index, length = 0) {
+    const snapshot = await this._caretControl.getSnapshot();
+
+    if (snapshot.getOrNull(this._caretId) === null) {
+      // The caret isn't actually represented in the caret snapshot. This is
+      // unexpected -- the code which sets up a session is supposed to ensure
+      // that the associated caret is represented in the file before the client
+      // ever has a chance to send an update -- but we can recover: We note the
+      // issue as a warning, and store a new caret first, before applying the
+      // update.
+      const newSessionChange =
+        await this._caretControl.changeForNewCaret(this._caretId, this._authorId);
+
+      this._caretControl.log.warn(`Got update for caret \`${this._caretId}\` before it was set up.`);
+
+      // **TODO:** This should possibly have the same kind of race-loss-retry
+      // logic as seen elsewhere in the codebase. However, for now -- and
+      // perhaps forever -- this is probably fine, because this whole situation
+      // isn't ever supposed to happen anyway.
+      await this._caretControl.update(newSessionChange);
+    }
+
+    const change =
+      await this._caretControl.changeForUpdate(this._caretId, docRevNum, index, length);
+    return this._caretControl.update(change);
+  }
+
+  /**
+   * Returns a particular change to the properties (document metadata). See
+   * {@link PropertyControl#getChange} for details.
+   *
+   * @param {Int} revNum The revision number of the change.
+   * @returns {PropertyChange} The requested change.
+   */
+  async property_getChange(revNum) {
+    return this._propertyControl.getChange(revNum);
+  }
+
+  /**
+   * Gets a change of the properties (document metadata) from the indicated base
+   * revision. See {@link PropertyControl#getChangeAfter} for details.
+   *
+   * @param {Int} baseRevNum Revision number for the document.
+   * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
+   *   this call, in msec. This value will be silently clamped to the allowable
+   *   range as defined by {@link Timeouts}. `null` is treated as the maximum
+   *   allowed value.
+   * @returns {PropertyChange} Delta and associated information.
+   */
+  async property_getChangeAfter(baseRevNum, timeoutMsec = null) {
+    return this._propertyControl.getChangeAfter(baseRevNum, timeoutMsec);
+  }
+
+  /**
+   * Returns a snapshot of the properties (document metadata). See
+   * {@link PropertyControl#snapshot} for details.
+   *
+   * @param {Int|null} [revNum = null] Which revision to get. If passed as
+   *   `null`, indicates the latest (most recent) revision.
+   * @returns {PropertySnapshot} The requested snapshot.
+   */
+  async property_getSnapshot(revNum = null) {
+    return this._propertyControl.getSnapshot(revNum);
+  }
+
+  /**
+   * Subclass-specific implementation which underlies {@link #canEdit}.
+   *
+   * @returns {boolean} `false`, always.
+   */
+  _impl_canEdit() {
+    return false;
+  }
+}


### PR DESCRIPTION
This PR makes it so that the server can now deal with an author/document combo where the author in question only has view access (not edit access) to the document. Specifically, this introduces a middle class in the server-side session hierarchy, which represents view-only sessions. The hierarchy is now `BaseSession` -> `ViewSession` -> `EditSession`. What I did was move all the methods which are valid for view-only sessions into `ViewSession` from `EditSession`, and the latter now only has the edit-specific methods. (**Note:** `ViewSession` still gets to modify its caret, because that's how sessions are tracked.)
