### PR TITLE
`export default class` spring cleaning, round 3.

### DIFF
--- a/local-modules/@bayou/doc-client/BodyClient.js
+++ b/local-modules/@bayou/doc-client/BodyClient.js
@@ -10,7 +10,7 @@ import { TInt, TString } from '@bayou/typecheck';
 import { StateMachine } from '@bayou/state-machine';
 import { Errors, Functor, InfoError } from '@bayou/util-common';
 
-import DocSession from './DocSession';
+import { DocSession } from './DocSession';
 
 /**
  * {Int} Minimum amount of time (in msec) to wait (and continue to retry
@@ -111,7 +111,7 @@ const bindMap = new WeakMap();
  * just wait until it comes back with a result, instead of having to set up a
  * low-duration timeout to repeatedly ask for new changes.
  */
-export default class BodyClient extends StateMachine {
+export class BodyClient extends StateMachine {
   /**
    * Constructs an instance. It is initially in state `detached`. The
    * constructed instance expects to be the primary non-human controller of the

--- a/local-modules/@bayou/doc-client/CaretTracker.js
+++ b/local-modules/@bayou/doc-client/CaretTracker.js
@@ -7,7 +7,7 @@ import { Condition, Delay } from '@bayou/promise-util';
 import { TInt, TObject } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import DocSession from './DocSession';
+import { DocSession } from './DocSession';
 
 /**
  * How long to wait (in msec) after sending a caret update before sending the
@@ -24,7 +24,7 @@ const MAX_IDLE_TIME_MSEC = 60 * 1000; // One minute.
 /**
  * Handler for the upload of caret info from a client.
  */
-export default class CaretTracker extends CommonBase {
+export class CaretTracker extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -9,8 +9,8 @@ import { EventSource } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { CommonBase } from '@bayou/util-common';
 
-import CaretTracker from './CaretTracker';
-import PropertyClient from './PropertyClient';
+import { CaretTracker } from './CaretTracker';
+import { PropertyClient } from './PropertyClient';
 
 /** Logger. */
 const log = new Logger('doc');
@@ -31,7 +31,7 @@ const log = new Logger('doc');
  *   connection with a server.
  * * `open()` &mdash; The network connection has been established.
  */
-export default class DocSession extends CommonBase {
+export class DocSession extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-client/PropertyClient.js
+++ b/local-modules/@bayou/doc-client/PropertyClient.js
@@ -6,7 +6,7 @@ import { PropertyDelta, PropertyOp, Timeouts } from '@bayou/doc-common';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, DataUtil, Errors } from '@bayou/util-common';
 
-import DocSession from './DocSession';
+import { DocSession } from './DocSession';
 
 /**
  * Accessor for document properties.
@@ -15,7 +15,7 @@ import DocSession from './DocSession';
  * anything locally and it doesn't batch updates to send to the server. This
  * should be fixed!
  */
-export default class PropertyClient extends CommonBase {
+export class PropertyClient extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-client/index.js
+++ b/local-modules/@bayou/doc-client/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BodyClient from './BodyClient';
-import DocSession from './DocSession';
+import { BodyClient } from './BodyClient';
+import { DocSession } from './DocSession';
 
 export { BodyClient, DocSession };

--- a/local-modules/@bayou/doc-common/BodyChange.js
+++ b/local-modules/@bayou/doc-common/BodyChange.js
@@ -4,13 +4,13 @@
 
 import { BaseChange } from '@bayou/ot-common';
 
-import BodyDelta from './BodyDelta';
+import { BodyDelta } from './BodyDelta';
 
 /**
  * Change class for representing changes to a document body. The `delta`s passed
  * to the constructor must be instances of {@link BodyDelta}.
  */
-export default class BodyChange extends BaseChange {
+export class BodyChange extends BaseChange {
   /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class.

--- a/local-modules/@bayou/doc-common/BodyDelta.js
+++ b/local-modules/@bayou/doc-common/BodyDelta.js
@@ -8,7 +8,7 @@ import { Logger } from '@bayou/see-all';
 import { TBoolean, TObject } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import BodyOp from './BodyOp';
+import { BodyOp } from './BodyOp';
 
 /**
  * {Logger} Logger for this module. **Note:** Just used for some temporary
@@ -36,7 +36,7 @@ const log = new Logger('body-delta');
  * instance, and this `EMPTY` instance is in turn used to make the contents for
  * a no-ops snapshot.
  */
-export default class BodyDelta extends BaseDelta {
+export class BodyDelta extends BaseDelta {
   /**
    * Given a Quill `Delta` instance, returns an instance of this class with the
    * same operations.

--- a/local-modules/@bayou/doc-common/BodyOp.js
+++ b/local-modules/@bayou/doc-common/BodyOp.js
@@ -21,7 +21,7 @@ const splitter = new GraphemeSplitter();
  * `fromQuillForm()` and an instance method `toQuillForm()` to convert back and
  * forth as needed.
  */
-export default class BodyOp extends BaseOp {
+export class BodyOp extends BaseOp {
   /** {string} Opcode constant for "delete" operations. */
   static get CODE_delete() {
     return 'delete';

--- a/local-modules/@bayou/doc-common/BodySnapshot.js
+++ b/local-modules/@bayou/doc-common/BodySnapshot.js
@@ -5,12 +5,12 @@
 import { BaseSnapshot } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import BodyChange from './BodyChange';
+import { BodyChange } from './BodyChange';
 
 /**
  * Snapshot of main document body contents.
  */
-export default class BodySnapshot extends BaseSnapshot {
+export class BodySnapshot extends BaseSnapshot {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-common/Caret.js
+++ b/local-modules/@bayou/doc-common/Caret.js
@@ -6,9 +6,9 @@ import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import { TInt, TObject, TString } from '@bayou/typecheck';
 import { ColorUtil, CommonBase, Errors } from '@bayou/util-common';
 
-import CaretDelta from './CaretDelta';
-import CaretId from './CaretId';
-import CaretOp from './CaretOp';
+import { CaretDelta } from './CaretDelta';
+import { CaretId } from './CaretId';
+import { CaretOp } from './CaretOp';
 
 /**
  * {Map<string, function>} Map from each allowed caret field name to a type
@@ -51,7 +51,7 @@ let DEFAULT = null;
  * information about a session from the user's perspective, including the human
  * driving it. The caret per se is merely the most blatant aspect of it.
  */
-export default class Caret extends CommonBase {
+export class Caret extends CommonBase {
   /** {Caret} An instance with all default values. */
   static get DEFAULT() {
     if (DEFAULT === null) {

--- a/local-modules/@bayou/doc-common/CaretChange.js
+++ b/local-modules/@bayou/doc-common/CaretChange.js
@@ -4,13 +4,13 @@
 
 import { BaseChange } from '@bayou/ot-common';
 
-import CaretDelta from './CaretDelta';
+import { CaretDelta } from './CaretDelta';
 
 /**
  * Change class for representing changes to caret snapshots. The `delta`s passed
  * to the constructor must be instances of {@link CaretDelta}.
  */
-export default class CaretChange extends BaseChange {
+export class CaretChange extends BaseChange {
   /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class.

--- a/local-modules/@bayou/doc-common/CaretDelta.js
+++ b/local-modules/@bayou/doc-common/CaretDelta.js
@@ -5,7 +5,7 @@
 import { BaseDelta } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import CaretOp from './CaretOp';
+import { CaretOp } from './CaretOp';
 
 /**
  * Delta for caret information, consisting of a simple ordered list of
@@ -18,7 +18,7 @@ import CaretOp from './CaretOp';
  *
  * Instances of this class are immutable.
  */
-export default class CaretDelta extends BaseDelta {
+export class CaretDelta extends BaseDelta {
   /**
    * Main implementation of {@link #compose}.
    *

--- a/local-modules/@bayou/doc-common/CaretId.js
+++ b/local-modules/@bayou/doc-common/CaretId.js
@@ -15,7 +15,7 @@ const CARET_ID_REGEX = /^cr-[0-9a-z]{5}$/;
  * characters. (With an expected 5 bits of randomness in each character, that
  * allows for about 33 million simultaneous carets on any given document.)
  */
-export default class CaretId extends UtilityClass {
+export class CaretId extends UtilityClass {
   /**
    * Validates that the given value is a valid caret ID string. Throws an
    * error if not.

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -5,13 +5,13 @@
 import { BaseOp } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import Caret from './Caret';
-import CaretId from './CaretId';
+import { Caret } from './Caret';
+import { CaretId } from './CaretId';
 
 /**
  * Operation which can be applied to a `Caret` or `CaretSnapshot`.
  */
-export default class CaretOp extends BaseOp {
+export class CaretOp extends BaseOp {
   /** {string} Opcode constant for "add" operations (add a new caret). */
   static get CODE_add() {
     return 'add';

--- a/local-modules/@bayou/doc-common/CaretSnapshot.js
+++ b/local-modules/@bayou/doc-common/CaretSnapshot.js
@@ -5,11 +5,11 @@
 import { BaseSnapshot } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import Caret from './Caret';
-import CaretChange from './CaretChange';
-import CaretDelta from './CaretDelta';
-import CaretId from './CaretId';
-import CaretOp from './CaretOp';
+import { Caret } from './Caret';
+import { CaretChange } from './CaretChange';
+import { CaretDelta } from './CaretDelta';
+import { CaretId } from './CaretId';
+import { CaretOp } from './CaretOp';
 
 
 /**
@@ -19,7 +19,7 @@ import CaretOp from './CaretOp';
  * When thought of in terms of a map, instances of this class can be taken to
  * be maps from caret ID strings to `Caret` values.
  */
-export default class CaretSnapshot extends BaseSnapshot {
+export class CaretSnapshot extends BaseSnapshot {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-common/Property.js
+++ b/local-modules/@bayou/doc-common/Property.js
@@ -10,7 +10,7 @@ import { CommonBase, DataUtil } from '@bayou/util-common';
  * single property within a `PropertySnapshot`. Instances of this class are
  * always frozen (immutable).
  */
-export default class Property extends CommonBase {
+export class Property extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-common/PropertyChange.js
+++ b/local-modules/@bayou/doc-common/PropertyChange.js
@@ -4,14 +4,14 @@
 
 import { BaseChange } from '@bayou/ot-common';
 
-import PropertyDelta from './PropertyDelta';
+import { PropertyDelta } from './PropertyDelta';
 
 /**
  * Change class for representing changes to one or more document properties
  * (that is, the structured document metadata). The `delta`s passed to the
  * constructor must be instances of {@link PropertyDelta}.
  */
-export default class PropertyChange extends BaseChange {
+export class PropertyChange extends BaseChange {
   /**
    * {class} Class (constructor function) of delta objects to be used with
    * instances of this class.

--- a/local-modules/@bayou/doc-common/PropertyDelta.js
+++ b/local-modules/@bayou/doc-common/PropertyDelta.js
@@ -5,7 +5,7 @@
 import { BaseDelta } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import PropertyOp from './PropertyOp';
+import { PropertyOp } from './PropertyOp';
 
 /**
  * Delta for property (document metadata) information, consisting of a simple
@@ -18,7 +18,7 @@ import PropertyOp from './PropertyOp';
  *
  * Instances of this class are immutable.
  */
-export default class PropertyDelta extends BaseDelta {
+export class PropertyDelta extends BaseDelta {
   /**
    * Main implementation of {@link #compose}.
    *

--- a/local-modules/@bayou/doc-common/PropertyOp.js
+++ b/local-modules/@bayou/doc-common/PropertyOp.js
@@ -6,12 +6,12 @@ import { BaseOp } from '@bayou/ot-common';
 import { TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import Property from './Property';
+import { Property } from './Property';
 
 /**
  * Operation which can be applied to a `PropertySnapshot`.
  */
-export default class PropertyOp extends BaseOp {
+export class PropertyOp extends BaseOp {
   /** {string} Opcode constant for "delete property" operations. */
   static get CODE_delete() {
     return 'delete';

--- a/local-modules/@bayou/doc-common/PropertySnapshot.js
+++ b/local-modules/@bayou/doc-common/PropertySnapshot.js
@@ -6,9 +6,9 @@ import { BaseSnapshot } from '@bayou/ot-common';
 import { TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import PropertyChange from './PropertyChange';
-import PropertyDelta from './PropertyDelta';
-import PropertyOp from './PropertyOp';
+import { PropertyChange } from './PropertyChange';
+import { PropertyDelta } from './PropertyDelta';
+import { PropertyOp } from './PropertyOp';
 
 /**
  * Snapshot of information about all the properties of a particular document.
@@ -17,7 +17,7 @@ import PropertyOp from './PropertyOp';
  * When thought of in terms of a map, instances of this class can be taken to
  * be maps from string keys to arbitrary data values.
  */
-export default class PropertySnapshot extends BaseSnapshot {
+export class PropertySnapshot extends BaseSnapshot {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -11,7 +11,7 @@ import { CommonBase } from '@bayou/util-common';
  * class is just a container for the info. See {@link doc-client/DocSession} for
  * usage.
  */
-export default class SessionInfo extends CommonBase {
+export class SessionInfo extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-common/TheModule.js
+++ b/local-modules/@bayou/doc-common/TheModule.js
@@ -5,26 +5,26 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import BodyChange from './BodyChange';
-import BodyDelta from './BodyDelta';
-import BodyOp from './BodyOp';
-import BodySnapshot from './BodySnapshot';
-import Caret from './Caret';
-import CaretChange from './CaretChange';
-import CaretDelta from './CaretDelta';
-import CaretOp from './CaretOp';
-import CaretSnapshot from './CaretSnapshot';
-import Property from './Property';
-import PropertyChange from './PropertyChange';
-import PropertyDelta from './PropertyDelta';
-import PropertyOp from './PropertyOp';
-import PropertySnapshot from './PropertySnapshot';
-import SessionInfo from './SessionInfo';
+import { BodyChange } from './BodyChange';
+import { BodyDelta } from './BodyDelta';
+import { BodyOp } from './BodyOp';
+import { BodySnapshot } from './BodySnapshot';
+import { Caret } from './Caret';
+import { CaretChange } from './CaretChange';
+import { CaretDelta } from './CaretDelta';
+import { CaretOp } from './CaretOp';
+import { CaretSnapshot } from './CaretSnapshot';
+import { Property } from './Property';
+import { PropertyChange } from './PropertyChange';
+import { PropertyDelta } from './PropertyDelta';
+import { PropertyOp } from './PropertyOp';
+import { PropertySnapshot } from './PropertySnapshot';
+import { SessionInfo } from './SessionInfo';
 
 /**
  * Utilities for this module.
  */
-export default class TheModule extends UtilityClass {
+export class TheModule extends UtilityClass {
   /**
    * {string} Schema version string which uniquely identifies the structure of
    * documents and their constituent parts. Any time the formats change in an

--- a/local-modules/@bayou/doc-common/Timeouts.js
+++ b/local-modules/@bayou/doc-common/Timeouts.js
@@ -9,7 +9,7 @@ import { UtilityClass } from '@bayou/util-common';
  * Utility class that just holds common timeout-related constants and utility
  * functions.
  */
-export default class Timeouts extends UtilityClass {
+export class Timeouts extends UtilityClass {
   /**
    * {Int} The maximum valid timeout, in msec. This value is picked so as to
    * avoid "promise pileup" on code which issues requests which end up getting

--- a/local-modules/@bayou/doc-common/index.js
+++ b/local-modules/@bayou/doc-common/index.js
@@ -2,24 +2,24 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import TheModule from './TheModule';
-import BodyChange from './BodyChange';
-import BodyDelta from './BodyDelta';
-import BodyOp from './BodyOp';
-import BodySnapshot from './BodySnapshot';
-import Caret from './Caret';
-import CaretChange from './CaretChange';
-import CaretDelta from './CaretDelta';
-import CaretId from './CaretId';
-import CaretOp from './CaretOp';
-import CaretSnapshot from './CaretSnapshot';
-import Property from './Property';
-import PropertyChange from './PropertyChange';
-import PropertyDelta from './PropertyDelta';
-import PropertyOp from './PropertyOp';
-import PropertySnapshot from './PropertySnapshot';
-import SessionInfo from './SessionInfo';
-import Timeouts from './Timeouts';
+import { TheModule } from './TheModule';
+import { BodyChange } from './BodyChange';
+import { BodyDelta } from './BodyDelta';
+import { BodyOp } from './BodyOp';
+import { BodySnapshot } from './BodySnapshot';
+import { Caret } from './Caret';
+import { CaretChange } from './CaretChange';
+import { CaretDelta } from './CaretDelta';
+import { CaretId } from './CaretId';
+import { CaretOp } from './CaretOp';
+import { CaretSnapshot } from './CaretSnapshot';
+import { Property } from './Property';
+import { PropertyChange } from './PropertyChange';
+import { PropertyDelta } from './PropertyDelta';
+import { PropertyOp } from './PropertyOp';
+import { PropertySnapshot } from './PropertySnapshot';
+import { SessionInfo } from './SessionInfo';
+import { Timeouts } from './Timeouts';
 
 export {
   TheModule,

--- a/local-modules/@bayou/doc-id-default/DefaultIdSyntax.js
+++ b/local-modules/@bayou/doc-id-default/DefaultIdSyntax.js
@@ -15,7 +15,7 @@ const ID_REGEX = /^[-_a-zA-Z0-9]{1,32}$/;
 /**
  * Default ID syntax definitions. See module `README.md` for more details.
  */
-export default class DefaultIdSyntax {
+export class DefaultIdSyntax {
   /**
    * Default implementation of author ID syntax checking.
    *

--- a/local-modules/@bayou/doc-id-default/index.js
+++ b/local-modules/@bayou/doc-id-default/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import DefaultIdSyntax from './DefaultIdSyntax';
+import { DefaultIdSyntax } from './DefaultIdSyntax';
 
 export { DefaultIdSyntax };

--- a/local-modules/@bayou/doc-server/BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/BaseComplexMember.js
@@ -5,13 +5,13 @@
 import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import FileAccess from './FileAccess';
+import { FileAccess } from './FileAccess';
 
 /**
  * Base class for things that hook up to a {@link FileComplex} and for
  * `FileComplex` itself.
  */
-export default class BaseComplexMember extends CommonBase {
+export class BaseComplexMember extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -9,8 +9,8 @@ import { Delay } from '@bayou/promise-util';
 import { TBoolean, TFunction } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import BaseDataManager from './BaseDataManager';
-import ValidationStatus from './ValidationStatus';
+import { BaseDataManager } from './BaseDataManager';
+import { ValidationStatus } from './ValidationStatus';
 
 /** {Int} Initial amount of time (in msec) between update retries. */
 const INITIAL_UPDATE_RETRY_MSEC = 50;
@@ -52,7 +52,7 @@ const CHANGES_PER_STORED_SNAPSHOT = 1000;
  * in behavior between the subclasses is in whether full change history is
  * stored. See their descriptions for details.
  */
-export default class BaseControl extends BaseDataManager {
+export class BaseControl extends BaseDataManager {
   /**
    * {class} Class (constructor function) of change objects to be used with
    * instances of this class.

--- a/local-modules/@bayou/doc-server/BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/BaseDataManager.js
@@ -5,14 +5,14 @@
 import { FileOp } from '@bayou/file-store-ot';
 import { TArray } from '@bayou/typecheck';
 
-import BaseComplexMember from './BaseComplexMember';
-import ValidationStatus from './ValidationStatus';
+import { BaseComplexMember } from './BaseComplexMember';
+import { ValidationStatus } from './ValidationStatus';
 
 /**
  * Subclass of {@link BaseComplexMember} for things that take top-level
  * responsibility for managing data within a file.
  */
-export default class BaseDataManager extends BaseComplexMember {
+export class BaseDataManager extends BaseComplexMember {
   /**
    * {array<FileOp>} Array of {@link FileOp}s which when made into a
    * {@link FileChange} will initialize the portion of the file which this class

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -7,7 +7,7 @@ import { CaretId } from '@bayou/doc-common';
 import { TBoolean } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import FileComplex from './FileComplex';
+import { FileComplex } from './FileComplex';
 
 /**
  * Base class for the server-side representative of an access session for a
@@ -15,7 +15,7 @@ import FileComplex from './FileComplex';
  * of (concrete subclasses of) this class are exposed across an API boundary,
  * and as such all public methods are available for client use.
  */
-export default class BaseSession extends CommonBase {
+export class BaseSession extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/BodyControl.js
+++ b/local-modules/@bayou/doc-server/BodyControl.js
@@ -6,14 +6,14 @@ import { HtmlExport, Storage } from '@bayou/config-server';
 import { BodyChange, BodyDelta, BodySnapshot } from '@bayou/doc-common';
 import { RevisionNumber } from '@bayou/ot-common';
 
-import DurableControl from './DurableControl';
-import Paths from './Paths';
-import SnapshotManager from './SnapshotManager';
+import { DurableControl } from './DurableControl';
+import { Paths } from './Paths';
+import { SnapshotManager } from './SnapshotManager';
 
 /**
  * Controller for a given document's body content.
  */
-export default class BodyControl extends DurableControl {
+export class BodyControl extends DurableControl {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/BodyDeltaHtml.js
+++ b/local-modules/@bayou/doc-server/BodyDeltaHtml.js
@@ -9,7 +9,7 @@ import { UtilityClass } from '@bayou/util-common';
 /**
  * Utility class to convert a BodyDelta to HTML
  */
-export default class BodyDeltaHtml extends UtilityClass {
+export class BodyDeltaHtml extends UtilityClass {
   /**
    * Produces an HTML representation of the contents of this instance.
    *

--- a/local-modules/@bayou/doc-server/CaretColor.js
+++ b/local-modules/@bayou/doc-server/CaretColor.js
@@ -35,7 +35,7 @@ const TOP_CANDIDATES = 8;
  * top N choices for "most distinctly different color" and pick one of them
  * pseudo-randomly based on the (guaranteed unique) caret ID as the seed.
  */
-export default class CaretColor extends UtilityClass {
+export class CaretColor extends UtilityClass {
   /**
    * Given a caret ID and a set of existing colors, returns the color to use
    * for a new caret with that ID.

--- a/local-modules/@bayou/doc-server/CaretControl.js
+++ b/local-modules/@bayou/doc-server/CaretControl.js
@@ -6,10 +6,10 @@ import { Caret, CaretChange, CaretId, CaretOp, CaretSnapshot } from '@bayou/doc-
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 import { TInt, TString } from '@bayou/typecheck';
 
-import CaretColor from './CaretColor';
-import EphemeralControl from './EphemeralControl';
-import Paths from './Paths';
-import SnapshotManager from './SnapshotManager';
+import { CaretColor } from './CaretColor';
+import { EphemeralControl } from './EphemeralControl';
+import { Paths } from './Paths';
+import { SnapshotManager } from './SnapshotManager';
 
 /**
  * {Int} How long (in msec) that a caret must be inactive before it gets culled
@@ -23,7 +23,7 @@ const MAX_CARET_IDLE_MSEC = 5 * 60 * 1000; // Five minutes.
  * **TODO:** Caret data should be ephemeral. As of this writing, old data will
  * never get purged from the underlying file.
  */
-export default class CaretControl extends EphemeralControl {
+export class CaretControl extends EphemeralControl {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -7,8 +7,8 @@ import { Storage } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';
 
-import FileComplex from './FileComplex';
-import FileComplexCache from './FileComplexCache';
+import { FileComplex } from './FileComplex';
+import { FileComplexCache } from './FileComplexCache';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('doc-server');
@@ -22,7 +22,7 @@ const log = new Logger('doc-server');
  * document-related objects, in particular making sure that such objects have
  * an opportunity to get GC'ed once they're no longer in active use.
  */
-export default class DocServer extends Singleton {
+export class DocServer extends Singleton {
   /**
    * Constructs an instance. This is not meant to be used publicly.
    */

--- a/local-modules/@bayou/doc-server/DurableControl.js
+++ b/local-modules/@bayou/doc-server/DurableControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseControl from './BaseControl';
+import { BaseControl } from './BaseControl';
 
 /**
  * Base class for _durable_ document part controllers. Durable parts maintain
@@ -13,7 +13,7 @@ import BaseControl from './BaseControl';
  * which merely keys off of the value of the static property {@link #ephemeral}
  * defined here.
  */
-export default class DurableControl extends BaseControl {
+export class DurableControl extends BaseControl {
   /**
    * {boolean} Whether (`true`) or not (`false`) this instance controls an
    * ephemeral part. Defined as `false` for this class.

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -5,7 +5,7 @@
 import { BodyChange, PropertyChange } from '@bayou/doc-common';
 import { RevisionNumber, Timestamp } from '@bayou/ot-common';
 
-import ViewSession from './ViewSession';
+import { ViewSession } from './ViewSession';
 
 /**
  * Server side representative of a session which allows editing.
@@ -13,7 +13,7 @@ import ViewSession from './ViewSession';
  * See header comment on superclass {@link ViewSession} for a salient design
  * note.
  */
-export default class EditSession extends ViewSession {
+export class EditSession extends ViewSession {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/EphemeralControl.js
+++ b/local-modules/@bayou/doc-server/EphemeralControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseControl from './BaseControl';
+import { BaseControl } from './BaseControl';
 
 /**
  * Base class for _ephemeral_ document part controllers. Ephemeral parts do not
@@ -15,7 +15,7 @@ import BaseControl from './BaseControl';
  * which merely keys off of the value of the static property {@link #ephemeral}
  * defined here.
  */
-export default class EphemeralControl extends BaseControl {
+export class EphemeralControl extends BaseControl {
   /**
    * {boolean} Whether (`true`) or not (`false`) this instance controls an
    * ephemeral part. Defined as `true` for this class.

--- a/local-modules/@bayou/doc-server/FileAccess.js
+++ b/local-modules/@bayou/doc-server/FileAccess.js
@@ -18,7 +18,7 @@ const log = new Logger('doc');
  * in isolation, since otherwise they would all have mutual dependencies via
  * {@link FileComplex}.
  */
-export default class FileAccess extends CommonBase {
+export class FileAccess extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/FileBootstrap.js
+++ b/local-modules/@bayou/doc-server/FileBootstrap.js
@@ -9,12 +9,12 @@ import { Timestamp } from '@bayou/ot-common';
 import { Mutex } from '@bayou/promise-util';
 import { Errors } from '@bayou/util-common';
 
-import BaseDataManager from './BaseDataManager';
-import BodyControl from './BodyControl';
-import CaretControl from './CaretControl';
-import PropertyControl from './PropertyControl';
-import SchemaHandler from './SchemaHandler';
-import ValidationStatus from './ValidationStatus';
+import { BaseDataManager } from './BaseDataManager';
+import { BodyControl } from './BodyControl';
+import { CaretControl } from './CaretControl';
+import { PropertyControl } from './PropertyControl';
+import { SchemaHandler } from './SchemaHandler';
+import { ValidationStatus } from './ValidationStatus';
 
 /**
  * {BodyDelta} Message used as document to indicate a major validation error.
@@ -43,7 +43,7 @@ const FILE_CREATE_TIMEOUT_MSEC = 10000;
  * Handler for the "bootstrap" setup of a file, including initializing new
  * files, validating existing files, and dealing with validation problems.
  */
-export default class FileBootstrap extends BaseDataManager {
+export class FileBootstrap extends BaseDataManager {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/FileComplex.js
+++ b/local-modules/@bayou/doc-server/FileComplex.js
@@ -6,12 +6,12 @@ import { Storage } from '@bayou/config-server';
 import { TBoolean, TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import BaseComplexMember from './BaseComplexMember';
-import EditSession from './EditSession';
-import FileAccess from './FileAccess';
-import FileBootstrap from './FileBootstrap';
-import SessionCache from './SessionCache';
-import ViewSession from './ViewSession';
+import { BaseComplexMember } from './BaseComplexMember';
+import { EditSession } from './EditSession';
+import { FileAccess } from './FileAccess';
+import { FileBootstrap } from './FileBootstrap';
+import { SessionCache } from './SessionCache';
+import { ViewSession } from './ViewSession';
 
 /**
  * {Int} Maximum amount of time (in msec) to allow for the creation of new
@@ -28,7 +28,7 @@ const MAKE_SESSION_TIMEOUT_MSEC = 10 * 1000; // Ten seconds.
  * how many active editors there are on that document. (This guarantee is
  * provided by `DocServer`.)
  */
-export default class FileComplex extends BaseComplexMember {
+export class FileComplex extends BaseComplexMember {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/FileComplexCache.js
+++ b/local-modules/@bayou/doc-server/FileComplexCache.js
@@ -5,12 +5,12 @@
 import { Storage } from '@bayou/config-server';
 import { BaseCache } from '@bayou/weak-lru-cache';
 
-import FileComplex from './FileComplex';
+import { FileComplex } from './FileComplex';
 
 /**
  * Cache of active instances of {@link FileComplex}.
  */
-export default class FileComplexCache extends BaseCache {
+export class FileComplexCache extends BaseCache {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/Paths.js
+++ b/local-modules/@bayou/doc-server/Paths.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
  * Utility class that just provides the common `StoragePath` strings used
  * by the document storage format.
  */
-export default class Paths extends UtilityClass {
+export class Paths extends UtilityClass {
   /**
    * {string} `StoragePath` prefix string for document body (main content)
    * information.

--- a/local-modules/@bayou/doc-server/PropertyControl.js
+++ b/local-modules/@bayou/doc-server/PropertyControl.js
@@ -4,14 +4,14 @@
 
 import { PropertySnapshot } from '@bayou/doc-common';
 
-import DurableControl from './DurableControl';
-import Paths from './Paths';
-import SnapshotManager from './SnapshotManager';
+import { DurableControl } from './DurableControl';
+import { Paths } from './Paths';
+import { SnapshotManager } from './SnapshotManager';
 
 /**
  * Controller for the property metadata of a particular document.
  */
-export default class PropertyControl extends DurableControl {
+export class PropertyControl extends DurableControl {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/SchemaHandler.js
+++ b/local-modules/@bayou/doc-server/SchemaHandler.js
@@ -5,9 +5,9 @@
 import { TheModule as docCommon_TheModule } from '@bayou/doc-common';
 import { FileOp } from '@bayou/file-store-ot';
 
-import BaseDataManager from './BaseDataManager';
-import Paths from './Paths';
-import ValidationStatus from './ValidationStatus';
+import { BaseDataManager } from './BaseDataManager';
+import { Paths } from './Paths';
+import { ValidationStatus } from './ValidationStatus';
 
 /**
  * Handler for the schema of a file. As of this writing, this class merely knows
@@ -15,7 +15,7 @@ import ValidationStatus from './ValidationStatus';
  * long term, it will be the locus of responsibility for migration of content
  * from older schemas.
  */
-export default class SchemaHandler extends BaseDataManager {
+export class SchemaHandler extends BaseDataManager {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/SessionCache.js
+++ b/local-modules/@bayou/doc-server/SessionCache.js
@@ -5,12 +5,12 @@
 import { CaretId } from '@bayou/doc-common';
 import { BaseCache } from '@bayou/weak-lru-cache';
 
-import BaseSession from './BaseSession';
+import { BaseSession } from './BaseSession';
 
 /**
  * Cache of active instances of {@link BaseSession}.
  */
-export default class SessionCache extends BaseCache {
+export class SessionCache extends BaseCache {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/SnapshotManager.js
+++ b/local-modules/@bayou/doc-server/SnapshotManager.js
@@ -4,13 +4,13 @@
 
 import { CommonBase, Errors } from '@bayou/util-common';
 
-import BaseControl from './BaseControl';
+import { BaseControl } from './BaseControl';
 
 /**
  * Holder of cached snapshots for a document portion, along with the ability to
  * generate new snapshots as requested.
  */
-export default class SnapshotManager extends CommonBase {
+export class SnapshotManager extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/ValidationStatus.js
+++ b/local-modules/@bayou/doc-server/ValidationStatus.js
@@ -10,7 +10,7 @@ import { Errors, UtilityClass } from '@bayou/util-common';
  * string constants. This class is merely where the constants and type checker
  * code live.
  */
-export default class ValidationStatus extends UtilityClass {
+export class ValidationStatus extends UtilityClass {
   /**
    * {string} Validation status value, which indicates an unrecoverable error in
    * interpreting the document (or document portion) data.

--- a/local-modules/@bayou/doc-server/ViewSession.js
+++ b/local-modules/@bayou/doc-server/ViewSession.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseSession from './BaseSession';
+import { BaseSession } from './BaseSession';
 
 /**
  * Server side representative of a session which allows viewing. Instantiated
@@ -17,7 +17,7 @@ import BaseSession from './BaseSession';
  * underlying `*Control` instances, while implicitly adding author ID and/or
  * caret ID as appropriate to methods that perform modifications.
  */
-export default class ViewSession extends BaseSession {
+export class ViewSession extends BaseSession {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/index.js
+++ b/local-modules/@bayou/doc-server/index.js
@@ -2,21 +2,21 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseComplexMember from './BaseComplexMember';
-import BaseControl from './BaseControl';
-import BaseDataManager from './BaseDataManager';
-import BodyControl from './BodyControl';
-import BodyDeltaHtml from './BodyDeltaHtml';
-import CaretControl from './CaretControl';
-import DocServer from './DocServer';
-import EditSession from './EditSession';
-import DurableControl from './DurableControl';
-import EphemeralControl from './EphemeralControl';
-import FileAccess from './FileAccess';
-import FileComplex from './FileComplex';
-import PropertyControl from './PropertyControl';
-import SchemaHandler from './SchemaHandler';
-import ValidationStatus from './ValidationStatus';
+import { BaseComplexMember } from './BaseComplexMember';
+import { BaseControl } from './BaseControl';
+import { BaseDataManager } from './BaseDataManager';
+import { BodyControl } from './BodyControl';
+import { BodyDeltaHtml } from './BodyDeltaHtml';
+import { CaretControl } from './CaretControl';
+import { DocServer } from './DocServer';
+import { EditSession } from './EditSession';
+import { DurableControl } from './DurableControl';
+import { EphemeralControl } from './EphemeralControl';
+import { FileAccess } from './FileAccess';
+import { FileComplex } from './FileComplex';
+import { PropertyControl } from './PropertyControl';
+import { SchemaHandler } from './SchemaHandler';
+import { ValidationStatus } from './ValidationStatus';
 
 export {
   BaseComplexMember,

--- a/local-modules/@bayou/doc-store-default/DefaultDocStore.js
+++ b/local-modules/@bayou/doc-store-default/DefaultDocStore.js
@@ -9,7 +9,7 @@ import { DefaultIdSyntax } from '@bayou/doc-id-default';
  * Data storage implementation that is maximally accepting of IDs (e.g. all
  * authors exist).
  */
-export default class DefaultDocStore extends BaseDocStore {
+export class DefaultDocStore extends BaseDocStore {
   /**
    * Implementation as required by the superclass.
    *

--- a/local-modules/@bayou/doc-store-default/index.js
+++ b/local-modules/@bayou/doc-store-default/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import DefaultDocStore from './DefaultDocStore';
+import { DefaultDocStore } from './DefaultDocStore';
 
 export { DefaultDocStore };

--- a/local-modules/@bayou/doc-ui/BayouKeyHandlers.js
+++ b/local-modules/@bayou/doc-ui/BayouKeyHandlers.js
@@ -26,7 +26,7 @@ import { UtilityClass } from '@bayou/util-common';
  * });
  * ```
  */
-export default class BayouKeyHandlers extends UtilityClass {
+export class BayouKeyHandlers extends UtilityClass {
   /**
    * Convenience function that returns the group of key handlers that provide
    * default behavior (i.e., what you'd get from Quill if this class were not

--- a/local-modules/@bayou/doc-ui/BayouKeyboard.js
+++ b/local-modules/@bayou/doc-ui/BayouKeyboard.js
@@ -95,7 +95,7 @@ const MAC_SPECIFIC_BINDINGS = Object.freeze({
  * that overrides `onEnter(metaKeys)` so that it ignored the return/enter key.
  * This greatly simplifies the process of modifying keyboard behavior.
  */
-export default class BayouKeyboard extends Keyboard {
+export class BayouKeyboard extends Keyboard {
   /**
    * {object} Map from key names to integer keycodes. This is a frozen
    * (immutable) value.

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -33,7 +33,7 @@ const AVATAR_SCALE_FACTOR = AVATAR_DIMENSION / 400.0;
  * users editing the same document as the local user. It renders the selections
  * into an SVG element that overlays the Quill editor.
  */
-export default class CaretOverlay {
+export class CaretOverlay {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-ui/CaretState.js
+++ b/local-modules/@bayou/doc-ui/CaretState.js
@@ -25,7 +25,7 @@ const ERROR_DELAY_MSEC = 5000;
  * document. It watches for changes observed from the session proxy and
  * updates itself accordingly.
  */
-export default class CaretState {
+export class CaretState {
   /**
    * Constructs an instance of this class.
    *

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -11,10 +11,10 @@ import { TObject } from '@bayou/typecheck';
 import { DomUtil } from '@bayou/util-client';
 import { CommonBase, Errors } from '@bayou/util-common';
 
-import BayouKeyHandlers from './BayouKeyHandlers';
-import CaretOverlay from './CaretOverlay';
-import CaretState from './CaretState';
-import TitleClient from './TitleClient';
+import { BayouKeyHandlers } from './BayouKeyHandlers';
+import { CaretOverlay } from './CaretOverlay';
+import { CaretState } from './CaretState';
+import { TitleClient } from './TitleClient';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('editor-complex');
@@ -23,7 +23,7 @@ const log = new Logger('editor-complex');
  * Manager for the "complex" of objects and DOM nodes which in aggregate form
  * the client-side editor.
  */
-export default class EditorComplex extends CommonBase {
+export class EditorComplex extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-ui/TitleClient.js
+++ b/local-modules/@bayou/doc-ui/TitleClient.js
@@ -9,7 +9,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
  * Plumbing between the title field (managed by Quill) on the client and the
  * document model (specifically a `title` property) on the server.
  */
-export default class TitleClient extends CommonBase {
+export class TitleClient extends CommonBase {
   /**
    * Constructs an instance. The constructed instance expects to be the primary
    * non-human controller of the Quill instance it manages.

--- a/local-modules/@bayou/doc-ui/index.js
+++ b/local-modules/@bayou/doc-ui/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import CaretState from './CaretState';
-import EditorComplex from './EditorComplex';
+import { CaretState } from './CaretState';
+import { EditorComplex } from './EditorComplex';
 
 export { CaretState, EditorComplex };

--- a/local-modules/@bayou/env-client/ClientEnv.js
+++ b/local-modules/@bayou/env-client/ClientEnv.js
@@ -13,7 +13,7 @@ import { Errors, UtilityClass } from '@bayou/util-common';
  * easy to wrangle these uses, including especially for the purposes of testing
  * in isolation.
  */
-export default class ClientEnv extends UtilityClass {
+export class ClientEnv extends UtilityClass {
   /**
    * Initializes this module.
    *

--- a/local-modules/@bayou/env-client/index.js
+++ b/local-modules/@bayou/env-client/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import ClientEnv from './ClientEnv';
+import { ClientEnv } from './ClientEnv';
 
 export { ClientEnv };

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -9,7 +9,7 @@ import { Logger, LogRecord } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import Dirs from './Dirs';
+import { Dirs } from './Dirs';
 
 /** {Int} Maximum length of the `errors` string, in characters. */
 const MAX_ERRORS_LENGTH = 5000;
@@ -20,7 +20,7 @@ const log = new Logger('boot-info');
 /**
  * Information about the booting of this server.
  */
-export default class BootInfo extends CommonBase {
+export class BootInfo extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/env-server/BuildInfo.js
+++ b/local-modules/@bayou/env-server/BuildInfo.js
@@ -8,7 +8,7 @@ import path from 'path';
 import { Proppy } from '@bayou/proppy';
 import { CommonBase } from '@bayou/util-common';
 
-import Dirs from './Dirs';
+import { Dirs } from './Dirs';
 
 
 /**
@@ -16,7 +16,7 @@ import Dirs from './Dirs';
  * artifact, explicitly stored as a file at the top level of the product
  * artifact directory.
  */
-export default class BuildInfo extends CommonBase {
+export class BuildInfo extends CommonBase {
   /**
    * Constructs the instance.
    */

--- a/local-modules/@bayou/env-server/Dirs.js
+++ b/local-modules/@bayou/env-server/Dirs.js
@@ -12,7 +12,7 @@ import { Errors, Singleton } from '@bayou/util-common';
 /**
  * Various filesystem directories.
  */
-export default class Dirs extends Singleton {
+export class Dirs extends Singleton {
   /**
    * Constructs the instance.
    */

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -9,7 +9,7 @@ import { Logger } from '@bayou/see-all';
 import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import Dirs from './Dirs';
+import { Dirs } from './Dirs';
 
 /** {Logger} Logger. */
 const log = new Logger('pid');
@@ -18,7 +18,7 @@ const log = new Logger('pid');
  * This writes a PID file when {@link #init()} is called, and tries to remove it
  * when the process is shutting down.
  */
-export default class PidFile extends CommonBase {
+export class PidFile extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (such as writing the PID file); that stuff happens in

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -10,11 +10,11 @@ import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { Errors, Singleton } from '@bayou/util-common';
 
-import BootInfo from './BootInfo';
-import Dirs from './Dirs';
-import PidFile from './PidFile';
-import BuildInfo from './BuildInfo';
-import ShutdownManager from './ShutdownManager';
+import { BootInfo } from './BootInfo';
+import { Dirs } from './Dirs';
+import { PidFile } from './PidFile';
+import { BuildInfo } from './BuildInfo';
+import { ShutdownManager } from './ShutdownManager';
 
 /** {Int} Frequency of uptime metric logs, in msec per log. */
 const UPTIME_LOG_MSEC = 5 * 60 * 1000; // Five minutes.
@@ -25,7 +25,7 @@ const log = new Logger('env-server');
 /**
  * Miscellaneous server-side utilities.
  */
-export default class ServerEnv extends Singleton {
+export class ServerEnv extends Singleton {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/env-server/ShutdownManager.js
+++ b/local-modules/@bayou/env-server/ShutdownManager.js
@@ -10,8 +10,8 @@ import { Logger } from '@bayou/see-all';
 import { TObject } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import BootInfo from './BootInfo';
-import Dirs from './Dirs';
+import { BootInfo } from './BootInfo';
+import { Dirs } from './Dirs';
 
 /**
  * {Int} How long (in msec) to wait between iterations in the shutdown-file
@@ -40,7 +40,7 @@ const log = new Logger('control');
  * parts of the system can use to notice when shutdown is happening and have a
  * chance to exit cleanly.
  */
-export default class ShutdownManager extends CommonBase {
+export class ShutdownManager extends CommonBase {
   /**
    * Constructs an instance. Logging aside, this doesn't cause any external
    * action to take place (i.e. reacting to the control files); that stuff

--- a/local-modules/@bayou/env-server/index.js
+++ b/local-modules/@bayou/env-server/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Dirs from './Dirs';
-import ServerEnv from './ServerEnv';
+import { Dirs } from './Dirs';
+import { ServerEnv } from './ServerEnv';
 
 export { Dirs, ServerEnv };

--- a/local-modules/@bayou/env-server/tests/test_BuildInfo.js
+++ b/local-modules/@bayou/env-server/tests/test_BuildInfo.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import BuildInfo from '@bayou/env-server/BuildInfo';
+import { BuildInfo } from '@bayou/env-server/BuildInfo';
 
 describe('@bayou/env-server/BuildInfo', () => {
   describe('.info', () => {

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -40,7 +40,7 @@ const MAX_ATOMIC_COMPOSED_CHANGES = 1000;
  * File implementation that stores everything in the locally-accessible
  * filesystem.
  */
-export default class LocalFile extends BaseFile {
+export class LocalFile extends BaseFile {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -12,7 +12,7 @@ import { TheModule as fileStoreOt_TheModule } from '@bayou/file-store-ot';
 import { DefaultIdSyntax } from '@bayou/doc-id-default';
 import { Logger } from '@bayou/see-all';
 
-import LocalFile from './LocalFile';
+import { LocalFile } from './LocalFile';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('local-file');
@@ -21,7 +21,7 @@ const log = new Logger('local-file');
  * File storage implementation that stores everything in the locally-accessible
  * filesystem.
  */
-export default class LocalFileStore extends BaseFileStore {
+export class LocalFileStore extends BaseFileStore {
   /**
    * Constructs an instance. This is not meant to be used publicly.
    */

--- a/local-modules/@bayou/file-store-local/index.js
+++ b/local-modules/@bayou/file-store-local/index.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import LocalFile from './LocalFile';
-import LocalFileStore from './LocalFileStore';
+import { LocalFile } from './LocalFile';
+import { LocalFileStore } from './LocalFileStore';
 
 export { LocalFile, LocalFileStore };

--- a/local-modules/@bayou/file-store-ot/Errors.js
+++ b/local-modules/@bayou/file-store-ot/Errors.js
@@ -13,7 +13,7 @@ import { FrozenBuffer, InfoError, UtilityClass } from '@bayou/util-common';
  * **Note:** The names of the methods match the functor names, and because the
  * convention for those is `lowercase_underscore`, that is what's used.
  */
-export default class Errors extends UtilityClass {
+export class Errors extends UtilityClass {
   /**
    * Constructs an error indicating that a content blob was expected to be
    * absent from the file, but turns out to be present.

--- a/local-modules/@bayou/file-store-ot/FileChange.js
+++ b/local-modules/@bayou/file-store-ot/FileChange.js
@@ -4,14 +4,14 @@
 
 import { BaseChange } from '@bayou/ot-common';
 
-import FileDelta from './FileDelta';
+import { FileDelta } from './FileDelta';
 
 /**
  * Change class for representing changes to a file (writing and/or deleting
  * blobs and/or paths). The `delta`s passed to the constructor must be instances
  * of {@link FileDelta}.
  */
-export default class FileChange extends BaseChange {
+export class FileChange extends BaseChange {
   /** @override */
   static get _impl_deltaClass() {
     return FileDelta;

--- a/local-modules/@bayou/file-store-ot/FileDelta.js
+++ b/local-modules/@bayou/file-store-ot/FileDelta.js
@@ -5,8 +5,8 @@
 import { BaseDelta } from '@bayou/ot-common';
 import { Errors } from '@bayou/util-common';
 
-import FileOp from './FileOp';
-import StoragePath from './StoragePath';
+import { FileOp } from './FileOp';
+import { StoragePath } from './StoragePath';
 
 /**
  * Delta for file contents, consisting of a simple ordered list of operations.
@@ -19,7 +19,7 @@ import StoragePath from './StoragePath';
  *
  * Instances of this class are immutable.
  */
-export default class FileDelta extends BaseDelta {
+export class FileDelta extends BaseDelta {
   /**
    * Implementation as required by the superclass.
    *

--- a/local-modules/@bayou/file-store-ot/FileOp.js
+++ b/local-modules/@bayou/file-store-ot/FileOp.js
@@ -6,13 +6,13 @@ import { BaseOp } from '@bayou/ot-common';
 import { TInt } from '@bayou/typecheck';
 import { Errors, FrozenBuffer } from '@bayou/util-common';
 
-import StorageId from './StorageId';
-import StoragePath from './StoragePath';
+import { StorageId } from './StorageId';
+import { StoragePath } from './StoragePath';
 
 /**
  * Operation which can be applied to a {@link FileSnapshot}.
  */
-export default class FileOp extends BaseOp {
+export class FileOp extends BaseOp {
   /** {string} Opcode constant for "delete all" operations. */
   static get CODE_deleteAll() {
     return 'deleteAll';

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -7,11 +7,11 @@ import { TInt } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 import fileStoreOt_Errors from './Errors';
-import FileChange from './FileChange';
-import FileDelta from './FileDelta';
-import FileOp from './FileOp';
-import StorageId from './StorageId';
-import StoragePath from './StoragePath';
+import { FileChange } from './FileChange';
+import { FileDelta } from './FileDelta';
+import { FileOp } from './FileOp';
+import { StorageId } from './StorageId';
+import { StoragePath } from './StoragePath';
 
 /**
  * Snapshot of file contents. Instances of this class are always frozen
@@ -20,7 +20,7 @@ import StoragePath from './StoragePath';
  * When thought of in terms of a map, instances of this class can be taken to
  * be maps from string keys to arbitrary data values.
  */
-export default class FileSnapshot extends BaseSnapshot {
+export class FileSnapshot extends BaseSnapshot {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/file-store-ot/StorageId.js
+++ b/local-modules/@bayou/file-store-ot/StorageId.js
@@ -14,7 +14,7 @@ import { Errors, FrozenBuffer, UtilityClass } from '@bayou/util-common';
  * * content hashes &mdash; Content hashes as defined by
  *   {@link @bayou/util-common.FrozenBuffer}.
  */
-export default class StorageId extends UtilityClass {
+export class StorageId extends UtilityClass {
   /**
    * Validates that the given value is a valid storage ID string. Throws an
    * error if not.

--- a/local-modules/@bayou/file-store-ot/StoragePath.js
+++ b/local-modules/@bayou/file-store-ot/StoragePath.js
@@ -25,7 +25,7 @@ const PATH_REGEX = /^([/][a-zA-Z0-9_]+)+$/;
  * * Example path: `/foo_1/bar/baz/23`
  * * Example component: `puffin_biscuit_7`
  */
-export default class StoragePath extends UtilityClass {
+export class StoragePath extends UtilityClass {
   /**
    * Gets all the prefixes of the given storage path, where each prefix names
    * a "superdirectory" that the original `path` can be considered to be in.

--- a/local-modules/@bayou/file-store-ot/TheModule.js
+++ b/local-modules/@bayou/file-store-ot/TheModule.js
@@ -5,15 +5,15 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import FileChange from './FileChange';
-import FileDelta from './FileDelta';
-import FileOp from './FileOp';
-import FileSnapshot from './FileSnapshot';
+import { FileChange } from './FileChange';
+import { FileDelta } from './FileDelta';
+import { FileOp } from './FileOp';
+import { FileSnapshot } from './FileSnapshot';
 
 /**
  * Utilities for this module.
  */
-export default class TheModule extends UtilityClass {
+export class TheModule extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *

--- a/local-modules/@bayou/file-store-ot/index.js
+++ b/local-modules/@bayou/file-store-ot/index.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import Errors from './Errors';
-import FileChange from './FileChange';
-import FileDelta from './FileDelta';
-import FileOp from './FileOp';
-import FileSnapshot from './FileSnapshot';
-import StorageId from './StorageId';
-import StoragePath from './StoragePath';
-import TheModule from './TheModule';
+import { Errors } from './Errors';
+import { FileChange } from './FileChange';
+import { FileDelta } from './FileDelta';
+import { FileOp } from './FileOp';
+import { FileSnapshot } from './FileSnapshot';
+import { StorageId } from './StorageId';
+import { StoragePath } from './StoragePath';
+import { TheModule } from './TheModule';
 
 export {
   TheModule,

--- a/local-modules/@bayou/file-store/BaseFile.js
+++ b/local-modules/@bayou/file-store/BaseFile.js
@@ -25,7 +25,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
  * (a) maintain parallel structure where feasible, and (b) see if there turns
  * out to be any common functionality that really can be factored out.
  */
-export default class BaseFile extends CommonBase {
+export class BaseFile extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -5,7 +5,7 @@
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
-import BaseFile from './BaseFile';
+import { BaseFile } from './BaseFile';
 
 /**
  * Base class for file storage access. This is, essentially, the filesystem
@@ -13,7 +13,7 @@ import BaseFile from './BaseFile';
  * must override several methods defined by this class, as indicated in the
  * documentation. Methods to override are all named with the prefix `_impl_`.
  */
-export default class BaseFileStore extends CommonBase {
+export class BaseFileStore extends CommonBase {
   /**
    * Checks a file ID for full validity, beyond simply checking the syntax of
    * the ID. Returns the given ID if all is well, or throws an error if the ID

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -4,12 +4,12 @@
 
 import { BaseCache } from '@bayou/weak-lru-cache';
 
-import BaseFile from './BaseFile';
+import { BaseFile } from './BaseFile';
 
 /**
  * Cache of active instances of {@link BaseFile}.
  */
-export default class FileCache extends BaseCache {
+export class FileCache extends BaseCache {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/file-store/FileCodec.js
+++ b/local-modules/@bayou/file-store/FileCodec.js
@@ -5,7 +5,7 @@
 import { Codec } from '@bayou/codec';
 import { CommonBase } from '@bayou/util-common';
 
-import BaseFile from './BaseFile';
+import { BaseFile } from './BaseFile';
 
 /**
  * Combination of a `BaseFile` with a `Codec`.
@@ -17,7 +17,7 @@ import BaseFile from './BaseFile';
  * believe that at some point we will once again introduce these sorts of
  * methods.
  */
-export default class FileCodec extends CommonBase {
+export class FileCodec extends CommonBase {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/file-store/index.js
+++ b/local-modules/@bayou/file-store/index.js
@@ -2,10 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import BaseFile from './BaseFile';
-import BaseFileStore from './BaseFileStore';
-import FileCache from './FileCache';
-import FileCodec from './FileCodec';
+import { BaseFile } from './BaseFile';
+import { BaseFileStore } from './BaseFileStore';
+import { FileCache } from './FileCache';
+import { FileCodec } from './FileCodec';
 
 export {
   BaseFile,

--- a/local-modules/@bayou/injecty/AllConfigs.js
+++ b/local-modules/@bayou/injecty/AllConfigs.js
@@ -4,13 +4,13 @@
 
 import { Singleton } from '@bayou/util-common';
 
-import ConfigMap from './ConfigMap';
+import { ConfigMap } from './ConfigMap';
 
 /**
  * Module-internal singleton class which holds the system-wide instance of
  * {@link ConfigMap}.
  */
-export default class AllConfigs extends Singleton {
+export class AllConfigs extends Singleton {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/injecty/ConfigMap.js
+++ b/local-modules/@bayou/injecty/ConfigMap.js
@@ -8,7 +8,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
 /**
  * Map of names to injected configurations.
  */
-export default class ConfigMap extends CommonBase {
+export class ConfigMap extends CommonBase {
   /**
    * Constructs an instance.
    */

--- a/local-modules/@bayou/injecty/InjectHandler.js
+++ b/local-modules/@bayou/injecty/InjectHandler.js
@@ -4,12 +4,12 @@
 
 import { BaseProxyHandler } from '@bayou/util-common';
 
-import ConfigMap from './ConfigMap';
+import { ConfigMap } from './ConfigMap';
 
 /**
  * Proxy handler which underlies {@link inject}.
  */
-export default class InjectHandler extends BaseProxyHandler {
+export class InjectHandler extends BaseProxyHandler {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/injecty/UseHandler.js
+++ b/local-modules/@bayou/injecty/UseHandler.js
@@ -4,12 +4,12 @@
 
 import { BaseProxyHandler } from '@bayou/util-common';
 
-import ConfigMap from './ConfigMap';
+import { ConfigMap } from './ConfigMap';
 
 /**
  * Proxy handler which underlies {@link use}.
  */
-export default class UseHandler extends BaseProxyHandler {
+export class UseHandler extends BaseProxyHandler {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/injecty/index.js
+++ b/local-modules/@bayou/injecty/index.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import AllConfigs from './AllConfigs';
-import InjectHandler from './InjectHandler';
-import UseHandler from './UseHandler';
+import { AllConfigs } from './AllConfigs';
+import { InjectHandler } from './InjectHandler';
+import { UseHandler } from './UseHandler';
 
 /**
  * Provider of injected objects and values, as properties on this instance.

--- a/local-modules/@bayou/injecty/tests/test_AllConfigs.js
+++ b/local-modules/@bayou/injecty/tests/test_AllConfigs.js
@@ -6,8 +6,8 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 // These classes aren't exported publicly, so they need to be imported by path.
-import AllConfigs from '@bayou/injecty/AllConfigs';
-import ConfigMap from '@bayou/injecty/ConfigMap';
+import { AllConfigs } from '@bayou/injecty/AllConfigs';
+import { ConfigMap } from '@bayou/injecty/ConfigMap';
 
 describe('@bayou/injecty/AllConfigs', () => {
   describe('.map', () => {

--- a/local-modules/@bayou/injecty/tests/test_ConfigMap.js
+++ b/local-modules/@bayou/injecty/tests/test_ConfigMap.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 // This class isn't exported publicly, so it needs to be imported by path.
-import ConfigMap from '@bayou/injecty/ConfigMap';
+import { ConfigMap } from '@bayou/injecty/ConfigMap';
 
 describe('@bayou/injecty/ConfigMap', () => {
   describe('constructor', () => {

--- a/local-modules/@bayou/injecty/tests/test_InjectHandler.js
+++ b/local-modules/@bayou/injecty/tests/test_InjectHandler.js
@@ -6,8 +6,8 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 // These classes aren't exported publicly, so they need to be imported by path.
-import ConfigMap from '@bayou/injecty/ConfigMap';
-import InjectHandler from '@bayou/injecty/InjectHandler';
+import { ConfigMap } from '@bayou/injecty/ConfigMap';
+import { InjectHandler } from '@bayou/injecty/InjectHandler';
 
 // **Note:** These tests all use proxy instances in the way expected of clients
 // of this module.

--- a/local-modules/@bayou/injecty/tests/test_UseHandler.js
+++ b/local-modules/@bayou/injecty/tests/test_UseHandler.js
@@ -6,8 +6,8 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 // These classes aren't exported publicly, so they need to be imported by path.
-import ConfigMap from '@bayou/injecty/ConfigMap';
-import UseHandler from '@bayou/injecty/UseHandler';
+import { ConfigMap } from '@bayou/injecty/ConfigMap';
+import { UseHandler } from '@bayou/injecty/UseHandler';
 
 // **Note:** These tests all use proxy instances in the way expected of clients
 // of this module.


### PR DESCRIPTION
This PR is the third in the series wherein `export default class` is walking quietly into the sunset.
