### PR TITLE
`Codecs`.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -31,7 +31,7 @@ export class ApiClient extends CommonBase {
    * @param {Codec} codec Codec instance to use. In order to function properly,
    *   its registry must include all of the encodable classes defined in
    *   `@bayou/api-common` classes. See
-   *   {@link @bayou/api-common.TheModule.registerCodecs}.
+   *   {@link @bayou/api-common.Codecs.registerCodecs}.
    */
   constructor(serverUrl, codec) {
     super();

--- a/local-modules/@bayou/api-common/Codecs.js
+++ b/local-modules/@bayou/api-common/Codecs.js
@@ -5,15 +5,15 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import { MockChange } from './MockChange';
-import { MockDelta } from './MockDelta';
-import { MockOp } from './MockOp';
-import { MockSnapshot } from './MockSnapshot';
+import { CodableError } from './CodableError';
+import { Message } from './Message';
+import { Response } from './Response';
+import { Remote } from './Remote';
 
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *
@@ -22,9 +22,9 @@ export class TheModule extends UtilityClass {
   static registerCodecs(registry) {
     Registry.check(registry);
 
-    registry.registerClass(MockChange);
-    registry.registerClass(MockDelta);
-    registry.registerClass(MockOp);
-    registry.registerClass(MockSnapshot);
+    registry.registerClass(CodableError);
+    registry.registerClass(Message);
+    registry.registerClass(Remote);
+    registry.registerClass(Response);
   }
 }

--- a/local-modules/@bayou/api-common/index.js
+++ b/local-modules/@bayou/api-common/index.js
@@ -2,9 +2,9 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule } from './TheModule';
 import { BearerToken } from './BearerToken';
 import { CodableError } from './CodableError';
+import { Codecs } from './Codecs';
 import { ConnectionError } from './ConnectionError';
 import { Message } from './Message';
 import { Remote } from './Remote';
@@ -12,9 +12,9 @@ import { Response } from './Response';
 import { TargetId } from './TargetId';
 
 export {
-  TheModule,
   BearerToken,
   CodableError,
+  Codecs,
   ConnectionError,
   Message,
   Remote,

--- a/local-modules/@bayou/app-common/Codecs.js
+++ b/local-modules/@bayou/app-common/Codecs.js
@@ -2,10 +2,10 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codecs as apiCommon_TheModule } from '@bayou/api-common';
+import { Codecs as apiCommon_Codecs } from '@bayou/api-common';
 import { Codec, Registry } from '@bayou/codec';
-import { Codecs as docCommon_TheModule } from '@bayou/doc-common';
-import { Codecs as otCommon_TheModule } from '@bayou/ot-common';
+import { Codecs as docCommon_Codecs } from '@bayou/doc-common';
+import { Codecs as otCommon_Codecs } from '@bayou/ot-common';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
@@ -47,9 +47,9 @@ export class Codecs extends UtilityClass {
   static makeFullCodec() {
     const registry = new Registry();
 
-    apiCommon_TheModule.registerCodecs(registry);
-    docCommon_TheModule.registerCodecs(registry);
-    otCommon_TheModule.registerCodecs(registry);
+    apiCommon_Codecs.registerCodecs(registry);
+    docCommon_Codecs.registerCodecs(registry);
+    otCommon_Codecs.registerCodecs(registry);
 
     return new Codec(registry);
   }
@@ -63,8 +63,8 @@ export class Codecs extends UtilityClass {
   static makeModelCodec() {
     const registry = new Registry();
 
-    docCommon_TheModule.registerCodecs(registry);
-    otCommon_TheModule.registerCodecs(registry);
+    docCommon_Codecs.registerCodecs(registry);
+    otCommon_Codecs.registerCodecs(registry);
 
     return new Codec(registry);
   }

--- a/local-modules/@bayou/app-common/Codecs.js
+++ b/local-modules/@bayou/app-common/Codecs.js
@@ -2,16 +2,16 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule as apiCommon_TheModule } from '@bayou/api-common';
+import { Codecs as apiCommon_TheModule } from '@bayou/api-common';
 import { Codec, Registry } from '@bayou/codec';
-import { TheModule as docCommon_TheModule } from '@bayou/doc-common';
-import { TheModule as otCommon_TheModule } from '@bayou/ot-common';
+import { Codecs as docCommon_TheModule } from '@bayou/doc-common';
+import { Codecs as otCommon_TheModule } from '@bayou/ot-common';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * {Codec} Standard {@link Codec} instance, constructed by
    * {@link #makeFullCodec}.

--- a/local-modules/@bayou/app-common/index.js
+++ b/local-modules/@bayou/app-common/index.js
@@ -2,6 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule } from './TheModule';
+import { Codecs } from './Codecs';
 
-export { TheModule };
+export { Codecs };

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -8,7 +8,7 @@ import path from 'path';
 import ws from 'ws';
 
 import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
 import { Dirs, ServerEnv } from '@bayou/env-server';

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -8,7 +8,7 @@ import path from 'path';
 import ws from 'ws';
 
 import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
 import { Dirs, ServerEnv } from '@bayou/env-server';
@@ -57,7 +57,7 @@ export class Application extends CommonBase {
      * {ContextInfo} The common info used to construct {@link Context}
      * instances.
      */
-    this._contextInfo = new ContextInfo(appCommon_TheModule.fullCodec, new AppAuthorizer(this));
+    this._contextInfo = new ContextInfo(Codecs.fullCodec, new AppAuthorizer(this));
 
     /**
      * {object} The "root access" object. This is the object which tokens

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -6,7 +6,7 @@ import express from 'express';
 import { camelCase } from 'lodash';
 import { inspect } from 'util';
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { Auth, Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -6,7 +6,7 @@ import express from 'express';
 import { camelCase } from 'lodash';
 import { inspect } from 'util';
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { Auth, Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Logger } from '@bayou/see-all';
@@ -243,7 +243,7 @@ export class DebugTools extends CommonBase {
     const revNum = req.params.revNum;
     const body = this._getExistingBody(req);
     const change = (await body).getChange(revNum);
-    const result = appCommon_TheModule.modelCodec.encodeJson(await change, true);
+    const result = Codecs.modelCodec.encodeJson(await change, true);
 
     ServerUtil.sendPlainTextResponse(res, result);
   }
@@ -352,7 +352,7 @@ export class DebugTools extends CommonBase {
     const body = this._getExistingBody(req);
     const args = (revNum === undefined) ? [] : [revNum];
     const snapshot = (await body).getSnapshot(...args);
-    const result = appCommon_TheModule.modelCodec.encodeJson(await snapshot, true);
+    const result = Codecs.modelCodec.encodeJson(await snapshot, true);
 
     ServerUtil.sendPlainTextResponse(res, result);
   }
@@ -451,6 +451,6 @@ export class DebugTools extends CommonBase {
    */
   async _makeEncodedInfo(documentId, authorId) {
     const info = await this._rootAccess.makeSessionInfo(authorId, documentId);
-    return appCommon_TheModule.fullCodec.encodeData(info);
+    return Codecs.fullCodec.encodeData(info);
   }
 }

--- a/local-modules/@bayou/client-bundle/README.md
+++ b/local-modules/@bayou/client-bundle/README.md
@@ -3,15 +3,14 @@ The Client Environment
 
 ### CSS Modules
 
-The Arugula client code makes use of "CSS modules" so that our CSS
-can be broken up into smaller files. This also gives us the ability
-to easily control what styles are active in the DOM, and when.
+The client code makes use of "CSS modules" so that our CSS can be broken up into
+smaller files. This also gives us the ability to easily control what styles are
+active in the DOM, and when.
 
-When the CSS loaded processes a `.css` file it transforms the class
-names to globally unique values. This is to avoid naming collisions
-with other modules. When you import the CSS module into JavaScript
-you end up with an object that maps the class names that were in the
-CSS file to the unique name.
+When the CSS loaded processes a `.css` file it transforms the class names to
+globally unique values. This is to avoid naming collisions with other modules.
+When you import the CSS module into JavaScript you end up with an object that
+maps the class names that were in the CSS file to the unique name.
 
 #### Basic Usage
 

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiClient } from '@bayou/api-client';
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { CaretId, SessionInfo } from '@bayou/doc-common';
 import { EventSource } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -3,7 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ApiClient } from '@bayou/api-client';
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { CaretId, SessionInfo } from '@bayou/doc-common';
 import { EventSource } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
