### PR TITLE
Push basic API call log processing logic down one more layer.

### DIFF
--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -66,14 +66,15 @@ export default class Message extends CommonBase {
    * {object} Ad-hoc object with the contents of this instance, suitable for
    * logging. In particular, the {@link #targetId} is represented in redacted
    * form if this instance was constructed with a {@link BearerToken}.
+   *
+   * **Note:** The {@link #payload} is _not_ redacted, as doing so requires
+   * information not present in this class (namely, the actual object to which
+   * the {@link #targetId} is bound).
    */
   get logInfo() {
     const id       = this._id;
     const targetId = TargetId.safeString(this._targetId);
     const payload  = this._payload;
-
-    // **TODO:** Ultimately, we probably want to perform redaction on the
-    // `payload`.
 
     return { id, targetId, payload };
   }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -182,7 +182,7 @@ export default class ApiLog extends CommonBase {
         : target.logInfoFromPayload(payload, this._shouldRedact);
 
       if (payload !== newPayload) {
-        details.msg = Object.assign({}, details.msg, { payload });
+        details.msg = Object.assign({}, msg, { payload: newPayload });
       }
     }
 

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -136,7 +136,7 @@ export default class ApiLog extends CommonBase {
   _logCompletedCall(details, response, target) {
     const msg          = details.msg;
     const method       = msg ? msg.payload.name : '<unknown>';
-    const ok           = response.error ? true : false;
+    const ok           = response.error ? false : true;
     const endTime      = this._now();
     const durationMsec = endTime - details.startTime;
 

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -171,15 +171,17 @@ export default class ApiLog extends CommonBase {
   _logInfoCommon(details) {
     details = Object.assign({}, details);
 
-    const target = details.target;
+    const { msg, target } = details;
 
     if (target !== null) {
       // Replace a non-null target with its class name.
       details.target = `class ${target.className}`;
     }
 
-    // `msg` typically gets updated, so clone it proactively.
-    details.msg = Object.assign({}, details.msg);
+    if (msg !== null) {
+      // A non-`null` `msg` typically gets updated, so clone it proactively.
+      details.msg = Object.assign({}, details.msg);
+    }
 
     return details;
   }

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -67,7 +67,7 @@ export default class ApiLog extends CommonBase {
       // This is indicative of a bug in this module. The user of `ApiLog` should
       // have called `incomingMessage(msg)` but apparently didn't.
       details = this._initialDetails(msg);
-      this._log.event.orphanMessage(this._redactInitialDetails(details));
+      this._log.event.orphanMessage(this._logInfoInitial(details));
     }
 
     if (response.error) {
@@ -98,7 +98,7 @@ export default class ApiLog extends CommonBase {
     const details = this._initialDetails(msg, target);
 
     this._pending.set(msg, details);
-    this._log.event.apiReceived(this._redactInitialDetails(details));
+    this._log.event.apiReceived(this._logInfoInitial(details));
   }
 
   /**
@@ -153,7 +153,7 @@ export default class ApiLog extends CommonBase {
       details.error  = response.originalError;
     }
 
-    this._log.event.apiReturned(this._redactFullDetails(details, target));
+    this._log.event.apiReturned(this._logInfoFull(details, target));
 
     // For ease of downstream handling (especially graphing), log a metric of
     // just the method name, success flag, and elapsed time.
@@ -161,26 +161,14 @@ export default class ApiLog extends CommonBase {
   }
 
   /**
-   * Gets the current time, in the usual Unix Epoch msec form.
-   *
-   * **Note:** This method exists so as to make this class a little easier to
-   * test.
-   *
-   * @returns {Int} The current time in msec since the Unix Epoch.
-   */
-  _now() {
-    return Date.now();
-  }
-
-  /**
-   * Helper for the two main details processing methods, which gets a clone of
-   * the given call details object and does the common processing on it for both
-   * cases.
+   * Helper for the two main logging-oriented details processing methods, which
+   * gets a clone of the given call details object and does the common
+   * processing on it for both cases.
    *
    * @param {object} details Ad-hoc object with call details.
    * @returns {object} Cloned and processed version of `details`.
    */
-  _redactCommon(details) {
+  _logInfoCommon(details) {
     details = Object.assign({}, details);
 
     const target = details.target;
@@ -206,10 +194,10 @@ export default class ApiLog extends CommonBase {
    * @returns {object} Possibly value-redacted form of `details`, or `details`
    *   itself if this instance is not performing redaction.
    */
-  _redactFullDetails(details) {
+  _logInfoFull(details) {
     const { msg, result, target: target_unused } = details;
 
-    details = this._redactCommon(details);
+    details = this._logInfoCommon(details);
 
     if (this._shouldRedact) {
       // **TODO:** Use `target` to drive selective redaction of the message
@@ -239,10 +227,10 @@ export default class ApiLog extends CommonBase {
    *   state of affairs _before_ a call has been made.
    * @returns {object} Logging-appropriate form of `detail`.
    */
-  _redactInitialDetails(details) {
+  _logInfoInitial(details) {
     const { msg, target: target_unused } = details;
 
-    details = this._redactCommon(details);
+    details = this._logInfoCommon(details);
 
     if ((msg !== null) && this._shouldRedact) {
       // When redacting the incoming details, we are not selective (that is, we
@@ -255,5 +243,17 @@ export default class ApiLog extends CommonBase {
     }
 
     return details;
+  }
+
+  /**
+   * Gets the current time, in the usual Unix Epoch msec form.
+   *
+   * **Note:** This method exists so as to make this class a little easier to
+   * test.
+   *
+   * @returns {Int} The current time in msec since the Unix Epoch.
+   */
+  _now() {
+    return Date.now();
   }
 }

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -144,7 +144,7 @@ export default class BaseConnection extends CommonBase {
         error = e;
       }
 
-      this._apiLog.incomingMessage(msg);
+      this._apiLog.incomingMessage(msg, target);
 
       if (error === null) {
         try {

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -138,16 +138,24 @@ export default class BaseConnection extends CommonBase {
     let error  = null;
 
     if (msg instanceof Message) {
-      this._apiLog.incomingMessage(msg);
       try {
         target = await this._getTarget(msg);
-        result = await this._actOnMessage(msg, target);
       } catch (e) {
         error = e;
       }
+
+      this._apiLog.incomingMessage(msg);
+
+      if (error === null) {
+        try {
+          result = await this._actOnMessage(msg, target);
+        } catch (e) {
+          error = e;
+        }
+      }
     } else if (msg instanceof Error) {
       error = msg;
-      msg = null; // Salient for logging.
+      msg   = null; // Salient for logging.
     } else {
       // Shouldn't happen because `_decodeMessage()` should only return one of
       // the above two types.

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BearerToken, TargetId } from '@bayou/api-common';
-import { TObject } from '@bayou/typecheck';
+import { TFunction, TObject } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 import Schema from './Schema';
@@ -50,10 +50,27 @@ export default class Target extends CommonBase {
   }
 
   /**
-  * {object} The object which this instance represents, wraps, and generally
-  * provides access to. Accessing this property indicates that this instance is
-  * _not_ currently idle.
-  */
+   * {string} The name of the class which {@link #directObject} is an instance
+   * of.
+   */
+  get className() {
+    const clazz = this._directObject.constructor;
+
+    if ((clazz !== Object) && TFunction.isClass(clazz)) {
+      const name = clazz.name;
+      if (typeof name === 'string') {
+        return name;
+      }
+    }
+
+    return '<unknown>';
+  }
+
+  /**
+   * {object} The object which this instance represents, wraps, and generally
+   * provides access to. Accessing this property indicates that this instance is
+   * _not_ currently idle.
+   */
   get directObject() {
     return this._directObject;
   }

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -191,8 +191,9 @@ export default class Target extends CommonBase {
       return payload;
     }
 
-    // **TODO:** Fill me in.
-    return payload;
+    // **TODO:** Redaction should be driven by target-specific metadata.
+
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
   }
 
   /**

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -197,7 +197,8 @@ export default class Target extends CommonBase {
       return payload;
     }
 
-    // **TODO:** Redaction should be driven by target-specific metadata.
+    // **TODO:** Redaction should be driven by target-specific metadata, based
+    // on `payload.name` (the method name) as well.
 
     return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
   }
@@ -216,6 +217,10 @@ export default class Target extends CommonBase {
    *   `payload` if no modifications needed to be made.
    */
   logInfoFromResult(result, payload_unused, shouldRedact) {
+    if ((result === undefined) || (result === null)) {
+      return result;
+    }
+
     if (!shouldRedact) {
       // **TODO:** This should ultimately do some processing, including
       // truncating long arrays / objects / strings, redacting strings that look
@@ -223,7 +228,9 @@ export default class Target extends CommonBase {
       return result;
     }
 
-    // **TODO:** Fill me in.
-    return result;
+    // **TODO:** Redaction should be driven by target-specific metadata, based
+    // on `payload.name` (the method name) as well.
+
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
   }
 }

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -103,4 +103,53 @@ export default class Target extends CommonBase {
 
     return impl.apply(obj, payload.args);
   }
+
+  /**
+   * Converts the given payload (as presumably passed to an earlier call to
+   * {@link #call}, or about to be used as such), so as to be suitable for
+   * logging, including performing any necessary redaction.
+   *
+   * @param {Functor} payload The call payload.
+   * @param {boolean} shouldRedact Whether redaction should be performed in
+   *   general. Even when `false`, some redaction may be performed out of an
+   *   abundance of caution.
+   * @returns {Functor} The processed replacement for `payload`, or the original
+   *   `payload` if no modifications needed to be made.
+   */
+  logInfoFromPayload(payload, shouldRedact) {
+    if (!shouldRedact) {
+      // **TODO:** This should ultimately do some processing, including
+      // truncating long arrays / objects / strings, redacting strings that look
+      // like tokens, and so on.
+      return payload;
+    }
+
+    // **TODO:** Fill me in.
+    return payload;
+  }
+
+  /**
+   * Converts the given call result (as presumably returned from an earlier call
+   * to {@link #call}), so as to be suitable for logging, including performing
+   * any necessary redaction.
+   *
+   * @param {*} result The result of the call in question.
+   * @param {Functor} payload_unused The call payload which produced `result`.
+   * @param {boolean} shouldRedact Whether redaction should be performed in
+   *   general. Even when `false`, some redaction may be performed out of an
+   *   abundance of caution.
+   * @returns {Functor} The processed replacement for `payload`, or the original
+   *   `payload` if no modifications needed to be made.
+   */
+  logInfoFromResult(result, payload_unused, shouldRedact) {
+    if (!shouldRedact) {
+      // **TODO:** This should ultimately do some processing, including
+      // truncating long arrays / objects / strings, redacting strings that look
+      // like tokens, and so on.
+      return result;
+    }
+
+    // **TODO:** Fill me in.
+    return result;
+  }
 }

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -21,7 +21,9 @@ const MAX_REDACTION_DEPTH = 4;
 export default class Target extends CommonBase {
   /**
    * Like {@link #logInfoFromPayload}, except only to be used when processing
-   * `null` as a target (e.g. when a target ID was not valid).
+   * `null` as a target (e.g. when a target ID was not valid). Since there is
+   * no metadata available in this case, when redaction is on, this method
+   * performs full value redaction.
    *
    * @param {Functor} payload The call payload.
    * @param {boolean} shouldRedact Whether redaction should be performed in
@@ -43,17 +45,22 @@ export default class Target extends CommonBase {
 
   /**
    * Like {@link #logInfoFromResult}, except only to be used when processing
-   * `null` as a target (e.g. when a target ID was not valid).
+   * `null` as a target (e.g. when a target ID was not valid). Since there is
+   * no metadata available in this case, when redaction is on, this method
+   * performs full value redaction.
    *
    * @param {*} result The result of the call in question.
-   * @param {Functor} payload_unused The call payload which produced `result`.
    * @param {boolean} shouldRedact Whether redaction should be performed in
    *   general. Even when `false`, some redaction may be performed out of an
    *   abundance of caution.
    * @returns {Functor} The processed replacement for `payload`, or the original
    *   `payload` if no modifications needed to be made.
    */
-  static logInfoFromResultForNullTarget(result, payload_unused, shouldRedact) {
+  static logInfoFromResultForNullTarget(result, shouldRedact) {
+    if ((result === undefined) || (result === null)) {
+      return result;
+    }
+
     if (!shouldRedact) {
       // **TODO:** This should ultimately do some processing, including
       // truncating long arrays / objects / strings, redacting strings that look
@@ -61,8 +68,7 @@ export default class Target extends CommonBase {
       return result;
     }
 
-    // **TODO:** Fill me in.
-    return result;
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
   }
 
   /**

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -3,10 +3,14 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { BearerToken, TargetId } from '@bayou/api-common';
+import { RedactUtil } from '@bayou/see-all';
 import { TFunction, TObject } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 import Schema from './Schema';
+
+/** {Int} Maximum depth to produce when redacting values. */
+const MAX_REDACTION_DEPTH = 4;
 
 /**
  * Wrapper for an object which is callable through the API. A target can be
@@ -15,6 +19,52 @@ import Schema from './Schema';
  * generally available without additional authorization checks).
  */
 export default class Target extends CommonBase {
+  /**
+   * Like {@link #logInfoFromPayload}, except only to be used when processing
+   * `null` as a target (e.g. when a target ID was not valid).
+   *
+   * @param {Functor} payload The call payload.
+   * @param {boolean} shouldRedact Whether redaction should be performed in
+   *   general. Even when `false`, some redaction may be performed out of an
+   *   abundance of caution.
+   * @returns {Functor} The processed replacement for `payload`, or the original
+   *   `payload` if no modifications needed to be made.
+   */
+  static logInfoFromPayloadForNullTarget(payload, shouldRedact) {
+    if (!shouldRedact) {
+      // **TODO:** This should ultimately do some processing, including
+      // truncating long arrays / objects / strings, redacting strings that look
+      // like tokens, and so on.
+      return payload;
+    }
+
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
+  }
+
+  /**
+   * Like {@link #logInfoFromResult}, except only to be used when processing
+   * `null` as a target (e.g. when a target ID was not valid).
+   *
+   * @param {*} result The result of the call in question.
+   * @param {Functor} payload_unused The call payload which produced `result`.
+   * @param {boolean} shouldRedact Whether redaction should be performed in
+   *   general. Even when `false`, some redaction may be performed out of an
+   *   abundance of caution.
+   * @returns {Functor} The processed replacement for `payload`, or the original
+   *   `payload` if no modifications needed to be made.
+   */
+  static logInfoFromResultForNullTarget(result, payload_unused, shouldRedact) {
+    if (!shouldRedact) {
+      // **TODO:** This should ultimately do some processing, including
+      // truncating long arrays / objects / strings, redacting strings that look
+      // like tokens, and so on.
+      return result;
+    }
+
+    // **TODO:** Fill me in.
+    return result;
+  }
+
   /**
    * Constructs an instance which wraps the given object.
    *

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken, Message } from '@bayou/api-common';
+import { Target } from '@bayou/api-server';
 import { MockLogger } from '@bayou/see-all/mocks';
 import { Functor } from '@bayou/util-common';
 
@@ -22,7 +23,7 @@ describe('@bayou/api-server/ApiLog', () => {
         const token  = new BearerToken('foo', 'foo-bar');
         const msg    = new Message(123, token, new Functor('x', 'y'));
 
-        apiLog.incomingMessage(msg);
+        apiLog.incomingMessage(msg, new Target('x', {}));
 
         const record = logger.record;
 

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -72,6 +72,19 @@ describe('@bayou/api-server/Target', () => {
     });
   });
 
+  describe('.className', () => {
+    it('is the name of the class (constructor function) of `directObject`, if it has a class', () => {
+      class Florp {}
+      const t = new Target('x', new Florp());
+      assert.strictEqual(t.className, 'Florp');
+    });
+
+    it('is `<unknown>` if `directObject` is a plain object', () => {
+      const t = new Target('x', { x: 10 });
+      assert.strictEqual(t.className, '<unknown>');
+    });
+  });
+
   describe('.directObject', () => {
     it('is the same as the `directObject` passed to the constructor', () => {
       for (const obj of VALID_DIRECTS) {


### PR DESCRIPTION
This PR moves the log processing in `api-server` from `ApiLog` down into `Target`, where it is now well-positioned to be able to use target-aware redaction instead of the current all-or-nothing approach. (A future PR will actually add the target-specific infrastructure and logic.) As part of this, `ApiLog.incomingMessage()` now takes the resolved `target`, making it possible to do target-aware redaction on the incoming side (before the call is dispatched).

Tangentially related, as of this PR, API calls log the class name of the target, to provide an additional useful signal. (E.g. when operating on a view-only session, you'll see that the class is specifically `ViewSession`.)

This PR is WIP on ARU-962.