### PR TITLE
Add `wrapRedacted()` and `wrapTruncated()`.

### DIFF
--- a/local-modules/@bayou/see-all/RedactUtil.js
+++ b/local-modules/@bayou/see-all/RedactUtil.js
@@ -152,4 +152,26 @@ export default class RedactUtil extends UtilityClass {
       }
     }
   }
+
+  /**
+   * Wrap the given value in a `redacted(...)` functor, as a way to indicate
+   * that the value is indeed redacted in some way.
+   *
+   * @param {*} value Value to wrap.
+   * @returns {Functor} Appropriately-wrapped form.
+   */
+  static wrapRedacted(value) {
+    return new Functor('redacted', value);
+  }
+
+  /**
+   * Wrap the given value in a `truncated(...)` functor, as a way to indicate
+   * that the value is indeed truncated in some way.
+   *
+   * @param {*} value Value to wrap.
+   * @returns {Functor} Appropriately-wrapped form.
+   */
+  static wrapTruncated(value) {
+    return new Functor('truncated', value);
+  }
 }

--- a/local-modules/@bayou/see-all/tests/test_RedactUtil.js
+++ b/local-modules/@bayou/see-all/tests/test_RedactUtil.js
@@ -365,4 +365,34 @@ describe('@bayou/see-all/RedactUtil', () => {
       });
     });
   });
+
+  describe('wrapRedacted()', () => {
+    it('wraps as expected', () => {
+      function test(v) {
+        const expect = new Functor('redacted', v);
+        const got    = RedactUtil.wrapRedacted(v);
+        assert.deepEqual(got, expect);
+      }
+
+      test(true);
+      test('foo');
+      test([1, 2, 3]);
+      test(new Map());
+    });
+  });
+
+  describe('wrapTruncated()', () => {
+    it('wraps as expected', () => {
+      function test(v) {
+        const expect = new Functor('truncated', v);
+        const got    = RedactUtil.wrapTruncated(v);
+        assert.deepEqual(got, expect);
+      }
+
+      test(false);
+      test('blort');
+      test(['x']);
+      test(/boop/);
+    });
+  });
 });


### PR DESCRIPTION
These are to provide standardized behavior around redaction / truncation.