### PR TITLE
Spring cleaning for test descriptions.

### DIFF
--- a/local-modules/@bayou/api-common/tests/test_Remote.js
+++ b/local-modules/@bayou/api-common/tests/test_Remote.js
@@ -49,7 +49,7 @@ describe('@bayou/api-common/Remote', () => {
   });
 
   describe('.targetId', () => {
-    it('should be the same as the `targetID` passed to the constructor', () => {
+    it('is the same as the `targetID` passed to the constructor', () => {
       for (const id of VALID_IDS) {
         const r = new Remote(id);
         assert.strictEqual(r.targetId, id);
@@ -58,7 +58,7 @@ describe('@bayou/api-common/Remote', () => {
   });
 
   describe('deconstruct()', () => {
-    it('should be a single-element array with the same contents as the `targetId` passed to the constructor', () => {
+    it('is a single-element array with the same contents as the `targetId` passed to the constructor', () => {
       for (const id of VALID_IDS) {
         const r   = new Remote(id);
         const dec = r.deconstruct();

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -71,7 +71,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
   });
 
   describe('targetFromToken()', () => {
-    it('should call through to the `_impl` given a `BearerToken`', async () => {
+    it('calls through to the `_impl` given a `BearerToken`', async () => {
       class Authie extends BaseTokenAuthorizer {
         async _impl_targetFromToken(value) {
           return { got: value };

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -121,7 +121,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
   });
 
   describe('encodeJson()', () => {
-    it('should produce a string', () => {
+    it('produces a string', () => {
       assert.isString(encodeJson(null));
       assert.isString(encodeJson(914));
       assert.isString(encodeJson([1, 2, 3]));
@@ -135,7 +135,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
   });
 
   describe('encodeJsonBuffer()', () => {
-    it('should produce a `FrozenBuffer`', () => {
+    it('produces a `FrozenBuffer`', () => {
       assert.instanceOf(encodeJsonBuffer(null), FrozenBuffer);
       assert.instanceOf(encodeJsonBuffer(914), FrozenBuffer);
       assert.instanceOf(encodeJsonBuffer([1, 2, 3]), FrozenBuffer);

--- a/local-modules/@bayou/codec/tests/test_Registry.js
+++ b/local-modules/@bayou/codec/tests/test_Registry.js
@@ -28,7 +28,7 @@ describe('@bayou/codec/Registry', () => {
       assert.doesNotThrow(() => reg.registerClass(RegistryTestClass));
     });
 
-    it('should allow classes without `CODEC_TAG`', () => {
+    it('allows classes without `CODEC_TAG`', () => {
       class NoCodecTag {
         deconstruct() {
           return 'NoCodecTag!';

--- a/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
@@ -33,7 +33,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isTrue(IdSyntax.isAuthorId('123abc7890ABC456789012'));
     });
 
-    it('should allow underscores and hyphens', () => {
+    it('allows underscores and hyphens', () => {
       assert.isTrue(IdSyntax.isAuthorId('123456789_123456789-12'));
     });
 
@@ -57,7 +57,7 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isTrue(IdSyntax.isDocumentId('123abc7890ABC456789012'));
     });
 
-    it('should allow underscores and hyphens', () => {
+    it('allows underscores and hyphens', () => {
       assert.isTrue(IdSyntax.isDocumentId('123456789_123456789-12'));
     });
 

--- a/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/tests/test_IdSyntax.js
@@ -37,11 +37,11 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isTrue(IdSyntax.isAuthorId('123456789_123456789-12'));
     });
 
-    it('should not allow non-ASCII characters', () => {
+    it('does not allow non-ASCII characters', () => {
       assert.isFalse(IdSyntax.isAuthorId('123456789•123456789•12'));
     });
 
-    it('should not allow non-alphanum characters', () => {
+    it('does not allow non-alphanum characters', () => {
       assert.isFalse(IdSyntax.isAuthorId('123456789\t123456789+12'));
     });
 
@@ -61,11 +61,11 @@ describe('@bayou/config-common-default/IdSyntax', () => {
       assert.isTrue(IdSyntax.isDocumentId('123456789_123456789-12'));
     });
 
-    it('should not allow non-ASCII characters', () => {
+    it('does not allow non-ASCII characters', () => {
       assert.isFalse(IdSyntax.isDocumentId('123456789•123456789•12'));
     });
 
-    it('should not allow non-alphanum characters', () => {
+    it('does not allow non-alphanum characters', () => {
       assert.isFalse(IdSyntax.isDocumentId('123456789\t123456789+12'));
     });
 

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -33,7 +33,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('.nonTokenPrefix', () => {
-    it('should be a short but nonempty lowercase alpha string, ending with a dash', () => {
+    it('is a short but nonempty lowercase alpha string, ending with a dash', () => {
       const prefix = Auth.nonTokenPrefix;
 
       assert.isString(prefix, prefix);
@@ -42,7 +42,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('.rootTokens', () => {
-    it('should be an array of `BearerToken` instances', () => {
+    it('is an array of `BearerToken` instances', () => {
       const tokens = Auth.rootTokens;
 
       assert.isArray(tokens);

--- a/local-modules/@bayou/config-server-default/tests/test_Storage.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Storage.js
@@ -12,13 +12,13 @@ import { LocalFileStore } from '@bayou/file-store-local';
 
 describe('@bayou/config-server-default/Storage', () => {
   describe('.DEFAULT_DOCUMENT_BODY', () => {
-    it('should be an instance of `BodyDelta`', () => {
+    it('is an instance of `BodyDelta`', () => {
       assert.instanceOf(Storage.DEFAULT_DOCUMENT_BODY, BodyDelta);
     });
   });
 
   describe('.dataStore', () => {
-    it('should be an instance of `LocalDataStore`', () => {
+    it('is an instance of `LocalDataStore`', () => {
       assert.isObject(Storage.dataStore);
       assert.instanceOf(Storage.dataStore, LocalDataStore);
     });
@@ -33,7 +33,7 @@ describe('@bayou/config-server-default/Storage', () => {
   });
 
   describe('.fileStore', () => {
-    it('should be an instance of `LocalFileStore`', () => {
+    it('is an instance of `LocalFileStore`', () => {
       assert.isObject(Storage.fileStore);
       assert.instanceOf(Storage.fileStore, LocalFileStore);
     });

--- a/local-modules/@bayou/config-server/tests/test_BaseAuth.js
+++ b/local-modules/@bayou/config-server/tests/test_BaseAuth.js
@@ -14,7 +14,7 @@ describe('@bayou/config-server/BaseAuth', () => {
     for (const item of items) {
       const name = `TYPE_${item}`;
       describe(`.${name}`, () => {
-        it('should be a string', () => {
+        it('is a string', () => {
           assert.isString(BaseAuth[name]);
         });
       });

--- a/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
@@ -52,7 +52,7 @@ describe('@bayou/data-model-client/DocumentState', () => {
     assert.equal(newStarState, !initialStarState);
   });
 
-  it('should update the title state when passed the "set title" action', () => {
+  it('updates the title state when passed the "set title" action', () => {
     const reducer = DocumentState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
@@ -15,7 +15,7 @@ describe('@bayou/data-model-client/DocumentState', () => {
     assert.isNotNull(state);
   });
 
-  it('should not change the state if passed an unknown action', () => {
+  it('does not change the state if passed an unknown action', () => {
     const reducer = DocumentState.reducer;
     const initialState = Object.freeze({ a:1, b:2, c:3 });
     const newState = reducer(initialState, { type: 'unknown_action' });
@@ -23,7 +23,7 @@ describe('@bayou/data-model-client/DocumentState', () => {
     assert.deepEqual(newState, initialState);
   });
 
-  it('should not modify prior state object when applying a known action', () => {
+  it('does not modify prior state object when applying a known action', () => {
     const reducer = DocumentState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_DragState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DragState.js
@@ -15,7 +15,7 @@ describe('@bayou/data-model-client/DragState', () => {
     assert.isNotNull(state);
   });
 
-  it('should not change the state if passed an unknown action', () => {
+  it('does not change the state if passed an unknown action', () => {
     const reducer = DragState.reducer;
     const initialState = Object.freeze({ a:1, b:2, c:3 });
     const newState = reducer(initialState, { type: 'unknown_action' });
@@ -23,7 +23,7 @@ describe('@bayou/data-model-client/DragState', () => {
     assert.deepEqual(newState, initialState);
   });
 
-  it('should not modify prior state object when applying a known action', () => {
+  it('does not modify prior state object when applying a known action', () => {
     const reducer = DragState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_DragState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DragState.js
@@ -36,7 +36,7 @@ describe('@bayou/data-model-client/DragState', () => {
     assert.doesNotThrow(() => reducer(initialState, action));
   });
 
-  it('should update the drag index state when passed the "set drag index" action', () => {
+  it('updates the drag index state when passed the "set drag index" action', () => {
     const reducer = DragState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
@@ -15,7 +15,7 @@ describe('@bayou/data-model-client/OwnerState', () => {
     assert.isNotNull(state);
   });
 
-  it('should not change the state if passed an unknown action', () => {
+  it('does not change the state if passed an unknown action', () => {
     const reducer = OwnerState.reducer;
     const initialState = Object.freeze({ a:1, b:2, c:3 });
     const newState = reducer(initialState, { type: 'unknown_action' });
@@ -23,7 +23,7 @@ describe('@bayou/data-model-client/OwnerState', () => {
     assert.deepEqual(newState, initialState);
   });
 
-  it('should not modify prior state object when applying a known action', () => {
+  it('does not modify prior state object when applying a known action', () => {
     const reducer = OwnerState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_OwnerState.js
@@ -36,7 +36,7 @@ describe('@bayou/data-model-client/OwnerState', () => {
     assert.doesNotThrow(() => reducer(initialState, action));
   });
 
-  it('should update the owner name state when passed the "set owner name" action', () => {
+  it('updates the owner name state when passed the "set owner name" action', () => {
     const reducer = OwnerState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_SharingState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_SharingState.js
@@ -15,7 +15,7 @@ describe('@bayou/data-model-client/SharingState', () => {
     assert.isNotNull(state);
   });
 
-  it('should not change the state if passed an unknown action', () => {
+  it('does not change the state if passed an unknown action', () => {
     const reducer = SharingState.reducer;
     const initialState = Object.freeze({ a:1, b:2, c:3 });
     const newState = reducer(initialState, { type: 'unknown_action' });
@@ -23,7 +23,7 @@ describe('@bayou/data-model-client/SharingState', () => {
     assert.deepEqual(newState, initialState);
   });
 
-  it('should not modify prior state object when applying a known action', () => {
+  it('does not modify prior state object when applying a known action', () => {
     const reducer = SharingState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/data-model-client/tests/test_SharingState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_SharingState.js
@@ -36,7 +36,7 @@ describe('@bayou/data-model-client/SharingState', () => {
     assert.doesNotThrow(() => reducer(initialState, action));
   });
 
-  it('should update the sharing state when passed the "set sharing state" action', () => {
+  it('updates the sharing state when passed the "set sharing state" action', () => {
     const reducer = SharingState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -94,7 +94,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.throws(() => { caret1.diff(caret2); });
     });
 
-    it('should result in an `index` diff if that in fact changes', () => {
+    it('results in an `index` diff if that in fact changes', () => {
       const older   = caret1;
       const op      = CaretOp.op_setField(older.id, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
@@ -117,7 +117,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.doesNotThrow(() => { caret1.diffFields(caret2, 'cr-florp'); });
     });
 
-    it('should result in an `index` diff if that in fact changes', () => {
+    it('results in an `index` diff if that in fact changes', () => {
       const older   = caret1;
       const op      = CaretOp.op_setField(older.id, 'index', 99999);
       const newer   = older.compose(new CaretDelta([op]));
@@ -127,7 +127,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(diffOps[0], op);
     });
 
-    it('should result in a `length` diff if that in fact changes', () => {
+    it('results in a `length` diff if that in fact changes', () => {
       const older   = caret1;
       const op      = CaretOp.op_setField(older.id, 'length', 99999);
       const newer   = older.compose(new CaretDelta([op]));
@@ -137,7 +137,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(diffOps[0], op);
     });
 
-    it('should result in a `color` diff if that in fact changes', () => {
+    it('results in a `color` diff if that in fact changes', () => {
       const older   = caret1;
       const op      = CaretOp.op_setField(older.id, 'color', '#abcdef');
       const newer   = older.compose(new CaretDelta([op]));

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -40,35 +40,35 @@ describe('@bayou/doc-common/Caret', () => {
       test(caret3);
     });
 
-    it('should update `authorId` given the appropriate op', () => {
+    it('updates `authorId` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.id, 'authorId', 'boop');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.authorId, 'boop');
     });
 
-    it('should update `index` given the appropriate op', () => {
+    it('updates `index` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.id, 'index', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.index, 99999);
     });
 
-    it('should update `length` given the appropriate op', () => {
+    it('updates `length` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.id, 'length', 99999);
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.length, 99999);
     });
 
-    it('should update `color` given the appropriate op', () => {
+    it('updates `color` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.id, 'color', '#aabbcc');
       const result = caret1.compose(new CaretDelta([op]));
 
       assert.strictEqual(result.color, '#aabbcc');
     });
 
-    it('should update `revNum` given the appropriate op', () => {
+    it('updates `revNum` given the appropriate op', () => {
       const op     = CaretOp.op_setField(caret1.id, 'revNum', 12345);
       const result = caret1.compose(new CaretDelta([op]));
 

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -27,7 +27,7 @@ const caret3 = newCaret('cr-33333', 3, 99, '#333333', 'third-author');
 
 describe('@bayou/doc-common/Caret', () => {
   describe('compose()', () => {
-    it('should produce an equal instance when passed an empty delta', () => {
+    it('produces an equal instance when passed an empty delta', () => {
       let which = 0;
       function test(caret) {
         which++;
@@ -83,7 +83,7 @@ describe('@bayou/doc-common/Caret', () => {
   });
 
   describe('diff()', () => {
-    it('should produce an empty diff when passed itself', () => {
+    it('produces an empty diff when passed itself', () => {
       const result = caret1.diff(caret1);
 
       assert.instanceOf(result, CaretDelta);
@@ -106,7 +106,7 @@ describe('@bayou/doc-common/Caret', () => {
   });
 
   describe('diffFields()', () => {
-    it('should produce an empty diff when passed itself', () => {
+    it('produces an empty diff when passed itself', () => {
       const result = caret1.diffFields(caret1, 'cr-florp');
 
       assert.instanceOf(result, CaretDelta);

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -71,7 +71,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     describe('`delete` preceded by anything for that caret', () => {
-      it('should result in just the `delete`', () => {
+      it('results in just the `delete`', () => {
         const endOp = CaretOp.op_delete('cr-sessi');
 
         test(
@@ -107,7 +107,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     describe('`setField` after `delete`', () => {
-      it('should result in just the `delete`', () => {
+      it('results in just the `delete`', () => {
         const endOp = CaretOp.op_delete('cr-sess1');
         const setOp = CaretOp.op_setField('cr-sess1', 'revNum', 123);
 
@@ -138,7 +138,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     describe('`setField` after `add`', () => {
-      it('should result in a modified `add`', () => {
+      it('results in a modified `add`', () => {
         const beginOp  = CaretOp.op_add(new Caret('cr-sess1', { authorId: 'xyz' }));
         const setOp    = CaretOp.op_setField('cr-sess1', 'revNum', 123);
         const resultOp = CaretOp.op_add(new Caret('cr-sess1', { authorId: 'xyz', revNum: 123 }));

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -57,7 +57,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
       assert.throws(() => delta.compose(new MockDelta([]), true));
     });
 
-    it('should not include `delete` ops when `wantDocument` is `true`', () => {
+    it('does not include `delete` ops when `wantDocument` is `true`', () => {
       const op1    = CaretOp.op_add(new Caret('cr-aaaaa', { authorId: 'xyz' }));
       const op2    = CaretOp.op_add(new Caret('cr-bbbbb', { authorId: 'xyz' }));
       const op3    = CaretOp.op_add(new Caret('cr-ccccc', { authorId: 'xyz' }));

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -172,7 +172,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test(new CaretSnapshot(999, [op1, op2, op3]));
     });
 
-    it('should update `revNum` given a change with a different `revNum`', () => {
+    it('updates `revNum` given a change with a different `revNum`', () => {
       const snap     = new CaretSnapshot(1,  [op1, op2]);
       const expected = new CaretSnapshot(999,[op1, op2]);
       const result   = snap.compose(new CaretChange(999, []));
@@ -196,7 +196,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.throws(() => { snap.compose(change); });
     });
 
-    it('should update a pre-existing caret given an appropriate op', () => {
+    it('updates a pre-existing caret given an appropriate op', () => {
       const c1       = newCaretOp('cr-foooo', 1, 2, '#333333', 'dd');
       const c2       = newCaretOp('cr-foooo', 3, 2, '#333333', 'dd');
       const snap     = new CaretSnapshot(1, [op1, c1]);

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -226,7 +226,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.deepEqual(result.delta, CaretDelta.EMPTY);
     });
 
-    it('should result in a `revNum` diff if that in fact changes', () => {
+    it('results in a `revNum` diff if that in fact changes', () => {
       const snap1  = new CaretSnapshot(1, [op1, op2]);
       const snap2  = new CaretSnapshot(9, [op1, op2]);
       const result = snap1.diff(snap2);
@@ -239,7 +239,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(composed.equals(expected));
     });
 
-    it('should result in a caret removal if that in fact happens', () => {
+    it('results in a caret removal if that in fact happens', () => {
       const snap1  = new CaretSnapshot(4, [op1, op2]);
       const snap2  = new CaretSnapshot(4, [op1]);
       const result = snap1.diff(snap2);
@@ -249,7 +249,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(composed.equals(expected));
     });
 
-    it('should result in a caret addition if that in fact happens', () => {
+    it('results in a caret addition if that in fact happens', () => {
       const snap1  = new CaretSnapshot(1, [op1]);
       const snap2  = new CaretSnapshot(1, [op1, op2]);
       const result = snap1.diff(snap2);
@@ -259,7 +259,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(composed.equals(expected));
     });
 
-    it('should result in a caret update if that in fact happens', () => {
+    it('results in a caret update if that in fact happens', () => {
       const c1     = newCaretOp('cr-florp', 1, 3, '#444444', 'ff');
       const c2     = newCaretOp('cr-florp', 2, 4, '#555555', 'gg');
       const c3     = newCaretOp('cr-florp', 3, 5, '#666666', 'hh');

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -46,7 +46,7 @@ const op3 = CaretOp.op_add(caret3);
 
 describe('@bayou/doc-common/CaretSnapshot', () => {
   describe('.EMPTY', () => {
-    it('should be an empty instance', () => {
+    it('is an empty instance', () => {
       const EMPTY = CaretSnapshot.EMPTY;
 
       assert.strictEqual(EMPTY.revNum, 0);

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -89,7 +89,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       test([op1, op2, op3]);
     });
 
-    it('should produce a frozen instance', () => {
+    it('produces a frozen instance', () => {
       const snap = new CaretSnapshot(0, [op1]);
       assert.isFrozen(snap);
     });
@@ -158,7 +158,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('should produce an equal instance when passed an empty change with the same `revNum`', () => {
+    it('produces an equal instance when passed an empty change with the same `revNum`', () => {
       let which = 0;
       function test(snap) {
         which++;
@@ -217,7 +217,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('diff()', () => {
-    it('should produce an empty diff when passed itself', () => {
+    it('produces an empty diff when passed itself', () => {
       const snap   = new CaretSnapshot(123, [op1, op2]);
       const result = snap.diff(snap);
 

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -141,7 +141,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       test([op1, op5], [op7],      [op5, op7]);
     });
 
-    it('should not include deletions when `wantDocument` is `true`', () => {
+    it('does not include deletions when `wantDocument` is `true`', () => {
       const op1    = PropertyOp.op_set('aaa', '111');
       const op2    = PropertyOp.op_set('bbb', '222');
       const op3    = PropertyOp.op_set('ccc', '333');

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -97,7 +97,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.throws(() => delta.compose(new MockDelta([]), false));
     });
 
-    it('should result in no more than one op per named property, with `other` taking precedence', () => {
+    it('results in no more than one op per named property, with `other` taking precedence', () => {
       function test(ops1, ops2, expectOps) {
         const d1     = new PropertyDelta(ops1);
         const d2     = new PropertyDelta(ops2);

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -14,11 +14,11 @@ describe('@bayou/doc-common/PropertyDelta', () => {
   describe('.EMPTY', () => {
     const EMPTY = PropertyDelta.EMPTY;
 
-    it('should be an instance of `PropertyDelta`', () => {
+    it('is an instance of `PropertyDelta`', () => {
       assert.instanceOf(EMPTY, PropertyDelta);
     });
 
-    it('should be a frozen object', () => {
+    it('is a frozen object', () => {
       assert.isFrozen(EMPTY);
     });
 
@@ -30,7 +30,7 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.isFrozen(EMPTY.ops);
     });
 
-    it('should be `.isEmpty()`', () => {
+    it('is `.isEmpty()`', () => {
       assert.isTrue(EMPTY.isEmpty());
     });
   });

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -156,7 +156,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
         [PropertyOp.op_set('foo', 'bar'), PropertyOp.op_set('baz', 914)]));
     });
 
-    it('should update `revNum` given a change with a different `revNum`', () => {
+    it('updates `revNum` given a change with a different `revNum`', () => {
       const snap     = new PropertySnapshot(123, PropertyDelta.EMPTY);
       const expected = new PropertySnapshot(456, PropertyDelta.EMPTY);
       const result   = snap.compose(new PropertyChange(456, PropertyDelta.EMPTY));
@@ -176,7 +176,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should update a pre-existing property given an appropriate op', () => {
+    it('updates a pre-existing property given an appropriate op', () => {
       const op       = PropertyOp.op_set('florp', 'like');
       const snap     = new PropertySnapshot(0, [PropertyOp.op_set('florp', 'unlike')]);
       const expected = new PropertySnapshot(0, [op]);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -55,7 +55,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       test([PropertyOp.op_set('x', 'y'), PropertyOp.op_set('z', 'pdq')]);
     });
 
-    it('should produce a frozen instance', () => {
+    it('produces a frozen instance', () => {
       const snap = new PropertySnapshot(0, [PropertyOp.op_set('x', 'y')]);
       assert.isFrozen(snap);
     });
@@ -138,7 +138,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('should produce an equal instance when passed an empty change with the same `revNum`', () => {
+    it('produces an equal instance when passed an empty change with the same `revNum`', () => {
       let which = 0;
       function test(snap) {
         which++;
@@ -198,7 +198,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('diff()', () => {
-    it('should produce an empty diff when passed itself', () => {
+    it('produces an empty diff when passed itself', () => {
       const snap = new PropertySnapshot(914,
         [PropertyOp.op_set('a', 10), PropertyOp.op_set('b', 20)]);
       const result = snap.diff(snap);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -11,7 +11,7 @@ import { DataUtil, Functor } from '@bayou/util-common';
 
 describe('@bayou/doc-common/PropertySnapshot', () => {
   describe('.EMPTY', () => {
-    it('should be an empty instance', () => {
+    it('is an empty instance', () => {
       const EMPTY = PropertySnapshot.EMPTY;
 
       assert.strictEqual(EMPTY.revNum, 0);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -208,7 +208,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.deepEqual(result.delta, PropertyDelta.EMPTY);
     });
 
-    it('should result in a `revNum` diff if that in fact changes', () => {
+    it('results in a `revNum` diff if that in fact changes', () => {
       const snap1 = new PropertySnapshot(123, [PropertyOp.op_set('a', 10)]);
       const snap2 = new PropertySnapshot(456, [PropertyOp.op_set('a', 10)]);
       const result = snap1.diff(snap2);
@@ -219,7 +219,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(composed.equals(expected));
     });
 
-    it('should result in a property removal if that in fact happens', () => {
+    it('results in a property removal if that in fact happens', () => {
       const snap1 = new PropertySnapshot(0, [
         PropertyOp.op_set('a', 10),
         PropertyOp.op_set('b', 20),

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -62,13 +62,13 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.authorToken', () => {
-    it('should be the constructed value if constructed from a string', () => {
+    it('is the constructed value if constructed from a string', () => {
       const token  = 'florp';
       const result = new SessionInfo(SERVER_URL, token, 'x');
       assert.strictEqual(result.authorToken, token);
     });
 
-    it('should be the constructed value if constructed from a `BearerToken`', () => {
+    it('is the constructed value if constructed from a `BearerToken`', () => {
       const token  = new BearerToken('the-id', 'the-secret');
       const result = new SessionInfo(SERVER_URL, token, 'boop');
       assert.strictEqual(result.authorToken, token);
@@ -76,7 +76,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.documentId', () => {
-    it('should be the constructed value', () => {
+    it('is the constructed value', () => {
       const id     = 'blort';
       const result = new SessionInfo(SERVER_URL, 'token', id);
       assert.strictEqual(result.documentId, id);
@@ -84,7 +84,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.serverUrl', () => {
-    it('should be the constructed value', () => {
+    it('is the constructed value', () => {
       const url    = 'https://milk.com:1234/florp';
       const result = new SessionInfo(url, 'token', 'x');
       assert.strictEqual(result.serverUrl, url);
@@ -92,13 +92,13 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.caretId', () => {
-    it('should be the constructed value', () => {
+    it('is the constructed value', () => {
       const id     = 'zorch';
       const result = new SessionInfo(SERVER_URL, 'token', 'doc', id);
       assert.strictEqual(result.caretId, id);
     });
 
-    it('should be `null` if not passed in the constructor', () => {
+    it('is `null` if not passed in the constructor', () => {
       const result = new SessionInfo(SERVER_URL, 'token', 'doc');
       assert.isNull(result.caretId);
     });
@@ -157,7 +157,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.deepEqual(si.logTags, [did, cid]);
     });
 
-    it('should be just the `documentId` if `caretId === null`', () => {
+    it('is just the `documentId` if `caretId === null`', () => {
       const id = 'docness';
       const si = new SessionInfo(SERVER_URL, 'token', id);
       assert.deepEqual(si.logTags, [id]);

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -126,7 +126,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.strictEqual(info.caretId, si.caretId);
     });
 
-    it('should not bind `caretId` if the instance has no `caretId`', () => {
+    it('does not bind `caretId` if the instance has no `caretId`', () => {
       const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
       const info = si.logInfo;
 

--- a/local-modules/@bayou/doc-common/tests/test_Timeouts.js
+++ b/local-modules/@bayou/doc-common/tests/test_Timeouts.js
@@ -9,12 +9,12 @@ import { Timeouts } from '@bayou/doc-common';
 
 describe('@bayou/doc-common/Timeouts', () => {
   describe('.MAX_TIMEOUT_MSEC', () => {
-    it('should be an integer', () => {
+    it('is an integer', () => {
       const max = Timeouts.MAX_TIMEOUT_MSEC;
       assert.isTrue(Number.isSafeInteger(max));
     });
 
-    it('should be greater than the minimum', () => {
+    it('is greater than the minimum', () => {
       const max = Timeouts.MAX_TIMEOUT_MSEC;
       const min = Timeouts.MIN_TIMEOUT_MSEC;
       assert.isTrue(max > min);
@@ -22,7 +22,7 @@ describe('@bayou/doc-common/Timeouts', () => {
   });
 
   describe('.MIN_TIMEOUT_MSEC', () => {
-    it('should be a positive integer', () => {
+    it('is a positive integer', () => {
       const min = Timeouts.MIN_TIMEOUT_MSEC;
       assert.isTrue(Number.isSafeInteger(min));
       assert.isAtLeast(min, 0);

--- a/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
@@ -28,7 +28,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isAuthorId('123abc7890ABC456789012'));
     });
 
-    it('should allow underscores and hyphens', () => {
+    it('allows underscores and hyphens', () => {
       assert.isTrue(DefaultIdSyntax.isAuthorId('123456789_123456789-12'));
     });
 
@@ -52,7 +52,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isDocumentId('123abc7890ABC456789012'));
     });
 
-    it('should allow underscores and hyphens', () => {
+    it('allows underscores and hyphens', () => {
       assert.isTrue(DefaultIdSyntax.isDocumentId('123456789_123456789-12'));
     });
 
@@ -76,7 +76,7 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isFileId('123abc7890ABC456789012'));
     });
 
-    it('should allow underscores and hyphens', () => {
+    it('allows underscores and hyphens', () => {
       assert.isTrue(DefaultIdSyntax.isFileId('123456789_123456789-12'));
     });
 

--- a/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
+++ b/local-modules/@bayou/id-syntax-default/tests/test_DefaultIdSyntax.js
@@ -32,11 +32,11 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isAuthorId('123456789_123456789-12'));
     });
 
-    it('should not allow non-ASCII characters', () => {
+    it('does not allow non-ASCII characters', () => {
       assert.isFalse(DefaultIdSyntax.isAuthorId('123456789•123456789•12'));
     });
 
-    it('should not allow non-alphanum characters', () => {
+    it('does not allow non-alphanum characters', () => {
       assert.isFalse(DefaultIdSyntax.isAuthorId('123456789\t123456789+12'));
     });
 
@@ -56,11 +56,11 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isDocumentId('123456789_123456789-12'));
     });
 
-    it('should not allow non-ASCII characters', () => {
+    it('does not allow non-ASCII characters', () => {
       assert.isFalse(DefaultIdSyntax.isDocumentId('123456789•123456789•12'));
     });
 
-    it('should not allow non-alphanum characters', () => {
+    it('does not allow non-alphanum characters', () => {
       assert.isFalse(DefaultIdSyntax.isDocumentId('123456789\t123456789+12'));
     });
 
@@ -80,11 +80,11 @@ describe('@bayou/id-syntax-default/DefaultIdSyntax', () => {
       assert.isTrue(DefaultIdSyntax.isFileId('123456789_123456789-12'));
     });
 
-    it('should not allow non-ASCII characters', () => {
+    it('does not allow non-ASCII characters', () => {
       assert.isFalse(DefaultIdSyntax.isFileId('123456789•123456789•12'));
     });
 
-    it('should not allow non-alphanum characters', () => {
+    it('does not allow non-alphanum characters', () => {
       assert.isFalse(DefaultIdSyntax.isFileId('123456789\t123456789+12'));
     });
 

--- a/local-modules/@bayou/proppy/tests/test_Proppy.js
+++ b/local-modules/@bayou/proppy/tests/test_Proppy.js
@@ -90,7 +90,7 @@ describe('@bayou/proppy/Proppy', () => {
       _testStringParsing(input, { key: 'value\nthis is a multiline value' });
     });
 
-    it('should parse accepted escape sequences', () => {
+    it('parses accepted escape sequences', () => {
       let input = null;
 
       input = '"key\\\\" = "value"';

--- a/local-modules/@bayou/proppy/tests/test_Proppy.js
+++ b/local-modules/@bayou/proppy/tests/test_Proppy.js
@@ -63,7 +63,7 @@ describe('@bayou/proppy/Proppy', () => {
       _testStringParsing(input, { '_.-/-._': 'mound' });
     });
 
-    it('should not accept unquoted keys or values that have unblessed characters', () => {
+    it('does not accept unquoted keys or values that have unblessed characters', () => {
       let input = null;
 
       // Non-7-bit character
@@ -109,7 +109,7 @@ describe('@bayou/proppy/Proppy', () => {
       _testStringParsing(input, { 'key\t': 'value' });
     });
 
-    it('should not accept unapproved escape sequences', () => {
+    it('does not accept unapproved escape sequences', () => {
       let input = null;
 
       input = '"key\\r" = value';
@@ -119,7 +119,7 @@ describe('@bayou/proppy/Proppy', () => {
       assert.throws(() => _testStringParsing(input, { 'key\b': 'value' }));
     });
 
-    it('should not accept approved escape sequences in unquoted keys or values', () => {
+    it('does not accept approved escape sequences in unquoted keys or values', () => {
       let input = null;
 
       input = 'key\\\\ = value';

--- a/local-modules/@bayou/typecheck/tests/test_TFunction.js
+++ b/local-modules/@bayou/typecheck/tests/test_TFunction.js
@@ -77,7 +77,7 @@ const NON_FUNCTIONS = [
 
 describe('@bayou/typecheck/TFunction', () => {
   describe('check()', () => {
-    it('should succeed when passed a function', () => {
+    it('succeeds when passed a function', () => {
       function test(value) {
         assert.strictEqual(TFunction.check(value), value);
       }
@@ -99,7 +99,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('checkCallable()', () => {
-    it('should succeed when passed a callable function', () => {
+    it('succeeds when passed a callable function', () => {
       function test(value) {
         assert.strictEqual(TFunction.checkCallable(value), value);
       }
@@ -131,7 +131,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('checkCallableOrNull()', () => {
-    it('should succeed when passed a callable function', () => {
+    it('succeeds when passed a callable function', () => {
       function test(value) {
         assert.strictEqual(TFunction.checkCallableOrNull(value), value);
       }
@@ -141,7 +141,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should succeed when passed `null`', () => {
+    it('succeeds when passed `null`', () => {
       assert.isNull(TFunction.checkCallableOrNull(null));
     });
 
@@ -171,7 +171,7 @@ describe('@bayou/typecheck/TFunction', () => {
   });
 
   describe('checkClass(value)', () => {
-    it('should succeed when passed a class', () => {
+    it('succeeds when passed a class', () => {
       function test(value) {
         assert.strictEqual(TFunction.checkClass(value), value);
       }

--- a/local-modules/@bayou/typecheck/tests/test_TFunction.js
+++ b/local-modules/@bayou/typecheck/tests/test_TFunction.js
@@ -87,7 +87,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed anything other than a function', () => {
+    it('fails when passed anything other than a function', () => {
       function test(value) {
         assert.throws(() => { TFunction.check(value); });
       }
@@ -109,7 +109,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-callable function', () => {
+    it('fails when passed a non-callable function', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkCallable(value); });
       }
@@ -119,7 +119,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-function', () => {
+    it('fails when passed a non-function', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkCallable(value); });
       }
@@ -145,7 +145,7 @@ describe('@bayou/typecheck/TFunction', () => {
       assert.isNull(TFunction.checkCallableOrNull(null));
     });
 
-    it('should fail when passed a non-callable function', () => {
+    it('fails when passed a non-callable function', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkCallableOrNull(value); });
       }
@@ -155,7 +155,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-`null` non-function', () => {
+    it('fails when passed a non-`null` non-function', () => {
       function test(value) {
         if (value === null) {
           return;
@@ -181,7 +181,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-class function', () => {
+    it('fails when passed a non-class function', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkClass(value); });
       }
@@ -191,7 +191,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-function', () => {
+    it('fails when passed a non-function', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkClass(value); });
       }
@@ -246,7 +246,7 @@ describe('@bayou/typecheck/TFunction', () => {
       test(Blort, SubBlort);
     });
 
-    it('should fail when passed a non-class function for `value`', () => {
+    it('fails when passed a non-class function for `value`', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkClass(value, Object); });
       }
@@ -256,7 +256,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-function for `value`', () => {
+    it('fails when passed a non-function for `value`', () => {
       function test(value) {
         assert.throws(() => { TFunction.checkClass(value, Object); });
       }
@@ -266,7 +266,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-class for `ancestor`', () => {
+    it('fails when passed a non-class for `ancestor`', () => {
       function test(ancestor) {
         assert.throws(() => { TFunction.checkClass(Object, ancestor); },
           /./, /./, inspect(ancestor));
@@ -405,7 +405,7 @@ describe('@bayou/typecheck/TFunction', () => {
       }
     });
 
-    it('should fail when passed a non-class for `ancestor`', () => {
+    it('fails when passed a non-class for `ancestor`', () => {
       function test(ancestor) {
         assert.throws(() => { TFunction.isClass(Object, ancestor); },
           /./, /./, inspect(ancestor));

--- a/local-modules/@bayou/typecheck/tests/test_TInt.js
+++ b/local-modules/@bayou/typecheck/tests/test_TInt.js
@@ -61,7 +61,7 @@ describe('@bayou/typecheck/TInt', () => {
   });
 
   describe('maxInc()', () => {
-    it('should allow value <= maxInc', () => {
+    it('allows value <= maxInc', () => {
       assert.doesNotThrow(() => TInt.maxInc(4, 4));
       assert.doesNotThrow(() => TInt.maxInc(4, 5));
     });
@@ -132,7 +132,7 @@ describe('@bayou/typecheck/TInt', () => {
   });
 
   describe('rangeInc()', () => {
-    it('should allow `minInc <= value <= maxInc`', () => {
+    it('allows `minInc <= value <= maxInc`', () => {
       assert.doesNotThrow(() => TInt.rangeInc(11, 3, 27));
     });
 
@@ -150,7 +150,7 @@ describe('@bayou/typecheck/TInt', () => {
   });
 
   describe('unsignedByte()', () => {
-    it('should allow integer values in range `[0..255]`', () => {
+    it('allows integer values in range `[0..255]`', () => {
       assert.strictEqual(TInt.unsignedByte(0),   0);
       assert.strictEqual(TInt.unsignedByte(1),   1);
       assert.strictEqual(TInt.unsignedByte(128), 128);

--- a/local-modules/@bayou/typecheck/tests/test_TInt.js
+++ b/local-modules/@bayou/typecheck/tests/test_TInt.js
@@ -140,7 +140,7 @@ describe('@bayou/typecheck/TInt', () => {
       assert.throws(() => TInt.rangeInc(2, 3, 27));
     });
 
-    it('should not throw an error when `value === maxInc`', () => {
+    it('does not throw an error when `value === maxInc`', () => {
       assert.doesNotThrow(() => TInt.rangeInc(27, 3, 27));
     });
 

--- a/local-modules/@bayou/typecheck/tests/test_TNumber.js
+++ b/local-modules/@bayou/typecheck/tests/test_TNumber.js
@@ -43,7 +43,7 @@ describe('@bayou/typecheck/TNumber', () => {
   });
 
   describe('range()', () => {
-    it('should allow values in the specified range', () => {
+    it('allows values in the specified range', () => {
       function test(v, minInc, maxExc) {
         assert.strictEqual(TNumber.range(v, minInc, maxExc), v);
       }
@@ -70,7 +70,7 @@ describe('@bayou/typecheck/TNumber', () => {
   });
 
   describe('rangeInc()', () => {
-    it('should allow values in the specified range', () => {
+    it('allows values in the specified range', () => {
       function test(v, minInc, maxInc) {
         assert.strictEqual(TNumber.rangeInc(v, minInc, maxInc), v);
       }

--- a/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
@@ -26,7 +26,7 @@ describe('@bayou/util-common/DeferredLoader', () => {
   });
 
   describe('makeProxy() result access', () => {
-    it('should succeed in getting properties from the loaded value', () => {
+    it('succeeds in getting properties from the loaded value', () => {
       const loaded = { a: ['blort'], b: ['florp'] };
       function loader() { return loaded; }
 

--- a/local-modules/@bayou/util-common/tests/test_IterableUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_IterableUtil.js
@@ -80,7 +80,7 @@ describe('@bayou/util-common/IterableUtil', () => {
       assert.deepEqual(result3, expected);
     });
 
-    it('should work in the face of interleaved iteration', () => {
+    it('works in the face of interleaved iteration', () => {
       const iterator = new Set([1, 2, 3, 'florp', 5, 6.7]).keys();
       const wrapped  = IterableUtil.multiUseSafe(iterator);
       const expected = [1, 2, 3, 'florp', 5, 6.7];

--- a/local-modules/@bayou/util-common/tests/test_Singleton.js
+++ b/local-modules/@bayou/util-common/tests/test_Singleton.js
@@ -17,7 +17,7 @@ describe('@bayou/util-common/Singleton', () => {
       assert.strictEqual(test1, test2);
     });
 
-    it('should allow manual construction if it has not ever been constructed', () => {
+    it('allows manual construction if it has not ever been constructed', () => {
       class TestClass extends Singleton { /*empty*/ }
 
       const test1 = new TestClass();

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -40,7 +40,7 @@ describe('@bayou/util-core/CommonBase', () => {
   });
 
   describe('coerce()', () => {
-    it('should call through to `_impl_coerce()`', () => {
+    it('calls through to `_impl_coerce()`', () => {
       let gotValue = null;
       class HasCoerce extends CommonBase {
         static _impl_coerce(value) {
@@ -66,7 +66,7 @@ describe('@bayou/util-core/CommonBase', () => {
   });
 
   describe('coerceOrNull()', () => {
-    it('should call through to `_impl_coerce()` if there is no `_impl_coerceOrNull()`', () => {
+    it('calls through to `_impl_coerce()` if there is no `_impl_coerceOrNull()`', () => {
       let gotValue = null;
       class HasCoerce extends CommonBase {
         static _impl_coerce(value) {
@@ -80,7 +80,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(gotValue, 123);
     });
 
-    it('should call through to `_impl_coerce()` if there is no `_impl_coerceOrNull()` and convert a throw into a `null`', () => {
+    it('calls through to `_impl_coerce()` if there is no `_impl_coerceOrNull()` and convert a throw into a `null`', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerce(value_unused) {
           throw new Error('oy');
@@ -91,7 +91,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.isNull(value);
     });
 
-    it('should call through to `_impl_coerceOrNull()`', () => {
+    it('calls through to `_impl_coerceOrNull()`', () => {
       let gotValue = null;
       class HasCoerce extends CommonBase {
         static _impl_coerceOrNull(value) {
@@ -105,7 +105,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(gotValue, 123);
     });
 
-    it('should call through to `_impl_coerceOrNull()` and accept a `null` return value', () => {
+    it('calls through to `_impl_coerceOrNull()` and accept a `null` return value', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerceOrNull(value_unused) {
           return null;

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -152,7 +152,7 @@ describe('@bayou/util-core/DataUtil', () => {
     describe('with `nonDataConverter === null`', () => {
       commonTests(null);
 
-      it('should fail if given a function or a composite that contains same', () => {
+      it('fails if given a function or a composite that contains same', () => {
         function test(value) {
           assert.throws(() => { DataUtil.deepFreeze(value); });
         }
@@ -165,7 +165,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test({ a: 10, b: { c: { d: test } } });
       });
 
-      it('should fail if given a non-plain object or a composite that contains same', () => {
+      it('fails if given a non-plain object or a composite that contains same', () => {
         function test(value) {
           assert.throws(() => { DataUtil.deepFreeze(value); });
         }

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -68,7 +68,7 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.isNotFrozen(orig);
       });
 
-      it('should work on arrays with holes', () => {
+      it('works on arrays with holes', () => {
         const orig = [1, 2, 3];
         orig[37]   = ['florp'];
         orig[914]  = [[['like']]];
@@ -79,7 +79,7 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.deepEqual(popsicle, orig);
       });
 
-      it('should work on arrays with additional string-named properties', () => {
+      it('works on arrays with additional string-named properties', () => {
         const orig = [1, 2, 3];
         orig.florp = ['florp'];
         orig.like  = [[['like']]];
@@ -90,7 +90,7 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.deepEqual(popsicle, orig);
       });
 
-      it('should work on arrays with additional symbol-named properties', () => {
+      it('works on arrays with additional symbol-named properties', () => {
         const orig = [1, 2, 3];
         orig[Symbol('florp')] = ['florp'];
         orig[Symbol('like')] = [[['like']]];
@@ -101,7 +101,7 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.deepEqual(popsicle, orig);
       });
 
-      it('should work on objects with symbol-named properties', () => {
+      it('works on objects with symbol-named properties', () => {
         const orig = { a: 10, [Symbol('b')]: 20 };
 
         const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
@@ -119,7 +119,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test(FrozenBuffer.coerce('florp'));
       });
 
-      it('should work on functors with freezable arguments', () => {
+      it('works on functors with freezable arguments', () => {
         function test(...args) {
           const ftor = new Functor(...args);
           const popsicle = DataUtil.deepFreeze(ftor, nonDataConverter);
@@ -135,7 +135,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test('blort', new Functor('x', [1, 2, 3]), [4, 5, 6]);
       });
 
-      it('should work on already-deep-frozen functors', () => {
+      it('works on already-deep-frozen functors', () => {
         function test(...args) {
           const ftor = new Functor(...args);
           const popsicle = DataUtil.deepFreeze(ftor, nonDataConverter);

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -60,7 +60,7 @@ describe('@bayou/util-core/DataUtil', () => {
         test({ x: [[[[[123]]]]], y: [37, [37], [[37]], [[[37]]]], z: [{ x: 10 }] });
       });
 
-      it('should not freeze the originally passed value', () => {
+      it('does not freeze the originally passed value', () => {
         const orig = [1, 2, 3];
         const popsicle = DataUtil.deepFreeze(orig, nonDataConverter);
 

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -196,7 +196,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
         }
       });
 
-      it('should not share the original buffer data; should be a copy', () => {
+      it('does not share the original buffer data; should be a copy', () => {
         const nodeBuf1 = Buffer.from('blortch', 'utf8');
         const nodeBuf2 = Buffer.from(nodeBuf1);
         const buf      = new FrozenBuffer(nodeBuf1);

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -164,7 +164,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
         assert.doesNotThrow(() => new FrozenBuffer('RkxPUlAK', 'base64'));
       });
 
-      it('should produce bytes identical to the expected base-64 decoding', () => {
+      it('produces bytes identical to the expected base-64 decoding', () => {
         function test(string) {
           const nodeBuf = Buffer.from(string, 'utf8');
           const base64  = nodeBuf.toString('base64');

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -212,17 +212,17 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('.base64', () => {
-    it('should be as expected when originally constructed from a `Buffer`', () => {
+    it('is as expected when originally constructed from a `Buffer`', () => {
       const buf = new FrozenBuffer(Buffer.from('florp splat', 'utf8'));
       assert.strictEqual(buf.base64, 'ZmxvcnAgc3BsYXQ=');
     });
 
-    it('should be as expected when originally constructed from a UTF-8 string', () => {
+    it('is as expected when originally constructed from a UTF-8 string', () => {
       const buf = new FrozenBuffer('blort splat florp');
       assert.strictEqual(buf.base64, 'YmxvcnQgc3BsYXQgZmxvcnA=');
     });
 
-    it('should be as expected when originally constructed from a base-64 string', () => {
+    it('is as expected when originally constructed from a base-64 string', () => {
       const base64 = 'ZmxvcnAgc3BsYXQ=';
       const buf = new FrozenBuffer(base64, 'base64');
       assert.strictEqual(buf.base64, base64);
@@ -230,19 +230,19 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('.hashLength', () => {
-    it('should be `256`', () => {
+    it('is `256`', () => {
       assert.strictEqual(new FrozenBuffer('x').hashLength, 256);
     });
   });
 
   describe('.hashName', () => {
-    it('should be `sha3`', () => {
+    it('is `sha3`', () => {
       assert.strictEqual(new FrozenBuffer('x').hashName, 'sha3');
     });
   });
 
   describe('.hash', () => {
-    it('should be a 256 SHA-3 with length, in the prescribed format', () => {
+    it('is a 256 SHA-3 with length, in the prescribed format', () => {
       // **Note:** You can validate this result via the command-line `openssl`
       // tool: `printf '<data>' | openssl dgst -sha256`
       const data = 'This is the most important data you have ever observed.';
@@ -254,12 +254,12 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('.length', () => {
-    it('should be the expected length from a Buffer', () => {
+    it('is the expected length from a Buffer', () => {
       const buf = new FrozenBuffer(Buffer.alloc(9000));
       assert.strictEqual(buf.length, 9000);
     });
 
-    it('should be the expected length from a UTF-8 string', () => {
+    it('is the expected length from a UTF-8 string', () => {
       assert.strictEqual(new FrozenBuffer('12345').length, 5);
 
       // Because of UTF-8 encoding.
@@ -270,7 +270,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('.string', () => {
-    it('should be the same string given in the UTF-8 string constructor', () => {
+    it('is the same string given in the UTF-8 string constructor', () => {
       function test(string) {
         const buf = new FrozenBuffer(string);
         assert.strictEqual(buf.string, string);
@@ -281,7 +281,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       }
     });
 
-    it('should be the UTF-8 decoding of the Buffer given in the constructor', () => {
+    it('is the UTF-8 decoding of the Buffer given in the constructor', () => {
       function test(string) {
         const nodeBuf = Buffer.from(string, 'utf8');
         const buf = new FrozenBuffer(nodeBuf);
@@ -361,7 +361,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('toBuffer()', () => {
-    it('should be a buffer with the same contents as given in the constructor', () => {
+    it('is a buffer with the same contents as given in the constructor', () => {
       const nodeBuf = Buffer.alloc(9000);
 
       for (let i = 0; i < nodeBuf.length; i++) {
@@ -375,7 +375,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       assert.deepEqual(result, nodeBuf);
     });
 
-    it('should be the UTF-8 encoding of the string given in the UTF-8 string constructor', () => {
+    it('is the UTF-8 encoding of the string given in the UTF-8 string constructor', () => {
       function test(string) {
         const buf = new FrozenBuffer(string);
         const nodeBuf = Buffer.from(string, 'utf8');
@@ -387,7 +387,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       }
     });
 
-    it('should be independent of the internally-stored buffer and to other results from this method', () => {
+    it('is independent of the internally-stored buffer and to other results from this method', () => {
       const nodeBuf = Buffer.from('abc', 'utf8');
       const origBuf = new FrozenBuffer(nodeBuf);
       const toBuf1  = origBuf.toBuffer();

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -70,7 +70,7 @@ describe('@bayou/util-core/Functor', () => {
   });
 
   describe('.args', () => {
-    it('should be a frozen array', () => {
+    it('is a frozen array', () => {
       const ftor = new Functor('blort', 'a', ['b'], { c: 30 });
       assert.isArray(ftor.args);
       assert.isFrozen(ftor.args);

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -207,7 +207,7 @@ describe('@bayou/util-core/Functor', () => {
   });
 
   describe('toString()', () => {
-    it('should produce expected strings in various cases', () => {
+    it('produces expected strings in various cases', () => {
       function test(expect, name, ...args) {
         const result = new Functor(name, ...args);
         assert.strictEqual(result.toString(), expect);
@@ -247,7 +247,7 @@ describe('@bayou/util-core/Functor', () => {
       test(alreadyFrozenInstance);
     });
 
-    it('should produce an instance with all frozen arguments equal to the original arguments', () => {
+    it('produces an instance with all frozen arguments equal to the original arguments', () => {
       function test(...args) {
         const result = new Functor('florp', ...args).withFrozenArgs();
 

--- a/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
@@ -26,7 +26,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
       test(value, ['blort'], { blort: 'blort' });
     });
 
-    it('should fail if a property is missing', () => {
+    it('fails if a property is missing', () => {
       function test(value, keys) {
         assert.throws(() => ObjectUtil.extract(value, keys));
       }


### PR DESCRIPTION
This PR is similar to my last one, and starts to eat away at the long tail of `it('should...')` test descriptions.

BTW / ICYC, before I started making this all consistent (a couple months ago), we were about 50-50 on whether tests were `it('should <verb>...')` vs. `it('<verb>s...')`, with the latter ever so slightly in the lead.