### PR TITLE
`export default class` spring cleaning round 2.

### DIFF
--- a/local-modules/@bayou/client-bundle/ClientBundle.js
+++ b/local-modules/@bayou/client-bundle/ClientBundle.js
@@ -8,13 +8,13 @@ import webpack from 'webpack';
 import { Delay } from '@bayou/promise-util';
 import { Singleton } from '@bayou/util-common';
 
-import WebpackConfig from './WebpackConfig';
+import { WebpackConfig } from './WebpackConfig';
 
 /**
  * Wrapper around Webpack which can do both one-off builds as well as run
  * Webpack's "dev mode." Includes a request handler for hookup to Express.
  */
-export default class ClientBundle extends Singleton {
+export class ClientBundle extends Singleton {
   /**
    * Constructs the instance.
    */

--- a/local-modules/@bayou/client-bundle/ProgressMessage.js
+++ b/local-modules/@bayou/client-bundle/ProgressMessage.js
@@ -5,7 +5,7 @@
 /**
  * Simple plugin to produce progress messages while building Webpack bundles.
  */
-export default class ProgressMessage {
+export class ProgressMessage {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/client-bundle/WebpackConfig.js
+++ b/local-modules/@bayou/client-bundle/WebpackConfig.js
@@ -10,13 +10,13 @@ import { Dirs } from '@bayou/env-server';
 import { Logger } from '@bayou/see-all';
 import { JsonUtil, Singleton } from '@bayou/util-common';
 
-import ProgressMessage from './ProgressMessage';
+import { ProgressMessage } from './ProgressMessage';
 
 /**
  * Utility class which provides the Webpack configuration needed for client
  * builds.
  */
-export default class WebpackConfig extends Singleton {
+export class WebpackConfig extends Singleton {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/client-bundle/index.js
+++ b/local-modules/@bayou/client-bundle/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import ClientBundle from './ClientBundle';
+import { ClientBundle } from './ClientBundle';
 
 export { ClientBundle };

--- a/local-modules/@bayou/codec/Codec.js
+++ b/local-modules/@bayou/codec/Codec.js
@@ -4,14 +4,14 @@
 
 import { CommonBase, FrozenBuffer } from '@bayou/util-common';
 
-import ConstructorCall from './ConstructorCall';
-import Registry from './Registry';
+import { ConstructorCall } from './ConstructorCall';
+import { Registry } from './Registry';
 
 /**
  * Encoder and decoder of values for transport over an API or for storage on
  * disk or in databases, with binding to a name-to-class registry.
  */
-export default class Codec extends CommonBase {
+export class Codec extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/codec/ConstructorCall.js
+++ b/local-modules/@bayou/codec/ConstructorCall.js
@@ -10,7 +10,7 @@ import { CommonBase, Errors, Functor, ObjectUtil } from '@bayou/util-common';
  * values produced by {@link Codec#encode} and accepted by {@link Codec#decode}.
  * Instances of this class are always frozen (immutable).
  */
-export default class ConstructorCall extends CommonBase {
+export class ConstructorCall extends CommonBase {
   /**
    * Reviver function suitable for use with `JSON.parse()`, which handles
    * conversion of the JSON encoding form as defined by this module into

--- a/local-modules/@bayou/codec/ItemCodec.js
+++ b/local-modules/@bayou/codec/ItemCodec.js
@@ -6,7 +6,7 @@ import { Logger } from '@bayou/see-all';
 import { TArray, TFunction, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
-import ConstructorCall from './ConstructorCall';
+import { ConstructorCall } from './ConstructorCall';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('codec');
@@ -53,7 +53,7 @@ const log = new Logger('codec');
  * **Note:** For the purposes of this class, `null`, arrays, plain objects, and
  * class instances are all considered values with distinct types.
  */
-export default class ItemCodec extends CommonBase {
+export class ItemCodec extends CommonBase {
   /**
    * Gets the tag string (either explicit or implicit) of the given payload.
    * This returns `null` if the payload can't possibly be valid.

--- a/local-modules/@bayou/codec/Registry.js
+++ b/local-modules/@bayou/codec/Registry.js
@@ -4,14 +4,14 @@
 
 import { CommonBase, Errors } from '@bayou/util-common';
 
-import ItemCodec from './ItemCodec';
-import SpecialCodecs from './SpecialCodecs';
+import { ItemCodec } from './ItemCodec';
+import { SpecialCodecs } from './SpecialCodecs';
 
 /**
  * Methods for registering and looking up item codecs by name. The names are
  * how classes/types are identified when encoding and decoding instances.
  */
-export default class Registry extends CommonBase {
+export class Registry extends CommonBase {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/codec/SpecialCodecs.js
+++ b/local-modules/@bayou/codec/SpecialCodecs.js
@@ -4,13 +4,13 @@
 
 import { FrozenBuffer, Functor, ObjectUtil, UtilityClass } from '@bayou/util-common';
 
-import ItemCodec from './ItemCodec';
+import { ItemCodec } from './ItemCodec';
 
 /**
  * Utility class which holds special `ItemCodec`s (that is, ones that aren't
  * straightforward coders for class instances).
  */
-export default class SpecialCodecs extends UtilityClass {
+export class SpecialCodecs extends UtilityClass {
   /** {ItemCodec} Codec used for coding arrays. */
   static get ARRAY() {
     return new ItemCodec(ItemCodec.tagFromType('array'), 'array', this._arrayPredicate,

--- a/local-modules/@bayou/codec/index.js
+++ b/local-modules/@bayou/codec/index.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Codec from './Codec';
-import ConstructorCall from './ConstructorCall';
-import ItemCodec from './ItemCodec';
-import Registry from './Registry';
+import { Codec } from './Codec';
+import { ConstructorCall } from './ConstructorCall';
+import { ItemCodec } from './ItemCodec';
+import { Registry } from './Registry';
 
 export { Codec, ConstructorCall, ItemCodec, Registry };

--- a/local-modules/@bayou/config-client-default/Editor.js
+++ b/local-modules/@bayou/config-client-default/Editor.js
@@ -6,12 +6,12 @@ import Quill from 'quill';
 
 import { UtilityClass } from '@bayou/util-common';
 
-import QuillProm from './QuillProm';
+import { QuillProm } from './QuillProm';
 
 /**
  * Utility functionality regarding the setup of interactive editors.
  */
-export default class Editor extends UtilityClass {
+export class Editor extends UtilityClass {
   /**
    * {Quill} Implementation of standard configuration point. See `package.json`
    * in this directory for details of the version we return here.

--- a/local-modules/@bayou/config-client-default/QuillProm.js
+++ b/local-modules/@bayou/config-client-default/QuillProm.js
@@ -17,4 +17,4 @@ import { PromSubclasser } from '@bayou/quill-util';
  */
 const QuillProm = PromSubclasser.makeSubclass(Quill);
 
-export default QuillProm;
+export { QuillProm };

--- a/local-modules/@bayou/config-client-default/index.js
+++ b/local-modules/@bayou/config-client-default/index.js
@@ -4,7 +4,7 @@
 
 import { inject } from '@bayou/injecty';
 
-import Editor from './Editor';
+import { Editor } from './Editor';
 
 /**
  * Injects all of the definitions here into the global configuration.

--- a/local-modules/@bayou/config-client/Editor.js
+++ b/local-modules/@bayou/config-client/Editor.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the setup of interactive editors.
  */
-export default class Editor extends UtilityClass {
+export class Editor extends UtilityClass {
   /**
    * {Quill} The class to use as the Quill editor. The interface of this class
    * is expected to be compatible with the `Quill` class as defined by the Quill

--- a/local-modules/@bayou/config-client/index.js
+++ b/local-modules/@bayou/config-client/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Editor from './Editor';
+import { Editor } from './Editor';
 
 export {
   Editor

--- a/local-modules/@bayou/config-common-default/IdSyntax.js
+++ b/local-modules/@bayou/config-common-default/IdSyntax.js
@@ -9,7 +9,7 @@ import { BaseIdSyntax } from '@bayou/config-common';
  * Utility functionality regarding ID strings. This implementation uses the
  * default definitions provided by {@link @bayou/doc-id-default}.
  */
-export default class IdSyntax extends BaseIdSyntax {
+export class IdSyntax extends BaseIdSyntax {
   /**
    * Implementation of standard configuration point.
    *

--- a/local-modules/@bayou/config-common-default/Text.js
+++ b/local-modules/@bayou/config-common-default/Text.js
@@ -9,7 +9,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding text handling.
  */
-export default class Text extends UtilityClass {
+export class Text extends UtilityClass {
   /**
    * {Delta} Implementation of standard configuration point. See `package.json`
    * in this directory for details of the version we return here.

--- a/local-modules/@bayou/config-common-default/index.js
+++ b/local-modules/@bayou/config-common-default/index.js
@@ -4,8 +4,8 @@
 
 import { inject } from '@bayou/injecty';
 
-import IdSyntax from './IdSyntax';
-import Text from './Text';
+import { IdSyntax } from './IdSyntax';
+import { Text } from './Text';
 
 /**
  * Injects all of the definitions here into the global configuration.

--- a/local-modules/@bayou/config-common/BaseIdSyntax.js
+++ b/local-modules/@bayou/config-common/BaseIdSyntax.js
@@ -10,7 +10,7 @@ import { Errors, UtilityClass } from '@bayou/util-common';
  * Base class for {@link IdSyntax} (in this module) and its configured
  * implementations.
  */
-export default class BaseIdSyntax extends UtilityClass {
+export class BaseIdSyntax extends UtilityClass {
   /**
    * Checks whether the given value is syntactically valid as an author ID.
    *

--- a/local-modules/@bayou/config-common/IdSyntax.js
+++ b/local-modules/@bayou/config-common/IdSyntax.js
@@ -4,12 +4,12 @@
 
 import { use } from '@bayou/injecty';
 
-import BaseIdSyntax from './BaseIdSyntax';
+import { BaseIdSyntax } from './BaseIdSyntax';
 
 /**
  * Utility functionality regarding ID strings.
  */
-export default class IdSyntax extends BaseIdSyntax {
+export class IdSyntax extends BaseIdSyntax {
   /**
    * Checks whether the given value is syntactically valid as an author ID.
    * This method is only ever called with a non-empty string.

--- a/local-modules/@bayou/config-common/Text.js
+++ b/local-modules/@bayou/config-common/Text.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding text handling.
  */
-export default class Text extends UtilityClass {
+export class Text extends UtilityClass {
   /**
    * {Delta} The class to use for text "delta" (document and change
    * representation) functionality. The interface of this class is expected to

--- a/local-modules/@bayou/config-common/index.js
+++ b/local-modules/@bayou/config-common/index.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseIdSyntax from './BaseIdSyntax';
-import IdSyntax from './IdSyntax';
-import Text from './Text';
+import { BaseIdSyntax } from './BaseIdSyntax';
+import { IdSyntax } from './IdSyntax';
+import { Text } from './Text';
 
 export {
   BaseIdSyntax,

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -40,7 +40,7 @@ tokenMint.registerToken(THE_ROOT_TOKEN, Object.freeze({ type: BaseAuth.TYPE_root
 /**
  * Utility functionality regarding the network configuration of a server.
  */
-export default class Auth extends BaseAuth {
+export class Auth extends BaseAuth {
   /**
    * {string} Implementation of standard configuration point.
    */

--- a/local-modules/@bayou/config-server-default/Deployment.js
+++ b/local-modules/@bayou/config-server-default/Deployment.js
@@ -8,12 +8,12 @@ import { Assets } from '@bayou/assets-client';
 import { ServerEnv } from '@bayou/env-server';
 import { UtilityClass } from '@bayou/util-common';
 
-import Network from './Network';
+import { Network } from './Network';
 
 /**
  * Utility functionality regarding the deployment configuration of a server.
  */
-export default class Deployment extends UtilityClass {
+export class Deployment extends UtilityClass {
   /**
    * {array<string>} Implementation of standard configuration point.
    *

--- a/local-modules/@bayou/config-server-default/HtmlExport.js
+++ b/local-modules/@bayou/config-server-default/HtmlExport.js
@@ -11,7 +11,7 @@ const log = new Logger('html-export');
 /**
  * Utility functionality regarding exporting HTML
  */
-export default class HtmlExport extends UtilityClass {
+export class HtmlExport extends UtilityClass {
 /**
  * Converts the snapshot of given revision number to html.
  *

--- a/local-modules/@bayou/config-server-default/Logging.js
+++ b/local-modules/@bayou/config-server-default/Logging.js
@@ -10,7 +10,7 @@ import { UtilityClass } from '@bayou/util-common';
  * This (default) implementation treats redaction as a no-op, which is of course
  * inappropriate for a production configuration.
  */
-export default class Logging extends UtilityClass {
+export class Logging extends UtilityClass {
   /**
    * Implementation of standard configuration point.
    *

--- a/local-modules/@bayou/config-server-default/Network.js
+++ b/local-modules/@bayou/config-server-default/Network.js
@@ -7,7 +7,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the network configuration of a server.
  */
-export default class Network extends UtilityClass {
+export class Network extends UtilityClass {
   /**
    * {string} Implementation of standard configuration point.
    *

--- a/local-modules/@bayou/config-server-default/Storage.js
+++ b/local-modules/@bayou/config-server-default/Storage.js
@@ -10,7 +10,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the file / document storage system.
  */
-export default class Storage extends UtilityClass {
+export class Storage extends UtilityClass {
   /** {BodyDelta} Implementation of standard configuration point. */
   static get DEFAULT_DOCUMENT_BODY() {
     return new BodyDelta([

--- a/local-modules/@bayou/config-server-default/index.js
+++ b/local-modules/@bayou/config-server-default/index.js
@@ -4,12 +4,12 @@
 
 import { inject } from '@bayou/injecty';
 
-import Auth from './Auth';
-import Deployment from './Deployment';
-import HtmlExport from './HtmlExport';
-import Logging from './Logging';
-import Network from './Network';
-import Storage from './Storage';
+import { Auth } from './Auth';
+import { Deployment } from './Deployment';
+import { HtmlExport } from './HtmlExport';
+import { Logging } from './Logging';
+import { Network } from './Network';
+import { Storage } from './Storage';
 
 /**
  * Injects all of the definitions here into the global configuration.

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -4,12 +4,12 @@
 
 import { use } from '@bayou/injecty';
 
-import BaseAuth from './BaseAuth';
+import { BaseAuth } from './BaseAuth';
 
 /**
  * Authorization-related functionality.
  */
-export default class Auth extends BaseAuth {
+export class Auth extends BaseAuth {
   /**
    * {string} Prefix which when prepended to an arbitrary ID string is
    * guaranteed to result in string for which {@link #isToken} is `false`.

--- a/local-modules/@bayou/config-server/BaseAuth.js
+++ b/local-modules/@bayou/config-server/BaseAuth.js
@@ -10,7 +10,7 @@ import { UtilityClass } from '@bayou/util-common';
  * reasonable way to define constants needed by the configured implementations
  * and the clients of this configuration.
  */
-export default class BaseAuth extends UtilityClass {
+export class BaseAuth extends UtilityClass {
   /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
   static get TYPE_author() { return 'author'; }
 

--- a/local-modules/@bayou/config-server/BaseDocStore.js
+++ b/local-modules/@bayou/config-server/BaseDocStore.js
@@ -11,7 +11,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
  * the underlying system, _except_ for file data (the latter which is managed by
  * the module {@link @bayou/file-store}).
  */
-export default class BaseDocStore extends CommonBase {
+export class BaseDocStore extends CommonBase {
   /**
    * Checks the syntax of a value alleged to be an author ID. Returns the given
    * value if it's a syntactically correct author ID. Otherwise, throws an

--- a/local-modules/@bayou/config-server/Deployment.js
+++ b/local-modules/@bayou/config-server/Deployment.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the deployment configuration of a server.
  */
-export default class Deployment extends UtilityClass {
+export class Deployment extends UtilityClass {
   /**
    * {array<string>} Array of absolute filesystem paths to the asset directory
    * trees, in priority order (earliest directory "overrides" later ones when

--- a/local-modules/@bayou/config-server/HtmlExport.js
+++ b/local-modules/@bayou/config-server/HtmlExport.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding exporting HTML
  */
-export default class HtmlExport extends UtilityClass {
+export class HtmlExport extends UtilityClass {
 
   /**
    * Converts the snapshot of given revision number to html.

--- a/local-modules/@bayou/config-server/Logging.js
+++ b/local-modules/@bayou/config-server/Logging.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding log handling.
  */
-export default class Logging extends UtilityClass {
+export class Logging extends UtilityClass {
   /**
    * Performs redaction on an event log payload.
    *

--- a/local-modules/@bayou/config-server/Network.js
+++ b/local-modules/@bayou/config-server/Network.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the network configuration of a server.
  */
-export default class Network extends UtilityClass {
+export class Network extends UtilityClass {
   /**
    * {string} The base URL to use when constructing URLs to point at the
    * public-facing (set of) machine(s) which front for this server.

--- a/local-modules/@bayou/config-server/Storage.js
+++ b/local-modules/@bayou/config-server/Storage.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility functionality regarding the file / document storage system.
  */
-export default class Storage extends UtilityClass {
+export class Storage extends UtilityClass {
   /**
    * {@bayou/doc-common/BodyDelta} The body content to use for new documents.
    */

--- a/local-modules/@bayou/config-server/index.js
+++ b/local-modules/@bayou/config-server/index.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Auth from './Auth';
-import BaseAuth from './BaseAuth';
-import BaseDocStore from './BaseDocStore';
-import HtmlExport from './HtmlExport';
-import Deployment from './Deployment';
-import Logging from './Logging';
-import Network from './Network';
-import Storage from './Storage';
+import { Auth } from './Auth';
+import { BaseAuth } from './BaseAuth';
+import { BaseDocStore } from './BaseDocStore';
+import { HtmlExport } from './HtmlExport';
+import { Deployment } from './Deployment';
+import { Logging } from './Logging';
+import { Network } from './Network';
+import { Storage } from './Storage';
 
 export {
   Auth,

--- a/local-modules/@bayou/dev-mode/DevMode.js
+++ b/local-modules/@bayou/dev-mode/DevMode.js
@@ -37,7 +37,7 @@ const MAP_FILE_NAME = 'source-map.txt';
  * system as of this writing no longer supports overlays, but the actual code to
  * support it here is pretty minimal, so it remains.
  */
-export default class DevMode extends Singleton {
+export class DevMode extends Singleton {
   /**
    * Constructs the instance. Use `start()` to run it.
    */

--- a/local-modules/@bayou/dev-mode/index.js
+++ b/local-modules/@bayou/dev-mode/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import DevMode from './DevMode';
+import { DevMode } from './DevMode';
 
 export { DevMode };


### PR DESCRIPTION
This PR is the second in the series wherein `export default class` is walking quietly into the sunset.