### PR TITLE
Finish adding API logging metadata.

### DIFF
--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -28,7 +28,7 @@ export default class ApiLog extends CommonBase {
     this._log = BaseLogger.check(log);
 
     /** {boolean} Whether the logs should be redacted, generally speaking. */
-    this._shouldRedact = TBoolean.check(shouldRedact);
+    this._shouldRedact = TBoolean.check(shouldRedact) || true;
 
     /**
      * {Map<Message,object>} Map from messages that haven't yet been completely

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -28,7 +28,7 @@ export default class ApiLog extends CommonBase {
     this._log = BaseLogger.check(log);
 
     /** {boolean} Whether the logs should be redacted, generally speaking. */
-    this._shouldRedact = TBoolean.check(shouldRedact) || true;
+    this._shouldRedact = TBoolean.check(shouldRedact);
 
     /**
      * {Map<Message,object>} Map from messages that haven't yet been completely

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -58,6 +58,12 @@ export default class EditSession extends ViewSession {
 
     return bodyChangeResult;
   }
+  static get _loggingFor_body_update() {
+    return {
+      args: [true, false],
+      result: false
+    };
+  }
 
   /**
    * Applies an update to the properties (document metadata), assigning
@@ -85,6 +91,12 @@ export default class EditSession extends ViewSession {
     const change = new PropertyChange(baseRevNum + 1, delta, Timestamp.now(), this._authorId);
 
     return this._propertyControl.update(change);
+  }
+  static get _loggingFor_property_update() {
+    return {
+      args: [true, false],
+      result: false
+    };
   }
 
   /**

--- a/local-modules/@bayou/doc-server/ViewSession.js
+++ b/local-modules/@bayou/doc-server/ViewSession.js
@@ -42,6 +42,12 @@ export default class ViewSession extends BaseSession {
   async body_getChange(revNum) {
     return this._bodyControl.getChange(revNum);
   }
+  static get _loggingFor_body_getChange() {
+    return {
+      args: [true],
+      result: false
+    };
+  }
 
   /**
    * Gets a change of the document body from the indicated base revision. See
@@ -57,6 +63,12 @@ export default class ViewSession extends BaseSession {
   async body_getChangeAfter(baseRevNum, timeoutMsec = null) {
     return this._bodyControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
+  static get _loggingFor_body_getChangeAfter() {
+    return {
+      args: [true, true],
+      result: false
+    };
+  }
 
   /**
    * Returns a snapshot of the full document body contents. See
@@ -68,6 +80,12 @@ export default class ViewSession extends BaseSession {
    */
   async body_getSnapshot(revNum = null) {
     return this._bodyControl.getSnapshot(revNum);
+  }
+  static get _loggingFor_body_getSnapshot() {
+    return {
+      args: [true],
+      result: false
+    };
   }
 
   /**
@@ -99,6 +117,12 @@ export default class ViewSession extends BaseSession {
   async caret_getChangeAfter(baseRevNum, timeoutMsec = null) {
     return this._caretControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
+  static get _loggingFor_caret_getChangeAfter() {
+    return {
+      args: [true, true],
+      result: true
+    };
+  }
 
   /**
    * Gets a snapshot of all active caret information. This will throw an error
@@ -114,6 +138,12 @@ export default class ViewSession extends BaseSession {
    */
   async caret_getSnapshot(revNum = null) {
     return this._caretControl.getSnapshot(revNum);
+  }
+  static get _loggingFor_caret_getSnapshot() {
+    return {
+      args: [true],
+      result: true
+    };
   }
 
   /**
@@ -161,6 +191,12 @@ export default class ViewSession extends BaseSession {
       await this._caretControl.changeForUpdate(this._caretId, docRevNum, index, length);
     return this._caretControl.update(change);
   }
+  static get _loggingFor_caret_update() {
+    return {
+      args: [true, true, true],
+      result: true
+    };
+  }
 
   /**
    * Returns a particular change to the properties (document metadata). See
@@ -171,6 +207,12 @@ export default class ViewSession extends BaseSession {
    */
   async property_getChange(revNum) {
     return this._propertyControl.getChange(revNum);
+  }
+  static get _loggingFor_property_getChange() {
+    return {
+      args: [true],
+      result: false
+    };
   }
 
   /**
@@ -187,6 +229,12 @@ export default class ViewSession extends BaseSession {
   async property_getChangeAfter(baseRevNum, timeoutMsec = null) {
     return this._propertyControl.getChangeAfter(baseRevNum, timeoutMsec);
   }
+  static get _loggingFor_property_getChangeAfter() {
+    return {
+      args: [true, true],
+      result: false
+    };
+  }
 
   /**
    * Returns a snapshot of the properties (document metadata). See
@@ -198,6 +246,12 @@ export default class ViewSession extends BaseSession {
    */
   async property_getSnapshot(revNum = null) {
     return this._propertyControl.getSnapshot(revNum);
+  }
+  static get _loggingFor_property_getSnapshot() {
+    return {
+      args: [true],
+      result: false
+    };
   }
 
   /**


### PR DESCRIPTION
This PR adds logging metadata (for driving selective redaction) to the remaining — and arguably most interesting — classes that needed it, namely `EditSession` and `ViewSession` in the `doc-server` module.