### PR TITLE
`api-server` nuanced call redaction: signs of life!

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -197,11 +197,13 @@ taking into account recent additions to the language.
       * synthetic fields
       * methods
 
-  As an exception, methods that only serve as helpers for one other method will
-  sometimes get located immediately below the method being helped.
-
   Roughly speaking, you can think of this as an "instance sandwich on static
   bread."
+
+  As an exception, methods that only serve as helpers for one other method, or
+  are otherwise intimately associated with that method, will sometimes get
+  located immediately below the method being helped. Notable examples of this
+  are the logging metadata getter methods (see `MetaHandler` for an example).
 
 #### Enumerated constants
 

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -11,7 +11,6 @@ import BaseConnection from './BaseConnection';
  * Class to handle meta-requests.
  */
 export default class MetaHandler extends CommonBase {
-
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -11,6 +11,7 @@ import BaseConnection from './BaseConnection';
  * Class to handle meta-requests.
  */
 export default class MetaHandler extends CommonBase {
+
   /**
    * Constructs an instance.
    *
@@ -35,6 +36,9 @@ export default class MetaHandler extends CommonBase {
   connectionId() {
     return this._connection.connectionId;
   }
+  static get _loggingFor_connectionId() {
+    return { result: true };
+  }
 
   /**
    * API meta-method `ping`: No-op method that merely verifies (implicitly) that
@@ -44,6 +48,9 @@ export default class MetaHandler extends CommonBase {
    */
   ping() {
     return true;
+  }
+  static get _loggingFor_ping() {
+    return { result: true };
   }
 
   /**
@@ -55,5 +62,8 @@ export default class MetaHandler extends CommonBase {
    */
   serverInfo() {
     return Deployment.serverInfo();
+  }
+  static get _loggingFor_serverInfo() {
+    return { result: true };
   }
 }

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TObject, TString } from '@bayou/typecheck';
-import { CommonBase, PropertyIterable } from '@bayou/util-common';
+import { TArray, TBoolean, TObject, TString } from '@bayou/typecheck';
+import { CommonBase, ObjectUtil, PropertyIterable } from '@bayou/util-common';
 
 /**
  * {RegExp} Expression that matches method names that are _not_ to be offered
@@ -39,11 +39,25 @@ export default class Schema extends CommonBase {
 
     super();
 
+    const clazz = target.constructor;
+
+    /**
+     * {class|null} Class of the target, if it has a class (other than
+     * `Object`).
+     */
+    this._clazz = (clazz && (clazz !== Object)) ? clazz : null;
+
     /**
      * {Map<string, string>} Map from each name to a property descriptor
      * string.
      */
     this._properties = Schema._makeSchemaFor(target);
+
+    /**
+     * {Map<string, object>} Map from each name to its logging metadata.
+     * Populated on-demand as a cache.
+     */
+    this._logging = new Map();
 
     Object.freeze(this);
   }
