### PR TITLE
Two small class declaration tweaks.

### DIFF
--- a/local-modules/@bayou/injecty/ConfigMap.js
+++ b/local-modules/@bayou/injecty/ConfigMap.js
@@ -8,7 +8,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
 /**
  * Map of names to injected configurations.
  */
-export default class Configuration extends CommonBase {
+export default class ConfigMap extends CommonBase {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseDelta.js
@@ -14,7 +14,7 @@ import { MockDelta, MockOp } from '@bayou/ot-common/mocks';
 /**
  * Second mock "delta" class for testing.
  */
-export default class AnotherDelta extends BaseDelta {
+class AnotherDelta extends BaseDelta {
   _impl_isDocument() {
     return true;
   }


### PR DESCRIPTION
This PR consists of two wee one-line tweaks to remove a couple inconsistencies in `export default class` usage. This is a cleanup is in prep for a larger, mostly script-driven, spring cleaning.

FWIW these two inconsistencies were found with the following scriptlet:

```
grep -r --exclude-dir=out '^export default class ' . | awk '{ f = $1; c = $4; sub(/^.*\//, "", f); sub(/\.js:.*$/, "", f); if (f != c) print "eek", f, c }'
```