### PR TITLE
Another turn of the `BodyClient` crank.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -120,7 +120,10 @@ export default class BodyClient extends StateMachine {
   constructor(quill, docSession, manageEnabledState = true, pollingDelayMsec = 0) {
     super('detached', docSession.log);
 
-    /** {Quill} Editor object. */
+    /**
+     * {Quill|null} Editor object, or `null` if this instance has been told to
+     * detach.
+     */
     this._quill = quill;
 
     /**
@@ -233,6 +236,7 @@ export default class BodyClient extends StateMachine {
     // regard. What's done here is just an extra layer of protection which will
     // make bugs show up as very-noticeable failed method calls instead of
     // silently and incorrectly succeeding in talking to a server.
+    this._quill        = null;
     this._docSession   = null;
     this._sessionProxy = null;
 

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.3.4
+version = 1.3.5


### PR DESCRIPTION
This PR addresses a couple issues which recently came up, with regards to how `BodyClient` is getting used on the FE.

* Add a new method `hadRecentError()`, which lets `BodyClient` users know whether or not it makes sense to display some kind of "connection trouble" message when noticing that the client became disconnected.

* Make it so that a `BodyClient` instance will refuse to `start()` if there is _another_ instance of the class which is already using the same `Quill` instance. This is done because (a) there's never been an intention to support that use case, and (b) it would be a _lot_ more code to make it actually work than simply detect-and-prevent.
