### PR TITLE
Plumbing for nuanced redaction in the main API.

### DIFF
--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -2,9 +2,12 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Message, Response } from '@bayou/api-common';
 import { BaseLogger, RedactUtil } from '@bayou/see-all';
 import { TBoolean } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
+
+import Target from './Target';
 
 /** {Int} Maximum depth to produce when redacting values. */
 const MAX_REDACTION_DEPTH = 4;
@@ -47,8 +50,13 @@ export default class ApiLog extends CommonBase {
    *
    * @param {Message} msg Incoming message.
    * @param {Response} response Response to the message.
+   * @param {Target} target The target that produced the response.
    */
-  fullCall(msg, response) {
+  fullCall(msg, response, target) {
+    Message.check(msg);
+    Response.check(response);
+    Target.check(target);
+
     let details = this._pending.get(msg);
 
     if (details) {

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -62,6 +62,8 @@ export default class ApiLog extends CommonBase {
     if (details) {
       this._pending.delete(msg);
     } else {
+      // This is indicative of a bug in this module. The user of `ApiLog` should
+      // have called `incomingMessage(msg)` but apparently didn't.
       details = this._initialDetails(msg);
       this._log.event.orphanMessage(this._redactInitialDetails(details));
     }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -50,12 +50,14 @@ export default class ApiLog extends CommonBase {
    *
    * @param {Message} msg Incoming message.
    * @param {Response} response Response to the message.
-   * @param {Target} target The target that produced the response.
+   * @param {Target|null} target The target that produced the response, if any.
    */
   fullCall(msg, response, target) {
     Message.check(msg);
     Response.check(response);
-    Target.check(target);
+    if (target !== null) {
+      Target.check(target);
+    }
 
     let details = this._pending.get(msg);
 

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -76,7 +76,7 @@ export default class ApiLog extends CommonBase {
     }
 
     this._finishDetails(details, response);
-    this._logCompletedCall(details);
+    this._logCompletedCall(details, target);
   }
 
   /**
@@ -101,7 +101,7 @@ export default class ApiLog extends CommonBase {
     const details = this._initialDetails(null);
 
     this._finishDetails(details, response);
-    this._logCompletedCall(details);
+    this._logCompletedCall(details, null);
   }
 
   /**
@@ -142,12 +142,13 @@ export default class ApiLog extends CommonBase {
    * Performs end-of-call logging.
    *
    * @param {object} details Ad-hoc object with call details.
+   * @param {Target|null} target The target that handled the message, if any.
    */
-  _logCompletedCall(details) {
+  _logCompletedCall(details, target) {
     const { durationMsec, msg, ok } = details;
     const method = msg ? msg.payload.name : '<unknown>';
 
-    this._log.event.apiReturned(this._redactFullDetails(details));
+    this._log.event.apiReturned(this._redactFullDetails(details, target));
 
     // For ease of downstream handling (especially graphing), log a metric of
     // just the method name, success flag, and elapsed time.
@@ -175,15 +176,17 @@ export default class ApiLog extends CommonBase {
    * everything else will always get passed through as-is.
    *
    * @param {object} details Ad-hoc object will call details.
+   * @param {Target|null} target_unused The target that handled the message, if
+   *   any.
    * @returns {object} Possibly value-redacted form of `details`, or `details`
    *   itself if this instance is not performing redaction.
    */
-  _redactFullDetails(details) {
+  _redactFullDetails(details, target_unused) {
     if (!this._shouldRedact) {
       return details;
     }
 
-    // **TODO:** Use metadata to drive selective redaction of the message
+    // **TODO:** Use `target` to drive selective redaction of the message
     // payload.
 
     const { msg: origMsg, result: origResult } = details;

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -222,8 +222,8 @@ export default class BaseConnection extends CommonBase {
   }
 
   /**
-   * Helper for `handleJsonMessage()` which actually performs the method call
-   * requested by the given message.
+   * Helper for {@link @handleJsonMessage} which actually performs the method
+   * call requested by the given message.
    *
    * Because `undefined` is not used across the API boundary, a top-level
    * `undefined` result (which, notably, is what is returned from a method that

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -245,7 +245,7 @@ export default class BaseConnection extends CommonBase {
       throw ConnectionError.connectionClosing(this._connectionId);
     }
 
-    const target = await this._getTarget(msg.targetId);
+    const target = await this._getTarget(msg);
     const result = await target.call(msg.payload);
 
     if (result === undefined) {
@@ -343,16 +343,19 @@ export default class BaseConnection extends CommonBase {
    * having to do a heavyweight operation (e.g. a network round-trip) to
    * determine the authority of a token.
    *
-   * @param {string} idOrToken A target ID or bearer token in string form.
+   * @param {Message} msg The message whose target is to be determined.
    * @returns {Target} The target object that is associated with `idOrToken`.
    */
-  async _getTarget(idOrToken) {
-    const context = this._context;
+  async _getTarget(msg) {
+    Message.check(msg);
+
+    const targetId = msg.targetId;
+    const context  = this._context;
 
     if (context === null) {
       throw ConnectionError.connectionClosed(this._connectionId, 'Connection closed.');
     }
 
-    return context.getAuthorizedTarget(idOrToken);
+    return context.getAuthorizedTarget(targetId);
   }
 }

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -164,7 +164,7 @@ export default class BaseConnection extends CommonBase {
     if (msg === null) {
       this._apiLog.nonMessageResponse(response);
     } else {
-      this._apiLog.fullCall(msg, response);
+      this._apiLog.fullCall(msg, response, target);
     }
 
     return encodedResponse;

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -344,7 +344,7 @@ export default class BaseConnection extends CommonBase {
    * determine the authority of a token.
    *
    * @param {Message} msg The message whose target is to be determined.
-   * @returns {Target} The target object that is associated with `idOrToken`.
+   * @returns {Target} The target object that is associated with `msg`.
    */
   async _getTarget(msg) {
     Message.check(msg);
@@ -356,6 +356,8 @@ export default class BaseConnection extends CommonBase {
       throw ConnectionError.connectionClosed(this._connectionId, 'Connection closed.');
     }
 
-    return context.getAuthorizedTarget(targetId);
+    const result = await context.getAuthorizedTarget(targetId);
+
+    return Target.check(result);
   }
 }

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -224,7 +224,7 @@ export default class BaseConnection extends CommonBase {
   }
 
   /**
-   * Helper for {@link @handleJsonMessage} which actually performs the method
+   * Helper for {@link #handleJsonMessage} which actually performs the method
    * call requested by the given message.
    *
    * Because `undefined` is not used across the API boundary, a top-level

--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -871,7 +871,7 @@ export default class BodyClient extends StateMachine {
     // then there will soon be a `gotQuillEvent` event to be handled by this
     // instance, and after that gets done, it will once again be okay to
     // integrate changes from the server.
-    if ((this._snapshot.revNum === baseRevNum) || !this._isQuillChangePending()) {
+    if ((this._snapshot.revNum === baseRevNum) && !this._isQuillChangePending()) {
       this._updateWithChange(result);
     }
 


### PR DESCRIPTION
This PR adds most of the plumbing required so that API call logging in `ApiLog` is in a position to do redaction based on the actual target of the calls being so logged.

**Bonus:** Fix for my earlier removal of the logging around pending Quill changes. (The comment was correct but the code was wrong.) 