### PR TITLE
Over-redaction in `ApiLog`.

### DIFF
--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -54,8 +54,8 @@ export default class ApiLog extends CommonBase {
     if (details) {
       this._pending.delete(msg);
     } else {
-      this._log.warning('Orphan message:', msg);
       details = this._initialDetails(msg);
+      this._log.event.orphanMessage(this._redactInitialDetails(details));
     }
 
     if (response.error) {

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -179,10 +179,11 @@ export default class ApiLog extends CommonBase {
     // **TODO:** Use metadata to drive selective redaction of the message
     // payload.
 
+    const result  = RedactUtil.wrapRedacted(RedactUtil.redactValues(details.result, MAX_REDACTION_DEPTH));
     const payload = RedactUtil.wrapRedacted(RedactUtil.redactValues(origMsg.payload, MAX_REDACTION_DEPTH));
     const msg     = Object.assign({}, origMsg, { payload });
 
-    return Object.assign({}, details, { msg });
+    return Object.assign({}, details, { msg, result });
   }
 
   /**

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -170,20 +170,28 @@ export default class ApiLog extends CommonBase {
    *   itself if this instance is not performing redaction.
    */
   _redactFullDetails(details) {
-    const origMsg = details.msg;
-
-    if ((origMsg === null) || !this._shouldRedact) {
+    if (!this._shouldRedact) {
       return details;
     }
 
     // **TODO:** Use metadata to drive selective redaction of the message
     // payload.
 
-    const result  = RedactUtil.wrapRedacted(RedactUtil.redactValues(details.result, MAX_REDACTION_DEPTH));
-    const payload = RedactUtil.wrapRedacted(RedactUtil.redactValues(origMsg.payload, MAX_REDACTION_DEPTH));
-    const msg     = Object.assign({}, origMsg, { payload });
+    const { msg: origMsg, result: origResult } = details;
+    const replacements = {};
 
-    return Object.assign({}, details, { msg, result });
+    if (origResult) {
+      replacements.result =
+        RedactUtil.wrapRedacted(RedactUtil.redactValues(origResult, MAX_REDACTION_DEPTH));
+    }
+
+    if (origMsg) {
+      const payload =
+        RedactUtil.wrapRedacted(RedactUtil.redactValues(origMsg.payload, MAX_REDACTION_DEPTH));
+      replacements.msg = Object.assign({}, origMsg, { payload });
+    }
+
+    return Object.assign({}, details, replacements);
   }
 
   /**

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -101,7 +101,8 @@ export default class ApiLog extends CommonBase {
    * @param {Response} response Response which is being sent to the caller.
    */
   _finishDetails(details, response) {
-    details.endTime = this._now();
+    details.endTime      = this._now();
+    details.durationMsec = details.endTime - details.startTime;
 
     if (response.error) {
       details.ok     = false;
@@ -139,12 +140,8 @@ export default class ApiLog extends CommonBase {
    * @param {object} details Ad-hoc object with call details.
    */
   _logCompletedCall(details) {
-    const msg          = details.msg;
-    const method       = msg ? msg.payload.name : '<unknown>';
-    const durationMsec = details.endTime - details.startTime;
-    const ok           = details.ok;
-
-    details.durationMsec = durationMsec;
+    const { durationMsec, msg, ok } = details;
+    const method = msg ? msg.payload.name : '<unknown>';
 
     this._log.event.apiReturned(this._redactFullDetails(details));
 

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -59,7 +59,7 @@ export default class ApiLog extends CommonBase {
     }
 
     if (response.error) {
-      // TODO: Ultimately _some_ errors coming back from API calls shouldn't
+      // **TODO:** Ultimately _some_ errors coming back from API calls shouldn't
       // be considered console-log-worthy server errors. We will need to
       // differentiate them at some point.
       this._log.error('Error from API call:', response.originalError);
@@ -108,8 +108,6 @@ export default class ApiLog extends CommonBase {
       details.ok     = false;
       details.error  = response.originalError;
     } else {
-      // **TODO:** This will ultimately need to redact some information in
-      // `response.result`.
       details.ok     = true;
       details.result = response.result;
     }
@@ -123,9 +121,6 @@ export default class ApiLog extends CommonBase {
    */
   _initialDetails(msg) {
     const now = this._now();
-
-    // **TODO:** This will ultimately need to redact some information in `msg`
-    // beyond what `msg.logInfo` might have done.
 
     return {
       msg:       msg ? msg.logInfo : null,
@@ -145,8 +140,8 @@ export default class ApiLog extends CommonBase {
 
     this._log.event.apiReturned(this._redactFullDetails(details));
 
-    // For easy downstream, log a metric of just the method name, success flag,
-    // and elapsed time.
+    // For ease of downstream handling (especially graphing), log a metric of
+    // just the method name, success flag, and elapsed time.
     this._log.metric.apiCall({ ok, durationMsec, method });
   }
 

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ConnectionError, Message, Response } from '@bayou/api-common';
+import { Logging } from '@bayou/config-server';
 import { Condition } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { TBoolean } from '@bayou/typecheck';
@@ -55,7 +56,7 @@ export default class BaseConnection extends CommonBase {
     this._codec = this._context.codec;
 
     /** {ApiLog} The API logger to use. */
-    this._apiLog = new ApiLog(this._log);
+    this._apiLog = new ApiLog(this._log, Logging.shouldRedact());
 
     /** {boolean} Whether the connection should be aiming to become closed. */
     this._closing = false;

--- a/local-modules/@bayou/see-all/RedactUtil.js
+++ b/local-modules/@bayou/see-all/RedactUtil.js
@@ -59,6 +59,10 @@ export default class RedactUtil extends UtilityClass {
           return null;
         } else if (Array.isArray(value)) {
           return ['...'];
+        } else if (value instanceof Functor) {
+          // Treat this analogously to a constructed object: Show the name but
+          // no arguments.
+          return new Functor(value.name, '...');
         }
 
         const name = value.constructor ? value.constructor.name : null;
@@ -118,10 +122,16 @@ export default class RedactUtil extends UtilityClass {
             count++;
           }
           return result;
+        } else if (value instanceof Functor) {
+          // Show the name and recursively redact arguments.
+          const args = value.args.map(a => RedactUtil.redactValues(a, nextDepth));
+          return new Functor(value.name, ...args);
         }
 
         const name = value.constructor ? value.constructor.name : null;
         if ((typeof name === 'string') && (Object.getPrototypeOf(value) !== Object.prototype)) {
+          // **TODO:** Consider redacting the result of `deconstruct()` when
+          // that method is available on `value`.
           return new Functor(`new_${name}`, '...');
         } else {
           const keys   = Object.keys(value).sort();

--- a/local-modules/@bayou/see-all/tests/test_RedactUtil.js
+++ b/local-modules/@bayou/see-all/tests/test_RedactUtil.js
@@ -145,6 +145,13 @@ describe('@bayou/see-all/RedactUtil', () => {
       assert.deepEqual(redact([null, null, undefined]), expect);
     });
 
+    it('converts all functors to ones with the same name but with `...` for args', () => {
+      const orig   = new Functor('blort', 1, 2, 3);
+      const expect = new Functor('blort', '...');
+
+      assert.deepEqual(redact(orig), expect);
+    });
+
     it('converts all plain objects to `{ \'...\': \'...\' }`', () => {
       const expect = { '...': '...' };
 
@@ -237,6 +244,16 @@ describe('@bayou/see-all/RedactUtil', () => {
         }
       });
 
+      it('recursively redacts functor arguments', () => {
+        const orig = new Functor('blort', 'a', 123, new Functor('zorch', [[[[[123]]]]]));
+
+        for (let d = 1; d <= 6; d++) {
+          const args   = orig.args.map(a => RedactUtil.redactValues(a, d - 1));
+          const expect = new Functor(orig.name, ...args);
+          assert.deepEqual(RedactUtil.redactValues(orig, d), expect, `${d}`);
+        }
+      });
+
       it('represents all elements of small-enough plain objects', () => {
         const orig = {
           a: { b: { c: { d: { e: { f: 'boop' } } } } },
@@ -249,7 +266,7 @@ describe('@bayou/see-all/RedactUtil', () => {
           hh: { y: [], z: 'xyz' },
           ii: { z: new Map() },
           jj: { x: 'x', y: 'y', z: 'z' },
-          x1: 123,
+          x1: new Functor('whee', 'yo', 'yo', 'yo'),
           x2: 456,
           x3: 789,
           x4: 'beep',


### PR DESCRIPTION
This PR swings the pendulum hard to the other side of the redact-vs-not scale for `ApiLog`. That is, as of this PR, when configured for redaction, the system will now only log the basic structure of API calls and no payload data. This is definitely _over_-redaction, in that there is a ton of stuff which will now be dropped which (a) is safe to log (won't reveal private data), and (b) would be of use when trying to debug the system.