### PR TITLE
Spring cleaning for test descriptions.

### DIFF
--- a/local-modules/@bayou/api-common/tests/test_Remote.js
+++ b/local-modules/@bayou/api-common/tests/test_Remote.js
@@ -41,7 +41,7 @@ describe('@bayou/api-common/Remote', () => {
       }
     });
 
-    it('should reject invalid values for `targetId`', () => {
+    it('rejects invalid values for `targetId`', () => {
       for (const id of INVALID_IDS) {
         assert.throws(() => new Remote(id), /badValue/, inspect(id));
       }

--- a/local-modules/@bayou/api-common/tests/test_Remote.js
+++ b/local-modules/@bayou/api-common/tests/test_Remote.js
@@ -35,7 +35,7 @@ const INVALID_IDS = [
 
 describe('@bayou/api-common/Remote', () => {
   describe('constructor()', () => {
-    it('should accept valid IDs', () => {
+    it('accepts valid IDs', () => {
       for (const id of VALID_IDS) {
         assert.doesNotThrow(() => new Remote(id), id);
       }

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -106,7 +106,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       assert.deepEqual(result, { got: new BearerToken('yes', 'yes') });
     });
 
-    it('should reject a non-string non-`BearerToken` argument without calling through to the `_impl`', async () => {
+    it('rejects a non-string non-`BearerToken` argument without calling through to the `_impl`', async () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_targetFromToken(value_unused) {
           throw new Error('Should not have been called.');
@@ -135,7 +135,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       assert.isNull(result);
     });
 
-    it('should reject a bad subclass implementation', () => {
+    it('rejects a bad subclass implementation', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_targetFromToken(value_unused) {
           // Supposed to be an object or `null`.
@@ -168,7 +168,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       assert.throws(() => au.tokenFromString('nope'), /badValue/);
     });
 
-    it('should reject a non-string without calling through to any `_impl`', () => {
+    it('rejects a non-string without calling through to any `_impl`', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_isToken(value_unused) {
           throw new Error('Should not have been called.');
@@ -186,7 +186,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       assert.throws(() => au.tokenFromString(['x']), /badValue/);
     });
 
-    it('should reject a bad subclass implementation', () => {
+    it('rejects a bad subclass implementation', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_isToken(value_unused) {
           return true;

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -122,7 +122,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       await assert.isRejected(au.targetFromToken(['foo']), /badValue/);
     });
 
-    it('should accept `null` from the `_impl`', async () => {
+    it('accepts `null` from the `_impl`', async () => {
       class Authie extends BaseTokenAuthorizer {
         async _impl_targetFromToken(value_unused) {
           return null;

--- a/local-modules/@bayou/codec/tests/test_Codec_decode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_decode.js
@@ -44,13 +44,13 @@ describe('@bayou/codec/Codec.decode*()', () => {
       test([[[null]]]);
     });
 
-    it('should reject plain objects not in "encoded instance" form', () => {
+    it('rejects plain objects not in "encoded instance" form', () => {
       assert.throws(() => decodeData({}));
       assert.throws(() => decodeData({ a: 123 }));
       assert.throws(() => decodeData({ foo: [], x: [] }));
     });
 
-    it('should reject functions', () => {
+    it('rejects functions', () => {
       assert.throws(() => decodeData(function () { return true; }));
       assert.throws(() => decodeData(() => 123));
     });

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -72,7 +72,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(value));
     });
 
-    it('should accept plain objects and encode as a tagged entries array', () => {
+    it('accepts plain objects and encode as a tagged entries array', () => {
       function test(value) {
         const expect = ConstructorCall.from('object', ...Object.entries(value));
         assert.deepEqual(encodeData(value), expect);
@@ -94,7 +94,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.deepEqual(encodeData(orig), expect);
     });
 
-    it('should accept `FrozenBuffer`s and encode as a single base-64 string argument', () => {
+    it('accepts `FrozenBuffer`s and encode as a single base-64 string argument', () => {
       const orig   = new FrozenBuffer('florp');
       const expect = ConstructorCall.from('buf', 'ZmxvcnA=');
 
@@ -113,7 +113,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(noDeconstruct));
     });
 
-    it('should accept objects with a `CODEC_TAG` property and `deconstruct()` method', () => {
+    it('accepts objects with a `CODEC_TAG` property and `deconstruct()` method', () => {
       const fakeObject = new MockCodable();
 
       assert.doesNotThrow(() => encodeData(fakeObject));

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -19,15 +19,15 @@ describe('@bayou/codec/Codec.encode*()', () => {
   codec.registry.registerClass(MockCodable);
 
   describe('encodeData()', () => {
-    it('should reject function values', () => {
+    it('rejects function values', () => {
       assert.throws(() => encodeData(() => 1));
     });
 
-    it('should reject Symbols', () => {
+    it('rejects Symbols', () => {
       assert.throws(() => encodeData(Symbol('this better not work!')));
     });
 
-    it('should reject undefined', () => {
+    it('rejects undefined', () => {
       assert.throws(() => encodeData(undefined));
     });
 
@@ -54,7 +54,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       test([[[null]]]);
     });
 
-    it('should reject arrays with index holes', () => {
+    it('rejects arrays with index holes', () => {
       const value = [];
 
       value[1] = true;
@@ -63,7 +63,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(value));
     });
 
-    it('should reject arrays with non-numeric properties', () => {
+    it('rejects arrays with non-numeric properties', () => {
       const value = [];
 
       value['foo'] = 'bar';
@@ -101,7 +101,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.deepEqual(encodeData(orig), expect);
     });
 
-    it('should reject objects with no `deconstruct()` method', () => {
+    it('rejects objects with no `deconstruct()` method', () => {
       class NoDeconstruct {
         get CODEC_TAG() {
           return 'NoDeconstruct';

--- a/local-modules/@bayou/codec/tests/test_Registry.js
+++ b/local-modules/@bayou/codec/tests/test_Registry.js
@@ -39,7 +39,7 @@ describe('@bayou/codec/Registry', () => {
       assert.doesNotThrow(() => reg.registerClass(NoCodecTag));
     });
 
-    it('should reject a class without `deconstruct()`', () => {
+    it('rejects a class without `deconstruct()`', () => {
       class NoDeconstruct {
         get CODEC_TAG() {
           return 'NoDeconstruct';
@@ -50,7 +50,7 @@ describe('@bayou/codec/Registry', () => {
       assert.throws(() => reg.registerClass(NoDeconstruct));
     });
 
-    it('should reject non-classes', () => {
+    it('rejects non-classes', () => {
       const reg = new Registry();
       assert.throws(() => reg.registerClass(true));
       assert.throws(() => reg.registerClass(37));

--- a/local-modules/@bayou/codec/tests/test_Registry.js
+++ b/local-modules/@bayou/codec/tests/test_Registry.js
@@ -23,7 +23,7 @@ class RegistryTestClass {
 
 describe('@bayou/codec/Registry', () => {
   describe('register()', () => {
-    it('should accept a class with all salient properties', () => {
+    it('accepts a class with all salient properties', () => {
       const reg = new Registry();
       assert.doesNotThrow(() => reg.registerClass(RegistryTestClass));
     });

--- a/local-modules/@bayou/codec/tests/test_Registry.js
+++ b/local-modules/@bayou/codec/tests/test_Registry.js
@@ -76,7 +76,7 @@ describe('@bayou/codec/Registry', () => {
       assert.throws(() => reg.codecForPayload(Symbol('foo')));
     });
 
-    it('should return the named codec if it is registered', () => {
+    it('returns the named codec if it is registered', () => {
       const reg       = new Registry();
       const itemCodec = new ItemCodec('Boop', Boolean, null, () => 0, () => 0);
 
@@ -86,7 +86,7 @@ describe('@bayou/codec/Registry', () => {
       assert.strictEqual(testCodec, itemCodec);
     });
 
-    it('should return the codec for a special type if it is registered', () => {
+    it('returns the codec for a special type if it is registered', () => {
       const reg       = new Registry();
       const type      = 'symbol';
       const itemCodec = new ItemCodec(ItemCodec.tagFromType(type), type, null, () => 0, () => 0);

--- a/local-modules/@bayou/codec/tests/test_Registry.js
+++ b/local-modules/@bayou/codec/tests/test_Registry.js
@@ -63,7 +63,7 @@ describe('@bayou/codec/Registry', () => {
   });
 
   describe('codecForPayload()', () => {
-    it('should throw an error if an unregistered tag is requested', () => {
+    it('throws an error if an unregistered tag is requested', () => {
       const reg = new Registry();
 
       // Throws because `Boop` isn't a registered class.

--- a/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
@@ -45,7 +45,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isFalse(IdSyntax.isAuthorId('123456789\t123456789+12'));
     });
 
-    it('should throw an error given a non-string argument', () => {
+    it('throws an error given a non-string argument', () => {
       for (const id of NON_STRINGS) {
         assert.throws(() => IdSyntax.isAuthorId(id), /badValue/, id);
       }
@@ -69,7 +69,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isFalse(IdSyntax.isDocumentId('123456789\t123456789+12'));
     });
 
-    it('should throw an error given a non-string argument', () => {
+    it('throws an error given a non-string argument', () => {
       for (const id of NON_STRINGS) {
         assert.throws(() => IdSyntax.isDocumentId(id), /badValue/, id);
       }

--- a/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
@@ -29,7 +29,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
   });
 
   describe('isAuthorId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
+    it('accepts 32-character alphanum ASCII strings', () => {
       assert.isTrue(IdSyntax.isAuthorId('123abc7890ABC456789012'));
     });
 
@@ -53,7 +53,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
   });
 
   describe('isDocumentId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
+    it('accepts 32-character alphanum ASCII strings', () => {
       assert.isTrue(IdSyntax.isDocumentId('123abc7890ABC456789012'));
     });
 

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -92,7 +92,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('isToken()', () => {
-    it('should accept token syntax', () => {
+    it('accepts token syntax', () => {
       assert.isTrue(Auth.isToken(ROOT_TOKEN));
 
       for (const t of EXAMPLE_TOKENS) {

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -59,7 +59,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('getAuthorToken()', () => {
-    it('should return a `BearerToken` when given a valid author ID', async () => {
+    it('returns a `BearerToken` when given a valid author ID', async () => {
       const t = await Auth.getAuthorToken('some-author');
 
       assert.instanceOf(t, BearerToken);
@@ -72,13 +72,13 @@ describe('@bayou/config-server-default/Auth', () => {
       assert.isFalse(t1.sameToken(t2));
     });
 
-    it('should return a token whose full string conforms to `isToken()`', async () => {
+    it('returns a token whose full string conforms to `isToken()`', async () => {
       const t = await Auth.getAuthorToken('some-author');
 
       assert.isTrue(Auth.isToken(t.secretToken));
     });
 
-    it('should return a token which elicits a correct response from `tokenAuthority()`', async () => {
+    it('returns a token which elicits a correct response from `tokenAuthority()`', async () => {
       const AUTHOR_ID = 'that-author';
       const t         = await Auth.getAuthorToken(AUTHOR_ID);
       const authority = await Auth.tokenAuthority(t);

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -100,7 +100,7 @@ describe('@bayou/config-server-default/Auth', () => {
       }
     });
 
-    it('should reject non-token syntax', () => {
+    it('rejects non-token syntax', () => {
       assert.isFalse(Auth.isToken('00000000-11234def0'));
       assert.isFalse(Auth.isToken('-0000000-11234def'));
       assert.isFalse(Auth.isToken('z-0000000-1123cdef'));
@@ -117,7 +117,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('tokenAuthority()', () => {
-    it('should reject non-token values', async () => {
+    it('rejects non-token values', async () => {
       async function test(x) {
         await assert.isRejected(Auth.tokenAuthority(x), /badValue/);
       }

--- a/local-modules/@bayou/config-server-default/tests/test_Deployment.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Deployment.js
@@ -15,13 +15,13 @@ describe('@bayou/config-server-default/Deployment', () => {
   });
 
   describe('isRunningInDevelopment()', () => {
-    it('should return `true`', () => {
+    it('returns `true`', () => {
       assert.isTrue(Deployment.isRunningInDevelopment());
     });
   });
 
   describe('aboutToRun()', () => {
-    it('should return without throwing', () => {
+    it('returns without throwing', () => {
       assert.doesNotThrow(() => Deployment.aboutToRun(['argument is ignored']));
     });
   });

--- a/local-modules/@bayou/config-server-default/tests/test_Storage.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Storage.js
@@ -23,7 +23,7 @@ describe('@bayou/config-server-default/Storage', () => {
       assert.instanceOf(Storage.dataStore, LocalDataStore);
     });
 
-    it('should return the same actual object on every access', () => {
+    it('returns the same actual object on every access', () => {
       const store = Storage.dataStore;
 
       for (let i = 0; i < 10; i++) {
@@ -38,7 +38,7 @@ describe('@bayou/config-server-default/Storage', () => {
       assert.instanceOf(Storage.fileStore, LocalFileStore);
     });
 
-    it('should return the same actual object on every access', () => {
+    it('returns the same actual object on every access', () => {
       const store = Storage.fileStore;
 
       for (let i = 0; i < 10; i++) {

--- a/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { DocumentState } from '@bayou/data-model-client';
 
 describe('@bayou/data-model-client/DocumentState', () => {
-  it('should return default values when passed an undefined initial', () => {
+  it('returns default values when passed an undefined initial', () => {
     const reducer = DocumentState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });
 

--- a/local-modules/@bayou/data-model-client/tests/test_DragState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DragState.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { DragState } from '@bayou/data-model-client';
 
 describe('@bayou/data-model-client/DragState', () => {
-  it('should return default values when passed a null initial state', () => {
+  it('returns default values when passed a null initial state', () => {
     const reducer = DragState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });
 

--- a/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { OwnerState } from '@bayou/data-model-client';
 
 describe('@bayou/data-model-client/OwnerState', () => {
-  it('should return default values when passed a null initial state', () => {
+  it('returns default values when passed a null initial state', () => {
     const reducer = OwnerState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });
 

--- a/local-modules/@bayou/data-model-client/tests/test_SharingState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_SharingState.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { SharingState } from '@bayou/data-model-client';
 
 describe('@bayou/data-model-client/SharingState', () => {
-  it('should return default values when passed a null initial state', () => {
+  it('returns default values when passed a null initial state', () => {
     const reducer = SharingState.reducer;
     const state = reducer(undefined, { type: 'unknown_action' });
 

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -149,25 +149,25 @@ describe('@bayou/doc-common/Caret', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       assert.isTrue(caret1.equals(caret1));
       assert.isTrue(caret2.equals(caret2));
       assert.isTrue(caret3.equals(caret3));
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       const same = caret1.compose(CaretDelta.EMPTY);
       assert.notStrictEqual(caret1, same);
       assert.isTrue(caret1.equals(same));
     });
 
-    it('should return `false` when caret IDs differ', () => {
+    it('returns `false` when caret IDs differ', () => {
       const c1 = newCaret('cr-xxxxx', 1, 2, '#000011', 'some-author');
       const c2 = newCaret('cr-yyyyy', 1, 2, '#000011', 'some-author');
       assert.isFalse(c1.equals(c2));
     });
 
-    it('should return `false` when any field differs', () => {
+    it('returns `false` when any field differs', () => {
       const c1 = caret1;
       let   c2, op;
 
@@ -188,7 +188,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.isFalse(c1.equals(c2));
     });
 
-    it('should return `false` when passed a non-caret', () => {
+    it('returns `false` when passed a non-caret', () => {
       const caret = newCaret('cr-florp', 1, 2, '#000011', 'blorp');
 
       assert.isFalse(caret.equals(undefined));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -49,7 +49,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
       assert.deepEqual(result2.ops, []);
     });
 
-    it('should reject calls when `other` is not an instance of the class', () => {
+    it('rejects calls when `other` is not an instance of the class', () => {
       const delta = CaretDelta.EMPTY;
 
       assert.throws(() => delta.compose('blort', true));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -39,7 +39,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
       }
     }
 
-    it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
+    it('returns an empty result from `EMPTY.compose(EMPTY)`', () => {
       const result1 = CaretDelta.EMPTY.compose(CaretDelta.EMPTY, false);
       assert.instanceOf(result1, CaretDelta);
       assert.deepEqual(result1.ops, []);

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -63,13 +63,13 @@ describe('@bayou/doc-common/CaretId', () => {
       }
     });
 
-    it('should reject invalid ID strings', () => {
+    it('rejects invalid ID strings', () => {
       for (const s of INVALID_STRINGS) {
         assert.throws(() => CaretId.check(s), /badValue/, s);
       }
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       for (const v of NON_STRINGS) {
         assert.throws(() => CaretId.check(v), /badValue/, v);
       }
@@ -102,13 +102,13 @@ describe('@bayou/doc-common/CaretId', () => {
       assert.strictEqual('0zor0', CaretId.payloadFromId('cr-0zor0'));
     });
 
-    it('should reject invalid ID strings', () => {
+    it('rejects invalid ID strings', () => {
       for (const s of INVALID_STRINGS) {
         assert.throws(() => CaretId.payloadFromId(s), /badValue/, s);
       }
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       for (const v of NON_STRINGS) {
         assert.throws(() => CaretId.payloadFromId(v), /badValue/, v);
       }

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -77,19 +77,19 @@ describe('@bayou/doc-common/CaretId', () => {
   });
 
   describe('isInstance()', () => {
-    it('should return `true` for valid ID strings', () => {
+    it('returns `true` for valid ID strings', () => {
       for (const s of VALID_IDS) {
         assert.isTrue(CaretId.isInstance(s), s);
       }
     });
 
-    it('should return `false` for invalid ID strings', () => {
+    it('returns `false` for invalid ID strings', () => {
       for (const s of INVALID_STRINGS) {
         assert.isFalse(CaretId.isInstance(s), s);
       }
     });
 
-    it('should return `false` for non-strings', () => {
+    it('returns `false` for non-strings', () => {
       for (const v of NON_STRINGS) {
         assert.isFalse(CaretId.isInstance(v), v);
       }
@@ -97,7 +97,7 @@ describe('@bayou/doc-common/CaretId', () => {
   });
 
   describe('payloadFromId()', () => {
-    it('should return the payload from a valid id', () => {
+    it('returns the payload from a valid id', () => {
       assert.strictEqual('fooba', CaretId.payloadFromId('cr-fooba'));
       assert.strictEqual('0zor0', CaretId.payloadFromId('cr-0zor0'));
     });
@@ -116,14 +116,14 @@ describe('@bayou/doc-common/CaretId', () => {
   });
 
   describe('randomInstance()', () => {
-    it('should return values for which `isInstance()` is `true`', () => {
+    it('returns values for which `isInstance()` is `true`', () => {
       for (let i = 0; i < 10; i++) {
         const id = CaretId.randomInstance();
         assert.isTrue(CaretId.isInstance(id), id);
       }
     });
 
-    it('should return a different value every time (practically speaking)', () => {
+    it('returns a different value every time (practically speaking)', () => {
       // This is well under the count at which we can statistically expect a
       // collision to always occur -- at about 6800, the chance of a collision
       // is about 50% -- but collisions might still legitimately crop up in this

--- a/local-modules/@bayou/doc-common/tests/test_CaretId.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretId.js
@@ -57,7 +57,7 @@ const NON_STRINGS = [
 
 describe('@bayou/doc-common/CaretId', () => {
   describe('check()', () => {
-    it('should accept valid ID strings', () => {
+    it('accepts valid ID strings', () => {
       for (const s of VALID_IDS) {
         assert.strictEqual(CaretId.check(s), s, s);
       }

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -94,7 +94,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isFrozen(snap);
     });
 
-    it('should reject an array that is not all valid ops', () => {
+    it('rejects an array that is not all valid ops', () => {
       function test(value) {
         assert.throws(() => { new CaretSnapshot(0, value); });
       }
@@ -107,7 +107,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test([op1, op1]); // Duplicates aren't allowed.
     });
 
-    it('should reject a delta with disallowed ops', () => {
+    it('rejects a delta with disallowed ops', () => {
       function test(ops) {
         const delta = new CaretDelta(ops);
         assert.throws(() => { new CaretSnapshot(0, delta); });
@@ -127,7 +127,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test([op1, op1]);
     });
 
-    it('should reject invalid revision numbers', () => {
+    it('rejects invalid revision numbers', () => {
       function test(value) {
         assert.throws(() => { new CaretSnapshot(value, CaretDelta.EMPTY); });
       }
@@ -573,7 +573,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `contents`', () => {
+    it('rejects an invalid `contents`', () => {
       const snap = new CaretSnapshot(123, []);
 
       assert.throws(() => snap.withContents('blortch'));
@@ -596,7 +596,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `revNum`', () => {
+    it('rejects an invalid `revNum`', () => {
       const snap = new CaretSnapshot(1, [op1, op2]);
 
       assert.throws(() => snap.withRevNum('blortch'));
@@ -644,13 +644,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     describe('invalid argument', () => {
-      it('should reject invalid ID strings', () => {
+      it('rejects invalid ID strings', () => {
         const snap = new CaretSnapshot(1, [op1]);
         assert.throws(() => snap.withoutCaret(''));
         assert.throws(() => snap.withoutCaret('ZORCH_SPLAT'));
       });
 
-      it('should reject arguments that are neither strings nor `Caret`s', () => {
+      it('rejects arguments that are neither strings nor `Caret`s', () => {
         const snap = new CaretSnapshot(1, [op1]);
         assert.throws(() => snap.withoutCaret(undefined));
         assert.throws(() => snap.withoutCaret(null));

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -274,7 +274,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('entries()', () => {
-    it('should return an iterator', () => {
+    it('returns an iterator', () => {
       const snap   = new CaretSnapshot(0, []);
       const result = snap.entries();
 
@@ -311,7 +311,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       let snap;
 
       snap = new CaretSnapshot(0, []);
@@ -324,7 +324,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(snap.equals(snap));
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       let snap1, snap2;
 
       snap1 = new CaretSnapshot(0, []);
@@ -340,13 +340,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(snap1.equals(snap2));
     });
 
-    it('should return `true` when identical carets are passed in different orders', () => {
+    it('returns `true` when identical carets are passed in different orders', () => {
       const snap1 = new CaretSnapshot(37, [op1, op2, op3]);
       const snap2 = new CaretSnapshot(37, [op3, op1, op2]);
       assert.isTrue(snap1.equals(snap2));
     });
 
-    it('should return `true` when equal carets are not also `===`', () => {
+    it('returns `true` when equal carets are not also `===`', () => {
       const c1a = newCaretOp('cr-florp', 2, 3, '#444444', 'ab');
       const c1b = newCaretOp('cr-florp', 2, 3, '#444444', 'ab');
       const c2a = newCaretOp('cr-like0',  3, 0, '#dbdbdb', 'cd');
@@ -357,13 +357,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(snap1.equals(snap2));
     });
 
-    it('should return `false` when `revNum`s differ', () => {
+    it('returns `false` when `revNum`s differ', () => {
       const snap1 = new CaretSnapshot(1, [op1, op2, op3]);
       const snap2 = new CaretSnapshot(2, [op1, op2, op3]);
       assert.isFalse(snap1.equals(snap2));
     });
 
-    it('should return `false` when caret contents differ', () => {
+    it('returns `false` when caret contents differ', () => {
       let snap1, snap2;
 
       snap1 = new CaretSnapshot(1, [op1]);
@@ -412,7 +412,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
 
-    it('should return `false` when passed a non-snapshot', () => {
+    it('returns `false` when passed a non-snapshot', () => {
       const snap = new CaretSnapshot(1, [op1, op2, op3]);
 
       assert.isFalse(snap.equals(undefined));
@@ -426,7 +426,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('get()', () => {
-    it('should return the caret associated with an existing ID', () => {
+    it('returns the caret associated with an existing ID', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.strictEqual(snap.get(caret1.id), caret1);
@@ -450,7 +450,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('getOrNull()', () => {
-    it('should return the caret associated with an existing ID', () => {
+    it('returns the caret associated with an existing ID', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.strictEqual(snap.getOrNull(caret1.id), caret1);
@@ -458,7 +458,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(snap.getOrNull(caret3.id), caret3);
     });
 
-    it('should return `null` when given an ID that is not in the snapshot', () => {
+    it('returns `null` when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.isNull(snap.getOrNull(caret2.id));
@@ -474,7 +474,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('has()', () => {
-    it('should return `true` when given an ID for an existing caret', () => {
+    it('returns `true` when given an ID for an existing caret', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
 
       assert.isTrue(snap.has(caret1.id));
@@ -482,7 +482,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(snap.has(caret3.id));
     });
 
-    it('should return `false` when given an ID that is not in the snapshot', () => {
+    it('returns `false` when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.isFalse(snap.has(caret2.id));
@@ -498,14 +498,14 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('randomUnusedId()', () => {
-    it('should return a string for which `CaretId.isInstance()` is `true`', () => {
+    it('returns a string for which `CaretId.isInstance()` is `true`', () => {
       const snap = new CaretSnapshot(999, [op1, op2, op3]);
       const id   = snap.randomUnusedId();
 
       assert.isTrue(CaretId.isInstance(id));
     });
 
-    it('should return an ID that is not used', () => {
+    it('returns an ID that is not used', () => {
       // What we're doing here is mocking out `CaretSnapshot.has()` to lie about
       // the IDs in the instance N times, so that we can infer that the method
       // under test actually retries.
@@ -531,7 +531,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('withCaret()', () => {
-    it('should return `this` if the exact caret is already in the snapshot', () => {
+    it('returns `this` if the exact caret is already in the snapshot', () => {
       const snap = new CaretSnapshot(1, [op1]);
 
       assert.strictEqual(snap.withCaret(caret1), snap);
@@ -540,14 +540,14 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(snap.withCaret(cloneCaret), snap);
     });
 
-    it('should return an appropriately-constructed instance given a new caret', () => {
+    it('returns an appropriately-constructed instance given a new caret', () => {
       const snap     = new CaretSnapshot(1, [op1]);
       const expected = new CaretSnapshot(1, [op1, op2]);
 
       assert.isTrue(snap.withCaret(caret2).equals(expected));
     });
 
-    it('should return an appropriately-constructed instance given an updated caret', () => {
+    it('returns an appropriately-constructed instance given an updated caret', () => {
       const modCaret = new Caret(caret1, { index: 321 });
       const modOp    = CaretOp.op_add(modCaret);
       const snap     = new CaretSnapshot(1, [op1,   op2]);
@@ -558,13 +558,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('withContents()', () => {
-    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+    it('returns `this` if the given `contents` is `===` to the snapshot\'s', () => {
       const snap = new CaretSnapshot(123, CaretDelta.EMPTY);
 
       assert.strictEqual(snap.withContents(CaretDelta.EMPTY), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `contents`', () => {
+    it('returns an appropriately-constructed instance given a different `contents`', () => {
       const delta  = new CaretDelta([op1, op2, op3]);
       const snap   = new CaretSnapshot(111, [op1]);
       const result = snap.withContents(delta);
@@ -581,13 +581,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('withRevNum()', () => {
-    it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
+    it('returns `this` if the given `revNum` is the same as in the snapshot', () => {
       const snap = new CaretSnapshot(1, [op1]);
 
       assert.strictEqual(snap.withRevNum(1), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `revNum`', () => {
+    it('returns an appropriately-constructed instance given a different `revNum`', () => {
       const delta  = new CaretDelta([op1, op2]);
       const snap   = new CaretSnapshot(1, delta);
       const result = snap.withRevNum(2);
@@ -605,14 +605,14 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
 
   describe('withoutCaret()', () => {
     describe('valid `Caret` argument', () => {
-      it('should return `this` if there is no matching caret', () => {
+      it('returns `this` if there is no matching caret', () => {
         const snap = new CaretSnapshot(1, [op1]);
 
         assert.strictEqual(snap.withoutCaret(caret2), snap);
         assert.strictEqual(snap.withoutCaret(caret3), snap);
       });
 
-      it('should return an appropriately-constructed instance if there is a matching caret', () => {
+      it('returns an appropriately-constructed instance if there is a matching caret', () => {
         const snap     = new CaretSnapshot(1, [op1, op2]);
         const expected = new CaretSnapshot(1, [op2]);
 
@@ -629,13 +629,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
     });
 
     describe('valid ID argument', () => {
-      it('should return `this` if there is no matching caret', () => {
+      it('returns `this` if there is no matching caret', () => {
         const snap = new CaretSnapshot(1, [op1]);
 
         assert.strictEqual(snap.withoutCaret('cr-not00'), snap);
       });
 
-      it('should return an appropriately-constructed instance if there is a matching caret', () => {
+      it('returns an appropriately-constructed instance if there is a matching caret', () => {
         const snap     = new CaretSnapshot(1, [op1, op2]);
         const expected = new CaretSnapshot(1, [op2]);
 

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -56,7 +56,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('constructor()', () => {
-    it('should accept an array of valid ops', () => {
+    it('accepts an array of valid ops', () => {
       function test(value) {
         new CaretSnapshot(0, value);
       }
@@ -67,7 +67,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test([op1, op2, op3]);
     });
 
-    it('should accept valid revision numbers', () => {
+    it('accepts valid revision numbers', () => {
       function test(value) {
         new CaretSnapshot(value, CaretDelta.EMPTY);
       }
@@ -77,7 +77,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test(999999);
     });
 
-    it('should accept a valid delta', () => {
+    it('accepts a valid delta', () => {
       function test(ops) {
         const delta = new CaretDelta(ops);
         new CaretSnapshot(0, delta);

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -434,13 +434,13 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(snap.get(caret3.id), caret3);
     });
 
-    it('should throw an error when given an ID that is not in the snapshot', () => {
+    it('throws an error when given an ID that is not in the snapshot', () => {
       const snap = new CaretSnapshot(999, [op1, op3]);
 
       assert.throws(() => { snap.get(caret2.id); });
     });
 
-    it('should throw an error if given an invalid ID', () => {
+    it('throws an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.get(123); });
@@ -464,7 +464,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isNull(snap.getOrNull(caret2.id));
     });
 
-    it('should throw an error if given an invalid ID', () => {
+    it('throws an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.getOrNull(123); });
@@ -488,7 +488,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isFalse(snap.has(caret2.id));
     });
 
-    it('should throw an error if given an invalid ID', () => {
+    it('throws an error if given an invalid ID', () => {
       const snap = new CaretSnapshot(999, []);
 
       assert.throws(() => { snap.has(123); });

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -89,7 +89,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.deepEqual(result2.ops, []);
     });
 
-    it('should reject calls when `other` is not an instance of the class', () => {
+    it('rejects calls when `other` is not an instance of the class', () => {
       const delta = PropertyDelta.EMPTY;
 
       assert.throws(() => delta.compose('blort', false));

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -79,7 +79,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
   });
 
   describe('compose()', () => {
-    it('should return an empty result from `EMPTY.compose(EMPTY)`', () => {
+    it('returns an empty result from `EMPTY.compose(EMPTY)`', () => {
       const result1 = PropertyDelta.EMPTY.compose(PropertyDelta.EMPTY, false);
       assert.instanceOf(result1, PropertyDelta);
       assert.deepEqual(result1.ops, []);
@@ -156,7 +156,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       function test(ops) {
         const delta = new PropertyDelta(ops);
         assert.isTrue(delta.equals(delta));
@@ -167,7 +167,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       test([PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_delete('ccc')]);
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(ops) {
         const d1 = new PropertyDelta(ops);
         const d2 = new PropertyDelta(ops);
@@ -180,7 +180,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       test([PropertyOp.op_set('aaa', 'bbb'), PropertyOp.op_delete('ccc')]);
     });
 
-    it('should return `true` when equal ops are not also `===`', () => {
+    it('returns `true` when equal ops are not also `===`', () => {
       const ops1 = [PropertyOp.op_set('aaa', 'bbb')];
       const ops2 = [PropertyOp.op_set('aaa', 'bbb')];
       const d1 = new PropertyDelta(ops1);
@@ -190,7 +190,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.isTrue(d2.equals(d1));
     });
 
-    it('should return `false` when array lengths differ', () => {
+    it('returns `false` when array lengths differ', () => {
       const op1 = PropertyOp.op_set('aaa', 'bbb');
       const op2 = PropertyOp.op_delete('ccc');
       const d1 = new PropertyDelta([op1]);
@@ -200,7 +200,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.isFalse(d2.equals(d1));
     });
 
-    it('should return `false` when corresponding ops differ', () => {
+    it('returns `false` when corresponding ops differ', () => {
       function test(ops1, ops2) {
         const d1 = new PropertyDelta(ops1);
         const d2 = new PropertyDelta(ops2);
@@ -225,7 +225,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       test([op1, op2, op3, op4, op5], [op1, op2, op3, op4, op1]);
     });
 
-    it('should return `false` when passed a non-instance or an instance of a different class', () => {
+    it('returns `false` when passed a non-instance or an instance of a different class', () => {
       const delta = new PropertyDelta([]);
 
       assert.isFalse(delta.equals(undefined));

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -237,7 +237,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('entries()', () => {
-    it('should return an iterator', () => {
+    it('returns an iterator', () => {
       const snap   = new PropertySnapshot(0, []);
       const result = snap.entries();
 
@@ -289,7 +289,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       function test(...args) {
         const snap = new PropertySnapshot(...args);
         assert.isTrue(snap.equals(snap), inspect(snap));
@@ -306,7 +306,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(...args) {
         const snap1 = new PropertySnapshot(...args);
         const snap2 = new PropertySnapshot(...args);
@@ -326,7 +326,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should return `true` when identical construction ops are passed in different orders', () => {
+    it('returns `true` when identical construction ops are passed in different orders', () => {
       const snap1 = new PropertySnapshot(321, [
         PropertyOp.op_set('a', 10),
         PropertyOp.op_set('b', 20),
@@ -341,7 +341,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(snap1.equals(snap2));
     });
 
-    it('should return `true` when equal property values are not also `===`', () => {
+    it('returns `true` when equal property values are not also `===`', () => {
       const snap1 = new PropertySnapshot(37, [
         PropertyOp.op_set('a', [1, 2]),
         PropertyOp.op_set('b', { b: 20 }),
@@ -357,7 +357,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(snap2.equals(snap1));
     });
 
-    it('should return `false` when `revNum`s differ', () => {
+    it('returns `false` when `revNum`s differ', () => {
       const snap1 = new PropertySnapshot(123, [PropertyOp.op_set('a', 10)]);
       const snap2 = new PropertySnapshot(456, [PropertyOp.op_set('a', 10)]);
 
@@ -365,7 +365,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
 
-    it('should return `false` when a property value differs', () => {
+    it('returns `false` when a property value differs', () => {
       const snap1 = new PropertySnapshot(9, [
         PropertyOp.op_set('a', 10),
         PropertyOp.op_set('b', 20),
@@ -381,7 +381,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isFalse(snap2.equals(snap1));
     });
 
-    it('should return `false` when passed a non-snapshot', () => {
+    it('returns `false` when passed a non-snapshot', () => {
       const snap = PropertySnapshot.EMPTY;
 
       assert.isFalse(snap.equals(undefined));
@@ -395,7 +395,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('get()', () => {
-    it('should return the value associated with an existing property', () => {
+    it('returns the value associated with an existing property', () => {
       function test(name, value) {
         const op = PropertyOp.op_set(name, value);
         const snap = new PropertySnapshot(1, [
@@ -439,7 +439,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('getOrNull()', () => {
-    it('should return the value associated with an existing property', () => {
+    it('returns the value associated with an existing property', () => {
       function test(name, value) {
         const op = PropertyOp.op_set(name, value);
         const snap = new PropertySnapshot(1, [
@@ -475,7 +475,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.deepEqual(result.value, value);
     });
 
-    it('should return `null` when given a name that is not bound as a property', () => {
+    it('returns `null` when given a name that is not bound as a property', () => {
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.isNull(snap.getOrNull('x'));
@@ -483,7 +483,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('has()', () => {
-    it('should return `true` for an existing property', () => {
+    it('returns `true` for an existing property', () => {
       const snap = new PropertySnapshot(1, [
         PropertyOp.op_set('blort',  'zorch'),
         PropertyOp.op_set('florp',  'like'),
@@ -499,7 +499,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(snap.has('zither'));
     });
 
-    it('should return `false` for a non-existent property', () => {
+    it('returns `false` for a non-existent property', () => {
       const snap = new PropertySnapshot(1, [
         PropertyOp.op_set('blort', 'zorch'),
         PropertyOp.op_set('florp', 'like')
@@ -531,13 +531,13 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('withContents()', () => {
-    it('should return `this` if the given `contents` is `===` to the snapshot\'s', () => {
+    it('returns `this` if the given `contents` is `===` to the snapshot\'s', () => {
       const snap = new PropertySnapshot(123, PropertyDelta.EMPTY);
 
       assert.strictEqual(snap.withContents(PropertyDelta.EMPTY), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `contents`', () => {
+    it('returns an appropriately-constructed instance given a different `contents`', () => {
       const delta  = new PropertyDelta([PropertyOp.op_set('blort', 'zorch')]);
       const snap   = new PropertySnapshot(123, []);
       const result = snap.withContents(delta);
@@ -554,13 +554,13 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('withProperty()', () => {
-    it('should return `this` if the exact property is already in the snapshot', () => {
+    it('returns `this` if the exact property is already in the snapshot', () => {
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.strictEqual(snap.withProperty('blort', 'zorch'), snap);
     });
 
-    it('should return an appropriately-constructed instance given a new property', () => {
+    it('returns an appropriately-constructed instance given a new property', () => {
       const snap     = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
       const expected = new PropertySnapshot(1, [
         PropertyOp.op_set('blort', 'zorch'),
@@ -570,7 +570,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(snap.withProperty('florp', 'like').equals(expected));
     });
 
-    it('should return an appropriately-constructed instance given an updated property', () => {
+    it('returns an appropriately-constructed instance given an updated property', () => {
       const snap     = new PropertySnapshot(2, [PropertyOp.op_set('blort', 'zorch')]);
       const expected = new PropertySnapshot(2, [PropertyOp.op_set('blort', 'like')]);
 
@@ -579,13 +579,13 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('withRevNum()', () => {
-    it('should return `this` if the given `revNum` is the same as in the snapshot', () => {
+    it('returns `this` if the given `revNum` is the same as in the snapshot', () => {
       const snap = new PropertySnapshot(123, PropertyDelta.EMPTY);
 
       assert.strictEqual(snap.withRevNum(123), snap);
     });
 
-    it('should return an appropriately-constructed instance given a different `revNum`', () => {
+    it('returns an appropriately-constructed instance given a different `revNum`', () => {
       const delta  = new PropertyDelta([PropertyOp.op_set('blort', 'zorch')]);
       const snap   = new PropertySnapshot(123, delta);
       const result = snap.withRevNum(456);
@@ -602,14 +602,14 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('withoutProperty()', () => {
-    it('should return `this` if there is no matching property', () => {
+    it('returns `this` if there is no matching property', () => {
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.strictEqual(snap.withoutProperty('x'), snap);
       assert.strictEqual(snap.withoutProperty('y'), snap);
     });
 
-    it('should return an appropriately-constructed instance if there is a matching property', () => {
+    it('returns an appropriately-constructed instance if there is a matching property', () => {
       const snap = new PropertySnapshot(2, [
         PropertyOp.op_set('blort', 'zorch'),
         PropertyOp.op_set('florp', 'like')

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -21,7 +21,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('constructor()', () => {
-    it('should accept an array of valid ops', () => {
+    it('accepts an array of valid ops', () => {
       function test(value) {
         new PropertySnapshot(0, value);
       }
@@ -34,7 +34,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should accept valid revision numbers', () => {
+    it('accepts valid revision numbers', () => {
       function test(value) {
         new PropertySnapshot(value, PropertyDelta.EMPTY);
       }
@@ -44,7 +44,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       test(999999);
     });
 
-    it('should accept a valid delta', () => {
+    it('accepts a valid delta', () => {
       function test(ops) {
         const delta = new PropertyDelta(ops);
         new PropertySnapshot(0, delta);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -431,7 +431,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.deepEqual(result.value, value);
     });
 
-    it('should throw an error when given a name that is not bound as a property', () => {
+    it('throws an error when given a name that is not bound as a property', () => {
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', 'zorch')]);
 
       assert.throws(() => { snap.get('x'); });
@@ -510,7 +510,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isFalse(snap.has('x'));
     });
 
-    it('should throw an error when passed an argument that is not a valid name', () => {
+    it('throws an error when passed an argument that is not a valid name', () => {
       const snap = PropertySnapshot.EMPTY;
       function test(value) {
         assert.throws(() => { snap.has(value); });

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -60,7 +60,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isFrozen(snap);
     });
 
-    it('should reject an array that is not all valid ops', () => {
+    it('rejects an array that is not all valid ops', () => {
       function test(value) {
         assert.throws(() => { new PropertySnapshot(0, value); });
       }
@@ -81,7 +81,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should reject a delta with disallowed ops', () => {
+    it('rejects a delta with disallowed ops', () => {
       function test(ops) {
         const delta = new PropertyDelta(ops);
         assert.throws(() => { new PropertySnapshot(0, delta); });
@@ -100,7 +100,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       ]);
     });
 
-    it('should reject invalid revision numbers', () => {
+    it('rejects invalid revision numbers', () => {
       function test(value) {
         assert.throws(() => { new PropertySnapshot(value, PropertyDelta.EMPTY); });
       }
@@ -546,7 +546,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `contents`', () => {
+    it('rejects an invalid `contents`', () => {
       const snap = new PropertySnapshot(123, []);
 
       assert.throws(() => snap.withContents('blortch'));
@@ -594,7 +594,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.strictEqual(result.contents, delta);
     });
 
-    it('should reject an invalid `revNum`', () => {
+    it('rejects an invalid `revNum`', () => {
       const snap = new PropertySnapshot(123, []);
 
       assert.throws(() => snap.withRevNum('blortch'));

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -36,7 +36,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.isFrozen(result);
     });
 
-    it('should reject invalid arguments', () => {
+    it('rejects invalid arguments', () => {
       function test(...args) {
         assert.throws(() => new SessionInfo(...args));
       }
@@ -217,7 +217,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       test(new BearerToken('blort', 'florp'));
     });
 
-    it('should reject invalid arguments', () => {
+    it('rejects invalid arguments', () => {
       const si = new SessionInfo(SERVER_URL, 'token', 'doc');
 
       function test(value) {
@@ -250,7 +250,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       test('boop');
     });
 
-    it('should reject invalid IDs', () => {
+    it('rejects invalid IDs', () => {
       const si = new SessionInfo(SERVER_URL, 'token', 'doc');
 
       function test(value) {

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -165,14 +165,14 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('deconstruct()', () => {
-    it('should return a three-element array when constructed with three arguments', () => {
+    it('returns a three-element array when constructed with three arguments', () => {
       const si     = new SessionInfo(SERVER_URL, 'token', 'id');
       const result = si.deconstruct();
 
       assert.deepEqual(result, [SERVER_URL, 'token', 'id']);
     });
 
-    it('should return a four-element array when constructed with four non-`null` arguments', () => {
+    it('returns a four-element array when constructed with four non-`null` arguments', () => {
       const si     = new SessionInfo(SERVER_URL, 'token', 'id', 'c');
       const result = si.deconstruct();
 
@@ -181,7 +181,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('withAuthorToken()', () => {
-    it('should return a new instance given a string', () => {
+    it('returns a new instance given a string', () => {
       const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
       const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
 
@@ -199,7 +199,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       test('boop');
     });
 
-    it('should return a new instance given a `BearerToken`', () => {
+    it('returns a new instance given a `BearerToken`', () => {
       const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
       const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
 
@@ -232,7 +232,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('withCaretId()', () => {
-    it('should return a new instance given a valid `caretId`', () => {
+    it('returns a new instance given a valid `caretId`', () => {
       const orig1 = new SessionInfo(SERVER_URL, 'token', 'doc', 'caret-1');
       const orig2 = new SessionInfo(`${SERVER_URL}/123`, 'also-token', 'docky');
 
@@ -265,7 +265,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('withoutCaretId()', () => {
-    it('should return a new instance with `caretId === null`', () => {
+    it('returns a new instance with `caretId === null`', () => {
       function test(orig) {
         const result = orig.withoutCaretId();
         const expect = new SessionInfo(orig.serverUrl, orig.authorToken, orig.documentId);

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -13,24 +13,24 @@ const SERVER_URL = 'https://example.com:1234/the/path';
 
 describe('@bayou/doc-common/SessionInfo', () => {
   describe('constructor()', () => {
-    it('should accept four strings', () => {
+    it('accepts four strings', () => {
       // **TODO:** Will have to be updated when validation is improved. Likewise
       // throughout the file.
       const result = new SessionInfo(SERVER_URL, 'one', 'two', 'three');
       assert.isFrozen(result);
     });
 
-    it('should accept three strings', () => {
+    it('accepts three strings', () => {
       const result = new SessionInfo(SERVER_URL, 'one', 'two');
       assert.isFrozen(result);
     });
 
-    it('should accept three strings and `null`', () => {
+    it('accepts three strings and `null`', () => {
       const result = new SessionInfo(SERVER_URL, 'one', 'two', null);
       assert.isFrozen(result);
     });
 
-    it('should accept a `BearerToken` for the `authorToken` argument', () => {
+    it('accepts a `BearerToken` for the `authorToken` argument', () => {
       const token  = new BearerToken('x', 'y');
       const result = new SessionInfo(SERVER_URL, token, 'boop');
       assert.isFrozen(result);

--- a/local-modules/@bayou/doc-common/tests/test_Timeouts.js
+++ b/local-modules/@bayou/doc-common/tests/test_Timeouts.js
@@ -61,13 +61,13 @@ describe('@bayou/doc-common/Timeouts', () => {
       }
     });
 
-    it('should reject negative numbers', () => {
+    it('rejects negative numbers', () => {
       assert.throws(() => Timeouts.clamp(-1));
       assert.throws(() => Timeouts.clamp(-0.01));
       assert.throws(() => Timeouts.clamp(-123));
     });
 
-    it('should reject non-numbers that are not `null`', () => {
+    it('rejects non-numbers that are not `null`', () => {
       assert.throws(() => Timeouts.clamp(undefined));
       assert.throws(() => Timeouts.clamp(false));
       assert.throws(() => Timeouts.clamp('123'));

--- a/local-modules/@bayou/doc-common/tests/test_Timeouts.js
+++ b/local-modules/@bayou/doc-common/tests/test_Timeouts.js
@@ -34,7 +34,7 @@ describe('@bayou/doc-common/Timeouts', () => {
       assert.strictEqual(Timeouts.clamp(null), Timeouts.MAX_TIMEOUT_MSEC);
     });
 
-    it('should accept in-range integers as-is', () => {
+    it('accepts in-range integers as-is', () => {
       const min = Timeouts.MIN_TIMEOUT_MSEC;
       const max = Timeouts.MAX_TIMEOUT_MSEC;
 

--- a/local-modules/@bayou/env-server/tests/test_Dirs.js
+++ b/local-modules/@bayou/env-server/tests/test_Dirs.js
@@ -60,7 +60,7 @@ describe('@bayou/env-server/Dirs', () => {
   });
 
   describe('.VAR_DIR', () => {
-    it('should return a known subdirectory off of `BASE_DIR`', () => {
+    it('returns a known subdirectory off of `BASE_DIR`', () => {
       const baseDir = Dirs.theOne.BASE_DIR;
       const varDir = path.join(baseDir, 'var');
 

--- a/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
@@ -40,7 +40,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isFalse(DefaultIdSyntax.isAuthorId('123456789\t123456789+12'));
     });
 
-    it('should throw an error given a non-string argument', () => {
+    it('throws an error given a non-string argument', () => {
       for (const id of NON_STRINGS) {
         assert.throws(() => DefaultIdSyntax.isAuthorId(id), /badValue/, id);
       }
@@ -64,7 +64,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isFalse(DefaultIdSyntax.isDocumentId('123456789\t123456789+12'));
     });
 
-    it('should throw an error given a non-string argument', () => {
+    it('throws an error given a non-string argument', () => {
       for (const id of NON_STRINGS) {
         assert.throws(() => DefaultIdSyntax.isDocumentId(id), /badValue/, id);
       }
@@ -88,7 +88,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isFalse(DefaultIdSyntax.isFileId('123456789\t123456789+12'));
     });
 
-    it('should throw an error given a non-string argument', () => {
+    it('throws an error given a non-string argument', () => {
       for (const id of NON_STRINGS) {
         assert.throws(() => DefaultIdSyntax.isFileId(id), /badValue/, id);
       }

--- a/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
@@ -24,7 +24,7 @@ const NON_STRINGS = [
 
 describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
   describe('isAuthorId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
+    it('accepts 32-character alphanum ASCII strings', () => {
       assert.isTrue(DefaultIdSyntax.isAuthorId('123abc7890ABC456789012'));
     });
 
@@ -48,7 +48,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
   });
 
   describe('isDocumentId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
+    it('accepts 32-character alphanum ASCII strings', () => {
       assert.isTrue(DefaultIdSyntax.isDocumentId('123abc7890ABC456789012'));
     });
 
@@ -72,7 +72,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
   });
 
   describe('isFileId()', () => {
-    it('should accept 32-character alphanum ASCII strings', () => {
+    it('accepts 32-character alphanum ASCII strings', () => {
       assert.isTrue(DefaultIdSyntax.isFileId('123abc7890ABC456789012'));
     });
 

--- a/local-modules/@bayou/ot-common/tests/test_BaseOp.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseOp.js
@@ -124,12 +124,12 @@ describe('@bayou/ot-common/BaseOp', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when passed itself', () => {
+    it('returns `true` when passed itself', () => {
       const op = new MockOp('x', 'y', 'z');
       assert.isTrue(op.equals(op));
     });
 
-    it('should return `true` when passed an identically-constructed value', () => {
+    it('returns `true` when passed an identically-constructed value', () => {
       function test(...args) {
         const op1 = new MockOp(...args);
         const op2 = new MockOp(...args);
@@ -142,7 +142,7 @@ describe('@bayou/ot-common/BaseOp', () => {
       test('z', { a: 10, b: 20 });
     });
 
-    it('should return `false` when payloads differ', () => {
+    it('returns `false` when payloads differ', () => {
       function test(p1, p2) {
         const op1 = new MockOp(...p1);
         const op2 = new MockOp(...p2);
@@ -162,7 +162,7 @@ describe('@bayou/ot-common/BaseOp', () => {
       test(['x', { a: 10 }],  ['x', { a: 10, c: 'foo' }]);
     });
 
-    it('should return `false` when passed a non-instance', () => {
+    it('returns `false` when passed a non-instance', () => {
       const op = new MockOp('x');
 
       assert.isFalse(op.equals(undefined));

--- a/local-modules/@bayou/ot-common/tests/test_RevisionNumber.js
+++ b/local-modules/@bayou/ot-common/tests/test_RevisionNumber.js
@@ -162,7 +162,7 @@ describe('@bayou/ot-common/RevisionNumber', () => {
       test(333, 300);
     });
 
-    it('should reject non-negative integers below the specified limit', () => {
+    it('rejects non-negative integers below the specified limit', () => {
       function test(value, limit) {
         assert.throws(() => RevisionNumber.min(value, limit), /^badValue/);
       }

--- a/local-modules/@bayou/proppy/tests/test_Proppy.js
+++ b/local-modules/@bayou/proppy/tests/test_Proppy.js
@@ -20,25 +20,25 @@ describe('@bayou/proppy/Proppy', () => {
       _testStringParsing(input, { key: 'value' });
     });
 
-    it('should accept multiple keys and values', () => {
+    it('accepts multiple keys and values', () => {
       const input = 'key = value\nkey2 = value2\nkey3 = value3';
 
       _testStringParsing(input, { key: 'value', key2: 'value2', key3: 'value3' });
     });
 
-    it('should accept single quoted keys and values', () => {
+    it('accepts single quoted keys and values', () => {
       const input = "'key' = 'value'";
 
       _testStringParsing(input, { key: 'value' });
     });
 
-    it('should accept double quoted keys and values', () => {
+    it('accepts double quoted keys and values', () => {
       const input = '"key" = "value"';
 
       _testStringParsing(input, { key: 'value' });
     });
 
-    it('should accept unquoted keys and values if they consist entirely of blessed characters', () => {
+    it('accepts unquoted keys and values if they consist entirely of blessed characters', () => {
       let input = null;
 
       input = 'key = value';
@@ -83,7 +83,7 @@ describe('@bayou/proppy/Proppy', () => {
       assert.throws(() => _testStringParsing(input, { 'key+1': 'value+1' }));
     });
 
-    it('should accept unquoted keys and values if they consist entirely of blessed characters', () => {
+    it('accepts unquoted keys and values if they consist entirely of blessed characters', () => {
       const input = 'key = "value\n' +
                     'this is a multiline value"';
 

--- a/local-modules/@bayou/typecheck/tests/test_TArray.js
+++ b/local-modules/@bayou/typecheck/tests/test_TArray.js
@@ -11,7 +11,7 @@ import { TString } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TArray', () => {
   describe('check(value)', () => {
-    it('should return the provided value when passed an array', () => {
+    it('returns the provided value when passed an array', () => {
       const value = [1, 2, 3];
 
       assert.doesNotThrow(() => TArray.check(value));

--- a/local-modules/@bayou/typecheck/tests/test_TArray.js
+++ b/local-modules/@bayou/typecheck/tests/test_TArray.js
@@ -18,7 +18,7 @@ describe('@bayou/typecheck/TArray', () => {
       assert.strictEqual(TArray.check(value), value);
     });
 
-    it('should throw an Error when passed anything other than an array', () => {
+    it('throws an Error when passed anything other than an array', () => {
       assert.throws(() => TArray.check(3.1));
       assert.throws(() => TArray.check({ }));
       assert.throws(() => TArray.check('this better not work'));
@@ -32,7 +32,7 @@ describe('@bayou/typecheck/TArray', () => {
       assert.doesNotThrow(() => TArray.check(value, x => TInt.check(x)));
     });
 
-    it('should throw an error if an element checker fails', () => {
+    it('throws an error if an element checker fails', () => {
       const value = [1, 2, 3];
 
       assert.throws(() => TArray.check(value, x => TString.check(x)));

--- a/local-modules/@bayou/typecheck/tests/test_TBoolean.js
+++ b/local-modules/@bayou/typecheck/tests/test_TBoolean.js
@@ -14,11 +14,11 @@ describe('@bayou/typecheck/TBoolean', () => {
       assert.strictEqual(TBoolean.check(false), false);
     });
 
-    it('should throw an Error when passed undefined', () => {
+    it('throws an Error when passed undefined', () => {
       assert.throws(() => TBoolean.check(undefined));
     });
 
-    it('should throw an Error when passed anything other than a boolean', () => {
+    it('throws an Error when passed anything other than a boolean', () => {
       assert.throws(() => TBoolean.check('this better not work'));
       assert.throws(() => TBoolean.check([]));
       assert.throws(() => TBoolean.check({ }));

--- a/local-modules/@bayou/typecheck/tests/test_TBoolean.js
+++ b/local-modules/@bayou/typecheck/tests/test_TBoolean.js
@@ -9,7 +9,7 @@ import { TBoolean } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TBoolean', () => {
   describe('check()', () => {
-    it('should return the provided value when passed a boolean', () => {
+    it('returns the provided value when passed a boolean', () => {
       assert.strictEqual(TBoolean.check(true), true);
       assert.strictEqual(TBoolean.check(false), false);
     });

--- a/local-modules/@bayou/typecheck/tests/test_TBuffer.js
+++ b/local-modules/@bayou/typecheck/tests/test_TBuffer.js
@@ -14,7 +14,7 @@ describe('@bayou/typecheck/TBuffer', () => {
       assert.strictEqual(TBuffer.check(buf), buf);
     });
 
-    it('should reject non-Buffers', () => {
+    it('rejects non-Buffers', () => {
       function test(value) {
         assert.throws(() => TBuffer.check(value), /badValue/);
       }
@@ -38,7 +38,7 @@ describe('@bayou/typecheck/TBuffer', () => {
       assert.isNull(TBuffer.orNull(null));
     });
 
-    it('should reject non-`null` non-Buffers', () => {
+    it('rejects non-`null` non-Buffers', () => {
       function test(value) {
         assert.throws(() => TBuffer.check(value), /badValue/);
       }

--- a/local-modules/@bayou/typecheck/tests/test_TBuffer.js
+++ b/local-modules/@bayou/typecheck/tests/test_TBuffer.js
@@ -9,7 +9,7 @@ import { TBuffer } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TBuffer', () => {
   describe('check()', () => {
-    it('should accept valid instances', () => {
+    it('accepts valid instances', () => {
       const buf = Buffer.from('123');
       assert.strictEqual(TBuffer.check(buf), buf);
     });
@@ -29,12 +29,12 @@ describe('@bayou/typecheck/TBuffer', () => {
   });
 
   describe('orNull()', () => {
-    it('should accept valid instances', () => {
+    it('accepts valid instances', () => {
       const buf = Buffer.from('123');
       assert.strictEqual(TBuffer.orNull(buf), buf);
     });
 
-    it('should accept `null`', () => {
+    it('accepts `null`', () => {
       assert.isNull(TBuffer.orNull(null));
     });
 

--- a/local-modules/@bayou/typecheck/tests/test_TFunction.js
+++ b/local-modules/@bayou/typecheck/tests/test_TFunction.js
@@ -203,7 +203,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('checkClass(value, ancestor)', () => {
-    it('should accept a `null` ancestor', () => {
+    it('accepts a `null` ancestor', () => {
       function test(value) {
         assert.strictEqual(TFunction.checkClass(value, null), value);
       }
@@ -213,14 +213,14 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should accept a value that is the same as the given `ancestor`', () => {
+    it('accepts a value that is the same as the given `ancestor`', () => {
       class Blort { }
 
       assert.strictEqual(TFunction.checkClass(Map, Map), Map);
       assert.strictEqual(TFunction.checkClass(Blort, Blort), Blort);
     });
 
-    it('should accept a value that is a subclass of the given `ancestor`', () => {
+    it('accepts a value that is a subclass of the given `ancestor`', () => {
       class Blort { }
       class SubBlort extends Blort { }
       class UltraBlort extends SubBlort { }
@@ -347,7 +347,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('isClass(value, ancestor)', () => {
-    it('should accept a `null` ancestor', () => {
+    it('accepts a `null` ancestor', () => {
       assert.isTrue(TFunction.isClass(Map, null));
       assert.isFalse(TFunction.isClass(123, null));
     });

--- a/local-modules/@bayou/typecheck/tests/test_TFunction.js
+++ b/local-modules/@bayou/typecheck/tests/test_TFunction.js
@@ -283,7 +283,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('isCallable()', () => {
-    it('should return `true` when passed a callable function', () => {
+    it('returns `true` when passed a callable function', () => {
       function test(value) {
         assert.isTrue(TFunction.isCallable(value), value);
       }
@@ -293,7 +293,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should return `false` when passed a non-callable function', () => {
+    it('returns `false` when passed a non-callable function', () => {
       function test(value) {
         assert.isFalse(TFunction.isCallable(value), value);
       }
@@ -303,7 +303,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should return `false` when passed a non-function', () => {
+    it('returns `false` when passed a non-function', () => {
       function test(value) {
         assert.isFalse(TFunction.isCallable(value), value);
       }
@@ -315,7 +315,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('isClass(value)', () => {
-    it('should return `true` when passed a class', () => {
+    it('returns `true` when passed a class', () => {
       function test(value) {
         assert.isTrue(TFunction.isClass(value), value);
       }
@@ -325,7 +325,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should return `false` when passed a non-class function', () => {
+    it('returns `false` when passed a non-class function', () => {
       function test(value) {
         assert.isFalse(TFunction.isClass(value), value);
       }
@@ -335,7 +335,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should return `false` when passed a non-function', () => {
+    it('returns `false` when passed a non-function', () => {
       function test(value) {
         assert.isFalse(TFunction.isClass(value), value);
       }
@@ -352,14 +352,14 @@ describe('@bayou/typecheck/TFunction', () => {
       assert.isFalse(TFunction.isClass(123, null));
     });
 
-    it('should return `true` for a value that is the same as the given `ancestor`', () => {
+    it('returns `true` for a value that is the same as the given `ancestor`', () => {
       class Blort { }
 
       assert.isTrue(TFunction.isClass(Map, Map));
       assert.isTrue(TFunction.isClass(Blort, Blort));
     });
 
-    it('should return `true` for a value that is a subclass of the given `ancestor`', () => {
+    it('returns `true` for a value that is a subclass of the given `ancestor`', () => {
       class Blort { }
       class SubBlort extends Blort { }
       class UltraBlort extends SubBlort { }
@@ -370,7 +370,7 @@ describe('@bayou/typecheck/TFunction', () => {
       assert.isTrue(TFunction.isClass(UltraBlort, Blort));
     });
 
-    it('should return `false` when passed a class that is not the same as `ancestor` nor is a subclass of it', () => {
+    it('returns `false` when passed a class that is not the same as `ancestor` nor is a subclass of it', () => {
       function test(value, ancestor) {
         assert.isFalse(TFunction.isClass(value, ancestor));
       }
@@ -385,7 +385,7 @@ describe('@bayou/typecheck/TFunction', () => {
       test(Blort, SubBlort);
     });
 
-    it('should return `false` when passed a non-class function', () => {
+    it('returns `false` when passed a non-class function', () => {
       function test(value) {
         assert.isFalse(TFunction.isClass(value, Object), value);
       }
@@ -395,7 +395,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should return `false` when passed a non-function', () => {
+    it('returns `false` when passed a non-function', () => {
       function test(value) {
         assert.isFalse(TFunction.isClass(value, Object), value);
       }

--- a/local-modules/@bayou/typecheck/tests/test_TFunction.js
+++ b/local-modules/@bayou/typecheck/tests/test_TFunction.js
@@ -231,7 +231,7 @@ describe('@bayou/typecheck/TFunction', () => {
       assert.strictEqual(TFunction.checkClass(UltraBlort, Blort), UltraBlort);
     });
 
-    it('should reject a class that is not the same as or a subclass of the given `ancestor`', () => {
+    it('rejects a class that is not the same as or a subclass of the given `ancestor`', () => {
       function test(value, ancestor) {
         assert.throws(() => { TFunction.checkClass(value, ancestor); });
       }

--- a/local-modules/@bayou/typecheck/tests/test_TInt.js
+++ b/local-modules/@bayou/typecheck/tests/test_TInt.js
@@ -66,7 +66,7 @@ describe('@bayou/typecheck/TInt', () => {
       assert.doesNotThrow(() => TInt.maxInc(4, 5));
     });
 
-    it('should throw an error when `value > maxInc`', () => {
+    it('throws an error when `value > maxInc`', () => {
       assert.throws(() => TInt.maxInc(4, 3));
     });
   });
@@ -136,7 +136,7 @@ describe('@bayou/typecheck/TInt', () => {
       assert.doesNotThrow(() => TInt.rangeInc(11, 3, 27));
     });
 
-    it('should throw an error when `value < minInc`', () => {
+    it('throws an error when `value < minInc`', () => {
       assert.throws(() => TInt.rangeInc(2, 3, 27));
     });
 
@@ -144,7 +144,7 @@ describe('@bayou/typecheck/TInt', () => {
       assert.doesNotThrow(() => TInt.rangeInc(27, 3, 27));
     });
 
-    it('should throw an error when `value > maxInc`', () => {
+    it('throws an error when `value > maxInc`', () => {
       assert.throws(() => TInt.rangeInc(37, 3, 27));
     });
   });
@@ -157,7 +157,7 @@ describe('@bayou/typecheck/TInt', () => {
       assert.strictEqual(TInt.unsignedByte(255), 255);
     });
 
-    it('should throw an error when value is outsid of range `[0..255]`', () => {
+    it('throws an error when value is outsid of range `[0..255]`', () => {
       assert.throws(() => TInt.unsgignedByte(-1));
       assert.throws(() => TInt.unsgignedByte(256));
     });

--- a/local-modules/@bayou/typecheck/tests/test_TInt.js
+++ b/local-modules/@bayou/typecheck/tests/test_TInt.js
@@ -9,7 +9,7 @@ import { TInt } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TInt', () => {
   describe('check()', () => {
-    it('should accept safe integers', () => {
+    it('accepts safe integers', () => {
       function test(value) {
         assert.strictEqual(TInt.check(value), value);
       }

--- a/local-modules/@bayou/typecheck/tests/test_TInt.js
+++ b/local-modules/@bayou/typecheck/tests/test_TInt.js
@@ -20,13 +20,13 @@ describe('@bayou/typecheck/TInt', () => {
       test(10000000);
     });
 
-    it('should reject numbers which are not safe integers', () => {
+    it('rejects numbers which are not safe integers', () => {
       assert.throws(() => TInt.check(3.1));
       assert.throws(() => TInt.check(NaN));
       assert.throws(() => TInt.check(1e100));
     });
 
-    it('should reject a non-number value', () => {
+    it('rejects a non-number value', () => {
       assert.throws(() => TInt.check('this better not work'));
     });
   });

--- a/local-modules/@bayou/typecheck/tests/test_TNumber.js
+++ b/local-modules/@bayou/typecheck/tests/test_TNumber.js
@@ -9,7 +9,7 @@ import { TNumber } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TNumber', () => {
   describe('check()', () => {
-    it('should return the provided value when passed a number', () => {
+    it('returns the provided value when passed a number', () => {
       function test(v) {
         assert.strictEqual(TNumber.check(v), v);
       }

--- a/local-modules/@bayou/typecheck/tests/test_TNumber.js
+++ b/local-modules/@bayou/typecheck/tests/test_TNumber.js
@@ -21,7 +21,7 @@ describe('@bayou/typecheck/TNumber', () => {
       test(-Infinity);
     });
 
-    it('should accept NaN', () => {
+    it('accepts NaN', () => {
       // NaN somewhat ironically is in fact a number in this sense. But also,
       // because of IEEE754 wackiness, `NaN !== NaN`, so the usual strict
       // equality test can't be done.

--- a/local-modules/@bayou/typecheck/tests/test_TNumber.js
+++ b/local-modules/@bayou/typecheck/tests/test_TNumber.js
@@ -28,7 +28,7 @@ describe('@bayou/typecheck/TNumber', () => {
       assert.isNaN(TNumber.check(NaN));
     });
 
-    it('should throw an error when passed a non-number value', () => {
+    it('throws an error when passed a non-number value', () => {
       function test(v) {
         assert.throws(() => TNumber.check(v));
       }

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -120,7 +120,7 @@ describe('@bayou/typecheck/TObject', () => {
       test({ a: 10, b: 20 });
     });
 
-    it('should reject non-plain objects', () => {
+    it('rejects non-plain objects', () => {
       function test(value) {
         assert.throws(() => { TObject.plain(value); });
       }
@@ -134,7 +134,7 @@ describe('@bayou/typecheck/TObject', () => {
       test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
-    it('should reject non-objects', () => {
+    it('rejects non-objects', () => {
       function test(value) {
         assert.throws(() => { TObject.plain(value); });
       }
@@ -161,25 +161,25 @@ describe('@bayou/typecheck/TObject', () => {
       assert.strictEqual(TObject.withExactKeys(value, ['a', 'b', 'c']), value);
     });
 
-    it('should reject an object value which is missing a key', () => {
+    it('rejects an object value which is missing a key', () => {
       const value = { 'a': 1, 'b': 2 };
 
       assert.throws(() => TObject.withExactKeys(value, ['a', 'b', 'c']));
     });
 
-    it('should reject an object with a superset of keys', () => {
+    it('rejects an object with a superset of keys', () => {
       const value = { 'a': 1, 'b': 2, 'c': 3, 'd': 4 };
 
       assert.throws(() => TObject.withExactKeys(value, ['a', 'b', 'c']));
     });
 
-    it('should reject non-plain objects', () => {
+    it('rejects non-plain objects', () => {
       assert.throws(() => TObject.withExactKeys(new Map(),  []));
       assert.throws(() => TObject.withExactKeys(['z'],      []));
       assert.throws(() => TObject.withExactKeys(() => true, []));
     });
 
-    it('should reject non-objects', () => {
+    it('rejects non-objects', () => {
       assert.throws(() => TObject.withExactKeys('x',  []));
       assert.throws(() => TObject.withExactKeys(914,  []));
       assert.throws(() => TObject.withExactKeys(null, []));

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -9,7 +9,7 @@ import { TObject } from '@bayou/typecheck';
 
 describe('@bayou/typecheck/TObject', () => {
   describe('check(value)', () => {
-    it('should return the provided value when passed an object', () => {
+    it('returns the provided value when passed an object', () => {
       function test(value) {
         assert.strictEqual(TObject.check(value), value);
       }
@@ -55,7 +55,7 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('orNull(value)', () => {
-    it('should return the provided value when passed an object', () => {
+    it('returns the provided value when passed an object', () => {
       function test(value) {
         assert.strictEqual(TObject.orNull(value), value);
       }
@@ -66,7 +66,7 @@ describe('@bayou/typecheck/TObject', () => {
       test(new Map());
     });
 
-    it('should return `null` when passed `null`', () => {
+    it('returns `null` when passed `null`', () => {
       assert.isNull(TObject.orNull(null));
     });
 
@@ -79,7 +79,7 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('orNull(value, clazz)', () => {
-    it('should return the provided value when passed an object of a matching class', () => {
+    it('returns the provided value when passed an object of a matching class', () => {
       function test(value, clazz) {
         assert.strictEqual(TObject.orNull(value, clazz), value);
       }
@@ -92,7 +92,7 @@ describe('@bayou/typecheck/TObject', () => {
       test(new Map(),      Object);
     });
 
-    it('should return `null` when passed a `null` value, no matter what class is passed', () => {
+    it('returns `null` when passed a `null` value, no matter what class is passed', () => {
       assert.isNull(TObject.orNull(null, Object));
       assert.isNull(TObject.orNull(null, Set));
     });

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -20,7 +20,7 @@ describe('@bayou/typecheck/TObject', () => {
       test(new Map());
     });
 
-    it('should throw an Error when passed anything other than an object', () => {
+    it('throws an Error when passed anything other than an object', () => {
       assert.throws(() => TObject.check(null));
       assert.throws(() => TObject.check(undefined));
       assert.throws(() => TObject.check(54));
@@ -44,11 +44,11 @@ describe('@bayou/typecheck/TObject', () => {
       test(() => 123, Object);
     });
 
-    it('should throw an Error when passed a value not of the given class', () => {
+    it('throws an Error when passed a value not of the given class', () => {
       assert.throws(() => TObject.check(new Boolean(true), String));
     });
 
-    it('should throw an Error when passed anything other than an object', () => {
+    it('throws an Error when passed anything other than an object', () => {
       assert.throws(() => TObject.check(null, Object));
       assert.throws(() => TObject.check(54,   Object));
     });
@@ -70,7 +70,7 @@ describe('@bayou/typecheck/TObject', () => {
       assert.isNull(TObject.orNull(null));
     });
 
-    it('should throw an Error when passed anything other than an object or `null`', () => {
+    it('throws an Error when passed anything other than an object or `null`', () => {
       assert.throws(() => TObject.orNull(undefined));
       assert.throws(() => TObject.orNull(false));
       assert.throws(() => TObject.orNull(54));
@@ -97,12 +97,12 @@ describe('@bayou/typecheck/TObject', () => {
       assert.isNull(TObject.orNull(null, Set));
     });
 
-    it('should throw an Error when passed an object of a non-matching class', () => {
+    it('throws an Error when passed an object of a non-matching class', () => {
       assert.throws(() => TObject.orNull(new Map(), Set));
       assert.throws(() => TObject.orNull(new Set(), Map));
     });
 
-    it('should throw an Error when passed anything other than an object or `null`', () => {
+    it('throws an Error when passed anything other than an object or `null`', () => {
       assert.throws(() => TObject.orNull(false,   Boolean));
       assert.throws(() => TObject.orNull(914,     Number));
       assert.throws(() => TObject.orNull('florp', String));

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -30,7 +30,7 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('check(value, clazz)', () => {
-    it('should accept a value of the given class', () => {
+    it('accepts a value of the given class', () => {
       function test(value, clazz) {
         assert.strictEqual(TObject.check(value, clazz), value);
       }
@@ -110,7 +110,7 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('plain()', () => {
-    it('should accept plain objects', () => {
+    it('accepts plain objects', () => {
       function test(value) {
         assert.strictEqual(TObject.plain(value), value);
       }
@@ -149,13 +149,13 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('withExactKeys()', () => {
-    it('should accept an empty list of keys', () => {
+    it('accepts an empty list of keys', () => {
       const value = {};
 
       assert.strictEqual(TObject.withExactKeys(value, []), value);
     });
 
-    it('should accept an object with exactly the provided keys', () => {
+    it('accepts an object with exactly the provided keys', () => {
       const value = { 'a': 1, 'b': 2, 'c': 3 };
 
       assert.strictEqual(TObject.withExactKeys(value, ['a', 'b', 'c']), value);

--- a/local-modules/@bayou/typecheck/tests/test_TString.js
+++ b/local-modules/@bayou/typecheck/tests/test_TString.js
@@ -353,7 +353,7 @@ describe('@bayou/typecheck/TString', () => {
       test('This better work!');
     });
 
-    it('should throw if value is a string of length 0', () => {
+    it('throws if value is a string of length 0', () => {
       assert.throws(() => TString.nonEmpty(''));
     });
   });

--- a/local-modules/@bayou/util-common/tests/test_ColorSelector.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorSelector.js
@@ -48,7 +48,7 @@ describe('@bayou/util-common/ColorSelector', () => {
   });
 
   describe('nextCssColor()', () => {
-    it('should return a valid hex string representation of the RGB value of a given color', () => {
+    it('returns a valid hex string representation of the RGB value of a given color', () => {
       const selector = new ColorSelector();
       const hex = selector.nextCssColor();
 

--- a/local-modules/@bayou/util-common/tests/test_ColorUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorUtil.js
@@ -9,7 +9,7 @@ import { ColorUtil } from '@bayou/util-common';
 
 describe('@bayou/util-common/ColorUtil', () => {
   describe('checkCss()', () => {
-    it('should accept proper strings', () => {
+    it('accepts proper strings', () => {
       function test(v) {
         assert.doesNotThrow(() => ColorUtil.checkCss(v));
       }

--- a/local-modules/@bayou/util-common/tests/test_ColorUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorUtil.js
@@ -20,7 +20,7 @@ describe('@bayou/util-common/ColorUtil', () => {
       test('#def012');
     });
 
-    it('should reject improper strings', () => {
+    it('rejects improper strings', () => {
       function test(v) {
         assert.throws(() => ColorUtil.checkCss(v));
       }
@@ -37,7 +37,7 @@ describe('@bayou/util-common/ColorUtil', () => {
       test('#?@%^()');  // Oddball characters.
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       function test(v) {
         assert.throws(() => ColorUtil.checkCss(v));
       }
@@ -80,7 +80,7 @@ describe('@bayou/util-common/ColorUtil', () => {
       test(300, 1.0, 0.5, '#ff00ff'); // Pure magenta.
     });
 
-    it('should reject improper arguments', () => {
+    it('rejects improper arguments', () => {
       function test(h, s, l) {
         assert.throws(() => ColorUtil.cssFromHsl(h, s, l));
       }

--- a/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
@@ -9,7 +9,7 @@ import { DeferredLoader } from '@bayou/util-common';
 
 describe('@bayou/util-common/DeferredLoader', () => {
   describe('makeProxy()', () => {
-    it('should accept valid arguments', () => {
+    it('accepts valid arguments', () => {
       assert.doesNotThrow(() => { DeferredLoader.makeProxy('hello', () => true); });
     });
 

--- a/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
@@ -50,7 +50,7 @@ describe('@bayou/util-common/DeferredLoader', () => {
       assert.strictEqual(count, 1);
     });
 
-    it('should throw an error when trying to get properties not in the loaded value', () => {
+    it('throws an error when trying to get properties not in the loaded value', () => {
       const loaded = { yep: 'yep' };
       function loader() { return loaded; }
 
@@ -58,14 +58,14 @@ describe('@bayou/util-common/DeferredLoader', () => {
       assert.throws(() => { dl.nopeNotBound; });
     });
 
-    it('should throw an error if the loader throws an error', () => {
+    it('throws an error if the loader throws an error', () => {
       function loader() { throw new Error('oy'); }
 
       const dl = DeferredLoader.makeProxy('x', loader);
       assert.throws(() => { dl.anything; });
     });
 
-    it('should throw an error if the loader does not return an object', () => {
+    it('throws an error if the loader does not return an object', () => {
       function loader() { return 914; }
 
       const dl = DeferredLoader.makeProxy('x', loader);

--- a/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
@@ -13,12 +13,12 @@ describe('@bayou/util-common/DeferredLoader', () => {
       assert.doesNotThrow(() => { DeferredLoader.makeProxy('hello', () => true); });
     });
 
-    it('should reject invalid label arguments', () => {
+    it('rejects invalid label arguments', () => {
       assert.throws(() => { DeferredLoader.makeProxy('', () => true); });
       assert.throws(() => { DeferredLoader.makeProxy(37, () => true); });
     });
 
-    it('should reject invalid loader arguments', () => {
+    it('rejects invalid loader arguments', () => {
       assert.throws(() => { DeferredLoader.makeProxy('hello', null); });
       assert.throws(() => { DeferredLoader.makeProxy('hello', 'blort'); });
       assert.throws(() => { DeferredLoader.makeProxy('hello', new Map()); });

--- a/local-modules/@bayou/util-common/tests/test_IterableUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_IterableUtil.js
@@ -9,7 +9,7 @@ import { IterableUtil } from '@bayou/util-common';
 
 describe('@bayou/util-common/IterableUtil', () => {
   describe('multiUseSafe()', () => {
-    it('should throw an error if not passed an `Iterable`', () => {
+    it('throws an error if not passed an `Iterable`', () => {
       assert.throws(() => IterableUtil.multiUseSafe(123));
       assert.throws(() => IterableUtil.multiUseSafe('blort'));
       assert.throws(() => IterableUtil.multiUseSafe({}));

--- a/local-modules/@bayou/util-common/tests/test_JsonUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_JsonUtil.js
@@ -21,7 +21,7 @@ describe('@bayou/util-common/JsonUtil', () => {
       assert.throws(() => JsonUtil.parseFrozen(badString));
     });
 
-    it('should return a frozen object when passed a valid json string', () => {
+    it('returns a frozen object when passed a valid json string', () => {
       const jsonString = '{ "a": 1, "b": 2, "c": 3 }';
       const object = JsonUtil.parseFrozen(jsonString);
 

--- a/local-modules/@bayou/util-common/tests/test_JsonUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_JsonUtil.js
@@ -9,13 +9,13 @@ import { JsonUtil } from '@bayou/util-common';
 
 describe('@bayou/util-common/JsonUtil', () => {
   describe('parseFrozen(jsonString)', () => {
-    it('should throw an error if handed anything other than a string', () => {
+    it('throws an error if handed anything other than a string', () => {
       assert.throws(() => JsonUtil.parseFrozen([]));
       assert.throws(() => JsonUtil.parseFrozen({}));
       assert.throws(() => JsonUtil.parseFrozen(Symbol('in a row?')));
     });
 
-    it('should throw an Error when pass a string that isn\'t valid JSON', () => {
+    it('throws an Error when pass a string that isn\'t valid JSON', () => {
       const badString = '{ "a": 1, "b": 2, "c": 3 alksdj falsdj falsd jfalskd jfal;sdkjfaks}';
 
       assert.throws(() => JsonUtil.parseFrozen(badString));

--- a/local-modules/@bayou/util-common/tests/test_Random.js
+++ b/local-modules/@bayou/util-common/tests/test_Random.js
@@ -36,23 +36,23 @@ describe('@bayou/util-common/Random', () => {
   });
 
   describe('idString()', () => {
-    it('should reject a non-string prefix', () => {
+    it('rejects a non-string prefix', () => {
       assert.throws(() => Random.idString(true, 10));
     });
 
-    it('should reject an empty prefix', () => {
+    it('rejects an empty prefix', () => {
       assert.throws(() => Random.idString('', 10));
     });
 
-    it('should reject a non-number length', () => {
+    it('rejects a non-number length', () => {
       assert.throws(() => Random.idString('x', 'foo'));
     });
 
-    it('should reject a non-integer length', () => {
+    it('rejects a non-integer length', () => {
       assert.throws(() => Random.idString('x', 12.34));
     });
 
-    it('should reject a non-positive length', () => {
+    it('rejects a non-positive length', () => {
       assert.throws(() => Random.idString('x', 0));
       assert.throws(() => Random.idString('x', -1));
     });

--- a/local-modules/@bayou/util-common/tests/test_Random.js
+++ b/local-modules/@bayou/util-common/tests/test_Random.js
@@ -10,14 +10,14 @@ import { Random } from '@bayou/util-common';
 
 describe('@bayou/util-common/Random', () => {
   describe('byteBuffer()', () => {
-    it('should return a buffer of the requested length', () => {
+    it('returns a buffer of the requested length', () => {
       const length = 17;
       const randomBytes = Random.byteBuffer(length);
 
       assert.strictEqual(length, randomBytes.length);
     });
 
-    it('should return different results every time', () => {
+    it('returns different results every time', () => {
       const length = 23;
       const bytesA = Random.byteBuffer(length);
       const bytesB = Random.byteBuffer(length);
@@ -27,7 +27,7 @@ describe('@bayou/util-common/Random', () => {
   });
 
   describe('hexByteString()', () => {
-    it('should return a string of hex digits of the requested length', () => {
+    it('returns a string of hex digits of the requested length', () => {
       const length = 13;
       const string = Random.hexByteString(length);
 
@@ -57,7 +57,7 @@ describe('@bayou/util-common/Random', () => {
       assert.throws(() => Random.idString('x', -1));
     });
 
-    it('should return a string that starts with the indicated prefix', () => {
+    it('returns a string that starts with the indicated prefix', () => {
       function test(p) {
         const result = Random.idString(p, 4);
         assert.isTrue(result.startsWith(`${p}-`));
@@ -68,7 +68,7 @@ describe('@bayou/util-common/Random', () => {
       test('123456');
     });
 
-    it('should return a string with the expected number and kind of characters after the prefix', () => {
+    it('returns a string with the expected number and kind of characters after the prefix', () => {
       function test(l) {
         const result = Random.idString('x', l);
         assert.lengthOf(result, l + 2);
@@ -87,7 +87,7 @@ describe('@bayou/util-common/Random', () => {
   });
 
   describe('shortLabel()', () => {
-    it('should return a probably-random string of the form "[prefix]-[8 * base32ish random character]"', () => {
+    it('returns a probably-random string of the form "[prefix]-[8 * base32ish random character]"', () => {
       const label1A = Random.shortLabel('A');
       const label2A = Random.shortLabel('A');
 

--- a/local-modules/@bayou/util-common/tests/test_Singleton.js
+++ b/local-modules/@bayou/util-common/tests/test_Singleton.js
@@ -26,7 +26,7 @@ describe('@bayou/util-common/Singleton', () => {
       assert.strictEqual(test1, test2);
     });
 
-    it('should throw an error if the constructor is called after the singleton is created', () => {
+    it('throws an error if the constructor is called after the singleton is created', () => {
       class TestClass extends Singleton { /*empty*/ }
 
       assert.isNotNull(TestClass.theOne);

--- a/local-modules/@bayou/util-common/tests/test_Singleton.js
+++ b/local-modules/@bayou/util-common/tests/test_Singleton.js
@@ -9,7 +9,7 @@ import { Singleton } from '@bayou/util-common';
 
 describe('@bayou/util-common/Singleton', () => {
   describe('.theOne', () => {
-    it('should return the same object every time it is called', () => {
+    it('returns the same object every time it is called', () => {
       class TestClass extends Singleton { /*empty*/ }
       const test1 = TestClass.theOne;
       const test2 = TestClass.theOne;

--- a/local-modules/@bayou/util-common/tests/test_StringUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_StringUtil.js
@@ -31,7 +31,7 @@ describe('@bayou/util-common/StringUtil', () => {
       test(0x86bda720, 'These pretzels are making me thirsty.');
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       function test(v) {
         assert.throws(() => StringUtil.hash32(v));
       }

--- a/local-modules/@bayou/util-common/tests/test_WebsocketCodes.js
+++ b/local-modules/@bayou/util-common/tests/test_WebsocketCodes.js
@@ -9,7 +9,7 @@ import { WebsocketCodes } from '@bayou/util-common';
 
 describe('@bayou/util-common/WebsocketCodes', () => {
   describe('close()', () => {
-    it('should return a questioning string', () => {
+    it('returns a questioning string', () => {
       const readable = WebsocketCodes.close();
 
       assert.strictEqual(readable, 'close_?');
@@ -17,7 +17,7 @@ describe('@bayou/util-common/WebsocketCodes', () => {
   });
 
   describe('close(null)', () => {
-    it('should return a questioning string', () => {
+    it('returns a questioning string', () => {
       const readable = WebsocketCodes.close(null);
 
       assert.strictEqual(readable, 'close_?');
@@ -25,13 +25,13 @@ describe('@bayou/util-common/WebsocketCodes', () => {
   });
 
   describe('close(code)', () => {
-    it('should return a fixed format string if passed a known code', () => {
+    it('returns a fixed format string if passed a known code', () => {
       const output = WebsocketCodes.close(1000);
 
       assert.strictEqual(output, 'close_normal (1000)');
     });
 
-    it('should return a fixed format string if passed an unknown code', () => {
+    it('returns a fixed format string if passed an unknown code', () => {
       const output = WebsocketCodes.close(298374893247);
 
       assert.strictEqual(output, 'close_298374893247');

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -54,7 +54,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(gotValue, 123);
     });
 
-    it('should reject a `_impl_coerce()` result that is not an instance of the class', () => {
+    it('rejects a `_impl_coerce()` result that is not an instance of the class', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerce(value) {
           return value;
@@ -116,7 +116,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.isNull(value);
     });
 
-    it('should reject a `_impl_coerceOrNull()` result that is neither `null` nor an instance of the class', () => {
+    it('rejects a `_impl_coerceOrNull()` result that is neither `null` nor an instance of the class', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerceOrNull(value) {
           return value;

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -29,7 +29,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(Subclass1.check(subclass2), subclass2);
     });
 
-    it('should throw an Error if the supplied value is not an instance of the class or a subclass', () => {
+    it('throws an Error if the supplied value is not an instance of the class or a subclass', () => {
       class Subclass extends CommonBase {
         fiat() { /*empty*/ }
       }

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -9,7 +9,7 @@ import { CommonBase } from '@bayou/util-common';
 
 describe('@bayou/util-core/CommonBase', () => {
   describe('check()', () => {
-    it('should return the supplied value if it is an instance of the class or a subclass', () => {
+    it('returns the supplied value if it is an instance of the class or a subclass', () => {
       class Subclass1 extends CommonBase {
         fiat() { /*empty*/ }
       }

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -13,7 +13,7 @@ describe('@bayou/util-core/DataUtil', () => {
     // Tests that should work the same for both `null` and non-`null` values for
     // `nonDataConverter`.
     function commonTests(nonDataConverter) {
-      it('should return the given value if it is a primitive', () => {
+      it('returns the given value if it is a primitive', () => {
         function test(value) {
           const popsicle = DataUtil.deepFreeze(value, nonDataConverter);
           assert.strictEqual(popsicle, value);
@@ -28,7 +28,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test(Symbol('foo'));
       });
 
-      it('should return the provided value if it is already deep-frozen', () => {
+      it('returns the provided value if it is already deep-frozen', () => {
         function test(value) {
           const popsicle     = DataUtil.deepFreeze(value, nonDataConverter);
           const deepPopsicle = DataUtil.deepFreeze(popsicle, nonDataConverter);
@@ -45,7 +45,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test([[1, 2], [3, 4]]);
       });
 
-      it('should return a deep-frozen object if passed one that isn\'t already deep-frozen', () => {
+      it('returns a deep-frozen object if passed one that isn\'t already deep-frozen', () => {
         function test(value) {
           const popsicle = DataUtil.deepFreeze(value, nonDataConverter);
           assert.isTrue(DataUtil.isDeepFrozen(popsicle, nonDataConverter));
@@ -110,7 +110,7 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.deepEqual(popsicle, orig);
       });
 
-      it('should return a given `FrozenBuffer`', () => {
+      it('returns a given `FrozenBuffer`', () => {
         function test(value) {
           assert.strictEqual(DataUtil.deepFreeze(value, nonDataConverter), value);
         }
@@ -264,7 +264,7 @@ describe('@bayou/util-core/DataUtil', () => {
   });
 
   describe('equalData()', () => {
-    it('should return `true` for equal primitive values', () => {
+    it('returns `true` for equal primitive values', () => {
       function test(value) {
         assert.isTrue(DataUtil.equalData(value, value));
       }
@@ -280,7 +280,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(Symbol('foo'));
     });
 
-    it('should return `true` for equal-content arrays', () => {
+    it('returns `true` for equal-content arrays', () => {
       function test(v1, v2) {
         assert.isTrue(DataUtil.equalData(v1, v2), inspect(v1));
       }
@@ -297,7 +297,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(v1, v2);
     });
 
-    it('should return `true` for equal-content objects', () => {
+    it('returns `true` for equal-content objects', () => {
       function test(v1, v2) {
         assert.isTrue(DataUtil.equalData(v1, v2), v1);
       }
@@ -307,7 +307,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test({ a: 1, b: { b: 2 } }, { a: 1, b: { b: 2 } });
     });
 
-    it('should return `true` for equal-content `FrozenBuffer`s', () => {
+    it('returns `true` for equal-content `FrozenBuffer`s', () => {
       function test(content) {
         const buf1 = FrozenBuffer.coerce(content);
         const buf2 = FrozenBuffer.coerce(content);
@@ -318,7 +318,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test('Florps are now likes again.');
     });
 
-    it('should return `true` for equal-content functors', () => {
+    it('returns `true` for equal-content functors', () => {
       function test(v1, v2) {
         assert.isTrue(DataUtil.equalData(v1, v2), v1);
       }
@@ -328,7 +328,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('z', [1, [2]]), new Functor('z', [1, [2]]));
     });
 
-    it('should return `false` for non-data objects even if equal', () => {
+    it('returns `false` for non-data objects even if equal', () => {
       function test(value) {
         assert.isFalse(DataUtil.equalData(value, value), value);
       }
@@ -338,7 +338,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(/blort/);
     });
 
-    it('should return `false` for non-equal values', () => {
+    it('returns `false` for non-equal values', () => {
       function test(v1, v2) {
         assert.isFalse(DataUtil.equalData(v1, v2), inspect(v1));
       }
@@ -386,7 +386,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('x', 1, 2, 3), [1, 2, 3]);
     });
 
-    it('should return `false` given an object/array with non-data bindings', () => {
+    it('returns `false` given an object/array with non-data bindings', () => {
       function test(v) {
         const obj = { a: 10, b: v, c: 20 };
         assert.isFalse(DataUtil.equalData(obj, obj), inspect(v));
@@ -409,7 +409,7 @@ describe('@bayou/util-core/DataUtil', () => {
   });
 
   describe('isData()', () => {
-    it('should return `true` for primitive values', () => {
+    it('returns `true` for primitive values', () => {
       function test(value) {
         assert.isTrue(DataUtil.isData(value));
       }
@@ -423,7 +423,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(Symbol('foo'));
     });
 
-    it('should return `true` for appropriate composites', () => {
+    it('returns `true` for appropriate composites', () => {
       function test(value) {
         assert.isTrue(DataUtil.isData(value));
       }
@@ -445,7 +445,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(FrozenBuffer.coerce('florp'));
     });
 
-    it('should return `false` for non-plain objects or composites with same', () => {
+    it('returns `false` for non-plain objects or composites with same', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }
@@ -468,7 +468,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('x', [synthetic]));
     });
 
-    it('should return `false` for functions, generators and composites containing same', () => {
+    it('returns `false` for functions, generators and composites containing same', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }
@@ -486,7 +486,7 @@ describe('@bayou/util-core/DataUtil', () => {
   });
 
   describe('isDeepFrozen()', () => {
-    it('should return `true` for primitive values', () => {
+    it('returns `true` for primitive values', () => {
       function test(value) {
         assert.isTrue(DataUtil.isDeepFrozen(value));
       }
@@ -500,7 +500,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(Symbol('foo'));
     });
 
-    it('should return `true` for appropriate frozen composites', () => {
+    it('returns `true` for appropriate frozen composites', () => {
       function test(value) {
         assert.isTrue(DataUtil.isDeepFrozen(value));
       }
@@ -519,7 +519,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('x', new Functor('y', 914, 37)));
     });
 
-    it('should return `true` for `FrozenBuffer`s', () => {
+    it('returns `true` for `FrozenBuffer`s', () => {
       function test(value) {
         assert.isTrue(DataUtil.isDeepFrozen(value));
       }
@@ -528,7 +528,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(FrozenBuffer.coerce('blort'));
     });
 
-    it('should return `false` for composites that are not frozen even if all elements are', () => {
+    it('returns `false` for composites that are not frozen even if all elements are', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }
@@ -542,7 +542,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test({ a: 10, b: Object.freeze({ c: 30 }) });
     });
 
-    it('should return `false` for frozen composites with non-frozen elements', () => {
+    it('returns `false` for frozen composites with non-frozen elements', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }
@@ -558,7 +558,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('x', new Functor('y', [])));
     });
 
-    it('should return `false` for non-plain objects or composites with same', () => {
+    it('returns `false` for non-plain objects or composites with same', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }
@@ -581,7 +581,7 @@ describe('@bayou/util-core/DataUtil', () => {
       test(new Functor('x', Object.freeze([synthetic])));
     });
 
-    it('should return `false` for functions, generators and composites containing same', () => {
+    it('returns `false` for functions, generators and composites containing same', () => {
       function test(value) {
         assert.isFalse(DataUtil.isDeepFrozen(value));
       }

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -114,7 +114,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
 
   describe('constructor()', () => {
     describe('invalid arguments', () => {
-      it('should throw an error if the first argument is anything other than a string or `Buffer`', () => {
+      it('throws an error if the first argument is anything other than a string or `Buffer`', () => {
         assert.throws(() => new FrozenBuffer(1));
         assert.throws(() => new FrozenBuffer(true));
         assert.throws(() => new FrozenBuffer(null));

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -79,13 +79,13 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       }
     });
 
-    it('should reject invalid hash strings', () => {
+    it('rejects invalid hash strings', () => {
       for (const value of INVALID_HASHES) {
         assert.throws(() => { FrozenBuffer.checkHash(value); });
       }
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       for (const value of NON_STRINGS) {
         assert.throws(() => { FrozenBuffer.checkHash(value); });
       }
@@ -99,13 +99,13 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       }
     });
 
-    it('should reject invalid hash strings', () => {
+    it('rejects invalid hash strings', () => {
       for (const value of INVALID_HASHES) {
         assert.isFalse(FrozenBuffer.isHash(value), value);
       }
     });
 
-    it('should reject non-strings', () => {
+    it('rejects non-strings', () => {
       for (const value of NON_STRINGS) {
         assert.isFalse(FrozenBuffer.isHash(value), value);
       }

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -93,7 +93,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('isHash()', () => {
-    it('should return `true` for valid hash strings', () => {
+    it('returns `true` for valid hash strings', () => {
       for (const value of VALID_HASHES) {
         assert.isTrue(FrozenBuffer.isHash(value), value);
       }

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -73,7 +73,7 @@ const NON_STRINGS = [
 
 describe('@bayou/util-core/FrozenBuffer', () => {
   describe('checkHash()', () => {
-    it('should accept valid hash strings', () => {
+    it('accepts valid hash strings', () => {
       for (const value of VALID_HASHES) {
         assert.strictEqual(FrozenBuffer.checkHash(value), value);
       }
@@ -127,7 +127,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
     });
 
     describe('constructor(string, \'utf8\')', () => {
-      it('should accept valid arguments', () => {
+      it('accepts valid arguments', () => {
         assert.doesNotThrow(() => new FrozenBuffer(''));
         assert.doesNotThrow(() => new FrozenBuffer('hello'));
         assert.doesNotThrow(() => new FrozenBuffer('florp', 'utf8'));
@@ -159,7 +159,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
     });
 
     describe('constructor(string, \'base64\')', () => {
-      it('should accept valid arguments', () => {
+      it('accepts valid arguments', () => {
         assert.doesNotThrow(() => new FrozenBuffer('', 'base64'));
         assert.doesNotThrow(() => new FrozenBuffer('RkxPUlAK', 'base64'));
       });
@@ -179,7 +179,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
     });
 
     describe('constructor(Buffer)', () => {
-      it('should accept valid arguments', () => {
+      it('accepts valid arguments', () => {
         assert.doesNotThrow(() => new FrozenBuffer(Buffer.from('')));
         assert.doesNotThrow(() => new FrozenBuffer(Buffer.alloc(100, 123)));
       });

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -107,12 +107,12 @@ describe('@bayou/util-core/Functor', () => {
   });
 
   describe('equals()', () => {
-    it('should return `true` when compared to itself', () => {
+    it('returns `true` when compared to itself', () => {
       const ftor = new Functor('blort', 10);
       assert.isTrue(ftor.equals(ftor));
     });
 
-    it('should return `true` when the name and all arguments are `===`', () => {
+    it('returns `true` when the name and all arguments are `===`', () => {
       function test(...args) {
         const ftor1 = new Functor('blort', ...args);
         const ftor2 = new Functor('blort', ...args);
@@ -130,14 +130,14 @@ describe('@bayou/util-core/Functor', () => {
       test(new Set(['x', 'y']));
     });
 
-    it('should return `true` when the name is `===` and all arguments are `equalData()`', () => {
+    it('returns `true` when the name is `===` and all arguments are `equalData()`', () => {
       const ftor1 = new Functor('blort', 10, ['x', ['y']], { a: 123 }, new Functor('z'));
       const ftor2 = new Functor('blort', 10, ['x', ['y']], { a: 123 }, new Functor('z'));
       assert.isTrue(ftor1.equals(ftor2));
       assert.isTrue(ftor2.equals(ftor1));
     });
 
-    it('should return `true` when the name is `===` and all arguments are `.equals()`', () => {
+    it('returns `true` when the name is `===` and all arguments are `.equals()`', () => {
       function test(...args) {
         const args1 = args.map(x => new HasEquals(x));
         const args2 = args.map(x => new HasEquals(x));
@@ -151,21 +151,21 @@ describe('@bayou/util-core/Functor', () => {
       test('x', 'y', [123]);
     });
 
-    it('should return `false` when the names do not match', () => {
+    it('returns `false` when the names do not match', () => {
       const ftor1 = new Functor('blort', 10);
       const ftor2 = new Functor('florp', 10);
       assert.isFalse(ftor1.equals(ftor2));
       assert.isFalse(ftor2.equals(ftor1));
     });
 
-    it('should return `false` when argument counts do not match', () => {
+    it('returns `false` when argument counts do not match', () => {
       const ftor1 = new Functor('blort', 10);
       const ftor2 = new Functor('blort', 10, 20);
       assert.isFalse(ftor1.equals(ftor2));
       assert.isFalse(ftor2.equals(ftor1));
     });
 
-    it('should return `false` when an argument is not `===` or `equalData()` or `.equals()`', () => {
+    it('returns `false` when an argument is not `===` or `equalData()` or `.equals()`', () => {
       function test(args1, args2) {
         const ftor1 = new Functor('blort', ...args1);
         const ftor2 = new Functor('blort', ...args2);
@@ -191,7 +191,7 @@ describe('@bayou/util-core/Functor', () => {
       test([1, haseq, 1], [1, null, 1]);
     });
 
-    it('should return `false` when compared to a non-functor', () => {
+    it('returns `false` when compared to a non-functor', () => {
       const ftor = new Functor('blort', 10);
 
       function test(value) {
@@ -221,7 +221,7 @@ describe('@bayou/util-core/Functor', () => {
   });
 
   describe('withFrozenArgs()', () => {
-    it('should return `this` if the arguments are all already frozen / deep-frozen', () => {
+    it('returns `this` if the arguments are all already frozen / deep-frozen', () => {
       function test(...args) {
         const func   = new Functor('florp', ...args);
         const result = func.withFrozenArgs();

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -23,7 +23,7 @@ class HasEquals {
 
 describe('@bayou/util-core/Functor', () => {
   describe('constructor()', () => {
-    it('should accept valid names', () => {
+    it('accepts valid names', () => {
       function test(name) {
         const result = new Functor(name);
         assert.instanceOf(result, Functor, name);
@@ -40,7 +40,7 @@ describe('@bayou/util-core/Functor', () => {
       test('ABCDE-FGHIJ-KLMNO-PQRST-UVWXY-Z');
     });
 
-    it('should accept various amounts and types of arguments', () => {
+    it('accepts various amounts and types of arguments', () => {
       function test(...args) {
         const result = new Functor('blort', ...args);
         assert.instanceOf(result, Functor, inspect(args));

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -56,7 +56,7 @@ describe('@bayou/util-core/Functor', () => {
       test(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
     });
 
-    it('should reject invalid names', () => {
+    it('rejects invalid names', () => {
       function test(name) {
         assert.throws(() => { new Functor(name); });
       }
@@ -285,7 +285,7 @@ describe('@bayou/util-core/Functor', () => {
       test(Object.freeze({ a: [1, 2, 3], b: [2, 3, 4] }));
     });
 
-    it('should reject non-frozen non-data arguments', () => {
+    it('rejects non-frozen non-data arguments', () => {
       function test(...args) {
         const func = new Functor('florp', ...args);
         assert.throws(() => func.withFrozenArgs());

--- a/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
@@ -53,7 +53,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
       test({ a: 'aaa', b: 'bbb', 1: '111', 2: '222' });
     });
 
-    it('should reject inputs with keys not representable in plain objects with full fidelity', () => {
+    it('rejects inputs with keys not representable in plain objects with full fidelity', () => {
       function test(value) {
         const map = new Map([[value, 'whatever']]);
         assert.throws(() => ObjectUtil.fromMap(map), /badValue/);
@@ -75,7 +75,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
       test(['x']);
     });
 
-    it('should reject non-map inputs', () => {
+    it('rejects non-map inputs', () => {
       function test(value) {
         assert.throws(() => ObjectUtil.fromMap(value), /badValue/);
       }

--- a/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
@@ -9,7 +9,7 @@ import { ObjectUtil } from '@bayou/util-core';
 
 describe('@bayou/util-core/ObjectUtil', () => {
   describe('extract()', () => {
-    it('should return the extracted properties', () => {
+    it('returns the extracted properties', () => {
       function test(value, keys, expected) {
         const result = ObjectUtil.extract(value, keys);
         assert.isFrozen(result);
@@ -90,7 +90,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
   });
 
   describe('hasOwnProperty()', () => {
-    it('should return `true` when asked about an object\'s own propery', () => {
+    it('returns `true` when asked about an object\'s own propery', () => {
       const value = {};
 
       value.uniqueProperty = 'super neat!';
@@ -98,13 +98,13 @@ describe('@bayou/util-core/ObjectUtil', () => {
       assert.isTrue(ObjectUtil.hasOwnProperty(value, 'uniqueProperty'));
     });
 
-    it('should return `false` when asked about a property in a parent', () => {
+    it('returns `false` when asked about a property in a parent', () => {
       const value = {};
 
       assert.isFalse(ObjectUtil.hasOwnProperty(value, 'toString'));
     });
 
-    it('should return `false` when asked about an absent property', () => {
+    it('returns `false` when asked about an absent property', () => {
       const value = { x: 'this is a neat string!' };
 
       assert.isFalse(ObjectUtil.hasOwnProperty(value, 'floopty'));
@@ -112,7 +112,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
   });
 
   describe('isPlain()', () => {
-    it('should return `true` for plain objects', () => {
+    it('returns `true` for plain objects', () => {
       function test(value) {
         assert.isTrue(ObjectUtil.isPlain(value));
       }
@@ -123,7 +123,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
       test({ a: 10, b: 20, c: [1, 2, 3] });
     });
 
-    it('should return `false` for non-plain objects', () => {
+    it('returns `false` for non-plain objects', () => {
       function test(value) {
         assert.isFalse(ObjectUtil.isPlain(value));
       }
@@ -137,7 +137,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
       test({ [Symbol('foo')]: 'foo' });
     });
 
-    it('should return `false` for non-objects', () => {
+    it('returns `false` for non-objects', () => {
       function test(value) {
         assert.isFalse(ObjectUtil.isPlain(value));
       }


### PR DESCRIPTION
This PR excises "should" from the `it('...')` descriptions of a bunch of tests, rewriting them as active verb phrases. Specifically, I used good ole regex search-and-replace on four very commonly-used verbs — basically the "thick head" — which required no post-replace adjustment: `return`, `throw`, `accept`, and `reject`.

A future PR will start to eat at the long tail.
