### PR TITLE
Logging to help track down bug.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1122,7 +1122,8 @@ export default class BaseControl extends BaseDataManager {
         result.push(change);
         allowMissing = false; // Only allow missing changes at the _start_ of the range.
       } else if (!allowMissing) {
-        throw Errors.badUse(`Missing change in requested range: r${i}`);
+        const docId = this.fileAccess.documentId;
+        throw Errors.badUse(`Missing change in requested range: r${i}, for r${startInclusive}..r${endExclusive - 1} in doc ${docId}`);
       }
     }
 

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1004,8 +1004,8 @@ export default class BaseControl extends BaseDataManager {
    *   change is defined. That is, this is the snapshot of `change.revNum - 1`.
    * @param {BaseSnapshot} expectedSnapshot The implied expected result as
    *   defined by {@link #update}.
-   * @param {Int} timeoutMsec Timeout to use for calls that could significantly
-   *   block.
+   * @param {Int|null} timeoutMsec Timeout to use for calls that could
+   *   significantly block.
    * @returns {BaseChange|null} Result for the outer call to {@link #update}, or
    *   `null` if the attempt failed due to losing an append race.
    */
@@ -1112,7 +1112,7 @@ export default class BaseControl extends BaseDataManager {
    *   maximum allowed value.
    * @returns {array<BaseChange>} Array of changes, in order by revision number.
    */
-  async _getChangeRange(startInclusive, endExclusive, allowMissing, timeoutMsec) {
+  async _getChangeRange(startInclusive, endExclusive, allowMissing, timeoutMsec = null) {
     TBoolean.check(allowMissing);
 
     await this._checkRevNumRange(startInclusive, endExclusive, timeoutMsec);


### PR DESCRIPTION
This PR adds a bunch of logging around failure to find a change when in the main body of `BaseControl._getChangeRange()`.