### PR TITLE
Last licks on `it('should...')` spring cleaning.

### DIFF
--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -85,7 +85,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       assert.deepEqual(result, { got: token });
     });
 
-    it('should convert a string to a `BearerToken` then through to the `_impl`', async () => {
+    it('converts a string to a `BearerToken` then through to the `_impl`', async () => {
       class Authie extends BaseTokenAuthorizer {
         async _impl_targetFromToken(value) {
           return { got: value };
@@ -150,7 +150,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
   });
 
   describe('tokenFromString()', () => {
-    it('should validate via `isToken()` given a string, and call through to the `_impl`', () => {
+    it('validates via `isToken()` given a string, and calls through to the `_impl`', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_isToken(value) {
           return value.startsWith('token-');

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -33,7 +33,7 @@ class MockAuth extends BaseTokenAuthorizer {
 
 describe('@bayou/api-server/Context', () => {
   describe('constructor()', () => {
-    it('accepts valid arguments and produce a frozen instance', () => {
+    it('accepts valid arguments and produces a frozen instance', () => {
       const info   = new ContextInfo(new Codec(), new MockAuth());
       const result = new Context(info, new Logger('some-tag'));
 

--- a/local-modules/@bayou/codec/tests/test_Codec_decode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_decode.js
@@ -55,13 +55,13 @@ describe('@bayou/codec/Codec.decode*()', () => {
       assert.throws(() => decodeData(() => 123));
     });
 
-    it('should decode an encoded array back to the original array', () => {
+    it('decodes an encoded array back to the original array', () => {
       const orig    = [1, 2, 'buckle my shoe'];
       const encoded = encodeData(orig);
       assert.deepEqual(decodeData(encoded), orig);
     });
 
-    it('should decode an encoded `FrozenBuffer`s back to an equal instance', () => {
+    it('decodes an encoded `FrozenBuffer`s back to an equal instance', () => {
       const orig    = new FrozenBuffer('florp');
       const encoded = encodeData(orig);
       const decoded = decodeData(encoded);
@@ -70,7 +70,7 @@ describe('@bayou/codec/Codec.decode*()', () => {
       assert.deepEqual(decoded.toBuffer(), orig.toBuffer());
     });
 
-    it('should decode an encoded class instance as expected', () => {
+    it('decodes an encoded class instance as expected', () => {
       const apiObject = new MockCodable();
       const encoding  = encodeData(apiObject);
       const decoded   = decodeData(encoding);
@@ -80,7 +80,7 @@ describe('@bayou/codec/Codec.decode*()', () => {
   });
 
   describe('decodeJson()', () => {
-    it('should decode as expected', () => {
+    it('decodes as expected', () => {
       assert.strictEqual(decodeJson('null'), null);
       assert.strictEqual(decodeJson('914'), 914);
       assert.deepEqual(decodeJson('{ "object": [["a", 10], ["b", 20]] }'), { a: 10, b: 20 });
@@ -88,7 +88,7 @@ describe('@bayou/codec/Codec.decode*()', () => {
   });
 
   describe('decodeJsonBuffer()', () => {
-    it('should decode as expected', () => {
+    it('decodes as expected', () => {
       function bufAndDecode(s) {
         return decodeJsonBuffer(FrozenBuffer.coerce(s));
       }

--- a/local-modules/@bayou/codec/tests/test_Codec_decode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_decode.js
@@ -21,7 +21,7 @@ describe('@bayou/codec/Codec.decode*()', () => {
   codec.registry.registerClass(MockCodable);
 
   describe('decodeData()', () => {
-    it('should pass non-object values through as-is', () => {
+    it('passes non-object values through as-is', () => {
       function test(value) {
         assert.strictEqual(decodeData(value), value);
       }
@@ -33,7 +33,7 @@ describe('@bayou/codec/Codec.decode*()', () => {
       test(null);
     });
 
-    it('should pass arrays with only data values through as-is', () => {
+    it('passes arrays with only data values through as-is', () => {
       function test(value) {
         assert.deepEqual(decodeData(value), value);
       }

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -127,7 +127,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.isString(encodeJson([1, 2, 3]));
     });
 
-    it('should encode as expected', () => {
+    it('encodes as expected', () => {
       assert.strictEqual(encodeJson(null), 'null');
       assert.strictEqual(encodeJson(914), '914');
       assert.strictEqual(encodeJson({ a: 10, b: 20 }), '{"object":[["a",10],["b",20]]}');
@@ -141,7 +141,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.instanceOf(encodeJsonBuffer([1, 2, 3]), FrozenBuffer);
     });
 
-    it('should encode as expected', () => {
+    it('encodes as expected', () => {
       assert.strictEqual(encodeJsonBuffer(null).string, 'null');
       assert.strictEqual(encodeJsonBuffer(914).string, '914');
       assert.strictEqual(encodeJsonBuffer({ a: 10, b: 20 }).string, '{"object":[["a",10],["b",20]]}');

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -31,7 +31,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(undefined));
     });
 
-    it('passes through non-object values and null as-is', () => {
+    it('passes through non-object values and `null` as-is', () => {
       function test(value) {
         assert.strictEqual(encodeData(value), value);
       }
@@ -72,7 +72,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(value));
     });
 
-    it('accepts plain objects and encode as a tagged entries array', () => {
+    it('accepts plain objects and encodes them as a tagged entries array', () => {
       function test(value) {
         const expect = ConstructorCall.from('object', ...Object.entries(value));
         assert.deepEqual(encodeData(value), expect);
@@ -94,7 +94,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.deepEqual(encodeData(orig), expect);
     });
 
-    it('accepts `FrozenBuffer`s and encode as a single base-64 string argument', () => {
+    it('accepts `FrozenBuffer`s and encodes them as a single base-64 string argument', () => {
       const orig   = new FrozenBuffer('florp');
       const expect = ConstructorCall.from('buf', 'ZmxvcnA=');
 

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -31,7 +31,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       assert.throws(() => encodeData(undefined));
     });
 
-    it('should pass through non-object values and null as-is', () => {
+    it('passes through non-object values and null as-is', () => {
       function test(value) {
         assert.strictEqual(encodeData(value), value);
       }
@@ -43,7 +43,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       test(null);
     });
 
-    it('should pass through arrays with just data elements as-is', () => {
+    it('passes through arrays with just data elements as-is', () => {
       function test(value) {
         assert.deepEqual(encodeData(value), value);
       }

--- a/local-modules/@bayou/codec/tests/test_Codec_encode.js
+++ b/local-modules/@bayou/codec/tests/test_Codec_encode.js
@@ -84,7 +84,7 @@ describe('@bayou/codec/Codec.encode*()', () => {
       test({ c: 'yay', d: [1, 2, 3] });
     });
 
-    it('should sort plain object keys in encoded form', () => {
+    it('sorts plain object keys in encoded form', () => {
       const orig   = { d: [1, 2, 3], a: { c: 'cx', b: 'bx' } };
       const expect = ConstructorCall.from('object',
         ['a', ConstructorCall.from('object', ['b', 'bx'], ['c', 'cx'])],

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -130,7 +130,7 @@ describe('@bayou/config-server-default/Auth', () => {
       await test(EXAMPLE_TOKENS[0]); // Requires a token object, not a string.
     });
 
-    it('should indicate "no auth" for an unknown token', async () => {
+    it('indicates "no auth" for an unknown token', async () => {
       async function test(t) {
         const token = Auth.tokenFromString(t);
         const auth  = await Auth.tokenAuthority(token);
@@ -143,7 +143,7 @@ describe('@bayou/config-server-default/Auth', () => {
       }
     });
 
-    it('should indicate "root auth" for the staticly-known root token', async () => {
+    it('indicates "root auth" for the staticly-known root token', async () => {
       const token = Auth.tokenFromString(ROOT_TOKEN);
       const auth  = await Auth.tokenAuthority(token);
 
@@ -152,7 +152,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('tokenFromString()', () => {
-    it('should construct a token with the expected parts, given a valid token', () => {
+    it('constructs a token with the expected parts, given a valid token', () => {
       const id    = 'root-01233210';
       const full  = `${id}-aaaaaaa1`;
       const token = Auth.tokenFromString(full);
@@ -163,7 +163,7 @@ describe('@bayou/config-server-default/Auth', () => {
   });
 
   describe('tokenId()', () => {
-    it('should extract the ID of a valid token', () => {
+    it('extracts the ID of a valid token', () => {
       const id    = 'root-01234210';
       const token = `${id}-bbbbbbbb`;
       assert.strictEqual(Auth.tokenId(token), id);

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -52,7 +52,7 @@ describe('@bayou/config-server-default/Auth', () => {
       }
     });
 
-    it('should have only the one well-known token in it', () => {
+    it('has only the one well-known token in it', () => {
       assert.lengthOf(Auth.rootTokens, 1);
       assert.strictEqual(Auth.rootTokens[0].secretToken, ROOT_TOKEN);
     });
@@ -65,7 +65,7 @@ describe('@bayou/config-server-default/Auth', () => {
       assert.instanceOf(t, BearerToken);
     });
 
-    it('should always return a new token even given the same ID', async () => {
+    it('always returns a new token even given the same ID', async () => {
       const t1 = await Auth.getAuthorToken('florp');
       const t2 = await Auth.getAuthorToken('florp');
 

--- a/local-modules/@bayou/config-server-default/tests/test_Deployment.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Deployment.js
@@ -9,7 +9,7 @@ import { Deployment } from '@bayou/config-server-default';
 
 describe('@bayou/config-server-default/Deployment', () => {
   describe('findVarDirectory()', () => {
-    it('should append `/var` to its argument', () => {
+    it('appends `/var` to its argument', () => {
       assert.strictEqual(Deployment.findVarDirectory('/foo'), '/foo/var');
     });
   });

--- a/local-modules/@bayou/config-server/tests/test_BaseAuth.js
+++ b/local-modules/@bayou/config-server/tests/test_BaseAuth.js
@@ -20,7 +20,7 @@ describe('@bayou/config-server/BaseAuth', () => {
       });
     }
 
-    it('should have unique values for all items', () => {
+    it('has unique values for all items', () => {
       const set = new Set();
       for (const item of items) {
         const name = `TYPE_${item}`;

--- a/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
+++ b/local-modules/@bayou/data-model-client/tests/test_DocumentState.js
@@ -36,7 +36,7 @@ describe('@bayou/data-model-client/DocumentState', () => {
     assert.doesNotThrow(() => reducer(initialState, action));
   });
 
-  it('should invert the starred state when passed the "toggle star" action', () => {
+  it('inverts the starred state when passed the "toggle star" action', () => {
     const reducer = DocumentState.reducer;
 
     // Pass in undefined initial state to get back the default values

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -113,7 +113,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(result.ops, []);
     });
 
-    it('should diff fields even if given a non-matching caret ID', () => {
+    it('diffs fields even if given a non-matching caret ID', () => {
       assert.doesNotThrow(() => { caret1.diffFields(caret2, 'cr-florp'); });
     });
 

--- a/local-modules/@bayou/doc-common/tests/test_Caret.js
+++ b/local-modules/@bayou/doc-common/tests/test_Caret.js
@@ -75,7 +75,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.strictEqual(result.revNum, 12345);
     });
 
-    it('should refuse to compose if given a non-matching caret ID', () => {
+    it('refuses to compose if given a non-matching caret ID', () => {
       const op = CaretOp.op_setField(caret2.id, 'index', 55);
 
       assert.throws(() => { caret1.compose(new CaretDelta([op])); });
@@ -90,7 +90,7 @@ describe('@bayou/doc-common/Caret', () => {
       assert.deepEqual(result.ops, []);
     });
 
-    it('should refuse to diff if given a non-matching caret ID', () => {
+    it('refuses to diff if given a non-matching caret ID', () => {
       assert.throws(() => { caret1.diff(caret2); });
     });
 

--- a/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretDelta.js
@@ -170,7 +170,7 @@ describe('@bayou/doc-common/CaretDelta', () => {
     });
 
     describe('`setField` after `setField`', () => {
-      it('should drop earlier sets for the same field', () => {
+      it('drops earlier sets for the same field', () => {
         const setOp1 = CaretOp.op_setField('cr-sess1', 'revNum', 123);
         const setOp2 = CaretOp.op_setField('cr-sess1', 'revNum', 999);
 

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -180,7 +180,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should add a new caret given the appropriate op', () => {
+    it('adds a new caret given the appropriate op', () => {
       const snap     = new CaretSnapshot(1, []);
       const expected = new CaretSnapshot(1, [op1]);
       const change   = new CaretChange(1, [CaretOp.op_add(caret1)]);
@@ -189,7 +189,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should refuse to update a nonexistent caret', () => {
+    it('refuses to update a nonexistent caret', () => {
       const snap   = new CaretSnapshot(1, [op1]);
       const change = new CaretChange(1, [CaretOp.op_setField('cr-florp', 'index', 1)]);
 

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -144,7 +144,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
   });
 
   describe('.size', () => {
-    it('should indicate the count of carets', () => {
+    it('indicates the count of carets', () => {
       function test(ops) {
         const snap = new CaretSnapshot(1, ops);
         assert.strictEqual(snap.size, ops.length);
@@ -207,7 +207,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should remove a caret given the appropriate op', () => {
+    it('removes a caret given the appropriate op', () => {
       const snap     = new CaretSnapshot(1, [op1, op2]);
       const expected = new CaretSnapshot(1, [op2]);
       const result   = snap.compose(new CaretChange(1, [CaretOp.op_delete(caret1.id)]));

--- a/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_CaretSnapshot.js
@@ -285,7 +285,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
       assert.strictEqual(result[Symbol.iterator](), result);
     });
 
-    it('should in fact iterate over the properties', () => {
+    it('in fact iterates over the properties', () => {
       function test(ops) {
         // Expectations as a map of keys to values.
         const expectMap = new Map();
@@ -619,7 +619,7 @@ describe('@bayou/doc-common/CaretSnapshot', () => {
         assert.isTrue(snap.withoutCaret(caret1).equals(expected));
       });
 
-      it('should only pay attention to the ID of the given caret', () => {
+      it('only pays attention to the ID of the given caret', () => {
         const snap     = new CaretSnapshot(1, [op1, op2]);
         const expected = new CaretSnapshot(1, [op2]);
         const modCaret = new Caret(caret1, { revNum: 999999, index: 99 });

--- a/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertyDelta.js
@@ -22,11 +22,11 @@ describe('@bayou/doc-common/PropertyDelta', () => {
       assert.isFrozen(EMPTY);
     });
 
-    it('should have an empty `ops`', () => {
+    it('has an empty `ops`', () => {
       assert.strictEqual(EMPTY.ops.length, 0);
     });
 
-    it('should have a frozen `ops`', () => {
+    it('has a frozen `ops`', () => {
       assert.isFrozen(EMPTY.ops);
     });
 

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -422,7 +422,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       test('florp', ['like']);
     });
 
-    it('should always return a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
+    it('always returns a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', value)]);
 
@@ -466,7 +466,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       test('florp', ['like']);
     });
 
-    it('should always return a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
+    it('always returns a deep-frozen property value even when the constructor was passed an unfrozen value', () => {
       const value = [[['zorch']], ['splat'], 'foo'];
       const snap = new PropertySnapshot(1, [PropertyOp.op_set('blort', value)]);
 

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -165,7 +165,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should add a new property given the appropriate op', () => {
+    it('adds a new property given the appropriate op', () => {
       const op       = PropertyOp.op_set('florp', 'like');
       const snap     = new PropertySnapshot(0, []);
       const expected = new PropertySnapshot(0, [op]);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -117,7 +117,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
   });
 
   describe('.size', () => {
-    it('should indicate the count of bindings', () => {
+    it('indicates the count of bindings', () => {
       function test(ops) {
         const snap = new PropertySnapshot(1, ops);
         assert.strictEqual(snap.size, ops.length);
@@ -187,7 +187,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.isTrue(result.equals(expected));
     });
 
-    it('should remove a property given the appropriate op', () => {
+    it('removes a property given the appropriate op', () => {
       const snap   = new PropertySnapshot(0, [PropertyOp.op_set('florp', 'like')]);
       const change = new PropertyChange(0, [PropertyOp.op_delete('florp')]);
       const result = snap.compose(change);

--- a/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/tests/test_PropertySnapshot.js
@@ -248,7 +248,7 @@ describe('@bayou/doc-common/PropertySnapshot', () => {
       assert.strictEqual(result[Symbol.iterator](), result);
     });
 
-    it('should in fact iterate over the properties', () => {
+    it('in fact iterates over the properties', () => {
       function test(ops) {
         // Expectations as a map of keys to values.
         const expectMap = new Map();

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -105,21 +105,21 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.logInfo', () => {
-    it('should reflect the constructed `serverUrl`', () => {
+    it('reflects the constructed `serverUrl`', () => {
       const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
       const info = si.logInfo;
 
       assert.strictEqual(info.serverUrl, si.serverUrl);
     });
 
-    it('should reflect the constructed `documentId`', () => {
+    it('reflects the constructed `documentId`', () => {
       const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
       const info = si.logInfo;
 
       assert.strictEqual(info.documentId, si.documentId);
     });
 
-    it('should reflect the constructed `caretId` if present', () => {
+    it('reflects the constructed `caretId` if present', () => {
       const si   = new SessionInfo(SERVER_URL, 'token', 'doc', 'the-present-id');
       const info = si.logInfo;
 
@@ -133,14 +133,14 @@ describe('@bayou/doc-common/SessionInfo', () => {
       assert.doesNotHaveAnyKeys(info, { caretId: null });
     });
 
-    it('should include a redacted form of `authorToken` if it is a string', () => {
+    it('includes a redacted form of `authorToken` if it is a string', () => {
       const si   = new SessionInfo(SERVER_URL, 'token-token-whee-whee-whee-whee', 'doc');
       const info = si.logInfo;
 
       assert.strictEqual(info.authorToken, 'token-token-whee...');
     });
 
-    it('should include the `safeString` of `authorToken` if it is a `BearerToken`', () => {
+    it('includes the `safeString` of `authorToken` if it is a `BearerToken`', () => {
       const token = new BearerToken('token-id', 'the-full-secret');
       const si    = new SessionInfo(SERVER_URL, token, 'doc');
       const info  = si.logInfo;
@@ -150,7 +150,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.logTags', () => {
-    it('should include the `caretId` if non-`null`', () => {
+    it('includes the `caretId` if non-`null`', () => {
       const did = 'docness';
       const cid = 'caretness';
       const si = new SessionInfo(SERVER_URL, 'token', did, cid);

--- a/local-modules/@bayou/doc-common/tests/test_Timeouts.js
+++ b/local-modules/@bayou/doc-common/tests/test_Timeouts.js
@@ -45,7 +45,7 @@ describe('@bayou/doc-common/Timeouts', () => {
       assert.strictEqual(Timeouts.clamp(max), max);
     });
 
-    it('should clamp too-low whole numbers to the minimum', () => {
+    it('clamps too-low whole numbers to the minimum', () => {
       const min = Timeouts.MIN_TIMEOUT_MSEC;
 
       for (let i = 0; i < min; i += 37) {
@@ -53,7 +53,7 @@ describe('@bayou/doc-common/Timeouts', () => {
       }
     });
 
-    it('should clamp too-high integers to the maximum', () => {
+    it('clamps too-high integers to the maximum', () => {
       const max = Timeouts.MAX_TIMEOUT_MSEC;
 
       for (let i = max + 1; i < (max * 100); i += 1234567) {

--- a/local-modules/@bayou/doc-common/tests/test_Timeouts.js
+++ b/local-modules/@bayou/doc-common/tests/test_Timeouts.js
@@ -30,7 +30,7 @@ describe('@bayou/doc-common/Timeouts', () => {
   });
 
   describe('clamp()', () => {
-    it('should convert `null` to the maximum', () => {
+    it('converts `null` to the maximum', () => {
       assert.strictEqual(Timeouts.clamp(null), Timeouts.MAX_TIMEOUT_MSEC);
     });
 

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -147,7 +147,7 @@ describe('@bayou/doc-server/BaseControl', () => {
   });
 
   describe('constructor()', () => {
-    it('accepts a `FileAccess` and reflect it in the inherited getters', () => {
+    it('accepts a `FileAccess` and reflects it in the inherited getters', () => {
       const fa     = FILE_ACCESS;
       const result = new MockControl(fa, 'boop');
 

--- a/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseSnapshot.js
@@ -108,7 +108,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('compose()', () => {
-    it('calls through to the delta and wrap the result in a new instance', () => {
+    it('calls through to the delta and wraps the result in a new instance', () => {
       const snap   = new MockSnapshot(10, [new MockOp('x')]);
       const change = new MockChange(20, [new MockOp('y')]);
       const result = snap.compose(change);
@@ -295,7 +295,7 @@ describe('@bayou/ot-common/BaseSnapshot', () => {
   });
 
   describe('diff()', () => {
-    it('calls through to the impl and wrap the result in a timeless authorless change', () => {
+    it('calls through to the impl and wraps the result in a timeless authorless change', () => {
       const oldSnap = new MockSnapshot(10, []);
       const newSnap = new MockSnapshot(20, [new MockOp('x')]);
       const result  = oldSnap.diff(newSnap);

--- a/local-modules/@bayou/ot-common/tests/test_Timestamp.js
+++ b/local-modules/@bayou/ot-common/tests/test_Timestamp.js
@@ -117,7 +117,7 @@ describe('@bayou/ot-common/Timestamp', () => {
   });
 
   describe('constructor()', () => {
-    it('accepts two in-range integers and reflect those values in the corresponding fields', () => {
+    it('accepts two in-range integers and reflects those values in the corresponding fields', () => {
       function test(secs, usecs) {
         const result = new Timestamp(secs, usecs);
         assert.strictEqual(result.secs, secs);

--- a/local-modules/@bayou/proppy/tests/test_Proppy.js
+++ b/local-modules/@bayou/proppy/tests/test_Proppy.js
@@ -10,7 +10,7 @@ import { TObject } from '@bayou/typecheck';
 
 describe('@bayou/proppy/Proppy', () => {
   describe('parseString(value)', () => {
-    it('should ignore comments and blank lines', () => {
+    it('ignores comments and blank lines', () => {
       const input = '# this is comment line one\n' +
                     '# this is comment line two\n' +
                     '\n' +

--- a/local-modules/@bayou/typecheck/tests/test_TArray.js
+++ b/local-modules/@bayou/typecheck/tests/test_TArray.js
@@ -26,7 +26,7 @@ describe('@bayou/typecheck/TArray', () => {
   });
 
   describe('check(value, elementChecker)', () => {
-    it('should validate array elements with an element checker', () => {
+    it('validates array elements with an element checker', () => {
       const value = [1, 2, 3];
 
       assert.doesNotThrow(() => TArray.check(value, x => TInt.check(x)));

--- a/local-modules/@bayou/typecheck/tests/test_TNumber.js
+++ b/local-modules/@bayou/typecheck/tests/test_TNumber.js
@@ -55,7 +55,7 @@ describe('@bayou/typecheck/TNumber', () => {
       test(0, -1, 1);
     });
 
-    it('should disallow values out of the specified range', () => {
+    it('disallows values out of the specified range', () => {
       function test(v, minInc, maxExc) {
         assert.throws(() => TNumber.range(v, minInc, maxExc));
       }
@@ -83,7 +83,7 @@ describe('@bayou/typecheck/TNumber', () => {
       test(0, -1, 1);
     });
 
-    it('should disallow values out of the specified range', () => {
+    it('disallows values out of the specified range', () => {
       function test(v, minInc, maxInc) {
         assert.throws(() => TNumber.rangeInc(v, minInc, maxInc));
       }

--- a/local-modules/@bayou/util-common/tests/test_ColorSelector.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorSelector.js
@@ -16,7 +16,7 @@ describe('@bayou/util-common/ColorSelector', () => {
       assert.equal(hsl.hue, 0);
     });
 
-    it('should have a default hue angle stride of 53°', () => {
+    it('has a default hue angle stride of 53°', () => {
       const selector = new ColorSelector();
       const colorA = selector.nextColorHSL();
       const colorB = selector.nextColorHSL();
@@ -24,7 +24,7 @@ describe('@bayou/util-common/ColorSelector', () => {
       assert.equal(colorA.hue, colorB.hue - 53);
     });
 
-    it('should have a default HSL lightness of 87.5%', () => {
+    it('has a default HSL lightness of 87.5%', () => {
       const selector = new ColorSelector();
       const hsl = selector.nextColorHSL();
 

--- a/local-modules/@bayou/util-common/tests/test_ColorSelector.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorSelector.js
@@ -9,7 +9,7 @@ import { ColorSelector } from '@bayou/util-common';
 
 describe('@bayou/util-common/ColorSelector', () => {
   describe('constructor()', () => {
-    it('should default to a hue angle of pure red if given no seed', () => {
+    it('defaults to a hue angle of pure red if given no seed', () => {
       const selector = new ColorSelector();
       const hsl = selector.nextColorHSL();
 
@@ -31,7 +31,7 @@ describe('@bayou/util-common/ColorSelector', () => {
       assert.equal(hsl.lightness, 0.875);
     });
 
-    it('should set the initial hue angle to the seed value MOD 360', () => {
+    it('sets the initial hue angle to the seed value MOD 360', () => {
       const selector = new ColorSelector(397);
       const hsl = selector.nextColorHSL();
 

--- a/local-modules/@bayou/util-common/tests/test_ColorSelector.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorSelector.js
@@ -38,7 +38,7 @@ describe('@bayou/util-common/ColorSelector', () => {
       assert.equal(hsl.hue, 37);
     });
 
-    it('should advance the hue color angle by the given stride if provided to the constructor', () => {
+    it('advances the hue color angle by the given stride if provided to the constructor', () => {
       const selector = new ColorSelector(0, 37);
       const colorA = selector.nextColorHSL();
       const colorB = selector.nextColorHSL();

--- a/local-modules/@bayou/util-common/tests/test_ColorUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_ColorUtil.js
@@ -50,7 +50,7 @@ describe('@bayou/util-common/ColorUtil', () => {
   });
 
   describe('cssFromHsl()', () => {
-    it('should provide expected results', () => {
+    it('provides expected results', () => {
       function test(h, s, l, expected) {
         assert.strictEqual(ColorUtil.cssFromHsl(h, s, l), expected);
       }
@@ -123,7 +123,7 @@ describe('@bayou/util-common/ColorUtil', () => {
   });
 
   describe('hueFromCss()', () => {
-    it('should provide expected results', () => {
+    it('provides expected results', () => {
       function test(color, expected) {
         assert.strictEqual(ColorUtil.hueFromCss(color), expected, color);
       }

--- a/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
+++ b/local-modules/@bayou/util-common/tests/test_DeferredLoader.js
@@ -35,7 +35,7 @@ describe('@bayou/util-common/DeferredLoader', () => {
       assert.strictEqual(dl.b, loaded.b);
     });
 
-    it('should only ever call the loader once', () => {
+    it('only ever calls the loader once', () => {
       const loaded = { a: 10 };
       let   count  = 0;
       function loader() { count++; return loaded; }
@@ -72,7 +72,7 @@ describe('@bayou/util-common/DeferredLoader', () => {
       assert.throws(() => { dl.anything; });
     });
 
-    it('should only call the loader once even if it throws an error', () => {
+    it('only calls the loader once even if it throws an error', () => {
       let count = 0;
       function loader() { count++; throw new Error('oy'); }
 

--- a/local-modules/@bayou/util-common/tests/test_IterableUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_IterableUtil.js
@@ -31,7 +31,7 @@ describe('@bayou/util-common/IterableUtil', () => {
       assertAsIs(new Set([1, 2, 3]));
     });
 
-    it('should wrap the usual built-in suspeccts', () => {
+    it('wraps the usual built-in suspeccts', () => {
       let which = 0;
       function assertWrapped(iterable, expectedContents) {
         which++;

--- a/local-modules/@bayou/util-common/tests/test_IterableUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_IterableUtil.js
@@ -18,7 +18,7 @@ describe('@bayou/util-common/IterableUtil', () => {
       }));
     });
 
-    it('should pass a non-`Iterator` through as-is', () => {
+    it('passes a non-`Iterator` through as-is', () => {
       let which = 0;
       function assertAsIs(iterable) {
         which++;

--- a/local-modules/@bayou/util-common/tests/test_IterableUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_IterableUtil.js
@@ -67,7 +67,7 @@ describe('@bayou/util-common/IterableUtil', () => {
       assertWrapped(new Set([1, 2, 3]).values(),  [1, 2, 3]);
     });
 
-    it('should only call through to an underlying iterator once', () => {
+    it('only calls through to an underlying iterator once', () => {
       const iterator = new Set([1, 2, 'blort', 4, 5]).keys();
       const wrapped  = IterableUtil.multiUseSafe(iterator);
       const expected = [1, 2, 'blort', 4, 5];
@@ -110,7 +110,7 @@ describe('@bayou/util-common/IterableUtil', () => {
     });
   });
 
-  it('should only call through to the underlying iterator as needed', () => {
+  it('only calls through to the underlying iterator as needed', () => {
     let count = 0;
 
     function* rawIterator() {

--- a/local-modules/@bayou/util-common/tests/test_StringUtil.js
+++ b/local-modules/@bayou/util-common/tests/test_StringUtil.js
@@ -9,7 +9,7 @@ import { StringUtil } from '@bayou/util-common';
 
 describe('@bayou/util-common/StringUtil', () => {
   describe('hash32()', () => {
-    it('should hash as expected', () => {
+    it('hashes as expected', () => {
       function test(expected, s) {
         assert.strictEqual(StringUtil.hash32(s), expected);
       }

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -128,7 +128,7 @@ describe('@bayou/util-core/CommonBase', () => {
   });
 
   describe('mixInto()', () => {
-    it('should add its properties to the supplied class', () => {
+    it('adds its properties to the supplied class', () => {
       class NearlyEmptyClass {
         fiat() { /*empty*/ }
       }

--- a/local-modules/@bayou/util-core/tests/test_CommonBase.js
+++ b/local-modules/@bayou/util-core/tests/test_CommonBase.js
@@ -80,7 +80,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(gotValue, 123);
     });
 
-    it('calls through to `_impl_coerce()` if there is no `_impl_coerceOrNull()` and convert a throw into a `null`', () => {
+    it('calls through to `_impl_coerce()` if there is no `_impl_coerceOrNull()` and converts a throw into a `null`', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerce(value_unused) {
           throw new Error('oy');
@@ -105,7 +105,7 @@ describe('@bayou/util-core/CommonBase', () => {
       assert.strictEqual(gotValue, 123);
     });
 
-    it('calls through to `_impl_coerceOrNull()` and accept a `null` return value', () => {
+    it('calls through to `_impl_coerceOrNull()` and accepts a `null` return value', () => {
       class HasCoerce extends CommonBase {
         static _impl_coerceOrNull(value_unused) {
           return null;

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -188,7 +188,7 @@ describe('@bayou/util-core/DataUtil', () => {
     describe('with `nonDataConverter !== null`', () => {
       commonTests(inspect);
 
-      it('should convert a non-plain object via the converter function', () => {
+      it('converts a non-plain object via the converter function', () => {
         class Florp {
           inspect() {
             return '{florp}';
@@ -200,14 +200,14 @@ describe('@bayou/util-core/DataUtil', () => {
         assert.strictEqual(result, '{florp}');
       });
 
-      it('should convert a function via the converter function', () => {
+      it('converts a function via the converter function', () => {
         function someFunc() { return 10; }
         const result = DataUtil.deepFreeze(someFunc, inspect);
 
         assert.strictEqual(result, '[Function: someFunc]');
       });
 
-      it('should convert a plain object with synthetic properties via the converter function', () => {
+      it('converts a plain object with synthetic properties via the converter function', () => {
         const obj = {
           a: 10,
           b: 20,

--- a/local-modules/@bayou/util-core/tests/test_DataUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_DataUtil.js
@@ -239,7 +239,7 @@ describe('@bayou/util-core/DataUtil', () => {
       });
     });
 
-    it('should use the converter function recursively', () => {
+    it('uses the converter function recursively', () => {
       const obj = {
         get x() { return null; },
         a: 10,

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -335,7 +335,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('equals()', () => {
-    it('should consider identically-constructed instances to be equal', () => {
+    it('considers identically-constructed instances to be equal', () => {
       function test(string) {
         const buf1 = new FrozenBuffer(string);
         const buf2 = new FrozenBuffer(string);
@@ -353,7 +353,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       }
     });
 
-    it('should consider differently-constructed instances to be inequal', () => {
+    it('considers differently-constructed instances to be inequal', () => {
       assert.isFalse(new FrozenBuffer('').equals(new FrozenBuffer('x')));
       assert.isFalse(new FrozenBuffer('a').equals(new FrozenBuffer('b')));
       assert.isFalse(new FrozenBuffer('aa').equals(new FrozenBuffer('ab')));

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -145,7 +145,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
         }
       });
 
-      it('should treat a missing second argument as having passed `utf-8`', () => {
+      it('treats a missing second argument as having passed `utf-8`', () => {
         function test(string) {
           const buf1 = new FrozenBuffer(string);
           const buf2 = new FrozenBuffer(string, 'utf8');
@@ -295,7 +295,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
   });
 
   describe('copy()', () => {
-    it('should default to copying all data', () => {
+    it('defaults to copying all data', () => {
       const buf = new FrozenBuffer('12345');
       const nodeBuf = Buffer.alloc(5);
 

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -133,7 +133,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
         assert.doesNotThrow(() => new FrozenBuffer('florp', 'utf8'));
       });
 
-      it('should convert strings to bytes using UTF-8 encoding', () => {
+      it('converts strings to bytes using UTF-8 encoding', () => {
         function test(string) {
           const buf = new FrozenBuffer(string);
           const nodeBuf = Buffer.from(string, 'utf8');
@@ -184,7 +184,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
         assert.doesNotThrow(() => new FrozenBuffer(Buffer.alloc(100, 123)));
       });
 
-      it('should convert bytes to strings using UTF-8 encoding', () => {
+      it('converts bytes to strings using UTF-8 encoding', () => {
         function test(string) {
           const nodeBuf = Buffer.from(string, 'utf8');
           const buf     = new FrozenBuffer(nodeBuf);

--- a/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/tests/test_FrozenBuffer.js
@@ -303,7 +303,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       assert.deepEqual(nodeBuf, buf.toBuffer());
     });
 
-    it('should let the target start index be specified', () => {
+    it('lets the target start index be specified', () => {
       const buf = new FrozenBuffer('12345');
       const nodeBuf = Buffer.alloc(5);
 
@@ -312,7 +312,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       assert.strictEqual(nodeBuf.toString('utf8'), 'x1234');
     });
 
-    it('should let the target and source start indexes be specified', () => {
+    it('lets the target and source start indexes be specified', () => {
       const buf = new FrozenBuffer('12345');
       const nodeBuf = Buffer.alloc(5);
 
@@ -322,7 +322,7 @@ describe('@bayou/util-core/FrozenBuffer', () => {
       assert.strictEqual(nodeBuf.toString('utf8'), 'x345x');
     });
 
-    it('should let the target, source start, and source end indexes be specified', () => {
+    it('lets the target, source start, and source end indexes be specified', () => {
       const buf = new FrozenBuffer('12345');
       const nodeBuf = Buffer.alloc(5);
 

--- a/local-modules/@bayou/util-core/tests/test_Functor.js
+++ b/local-modules/@bayou/util-core/tests/test_Functor.js
@@ -76,7 +76,7 @@ describe('@bayou/util-core/Functor', () => {
       assert.isFrozen(ftor.args);
     });
 
-    it('should report the constructed args', () => {
+    it('reports the constructed args', () => {
       function test(...args) {
         const result = new Functor('blort', ...args);
         const resultArgs = result.args;
@@ -94,7 +94,7 @@ describe('@bayou/util-core/Functor', () => {
   });
 
   describe('.name', () => {
-    it('should report the constructed name', () => {
+    it('reports the constructed name', () => {
       function test(name) {
         const result = new Functor(name);
         assert.strictEqual(result.name, name);

--- a/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
+++ b/local-modules/@bayou/util-core/tests/test_ObjectUtil.js
@@ -38,7 +38,7 @@ describe('@bayou/util-core/ObjectUtil', () => {
   });
 
   describe('fromMap()', () => {
-    it('should convert valid instances', () => {
+    it('converts valid instances', () => {
       function test(value) {
         const map = new Map(Object.entries(value));
         const result = ObjectUtil.fromMap(map);

--- a/local-modules/@bayou/util-core/tests/test_UtilityClass.js
+++ b/local-modules/@bayou/util-core/tests/test_UtilityClass.js
@@ -9,11 +9,11 @@ import { UtilityClass } from '@bayou/util-core';
 
 describe('@bayou/util-core/UtilityClass', () => {
   describe('constructor()', () => {
-    it('should always throw an error', () => {
+    it('always throws an error', () => {
       assert.throws(() => { new UtilityClass(); });
     });
 
-    it('should always throw an error when called via `super`', () => {
+    it('always throws an error when called via `super`', () => {
       class Subclass extends UtilityClass {
         constructor() {
           super();


### PR DESCRIPTION
With this PR, all test `it(...)` texts are consistent in having active verb phrases instead of being of the form `it('should...')`. There may be a couple stray grammatical errors (e.g. because I missed a second clause in the same `it(...)` text). We can tweak those as we notice them.