### PR TITLE
Miscellanea.

### DIFF
--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -124,8 +124,7 @@ export default class ApiLog extends CommonBase {
 
     return {
       msg:       msg ? msg.logInfo : null,
-      startTime: now,
-      ok:        false
+      startTime: now
     };
   }
 

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -16,7 +16,7 @@ describe('@bayou/api-server/ApiLog', () => {
   describe('incomingMessage()', () => {
     // Common tests for both values of `shouldRedact`.
     function testCommon(shouldRedact) {
-      it('should log the redacted form of target when the target is a token', () => {
+      it('logs the redacted form of target when the target is a token', () => {
         const logger = new MockLogger();
         const apiLog = new ApiLog(logger, shouldRedact);
         const token  = new BearerToken('foo', 'foo-bar');

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -871,25 +871,8 @@ export default class BodyClient extends StateMachine {
     // then there will soon be a `gotQuillEvent` event to be handled by this
     // instance, and after that gets done, it will once again be okay to
     // integrate changes from the server.
-    if (this._snapshot.revNum === baseRevNum) {
-      // **TODO:** For now, we make the check for `_isQuillChangePending()`
-      // separately (instead of making the outer if have an `&&`), so that we
-      // can explicitly do some logging around the is-pending case. This is
-      // because (historically speaking) while always arguably incorrect to fail
-      // to perform this check, it only recently started causing problems in
-      // practice. We want to log in order to understand more about when the
-      // situation arises, in case it is a harbinger of some other nascent new
-      // problem.
-      if (this._isQuillChangePending()) {
-        const thisSnap   = this._snapshot;
-        const quillDelta = BodyDelta.fromQuillForm(this._quill.getContents());
-        const quillSnap  = new BodySnapshot(thisSnap.revNum + 1, quillDelta);
-        const diff       = thisSnap.diff(quillSnap);
-        this.log.event.quillChangePending(diff);
-        this._sessionProxy.logEvent('quillChangePending', diff); // Log it on the server too.
-      } else {
-        this._updateWithChange(result);
-      }
+    if ((this._snapshot.revNum === baseRevNum) || !this._isQuillChangePending()) {
+      this._updateWithChange(result);
     }
 
     // Fire off the next iteration of requesting server changes, after a short


### PR DESCRIPTION
A few miscellaneous items:

* Stop logging a superfluous `ok: false` on API calls that haven't actually executed yet.
* Stop logging all those `quillChangePending` events, becuase (a) the actual bug was fixed a while ago, (b) we know what's going on with these and it's okay, and (c) the data logged is PII and we don't want to leave it around when going into production.
* Do another increment of the work of making unit test `it(...)` phrases be in active form.
