### PR TITLE
Spring cleaning: Start to ban `export default class`.

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -98,8 +98,8 @@ taking into account recent additions to the language.
   import { BaseFile } from '@bayou/file-store';
   import { DataUtil, InfoError, Singleton } from '@bayou/util-common';
 
-  import RegularBlort from './RegularBlort';
-  import SpecialBlort from './SpecialBlort';
+  import { RegularBlort } from './RegularBlort';
+  import { SpecialBlort } from './SpecialBlort';
   ```
 
 * `import ... as` &mdash; If you have a name conflict that needs to be resolved,

--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -8,7 +8,7 @@ import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, WebsocketCodes } from '@bayou/util-common';
 
-import TargetMap from './TargetMap';
+import { TargetMap } from './TargetMap';
 
 /** Logger. */
 const log = new Logger('api');
@@ -19,7 +19,7 @@ const UNKNOWN_CONNECTION_ID = 'id_unknown';
 /**
  * Connection with the server, via a websocket.
  */
-export default class ApiClient extends CommonBase {
+export class ApiClient extends CommonBase {
   /**
    * Constructs an instance. This instance will connect to a websocket at the
    * same domain at the path `/api`. Once this constructor returns, it is safe

--- a/local-modules/@bayou/api-client/TargetHandler.js
+++ b/local-modules/@bayou/api-client/TargetHandler.js
@@ -13,7 +13,7 @@ import { Functor, MethodCacheProxyHandler } from '@bayou/util-common';
  * the properties it returns are always functions which perform calls to
  * `ApiClient._send()`.
  */
-export default class TargetHandler extends MethodCacheProxyHandler {
+export class TargetHandler extends MethodCacheProxyHandler {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-client/TargetMap.js
+++ b/local-modules/@bayou/api-client/TargetMap.js
@@ -6,7 +6,7 @@ import { TargetId } from '@bayou/api-common';
 import { TFunction, TObject } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
-import TargetHandler from './TargetHandler';
+import { TargetHandler } from './TargetHandler';
 
 /**
  * Map of the various targets being provided over a connection. Items present in
@@ -17,7 +17,7 @@ import TargetHandler from './TargetHandler';
  * of the fact that the _other_ side of the connection will balk if there turn
  * out to be auth requirements on targets that get referenced.
  */
-export default class TargetMap extends CommonBase {
+export class TargetMap extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-client/index.js
+++ b/local-modules/@bayou/api-client/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import ApiClient from './ApiClient';
+import { ApiClient } from './ApiClient';
 
 export { ApiClient };

--- a/local-modules/@bayou/api-client/tests/test_TargetHandler.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetHandler.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { BearerToken } from '@bayou/api-common';
 import { Functor } from '@bayou/util-common';
 
-import TargetHandler from '@bayou/api-client/TargetHandler';
+import { TargetHandler } from '@bayou/api-client/TargetHandler';
 
 describe('@bayou/api-client/TargetHandler', () => {
   describe('makeProxy()', () => {

--- a/local-modules/@bayou/api-client/tests/test_TargetMap.js
+++ b/local-modules/@bayou/api-client/tests/test_TargetMap.js
@@ -9,7 +9,7 @@ import { inspect } from 'util';
 import { BearerToken } from '@bayou/api-common';
 import { Functor } from '@bayou/util-common';
 
-import TargetMap from '@bayou/api-client/TargetMap';
+import { TargetMap } from '@bayou/api-client/TargetMap';
 
 /**
  * Class which has a {@link #sendMessage} that when invoked remembers the

--- a/local-modules/@bayou/api-common/BearerToken.js
+++ b/local-modules/@bayou/api-common/BearerToken.js
@@ -7,7 +7,7 @@ import { inspect } from 'util';
 import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import TargetId from './TargetId';
+import { TargetId } from './TargetId';
 
 /**
  * Bearer token, which is a kind of authentication / authorization key wherein
@@ -21,7 +21,7 @@ import TargetId from './TargetId';
  * token (which should have within it, somehow, both an ID portion and a secret
  * portion).
  */
-export default class BearerToken extends CommonBase {
+export class BearerToken extends CommonBase {
   /**
    * Redacts a string for use in error messages and logging. This is generally
    * done in logging and error-handling code which expects that its string

--- a/local-modules/@bayou/api-common/CodableError.js
+++ b/local-modules/@bayou/api-common/CodableError.js
@@ -13,7 +13,7 @@ import { InfoError } from '@bayou/util-common';
  * **Note:** We intentionally exclude stack trace info from the encoded form,
  * because that can be security-sensitive.
  */
-export default class CodableError extends InfoError {
+export class CodableError extends InfoError {
   /** {string} Name of this class for the sake of API coding. */
   static get CODEC_TAG() {
     return 'Error';

--- a/local-modules/@bayou/api-common/ConnectionError.js
+++ b/local-modules/@bayou/api-common/ConnectionError.js
@@ -7,14 +7,14 @@ import { inspect } from 'util';
 import { TString } from '@bayou/typecheck';
 import { InfoError } from '@bayou/util-common';
 
-import TargetId from './TargetId';
+import { TargetId } from './TargetId';
 
 /**
  * Error class for reporting errors coming from `ApiClient` related to the
  * connection or transport (as opposed to, e.g., being errors being relayed from
  * the far side of an API connection).
  */
-export default class ConnectionError extends InfoError {
+export class ConnectionError extends InfoError {
   /**
    * Constructs an error indicating that the API connection has been closed.
    * This error is reported in response to any API call made when the connection

--- a/local-modules/@bayou/api-common/Message.js
+++ b/local-modules/@bayou/api-common/Message.js
@@ -5,15 +5,15 @@
 import { TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Functor } from '@bayou/util-common';
 
-import BearerToken from './BearerToken';
-import TargetId from './TargetId';
+import { BearerToken } from './BearerToken';
+import { TargetId } from './TargetId';
 
 /**
  * Message being sent from client to server to requrest action. This includes
  * a message ID, target address, and a main payload indicating a method name
  * and arguments.
  */
-export default class Message extends CommonBase {
+export class Message extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-common/Remote.js
+++ b/local-modules/@bayou/api-common/Remote.js
@@ -4,14 +4,14 @@
 
 import { CommonBase } from '@bayou/util-common';
 
-import TargetId from './TargetId';
+import { TargetId } from './TargetId';
 
 /**
  * Encodable representation of an object that is proxied over a connection.
  * Instances of this class are what get encoded instead of encoding a
  * {@link ProxiedObject} (or its target).
  */
-export default class Remote extends CommonBase {
+export class Remote extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-common/Response.js
+++ b/local-modules/@bayou/api-common/Response.js
@@ -7,7 +7,7 @@ import { inspect } from 'util';
 import { TInt, TObject, TString } from '@bayou/typecheck';
 import { CommonBase, ErrorUtil, Errors, Functor, InfoError } from '@bayou/util-common';
 
-import CodableError from './CodableError';
+import { CodableError } from './CodableError';
 
 /**
  * Payload sent as a response to a method call.
@@ -17,7 +17,7 @@ import CodableError from './CodableError';
  * such that it will be decoded into an `Error` instance of some sort on the
  * far side of the connection.
  */
-export default class Response extends CommonBase {
+export class Response extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-common/TargetId.js
+++ b/local-modules/@bayou/api-common/TargetId.js
@@ -5,7 +5,7 @@
 import { TString } from '@bayou/typecheck';
 import { Errors, UtilityClass } from '@bayou/util-common';
 
-import BearerToken from './BearerToken';
+import { BearerToken } from './BearerToken';
 
 /** {RegExp} Regular expression which matches valid target IDs. */
 const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,256}$/;
@@ -22,7 +22,7 @@ const VALID_TARGET_ID_REGEX = /^[-_.a-zA-Z0-9]{1,256}$/;
  * alphanumerics, underscore (`_`), dash (`-`), or period (`.`), which is at
  * least one and no longer than 256 characters.
  */
-export default class TargetId extends UtilityClass {
+export class TargetId extends UtilityClass {
   /**
    * Checks a value of type `TargetId`.
    *

--- a/local-modules/@bayou/api-common/TheModule.js
+++ b/local-modules/@bayou/api-common/TheModule.js
@@ -5,15 +5,15 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import CodableError from './CodableError';
-import Message from './Message';
-import Response from './Response';
-import Remote from './Remote';
+import { CodableError } from './CodableError';
+import { Message } from './Message';
+import { Response } from './Response';
+import { Remote } from './Remote';
 
 /**
  * Utilities for this module.
  */
-export default class TheModule extends UtilityClass {
+export class TheModule extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *

--- a/local-modules/@bayou/api-common/index.js
+++ b/local-modules/@bayou/api-common/index.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import TheModule from './TheModule';
-import BearerToken from './BearerToken';
-import CodableError from './CodableError';
-import ConnectionError from './ConnectionError';
-import Message from './Message';
-import Remote from './Remote';
-import Response from './Response';
-import TargetId from './TargetId';
+import { TheModule } from './TheModule';
+import { BearerToken } from './BearerToken';
+import { CodableError } from './CodableError';
+import { ConnectionError } from './ConnectionError';
+import { Message } from './Message';
+import { Remote } from './Remote';
+import { Response } from './Response';
+import { TargetId } from './TargetId';
 
 export {
   TheModule,

--- a/local-modules/@bayou/api-server/ApiLog.js
+++ b/local-modules/@bayou/api-server/ApiLog.js
@@ -7,12 +7,12 @@ import { BaseLogger } from '@bayou/see-all';
 import { TBoolean } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import Target from './Target';
+import { Target } from './Target';
 
 /**
  * Handler of the logging of API calls.
  */
-export default class ApiLog extends CommonBase {
+export class ApiLog extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -9,11 +9,11 @@ import { Logger } from '@bayou/see-all';
 import { TBoolean } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
-import ApiLog from './ApiLog';
-import ContextInfo from './ContextInfo';
-import MetaHandler from './MetaHandler';
-import ProxiedObject from './ProxiedObject';
-import Target from './Target';
+import { ApiLog } from './ApiLog';
+import { ContextInfo } from './ContextInfo';
+import { MetaHandler } from './MetaHandler';
+import { ProxiedObject } from './ProxiedObject';
+import { Target } from './Target';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('api');
@@ -28,7 +28,7 @@ const log = new Logger('api');
  * lower-level connection (or the like). This class in turn mostly bottoms out
  * by calling on target objects, which perform the actual application services.
  */
-export default class BaseConnection extends CommonBase {
+export class BaseConnection extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
@@ -10,7 +10,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
  * Abstract class for mapping tokens to objects which embody the powers
  * authorized by those tokens.
  */
-export default class BaseTokenAuthorizer extends CommonBase {
+export class BaseTokenAuthorizer extends CommonBase {
   /**
    * {string} Prefix which when prepended to an arbitrary ID string is
    * guaranteed to result in string for which {@link #isToken} is `false`. This

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -7,9 +7,9 @@ import { BaseLogger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
-import ContextInfo from './ContextInfo';
-import ProxiedObject from './ProxiedObject';
-import Target from './Target';
+import { ContextInfo } from './ContextInfo';
+import { ProxiedObject } from './ProxiedObject';
+import { Target } from './Target';
 
 /**
  * Binding context for an API server or session therein. Instances of this class
@@ -18,7 +18,7 @@ import Target from './Target';
  * bearer tokens. In addition, this class is used to hold the knowledge of which
  * {@link Codec} to use for a session.
  */
-export default class Context extends CommonBase {
+export class Context extends CommonBase {
   /**
    * Constructs an instance which is initially empty.
    *

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -5,14 +5,14 @@
 import { Codec } from '@bayou/codec';
 import { CommonBase } from '@bayou/util-common';
 
-import BaseTokenAuthorizer from './BaseTokenAuthorizer';
-import Context from './Context';
+import { BaseTokenAuthorizer } from './BaseTokenAuthorizer';
+import { Context } from './Context';
 
 /**
  * All the info needed to construct instances of {@link Context}, except for
  * logging-related stuff (which tends to be different for every instance).
  */
-export default class ContextInfo extends CommonBase {
+export class ContextInfo extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/MetaHandler.js
+++ b/local-modules/@bayou/api-server/MetaHandler.js
@@ -5,12 +5,12 @@
 import { Deployment } from '@bayou/config-server';
 import { CommonBase } from '@bayou/util-common';
 
-import BaseConnection from './BaseConnection';
+import { BaseConnection } from './BaseConnection';
 
 /**
  * Class to handle meta-requests.
  */
-export default class MetaHandler extends CommonBase {
+export class MetaHandler extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/PostConnection.js
+++ b/local-modules/@bayou/api-server/PostConnection.js
@@ -4,13 +4,13 @@
 
 import contentType from 'content-type';
 
-import BaseConnection from './BaseConnection';
+import { BaseConnection } from './BaseConnection';
 
 /**
  * Direct handler for one-shot API requests that arrive over a standard HTTP
  * POST.
  */
-export default class PostConnection extends BaseConnection {
+export class PostConnection extends BaseConnection {
   /**
    * Constructs an instance. As a side effect, the contructor attaches the
    * constructed instance to the HTTP request, and arranges to respond.

--- a/local-modules/@bayou/api-server/ProxiedObject.js
+++ b/local-modules/@bayou/api-server/ProxiedObject.js
@@ -16,7 +16,7 @@ import { CommonBase } from '@bayou/util-common';
  * the response message sent to the client indicates that the result is a
  * proxied object and not a regular encoded value.
  */
-export default class ProxiedObject extends CommonBase {
+export class ProxiedObject extends CommonBase {
   /**
    * Constructs an instance which wraps the given object.
    *

--- a/local-modules/@bayou/api-server/Schema.js
+++ b/local-modules/@bayou/api-server/Schema.js
@@ -34,7 +34,7 @@ const VERBOTEN_NAMES = /^(then|catch)$/;
  * {@link #loggingForResult}, and {@link Target} for details about how these are
  * used.
  */
-export default class Schema extends CommonBase {
+export class Schema extends CommonBase {
   /**
    * Constructs an instance based on the given object.
    *

--- a/local-modules/@bayou/api-server/Target.js
+++ b/local-modules/@bayou/api-server/Target.js
@@ -7,7 +7,7 @@ import { RedactUtil } from '@bayou/see-all';
 import { TFunction, TObject } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
-import Schema from './Schema';
+import { Schema } from './Schema';
 
 /** {Int} Maximum depth to produce when redacting values. */
 const MAX_REDACTION_DEPTH = 4;
@@ -18,7 +18,7 @@ const MAX_REDACTION_DEPTH = 4;
  * who prove knowledge of a token's secret) or be "uncontrolled" (that is, be
  * generally available without additional authorization checks).
  */
-export default class Target extends CommonBase {
+export class Target extends CommonBase {
   /**
    * Like {@link #logInfoFromPayload}, except only to be used when processing
    * `null` as a target (e.g. when a target ID was not valid). Since there is

--- a/local-modules/@bayou/api-server/TokenMint.js
+++ b/local-modules/@bayou/api-server/TokenMint.js
@@ -48,7 +48,7 @@ function sequenceGenerator() {
  * across multiple back-end machines, nor one that wishes to have tokens be more
  * durable than OS processes).
  */
-export default class TokenMint extends CommonBase {
+export class TokenMint extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -8,7 +8,7 @@ import { Message } from '@bayou/api-common';
 import { Condition } from '@bayou/promise-util';
 import { Functor, WebsocketCodes } from '@bayou/util-common';
 
-import BaseConnection from './BaseConnection';
+import { BaseConnection } from './BaseConnection';
 
 /**
  * {Int} Number of messages that are proactively rejected while in the process
@@ -20,7 +20,7 @@ const MAX_MESSAGES_WHILE_CLOSING = 100;
 /**
  * Direct handler for API requests over a websocket connection.
  */
-export default class WsConnection extends BaseConnection {
+export class WsConnection extends BaseConnection {
   /**
    * Constructs an instance. As a side effect, the contructor attaches the
    * constructed instance to the websocket (as an event listener).

--- a/local-modules/@bayou/api-server/index.js
+++ b/local-modules/@bayou/api-server/index.js
@@ -2,16 +2,16 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseConnection from './BaseConnection';
-import BaseTokenAuthorizer from './BaseTokenAuthorizer';
-import Context from './Context';
-import ContextInfo from './ContextInfo';
-import PostConnection from './PostConnection';
-import ProxiedObject from './ProxiedObject';
-import Schema from './Schema';
-import Target from './Target';
-import TokenMint from './TokenMint';
-import WsConnection from './WsConnection';
+import { BaseConnection } from './BaseConnection';
+import { BaseTokenAuthorizer } from './BaseTokenAuthorizer';
+import { Context } from './Context';
+import { ContextInfo } from './ContextInfo';
+import { PostConnection } from './PostConnection';
+import { ProxiedObject } from './ProxiedObject';
+import { Schema } from './Schema';
+import { Target } from './Target';
+import { TokenMint } from './TokenMint';
+import { WsConnection } from './WsConnection';
 
 export {
   BaseConnection,

--- a/local-modules/@bayou/api-server/tests/test_ApiLog.js
+++ b/local-modules/@bayou/api-server/tests/test_ApiLog.js
@@ -11,7 +11,7 @@ import { MockLogger } from '@bayou/see-all/mocks';
 import { Functor } from '@bayou/util-common';
 
 // Not an exported class, so we have to import it as a file.
-import ApiLog from '../ApiLog';
+import { ApiLog } from '../ApiLog';
 
 describe('@bayou/api-server/ApiLog', () => {
   describe('incomingMessage()', () => {

--- a/local-modules/@bayou/app-common/TheModule.js
+++ b/local-modules/@bayou/app-common/TheModule.js
@@ -11,7 +11,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utilities for this module.
  */
-export default class TheModule extends UtilityClass {
+export class TheModule extends UtilityClass {
   /**
    * {Codec} Standard {@link Codec} instance, constructed by
    * {@link #makeFullCodec}.

--- a/local-modules/@bayou/app-common/index.js
+++ b/local-modules/@bayou/app-common/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import TheModule from './TheModule';
+import { TheModule } from './TheModule';
 
 export { TheModule };

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -5,13 +5,13 @@
 import { BaseTokenAuthorizer } from '@bayou/api-server';
 import { Auth } from '@bayou/config-server';
 
-import Application from './Application';
-import AuthorAccess from './AuthorAccess';
+import { Application } from './Application';
+import { AuthorAccess } from './AuthorAccess';
 
 /**
  * Application-specific implementation of {@link BaseTokenAuthorizer}.
  */
-export default class AppAuthorizer extends BaseTokenAuthorizer {
+export class AppAuthorizer extends BaseTokenAuthorizer {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -16,13 +16,13 @@ import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { CommonBase, Errors, PropertyIterable } from '@bayou/util-common';
 
-import AppAuthorizer from './AppAuthorizer';
-import DebugTools from './DebugTools';
-import Metrics from './Metrics';
-import RequestLogger from './RequestLogger';
-import RootAccess from './RootAccess';
-import ServerUtil from './ServerUtil';
-import VarInfo from './VarInfo';
+import { AppAuthorizer } from './AppAuthorizer';
+import { DebugTools } from './DebugTools';
+import { Metrics } from './Metrics';
+import { RequestLogger } from './RequestLogger';
+import { RootAccess } from './RootAccess';
+import { ServerUtil } from './ServerUtil';
+import { VarInfo } from './VarInfo';
 
 /**
  * {Int} How long to wait (in msec) between iterations in
@@ -43,7 +43,7 @@ const log = new Logger('app');
  * Web server for the application. This serves all application HTTP(S) requests,
  * including websocket requests.
  */
-export default class Application extends CommonBase {
+export class Application extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -18,7 +18,7 @@ const log = new Logger('author-access');
  * is through instances of this class that users ultimately exercise that
  * authority.
  */
-export default class AuthorAccess extends CommonBase {
+export class AuthorAccess extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -13,7 +13,7 @@ import { Logger } from '@bayou/see-all';
 import { RecentSink } from '@bayou/see-all-server';
 import { CommonBase } from '@bayou/util-common';
 
-import ServerUtil from './ServerUtil';
+import { ServerUtil } from './ServerUtil';
 
 /** Logger for this module. */
 const log = new Logger('app-debug');
@@ -25,7 +25,7 @@ const LOG_LENGTH_MSEC = 1000 * 60 * 60; // One hour.
  * Introspection to help with debugging. Includes a request handler for hookup
  * to Express.
  */
-export default class DebugTools extends CommonBase {
+export class DebugTools extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/Metrics.js
+++ b/local-modules/@bayou/app-setup/Metrics.js
@@ -10,7 +10,7 @@ import { CommonBase } from '@bayou/util-common';
 /**
  * Prometheus- / OpenMetrics-based metrics collection and reporting.
  */
-export default class Metrics extends CommonBase {
+export class Metrics extends CommonBase {
   /**
    * Constructs an instance. This also sets up default metrics collection. (As
    * such, the latter bit means that it's probably a bad idea to instantiate

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -10,9 +10,9 @@ import { Logger } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import Application from './Application';
-import RequestLogger from './RequestLogger';
-import ServerUtil from './ServerUtil';
+import { Application } from './Application';
+import { RequestLogger } from './RequestLogger';
+import { ServerUtil } from './ServerUtil';
 
 /** {Logger} Logger. */
 const log = new Logger('app-monitor');
@@ -20,7 +20,7 @@ const log = new Logger('app-monitor');
 /**
  * Web server for the monitoring endpoints.
  */
-export default class Monitor extends CommonBase {
+export class Monitor extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -15,7 +15,7 @@ import { CommonBase, Random } from '@bayou/util-common';
  * built-in `dev` style, intended to produce concise logs for display on a
  * developer's console.
  */
-export default class RequestLogger extends CommonBase {
+export class RequestLogger extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -25,7 +25,7 @@ const log = new Logger('root-access');
  * token(s) grant access to (along with whatever else is configured by the
  * hook {@link config-server.Deployment#rootAccess}).
  */
-export default class RootAccess extends CommonBase {
+export class RootAccess extends CommonBase {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/app-setup/ServerUtil.js
+++ b/local-modules/@bayou/app-setup/ServerUtil.js
@@ -13,7 +13,7 @@ const log = new Logger('app');
  * Utility functions for dealing with `Server`s (e.g., HTTP server objects and
  * the like).
  */
-export default class ServerUtil extends UtilityClass {
+export class ServerUtil extends UtilityClass {
   /**
    * Arranges for the given `Server` to stop listening for connections when
    * the system is trying to shut down.

--- a/local-modules/@bayou/app-setup/VarInfo.js
+++ b/local-modules/@bayou/app-setup/VarInfo.js
@@ -6,7 +6,7 @@ import { Auth } from '@bayou/config-server';
 import { ServerEnv } from '@bayou/env-server';
 import { CommonBase } from '@bayou/util-common';
 
-import Application from './Application';
+import { Application } from './Application';
 
 /**
  * "Variable" info (like, it varies and isn't just static to the system), which
@@ -16,7 +16,7 @@ import Application from './Application';
  * with what is (or ought to be) reported via `/metrics`. Look into combining
  * these or at least moving as much as is sensible to {@link Metrics}.
  */
-export default class VarInfo extends CommonBase {
+export class VarInfo extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/app-setup/index.js
+++ b/local-modules/@bayou/app-setup/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Application from './Application';
-import Monitor from './Monitor';
+import { Application } from './Application';
+import { Monitor } from './Monitor';
 
 export { Application, Monitor };

--- a/local-modules/@bayou/assets-client/Assets.js
+++ b/local-modules/@bayou/assets-client/Assets.js
@@ -12,7 +12,7 @@ const DIR = path.resolve(__dirname, 'files');
 /**
  * Default provider of static assets to serve to clients.
  */
-export default class Assets extends UtilityClass {
+export class Assets extends UtilityClass {
   /**
    * {array<string>} Default implementation of the configuration
    * {@link @bayou/config-server/Deployment#ASSET_DIRS}, which refers _just_ to

--- a/local-modules/@bayou/assets-client/index.js
+++ b/local-modules/@bayou/assets-client/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Assets from './Assets';
+import { Assets } from './Assets';
 
 export {
   Assets

--- a/local-modules/README.md
+++ b/local-modules/README.md
@@ -40,30 +40,29 @@ can be used in.
 ### Export conventions
 
 Modules defined here all export a set of explicit names and _no_ default. That
-is, even if there is only one export from a module, it is imported as
+is, even if there is only one export from a module, it is imported as:
 
 ```javascript
 import { Name } from 'the-module';
 ```
 
-This makes for consistency in `import` formatting and is also trivial to
-remember.
+This includes module-internal files which define classes:
 
-Internal to a module, the convention is a little more nuanced:
+```javascript
+import { ClassName } from './ClassName';
+```
 
-* Files are allowed to _either_ define a single class or define a collection of
-  data.
-* If a file defines a class, then that class is the single default export of
-  the file, and there are no other exports. In this case, the file's base name
-  and the class name should be the same including capitalization. For example,
-  the class `FooBlort` should reside in a file named `FooBlort.js` (and notably
-  not, `foo-blort.js`).
-* If a file defines a collection of data, then it is exported (as with the main
-  module) as a set of explicit names and _no_ default.
+This makes for consistency in `import` formatting (trivial to remember), is less
+error-prone (can't import a thing with the wrong name, compared to using a
+`default`), and better supports typechecking systems (such as TypeScript).
 
 As a slightly special case, if a module wants to export a set of utility
 functionality, it should do so by defining a utility class named `TheModule`
 per se, and exported as that name.
+
+**Note:** As of this writing, the codebase is in transition from a convention
+where `export default class` was used in module-internal contexts. **TODO:**
+Remove this note when the system is fully converted!
 
 #### Standard `index` form
 

--- a/scripts/tmp-convert-export-default
+++ b/scripts/tmp-convert-export-default
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+
+# Set `progName` to the program name, `progDir` to its directory, and `baseDir`
+# to `progDir`'s directory. Follows symlinks.
+function init-prog {
+    local newp p="$0"
+
+    while newp="$(readlink "$p")"; do
+        [[ ${newp} =~ ^/ ]] && p="${newp}" || p="$(dirname "$p")/${newp}"
+    done
+
+    progName="${p##*/}"
+    progDir="$(cd "$(dirname "$p")"; /bin/pwd -P)"
+    baseDir="$(cd "${progDir}/.."; /bin/pwd -P)"
+}
+init-prog
+
+
+#
+# Argument parsing
+#
+
+# Error during argument processing?
+argError=0
+
+# URL to contact.
+serverUrl='http://localhost:8080/api'
+
+# Need help?
+showHelp=0
+
+while true; do
+    case $1 in
+        -h|--help)
+            showHelp=1
+            break
+            ;;
+        --) # End of all options.
+            shift
+            break
+            ;;
+        -?*)
+            echo "Unknown option: $1" 1>&2
+            argError=1
+            break
+            ;;
+        *)  # Default case: No more options, break out of the loop.
+            break
+    esac
+
+    shift
+done
+
+if (( $# != 1 )); then
+    echo 'Missing <class-name> or too many arguments.' 1>&2
+    argError=1
+fi
+
+if (( ${showHelp} || ${argError} )); then
+    echo 'Usage:'
+    echo ''
+    echo "${progName} [<opt> ...] <class-name>"
+    echo '  Convert a class `.js` file from using `export default` to just plain'
+    echo '  `export`.'
+    echo ''
+    echo "${progName} [--help | -h]"
+    echo '  Display this message.'
+    exit ${argError}
+fi
+
+className="$1"
+
+#
+# Helper functions
+#
+
+function fix-file {
+    local inFile="$1"
+    outFile="$1-new"
+
+    awk -v "className=${className}" '
+    /^export default class / && ($4 == className) {
+        line = $0;
+        sub(/default /, "", line);
+        print line;
+        next;
+    }
+
+    /^import [A-Za-z]* from '"'"'[.@]/ && ($2 == className) {
+        $2 = "{ " $2 " }";
+        print;
+        next;
+    }
+
+    /require/ && (index($0, className) != 0) {
+        print "EEEEK REQUIRE", $0;
+        next;
+    }
+
+    { print; }
+    ' < "${inFile}" > "${outFile}"
+
+    mv "${outFile}" "${inFile}"
+}
+
+#
+# Main script
+#
+
+echo 'Finding files...'
+
+files=($(
+    grep --recursive --files-with-matches --exclude-dir='out' --include='*.js' \
+        '\b'"${className}"'\b' .
+))
+
+for f in "${files[@]}"; do
+    echo "Processing ${f}..."
+    fix-file "${f}"
+done


### PR DESCRIPTION
This PR is the start of what will probably be the biggest "spring cleaning" of the season. Specifically, I'm aiming to get rid of our usage of `export default class`, instead preserving class names in exports. This is specifically with regards to how modules are internally constructed (because we already _don't_ use `export default` from top-level modules). History:

Back in January, there was a bit of discussion about the wisdom-or-not of using `export default` in modern JS code. One of the things that came up is the fact that type inferencing systems (such as TypeScript) can do a better job when `export default` is avoided.

In addition, I know I've caused myself multiple moments of pain when I copy-pasta'd myself into something like:

```
import ClassWeWant from './SomeOtherName';
```

…which is always an absolute joy to debug. The non-`default` copy-pasta equivalent fails in a _much_ less subtle way.

I expect this conversion will take about four PRs total to safely get through the entire corpus. Note that this PR includes the script I'm using to actually accomplish the conversion.