@@ -282,7 +282,7 @@ export class DocSession extends CommonBase {
 
     this._eventSource.emit.opening();
     this._log.event.apiAboutToOpen(url);
-    this._apiClient = new ApiClient(url, appCommon_TheModule.fullCodec);
+    this._apiClient = new ApiClient(url, Codecs.fullCodec);
 
     try {
       this._log.event.apiOpening();

--- a/local-modules/@bayou/doc-common/Codecs.js
+++ b/local-modules/@bayou/doc-common/Codecs.js
@@ -24,7 +24,7 @@ import { SessionInfo } from './SessionInfo';
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * {string} Schema version string which uniquely identifies the structure of
    * documents and their constituent parts. Any time the formats change in an

--- a/local-modules/@bayou/doc-common/index.js
+++ b/local-modules/@bayou/doc-common/index.js
@@ -2,7 +2,6 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule } from './TheModule';
 import { BodyChange } from './BodyChange';
 import { BodyDelta } from './BodyDelta';
 import { BodyOp } from './BodyOp';
@@ -13,6 +12,7 @@ import { CaretDelta } from './CaretDelta';
 import { CaretId } from './CaretId';
 import { CaretOp } from './CaretOp';
 import { CaretSnapshot } from './CaretSnapshot';
+import { Codecs } from './Codecs';
 import { Property } from './Property';
 import { PropertyChange } from './PropertyChange';
 import { PropertyDelta } from './PropertyDelta';
@@ -22,7 +22,6 @@ import { SessionInfo } from './SessionInfo';
 import { Timeouts } from './Timeouts';
 
 export {
-  TheModule,
   BodyChange,
   BodyDelta,
   BodyOp,
@@ -33,6 +32,7 @@ export {
   CaretId,
   CaretOp,
   CaretSnapshot,
+  Codecs,
   Property,
   PropertyChange,
   PropertyDelta,

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { Storage } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';
@@ -30,7 +30,7 @@ export class DocServer extends Singleton {
     super();
 
     /** {Codec} Codec instance to use. */
-    this._codec = appCommon_TheModule.fullCodec;
+    this._codec = Codecs.fullCodec;
 
     /**
      * {FileComplexCache} Cache of {@link FileComplex} instances, mapped from

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { Storage } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';

--- a/local-modules/@bayou/doc-server/SchemaHandler.js
+++ b/local-modules/@bayou/doc-server/SchemaHandler.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule as docCommon_TheModule } from '@bayou/doc-common';
+import { Codecs as docCommon_TheModule } from '@bayou/doc-common';
 import { FileOp } from '@bayou/file-store-ot';
 
 import { BaseDataManager } from './BaseDataManager';

--- a/local-modules/@bayou/doc-server/SchemaHandler.js
+++ b/local-modules/@bayou/doc-server/SchemaHandler.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codecs as docCommon_TheModule } from '@bayou/doc-common';
+import { Codecs } from '@bayou/doc-common';
 import { FileOp } from '@bayou/file-store-ot';
 
 import { BaseDataManager } from './BaseDataManager';
@@ -26,7 +26,7 @@ export class SchemaHandler extends BaseDataManager {
     super(fileAccess, 'schema');
 
     /** {string} The document schema version to use and expect. */
-    this._schemaVersion = docCommon_TheModule.SCHEMA_VERSION;
+    this._schemaVersion = Codecs.SCHEMA_VERSION;
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { BaseComplexMember } from '@bayou/doc-server';
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { FileAccess } from '@bayou/doc-server';
 import { MockFile } from '@bayou/file-store/mocks';
 import { MockLogger } from '@bayou/see-all/mocks';

--- a/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseComplexMember.js
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import { BaseComplexMember } from '@bayou/doc-server';
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { FileAccess } from '@bayou/doc-server';
 import { MockFile } from '@bayou/file-store/mocks';
 import { MockLogger } from '@bayou/see-all/mocks';
@@ -15,7 +15,7 @@ import { MockLogger } from '@bayou/see-all/mocks';
 describe('@bayou/doc-server/BaseComplexMember', () => {
   describe('constructor()', () => {
     it('accepts a `FileAccess` and reflects it in the getters', () => {
-      const codec  = appCommon_TheModule.modelCodec;
+      const codec  = Codecs.modelCodec;
       const file   = new MockFile('blort');
       const fa     = new FileAccess(codec, 'x', file);
       const result = new BaseComplexMember(fa, 'boop');
@@ -35,7 +35,7 @@ describe('@bayou/doc-server/BaseComplexMember', () => {
     });
 
     it('uses the `logLabel` to create an appropriate `log`', () => {
-      const codec  = appCommon_TheModule.modelCodec;
+      const codec  = Codecs.modelCodec;
       const log    = new MockLogger();
       const fa     = new FileAccess(codec, 'x', new MockFile('file-id'), log);
       const result = new BaseComplexMember(fa, 'boop');

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { Timeouts } from '@bayou/doc-common';
 import { MockChange, MockDelta, MockOp, MockSnapshot } from '@bayou/ot-common/mocks';
 import { DurableControl, FileAccess } from '@bayou/doc-server';
@@ -13,7 +13,7 @@ import { MockControl } from '@bayou/doc-server/mocks';
 import { MockFile } from '@bayou/file-store/mocks';
 import { Errors as fileStoreOt_Errors, FileChange, FileSnapshot, FileOp } from '@bayou/file-store-ot';
 import { Timestamp } from '@bayou/ot-common';
-import { TheModule as mocks_TheModule } from '@bayou/ot-common/mocks';
+import { Codecs as mocks_TheModule } from '@bayou/ot-common/mocks';
 import { Errors, FrozenBuffer } from '@bayou/util-common';
 
 // **Note:** Even though these tests are written in terms of `DurableControl`

--- a/local-modules/@bayou/doc-server/tests/test_BaseControl.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseControl.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_Codecs } from '@bayou/app-common';
 import { Timeouts } from '@bayou/doc-common';
 import { MockChange, MockDelta, MockOp, MockSnapshot } from '@bayou/ot-common/mocks';
 import { DurableControl, FileAccess } from '@bayou/doc-server';
@@ -13,7 +13,7 @@ import { MockControl } from '@bayou/doc-server/mocks';
 import { MockFile } from '@bayou/file-store/mocks';
 import { Errors as fileStoreOt_Errors, FileChange, FileSnapshot, FileOp } from '@bayou/file-store-ot';
 import { Timestamp } from '@bayou/ot-common';
-import { Codecs as mocks_TheModule } from '@bayou/ot-common/mocks';
+import { Codecs as mocks_Codecs } from '@bayou/ot-common/mocks';
 import { Errors, FrozenBuffer } from '@bayou/util-common';
 
 // **Note:** Even though these tests are written in terms of `DurableControl`
@@ -21,8 +21,8 @@ import { Errors, FrozenBuffer } from '@bayou/util-common';
 // to all control classes. This is why it is labeled as being for `BaseControl`.
 describe('@bayou/doc-server/BaseControl', () => {
   /** {Codec} Convenient instance of `Codec`. */
-  const CODEC = appCommon_TheModule.makeModelCodec();
-  mocks_TheModule.registerCodecs(CODEC.registry);
+  const CODEC = appCommon_Codecs.makeModelCodec();
+  mocks_Codecs.registerCodecs(CODEC.registry);
 
   /** {FileAccess} Convenient instance of `FileAccess`. */
   const FILE_ACCESS = new FileAccess(CODEC, 'doc-xyz', new MockFile('blort'));

--- a/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
@@ -5,12 +5,12 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { BaseDataManager, FileAccess, ValidationStatus } from '@bayou/doc-server';
 import { MockFile } from '@bayou/file-store/mocks';
 
 /** {FileAccess} Convenient instance of `FileAccess`. */
-const FILE_ACCESS = new FileAccess(appCommon_TheModule.modelCodec, 'doc-123', new MockFile('blort'));
+const FILE_ACCESS = new FileAccess(Codecs.modelCodec, 'doc-123', new MockFile('blort'));
 
 describe('@bayou/doc-server/BaseDataManager', () => {
   describe('afterInit()', () => {

--- a/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
+++ b/local-modules/@bayou/doc-server/tests/test_BaseDataManager.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { BaseDataManager, FileAccess, ValidationStatus } from '@bayou/doc-server';
 import { MockFile } from '@bayou/file-store/mocks';
 

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -8,7 +8,7 @@ import path from 'path';
 import { Codec } from '@bayou/codec';
 import { Dirs } from '@bayou/env-server';
 import { BaseFileStore, FileCache } from '@bayou/file-store';
-import { TheModule as fileStoreOt_TheModule } from '@bayou/file-store-ot';
+import { Codecs as fileStoreOt_TheModule } from '@bayou/file-store-ot';
 import { DefaultIdSyntax } from '@bayou/doc-id-default';
 import { Logger } from '@bayou/see-all';
 

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -8,7 +8,7 @@ import path from 'path';
 import { Codec } from '@bayou/codec';
 import { Dirs } from '@bayou/env-server';
 import { BaseFileStore, FileCache } from '@bayou/file-store';
-import { Codecs as fileStoreOt_TheModule } from '@bayou/file-store-ot';
+import { Codecs } from '@bayou/file-store-ot';
 import { DefaultIdSyntax } from '@bayou/doc-id-default';
 import { Logger } from '@bayou/see-all';
 
@@ -30,7 +30,7 @@ export class LocalFileStore extends BaseFileStore {
 
     /** {Codec} Codec to use when reading and writing file OT objects. */
     this._codec = new Codec();
-    fileStoreOt_TheModule.registerCodecs(this._codec.registry);
+    Codecs.registerCodecs(this._codec.registry);
 
     /** {FileCache} Cache of {@link LocalFile} instances. */
     this._cache = new FileCache(log);

--- a/local-modules/@bayou/file-store-local/tests/TempFiles.js
+++ b/local-modules/@bayou/file-store-local/tests/TempFiles.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 import { Codec } from '@bayou/codec';
 import { LocalFile } from '@bayou/file-store-local';
-import { TheModule as fileStoreOt_TheModule } from '@bayou/file-store-ot';
+import { Codecs as fileStoreOt_TheModule } from '@bayou/file-store-ot';
 import { UtilityClass } from '@bayou/util-common';
 
 /** {Codec} Codec instance to use for `LocalFile` instances. */

--- a/local-modules/@bayou/file-store-local/tests/TempFiles.js
+++ b/local-modules/@bayou/file-store-local/tests/TempFiles.js
@@ -8,12 +8,12 @@ import path from 'path';
 
 import { Codec } from '@bayou/codec';
 import { LocalFile } from '@bayou/file-store-local';
-import { Codecs as fileStoreOt_TheModule } from '@bayou/file-store-ot';
+import { Codecs } from '@bayou/file-store-ot';
 import { UtilityClass } from '@bayou/util-common';
 
 /** {Codec} Codec instance to use for `LocalFile` instances. */
 const codec = new Codec();
-fileStoreOt_TheModule.registerCodecs(codec.registry);
+Codecs.registerCodecs(codec.registry);
 
 /**
  * Utility class to dole out unique temporary filesystem paths, so that the

--- a/local-modules/@bayou/file-store-ot/Codecs.js
+++ b/local-modules/@bayou/file-store-ot/Codecs.js
@@ -5,12 +5,15 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import { Timestamp } from './Timestamp';
+import { FileChange } from './FileChange';
+import { FileDelta } from './FileDelta';
+import { FileOp } from './FileOp';
+import { FileSnapshot } from './FileSnapshot';
 
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *
@@ -19,6 +22,9 @@ export class TheModule extends UtilityClass {
   static registerCodecs(registry) {
     Registry.check(registry);
 
-    registry.registerClass(Timestamp);
+    registry.registerClass(FileChange);
+    registry.registerClass(FileDelta);
+    registry.registerClass(FileOp);
+    registry.registerClass(FileSnapshot);
   }
 }

--- a/local-modules/@bayou/file-store-ot/index.js
+++ b/local-modules/@bayou/file-store-ot/index.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Codecs } from './Codecs';
 import { Errors } from './Errors';
 import { FileChange } from './FileChange';
 import { FileDelta } from './FileDelta';
@@ -9,10 +10,9 @@ import { FileOp } from './FileOp';
 import { FileSnapshot } from './FileSnapshot';
 import { StorageId } from './StorageId';
 import { StoragePath } from './StoragePath';
-import { TheModule } from './TheModule';
 
 export {
-  TheModule,
+  Codecs,
   Errors,
   FileChange,
   FileDelta,

--- a/local-modules/@bayou/ot-common/Codecs.js
+++ b/local-modules/@bayou/ot-common/Codecs.js
@@ -5,15 +5,12 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import { FileChange } from './FileChange';
-import { FileDelta } from './FileDelta';
-import { FileOp } from './FileOp';
-import { FileSnapshot } from './FileSnapshot';
+import { Timestamp } from './Timestamp';
 
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *
@@ -22,9 +19,6 @@ export class TheModule extends UtilityClass {
   static registerCodecs(registry) {
     Registry.check(registry);
 
-    registry.registerClass(FileChange);
-    registry.registerClass(FileDelta);
-    registry.registerClass(FileOp);
-    registry.registerClass(FileSnapshot);
+    registry.registerClass(Timestamp);
   }
 }

--- a/local-modules/@bayou/ot-common/index.js
+++ b/local-modules/@bayou/ot-common/index.js
@@ -2,20 +2,20 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule } from './TheModule';
 import { BaseChange } from './BaseChange';
 import { BaseDelta } from './BaseDelta';
 import { BaseOp } from './BaseOp';
 import { BaseSnapshot } from './BaseSnapshot';
+import { Codecs } from './Codecs';
 import { RevisionNumber } from './RevisionNumber';
 import { Timestamp } from './Timestamp';
 
 export {
-  TheModule,
   BaseChange,
   BaseDelta,
   BaseOp,
   BaseSnapshot,
+  Codecs,
   RevisionNumber,
   Timestamp
 };

--- a/local-modules/@bayou/ot-common/mocks/Codecs.js
+++ b/local-modules/@bayou/ot-common/mocks/Codecs.js
@@ -5,15 +5,15 @@
 import { Registry } from '@bayou/codec';
 import { UtilityClass } from '@bayou/util-common';
 
-import { CodableError } from './CodableError';
-import { Message } from './Message';
-import { Response } from './Response';
-import { Remote } from './Remote';
+import { MockChange } from './MockChange';
+import { MockDelta } from './MockDelta';
+import { MockOp } from './MockOp';
+import { MockSnapshot } from './MockSnapshot';
 
 /**
  * Utilities for this module.
  */
-export class TheModule extends UtilityClass {
+export class Codecs extends UtilityClass {
   /**
    * Registers this module's encodable classes with a given codec registry.
    *
@@ -22,9 +22,9 @@ export class TheModule extends UtilityClass {
   static registerCodecs(registry) {
     Registry.check(registry);
 
-    registry.registerClass(CodableError);
-    registry.registerClass(Message);
-    registry.registerClass(Remote);
-    registry.registerClass(Response);
+    registry.registerClass(MockChange);
+    registry.registerClass(MockDelta);
+    registry.registerClass(MockOp);
+    registry.registerClass(MockSnapshot);
   }
 }

--- a/local-modules/@bayou/ot-common/mocks/index.js
+++ b/local-modules/@bayou/ot-common/mocks/index.js
@@ -2,14 +2,14 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule } from './TheModule';
+import { Codecs } from './Codecs';
 import { MockChange } from './MockChange';
 import { MockDelta } from './MockDelta';
 import { MockOp } from './MockOp';
 import { MockSnapshot } from './MockSnapshot';
 
 export {
-  TheModule,
+  Codecs,
   MockChange,
   MockDelta,
   MockOp,

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Codecs as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs } from '@bayou/app-common';
 import { Editor } from '@bayou/config-client';
 import { SessionInfo } from '@bayou/doc-common';
 import { EditorComplex } from '@bayou/doc-ui';
@@ -148,7 +148,7 @@ export class TopControl {
    * @returns {SessionInfo} The parsed info.
    */
   _parseInfo(infoJson) {
-    const info = appCommon_TheModule.fullCodec.decodeJson(infoJson);
+    const info = Codecs.fullCodec.decodeJson(infoJson);
 
     return SessionInfo.check(info);
   }

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { TheModule as appCommon_TheModule } from '@bayou/app-common';
+import { Codecs as appCommon_TheModule } from '@bayou/app-common';
 import { Editor } from '@bayou/config-client';
 import { SessionInfo } from '@bayou/doc-common';
 import { EditorComplex } from '@bayou/doc-ui';


### PR DESCRIPTION
I noticed during the last spring cleaning that _every_ case of the generic "module utility" export `TheModule`, that class could reasonably be called `Codecs`. So that's what's going on here.