@@ -80,6 +94,78 @@ export default class Schema extends CommonBase {
     const result = this._properties.get(name);
 
     return result || null;
+  }
+
+  /**
+   * Indicates which arguments of a call to the named method should be logged,
+   * when performing redaction in general.
+   *
+   * **TODO:** Right now this is an array of all-or-nothing booleans, but in the
+   * future we might want to have a more structured redaction spec (e.g., if an
+   * argument is a plain object, which properties of that object to redact).
+   *
+   * @param {string} name Method name.
+   * @returns {array<boolean>} Array which indicates, for each (positional)
+   *   argument, whether (`true`) or not (`false`) to log the argument. If there
+   *   are more actual arguments than elements of the result of this call,
+   *   "extra" arguments should _not_ be logged so as to fail safe.
+   */
+  loggingForArgs(name) {
+    return this._getLogging(name).args;
+  }
+
+  /**
+   * Indicates whether the result of calling the named method should be
+   * logged, when performing redaction in general.
+   *
+   * **TODO:** Right now this is an all-or-nothing boolean, but in the future we
+   * might want to have a more structured redaction spec (e.g., if the return
+   * value is a plain object, which properties to redact).
+   *
+   * @param {string} name Method name.
+   * @returns {boolean} Whether (`true`) or not (`false`) to log the result
+   *   of calling the so-named method.
+   */
+  loggingForResult(name) {
+    return this._getLogging(name).result;
+  }
+
+  /**
+   * Gets the logging metadata for the given property. This provides sensible
+   * fail-safe default results when the metadata was not proactively defined.
+   *
+   * @param {string} name Property (method) name.
+   * @returns {object} Logging metadata.
+   */
+  _getLogging(name) {
+    const descriptor = this.getDescriptor(name);
+    const already    = this._logging.get(name);
+
+    if (already !== undefined) {
+      return already;
+    }
+
+    // Start with fail-safe defaults.
+    const result = { args: [], result: false };
+
+    if ((descriptor !== null) && (this._clazz !== null)) {
+      const logging = this._clazz[`_loggingFor_${name}`];
+      if (ObjectUtil.isPlain(logging)) {
+        if (typeof logging.result === 'boolean') {
+          result.result = logging.result;
+        }
+
+        if (Array.isArray(logging.args)) {
+          TArray.check(logging.args, x => TBoolean.check(x));
+          result.args = Object.freeze(logging.args.slice());
+        }
+      }
+    }
+
+    Object.freeze(result);
+
+    this._logging.set(name, result);
+    return result;
   }
 
   /**

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -24,6 +24,15 @@ const VERBOTEN_NAMES = /^(then|catch)$/;
  * * Constructor methods are excluded.
  * * Methods inherited from the base `Object` prototype are excluded.
  * * All other public methods are included.
+ *
+ * Instances of this class also provide information about how to log calls to
+ * methods, specifically with regards to redaction. This is driven by getters
+ * defined on the _class_ of the target, with names of the form
+ * `_loggingFor_<name>`, where `<name>` is the method name. These getters should
+ * each return a plain object that binds `args` (to an array of booleans) and/or
+ * `result` (to a boolean). See {@link #loggingForArgs},
+ * {@link #loggingForResult}, and {@link Target} for details about how these are
+ * used.
  */
 export default class Schema extends CommonBase {
   /**

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -102,9 +102,9 @@ export default class Target extends CommonBase {
    * of.
    */
   get className() {
-    const clazz = this._directObject.constructor;
+    const clazz = this.directClass;
 
-    if ((clazz !== Object) && TFunction.isClass(clazz)) {
+    if (clazz !== null) {
       const name = clazz.name;
       if (typeof name === 'string') {
         return name;
@@ -115,9 +115,20 @@ export default class Target extends CommonBase {
   }
 
   /**
+   * {class|null} The class of {@link #directObject} if it has one and isn't
+   * just (plain) `Object`.
+   */
+  get directClass() {
+    const clazz = this._directObject.constructor;
+
+    return ((clazz !== Object) && TFunction.isClass(clazz))
+      ? clazz
+      : null;
+  }
+
+  /**
    * {object} The object which this instance represents, wraps, and generally
-   * provides access to. Accessing this property indicates that this instance is
-   * _not_ currently idle.
+   * provides access to.
    */
   get directObject() {
     return this._directObject;

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -33,7 +33,7 @@ export default class Target extends CommonBase {
    *   `payload` if no modifications needed to be made.
    */
   static logInfoFromPayloadForNullTarget(payload, shouldRedact) {
-    if (!shouldRedact) {
+    if ((payload.args.length === 0) || !shouldRedact) {
       return Target._logInfoUnredacted(payload);
     } else {
       return Target._logInfoRedacted(payload);
@@ -193,7 +193,7 @@ export default class Target extends CommonBase {
    *   `payload` if no modifications needed to be made.
    */
   logInfoFromPayload(payload, shouldRedact) {
-    if (!shouldRedact) {
+    if ((payload.args.length === 0) || !shouldRedact) {
       return Target._logInfoUnredacted(payload);
     }
 
@@ -236,13 +236,19 @@ export default class Target extends CommonBase {
    * method available.
    *
    * @param {*} value Original value.
+   * @param {boolean} [isArgument = false] Whether to treat this as a call
+   *   payload argument. This is used to adjust the depth, so that an argument
+   *   redacted individually doesn't convert more depth than if the payload were
+   *   redacted as a unit.
    * @returns {*} Appropriately-processed form.
    */
-  static _logInfoRedacted(value) {
+  static _logInfoRedacted(value, isArgument = false) {
+    const depth = MAX_REDACTION_DEPTH - (isArgument ? 1 : 0);
+
     // **TODO:** This should ultimately do some processing, including
     // truncating long arrays / objects / strings, redacting strings that look
     // like tokens, and so on.
-    return RedactUtil.wrapRedacted(RedactUtil.redactValues(value, MAX_REDACTION_DEPTH));
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(value, depth));
   }
 
   /**
@@ -254,9 +260,13 @@ export default class Target extends CommonBase {
    * things out of an abundance of caution.
    *
    * @param {*} value Original value.
+   * @param {boolean} [isArgument_unused = false] Whether to treat this as a
+   *   call payload argument. This is used to adjust the depth, so that an
+   *   argument redacted individually doesn't convert more depth than if the
+   *   payload were redacted as a unit.
    * @returns {*} Appropriately-processed form.
    */
-  static _logInfoUnredacted(value) {
+  static _logInfoUnredacted(value, isArgument_unused = false) {
     // **TODO:** This should ultimately do some processing, including
     // truncating long arrays / objects / strings, redacting strings that look
     // like tokens, and so on.

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -34,13 +34,10 @@ export default class Target extends CommonBase {
    */
   static logInfoFromPayloadForNullTarget(payload, shouldRedact) {
     if (!shouldRedact) {
-      // **TODO:** This should ultimately do some processing, including
-      // truncating long arrays / objects / strings, redacting strings that look
-      // like tokens, and so on.
-      return payload;
+      return Target._logInfoUnredacted(payload);
+    } else {
+      return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
     }
-
-    return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
   }
 
   /**
@@ -59,16 +56,11 @@ export default class Target extends CommonBase {
   static logInfoFromResultForNullTarget(result, shouldRedact) {
     if ((result === undefined) || (result === null)) {
       return result;
+    } else if (!shouldRedact) {
+      return Target._logInfoUnredacted(result);
+    } else {
+      return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
     }
-
-    if (!shouldRedact) {
-      // **TODO:** This should ultimately do some processing, including
-      // truncating long arrays / objects / strings, redacting strings that look
-      // like tokens, and so on.
-      return result;
-    }
-
-    return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
   }
 
   /**
@@ -191,10 +183,7 @@ export default class Target extends CommonBase {
    */
   logInfoFromPayload(payload, shouldRedact) {
     if (!shouldRedact) {
-      // **TODO:** This should ultimately do some processing, including
-      // truncating long arrays / objects / strings, redacting strings that look
-      // like tokens, and so on.
-      return payload;
+      return Target._logInfoUnredacted(payload);
     }
 
     // **TODO:** Redaction should be driven by target-specific metadata, based
@@ -219,18 +208,31 @@ export default class Target extends CommonBase {
   logInfoFromResult(result, payload_unused, shouldRedact) {
     if ((result === undefined) || (result === null)) {
       return result;
-    }
-
-    if (!shouldRedact) {
-      // **TODO:** This should ultimately do some processing, including
-      // truncating long arrays / objects / strings, redacting strings that look
-      // like tokens, and so on.
-      return result;
+    } else if (!shouldRedact) {
+      return Target._logInfoUnredacted(result);
     }
 
     // **TODO:** Redaction should be driven by target-specific metadata, based
     // on `payload.name` (the method name) as well.
 
     return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
+  }
+
+  /**
+   * Helper for the various `logInfo*()` methods, which does processing of
+   * payloads and results when most redaction is off (that is when
+   * `shouldRedact` is passed as `false`).
+   *
+   * **Note:** Name notwithstanding, this method ultimately might redact some
+   * things out of an abundance of caution.
+   *
+   * @param {*} value Original value.
+   * @returns {*} Appropriately-processed form.
+   */
+  static _logInfoUnredacted(value) {
+    // **TODO:** This should ultimately do some processing, including
+    // truncating long arrays / objects / strings, redacting strings that look
+    // like tokens, and so on.
+    return value;
   }
 }

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -36,7 +36,7 @@ export default class Target extends CommonBase {
     if (!shouldRedact) {
       return Target._logInfoUnredacted(payload);
     } else {
-      return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
+      return Target._logInfoRedacted(payload);
     }
   }
 
@@ -59,7 +59,7 @@ export default class Target extends CommonBase {
     } else if (!shouldRedact) {
       return Target._logInfoUnredacted(result);
     } else {
-      return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
+      return Target._logInfoRedacted(result);
     }
   }
 
@@ -200,7 +200,7 @@ export default class Target extends CommonBase {
     // **TODO:** Redaction should be driven by target-specific metadata, based
     // on `payload.name` (the method name) as well.
 
-    return RedactUtil.wrapRedacted(RedactUtil.redactValues(payload, MAX_REDACTION_DEPTH));
+    return Target._logInfoRedacted(payload);
   }
 
   /**
@@ -226,7 +226,23 @@ export default class Target extends CommonBase {
     // **TODO:** Redaction should be driven by target-specific metadata, based
     // on `payload.name` (the method name) as well.
 
-    return RedactUtil.wrapRedacted(RedactUtil.redactValues(result, MAX_REDACTION_DEPTH));
+    return Target._logInfoRedacted(result);
+  }
+
+  /**
+   * Helper for the various `logInfo*()` methods, which does processing of
+   * payloads and results when most redaction is on (that is when
+   * `shouldRedact` is passed as `true`) and there is no more-specific redaction
+   * method available.
+   *
+   * @param {*} value Original value.
+   * @returns {*} Appropriately-processed form.
+   */
+  static _logInfoRedacted(value) {
+    // **TODO:** This should ultimately do some processing, including
+    // truncating long arrays / objects / strings, redacting strings that look
+    // like tokens, and so on.
+    return RedactUtil.wrapRedacted(RedactUtil.redactValues(value, MAX_REDACTION_DEPTH));
   }
 
   /**

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -205,7 +205,7 @@ export default class Target extends CommonBase {
     const newArgs = [];
     for (let i = 0; i < argsLen; i++) {
       const a = args[i];
-      args.push(logging[i] ? a : Target._logInfoRedacted(a, true));
+      newArgs.push(logging[i] ? a : Target._logInfoRedacted(a, true));
     }
 
     return new Functor(name, ...newArgs);

--- a/local-modules/@bayou/api-server/tests/test_Target.js
+++ b/local-modules/@bayou/api-server/tests/test_Target.js
@@ -73,7 +73,7 @@ describe('@bayou/api-server/Target', () => {
   });
 
   describe('.className', () => {
-    it('is the name of the class (constructor function) of `directObject`, if it has a class', () => {
+    it('is the name of the class (constructor function) of `directObject`, if it has a class and is not a plain object', () => {
       class Florp {}
       const t = new Target('x', new Florp());
       assert.strictEqual(t.className, 'Florp');
@@ -82,6 +82,19 @@ describe('@bayou/api-server/Target', () => {
     it('is `<unknown>` if `directObject` is a plain object', () => {
       const t = new Target('x', { x: 10 });
       assert.strictEqual(t.className, '<unknown>');
+    });
+  });
+
+  describe('.directClass', () => {
+    it('is the class (constructor function) of `directObject`, if it has a class and is not a plain object', () => {
+      class Florp {}
+      const t = new Target('x', new Florp());
+      assert.strictEqual(t.directClass, Florp);
+    });
+
+    it('is `null` if `directObject` is a plain object', () => {
+      const t = new Target('x', { x: 10 });
+      assert.isNull(t.directClass);
     });
   });
 

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -85,6 +85,12 @@ export default class AuthorAccess extends CommonBase {
     // of the connection as a reference, instead of by encoding its contents.
     return new ProxiedObject(session);
   }
+  static get _loggingFor_findExistingSession() {
+    return {
+      args:   [true, true],
+      result: true
+    };
+  }
 
   /**
    * Adds a binding to this instance's associated context for a new editing
@@ -111,6 +117,12 @@ export default class AuthorAccess extends CommonBase {
     // The `ProxiedObject` wrapper tells the API to return this to the far side
     // of the connection as a reference, instead of by encoding its contents.
     return new ProxiedObject(session);
+  }
+  static get _loggingFor_makeNewSession() {
+    return {
+      args:   [true],
+      result: true
+    };
   }
 
   /**

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -105,6 +105,12 @@ export default class RootAccess extends CommonBase {
     // exception.)
     return result;
   }
+  static get _loggingFor_makeSessionInfo() {
+    return {
+      args:   [true],
+      result: false
+    };
+  }
 
   /**
    * Registers a token to use for the given author ID. When done, the registered
@@ -118,6 +124,9 @@ export default class RootAccess extends CommonBase {
     TString.check(authorToken);
 
     this._tokenMap.set(authorId, Auth.tokenFromString(authorToken));
+  }
+  static get _loggingFor_useToken() {
+    return { args: [true, false] };
   }
 
   /**


### PR DESCRIPTION
This PR finishes up (in the sense of "good enough for now") the mechanism for log redaction in `api-server`, and goes ahead and uses it for a few of the easier classes.