### PR TITLE
`extends` and parens.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -73,7 +73,7 @@ export class ApiClient extends CommonBase {
      * element is an object that maps `resolve` and `reject` to functions that
      * obey the usual promise contract for functions of those names, and
      * `message` to the originally-sent {@link Message}. Initialized and reset
-     * in {@link #_resetConnection()}.
+     * in {@link #_resetConnection}.
      */
     this._callbacks = null;
 

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -275,7 +275,7 @@ export class BaseConnection extends CommonBase {
   }
 
   /**
-   * Helper for {@link #handleJsonMessage()} which parses the original incoming
+   * Helper for {@link #handleJsonMessage} which parses the original incoming
    * message.
    *
    * @param {string} msg Incoming message, in JSON-encoded form.
@@ -307,7 +307,7 @@ export class BaseConnection extends CommonBase {
   }
 
   /**
-   * Helper for {@link #handleJsonMessage()} which encodes a response for
+   * Helper for {@link #handleJsonMessage} which encodes a response for
    * sending back to the far side of a connection.
    *
    * @param {Response} response The response in question.

--- a/local-modules/@bayou/client-bundle/ProgressMessage.js
+++ b/local-modules/@bayou/client-bundle/ProgressMessage.js
@@ -2,16 +2,20 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CommonBase } from '@bayou/util-common';
+
 /**
  * Simple plugin to produce progress messages while building Webpack bundles.
  */
-export class ProgressMessage {
+export class ProgressMessage extends CommonBase {
   /**
    * Constructs an instance.
    *
    * @param {Logger} log The logger to use.
    */
   constructor(log) {
+    super();
+
     /** {Logger} Logger. */
     this._log = log;
 

--- a/local-modules/@bayou/client-bundle/README.md
+++ b/local-modules/@bayou/client-bundle/README.md
@@ -78,7 +78,7 @@ import styles from './some-component.ucss';
 
 // Border classes not active in the DOM yet.
 
-export class SomeComponent {
+export class SomeComponent extends SomeClass {
   ...
 
   lifecycleBegin() {

--- a/local-modules/@bayou/codec/Codec.js
+++ b/local-modules/@bayou/codec/Codec.js
@@ -66,7 +66,7 @@ export class Codec extends CommonBase {
   }
 
   /**
-   * Converts JSON-encoded text to a usable value. See {@link #decodeData()} for
+   * Converts JSON-encoded text to a usable value. See {@link #decodeData} for
    * details. Beyond what is specified there:
    *
    * * Plain objects which map a single string key to an array are decoded into
@@ -134,7 +134,7 @@ export class Codec extends CommonBase {
   }
 
   /**
-   * Converts an arbitrary value to JSON-encoded text. See {@link #encodeData()}
+   * Converts an arbitrary value to JSON-encoded text. See {@link #encodeData}
    * for details. Beyond what is specified there:
    *
    * * Instances of {@link ConstructorCall} are encoded as a single-binding

--- a/local-modules/@bayou/codec/mocks/MockCodable.js
+++ b/local-modules/@bayou/codec/mocks/MockCodable.js
@@ -2,15 +2,19 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { CommonBase } from '@bayou/util-common';
+
 /**
  * Trivial codec-compatible class for use in tests.
  */
-export class MockCodable {
+export class MockCodable extends CommonBase {
   static get CODEC_TAG() {
     return 'MockCodable';
   }
 
   constructor(...args) {
+    super();
+
     this.initialized = true;
     this.args        = args;
   }

--- a/local-modules/@bayou/doc-id-default/DefaultIdSyntax.js
+++ b/local-modules/@bayou/doc-id-default/DefaultIdSyntax.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TString } from '@bayou/typecheck';
+import { UtilityClass } from '@bayou/util-common';
 
 /**
  * {RexExp} Expression which is used to match all of the ID types.
@@ -15,7 +16,7 @@ const ID_REGEX = /^[-_a-zA-Z0-9]{1,32}$/;
 /**
  * Default ID syntax definitions. See module `README.md` for more details.
  */
-export class DefaultIdSyntax {
+export class DefaultIdSyntax extends UtilityClass {
   /**
    * Default implementation of author ID syntax checking.
    *

--- a/local-modules/@bayou/doc-ui/CaretOverlay.js
+++ b/local-modules/@bayou/doc-ui/CaretOverlay.js
@@ -6,6 +6,7 @@ import { CaretId, CaretOp, CaretSnapshot } from '@bayou/doc-common';
 import { Delay } from '@bayou/promise-util';
 import { QuillEvents, QuillGeometry } from '@bayou/quill-util';
 import { TObject } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
 
 /**
  * {Int} Amount of time (in msec) to wait after noticing a local edit before
@@ -33,7 +34,7 @@ const AVATAR_SCALE_FACTOR = AVATAR_DIMENSION / 400.0;
  * users editing the same document as the local user. It renders the selections
  * into an SVG element that overlays the Quill editor.
  */
-export class CaretOverlay {
+export class CaretOverlay extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -42,6 +43,8 @@ export class CaretOverlay {
    * @param {Element} svgElement The `<svg>` element to attach to.
    */
   constructor(editorComplex, svgElement) {
+    super();
+
     /** {EditorComplex} Editor complex that this instance is a part of. */
     this._editorComplex = editorComplex;
 

--- a/local-modules/@bayou/doc-ui/CaretState.js
+++ b/local-modules/@bayou/doc-ui/CaretState.js
@@ -4,7 +4,7 @@
 
 import { RevisionNumber } from '@bayou/ot-common';
 import { Condition, Delay } from '@bayou/promise-util';
-import { Errors } from '@bayou/util-common';
+import { CommonBase, Errors } from '@bayou/util-common';
 
 /**
  * {Int} Amount of time (in msec) to wait after receiving a caret update from
@@ -25,7 +25,7 @@ const ERROR_DELAY_MSEC = 5000;
  * document. It watches for changes observed from the session proxy and
  * updates itself accordingly.
  */
-export class CaretState {
+export class CaretState extends CommonBase {
   /**
    * Constructs an instance of this class.
    *
@@ -33,6 +33,8 @@ export class CaretState {
    *   instance will operate.
    */
   constructor(editorComplex) {
+    super();
+
     /**
      * {EditorComplex} The editor complex which this instance is associated
      * with.

--- a/local-modules/@bayou/env-server/PidFile.js
+++ b/local-modules/@bayou/env-server/PidFile.js
@@ -15,7 +15,7 @@ import { Dirs } from './Dirs';
 const log = new Logger('pid');
 
 /**
- * This writes a PID file when {@link #init()} is called, and tries to remove it
+ * This writes a PID file when {@link #init} is called, and tries to remove it
  * when the process is shutting down.
  */
 export class PidFile extends CommonBase {

--- a/local-modules/@bayou/file-store-local/LocalFile.js
+++ b/local-modules/@bayou/file-store-local/LocalFile.js
@@ -416,7 +416,7 @@ export class LocalFile extends BaseFile {
   }
 
   /**
-   * Helper for {@link #_waitThenFlushStorage()}, which does all the actual
+   * Helper for {@link #_waitThenFlushStorage}, which does all the actual
    * filesystem stuff when the file is supposed to be deleted.
    *
    * @returns {true} `true`, upon successful operation.
@@ -720,7 +720,7 @@ export class LocalFile extends BaseFile {
   }
 
   /**
-   * Helper for {@link #_waitThenFlushStorage()}, which does all the actual
+   * Helper for {@link #_waitThenFlushStorage}, which does all the actual
    * filesystem stuff when there is stuff to write.
    *
    * @returns {true} `true`, upon successful writing.

--- a/local-modules/@bayou/promise-util/CallPiler.js
+++ b/local-modules/@bayou/promise-util/CallPiler.js
@@ -3,6 +3,7 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TFunction } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
 
 /**
  * Function wrapper that guarantees only one call to the underlying function
@@ -39,7 +40,7 @@ import { TFunction } from '@bayou/typecheck';
  * Results 2 2
  * ```
  */
-export class CallPiler {
+export class CallPiler extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -47,6 +48,8 @@ export class CallPiler {
    * @param {...*} args Arguments to pass to the function.
    */
   constructor(func, ...args) {
+    super();
+
     /** {function} Function to call. */
     this._func = TFunction.checkCallable(func);
 

--- a/local-modules/@bayou/promise-util/Condition.js
+++ b/local-modules/@bayou/promise-util/Condition.js
@@ -3,17 +3,20 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { TBoolean } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
 
 /**
  * Boolean condition with promise-attached level triggers.
  */
-export class Condition {
+export class Condition extends CommonBase {
   /**
    * Constructs an instance.
    *
    * @param {boolean} [initialValue = false] Initial value.
    */
   constructor(initialValue = false) {
+    super();
+
     /** Current value. */
     this._value = TBoolean.check(initialValue);
 

--- a/local-modules/@bayou/quill-util/QuillGeometry.js
+++ b/local-modules/@bayou/quill-util/QuillGeometry.js
@@ -2,11 +2,13 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { UtilityClass } from '@bayou/util-common';
+
 /**
  * A collection of code to help with reconciling Quill contents
  * with on-screen pixel positions.
  */
-export class QuillGeometry {
+export class QuillGeometry extends UtilityClass {
   /**
    * Takes a Quill character offset and returns a bounding rectangle for an
    * insertion point cursor at that offset.

--- a/local-modules/@bayou/see-all-server/HumanSink.js
+++ b/local-modules/@bayou/see-all-server/HumanSink.js
@@ -103,21 +103,21 @@ export class HumanSink extends BaseSink {
     /**
      * {Int} Number of columns currently being reserved for log line prefixes.
      * This starts with a reasonable guess (to avoid initial churn) and gets
-     * updated in {@link #_makePrefix()}.
+     * updated in {@link #_makePrefix}.
      */
     this._prefixLength = MIN_PREFIX_LENGTH;
 
     /**
      * {Int} The maximum prefix observed over the previous
      * {@link #_recentLineCount} lines. This gets updated in
-     * {@link #_makePrefix()}.
+     * {@link #_makePrefix}.
      */
     this._recentMaxPrefix = 0;
 
     /**
      * {Int} The number of lines in the reckoning recorded by
      * {@link #_recentMaxPrefix} lines. This gets updated in
-     * {@link #_makePrefix()}.
+     * {@link #_makePrefix}.
      */
     this._recentLineCount = 0;
 

--- a/local-modules/@bayou/state-machine/StateMachine.js
+++ b/local-modules/@bayou/state-machine/StateMachine.js
@@ -5,7 +5,7 @@
 import { Condition } from '@bayou/promise-util';
 import { BaseLogger, Logger } from '@bayou/see-all';
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
-import { Errors, Functor, PropertyIterable } from '@bayou/util-common';
+import { CommonBase, Errors, Functor, PropertyIterable } from '@bayou/util-common';
 
 /**
  * Lightweight state machine framework. This allows a subclass to define
@@ -68,7 +68,7 @@ import { Errors, Functor, PropertyIterable } from '@bayou/util-common';
  * throws an exception. (2) a default handler for (any, error), which logs the
  * error and aborts the state machine.
  */
-export class StateMachine {
+export class StateMachine extends CommonBase {
   /**
    * Constructs an instance.
    *
@@ -80,6 +80,8 @@ export class StateMachine {
    *   an ongoing basis.
    */
   constructor(initialState, logger = null, verboseLogging = false) {
+    super();
+
     TString.check(initialState);
 
     /** {BaseLogger} Logger to use. */

--- a/local-modules/@bayou/testing-server/TestFiles.js
+++ b/local-modules/@bayou/testing-server/TestFiles.js
@@ -51,8 +51,7 @@ export class TestFiles extends UtilityClass {
    *
    * @param {string} dir Path to the subproduct directory.
    * @param {array<string>} moduleList A list of module names to scan for tests,
-   *   such as might have been returned from a call to
-   *   {@link #_localModulesIn()}.
+   *   such as might have been returned from a call to {@link #_localModulesIn}.
    * @returns {array<string>} List of filesystem paths for test files.
    */
   static _allTestFiles(dir, moduleList) {

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -8,6 +8,7 @@ import { SessionInfo } from '@bayou/doc-common';
 import { EditorComplex } from '@bayou/doc-ui';
 import { Logger } from '@bayou/see-all';
 import { TFunction, TObject } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('top');
@@ -16,13 +17,15 @@ const log = new Logger('top');
  * Top-level control for an editor. This is responsible for setting up the
  * browser environment and for keeping things going.
  */
-export class TopControl {
+export class TopControl extends CommonBase {
   /**
    * Constructs an instance.
    *
    * @param {Window} window The browser window in which we are operating.
    */
   constructor(window) {
+    super();
+
     /** {Window} The browser window in which we are operating. */
     this._window = window;
 

--- a/local-modules/@bayou/util-common/DeferredLoader.js
+++ b/local-modules/@bayou/util-common/DeferredLoader.js
@@ -14,8 +14,8 @@ import { BaseProxyHandler } from './BaseProxyHandler';
  * first access, it calls on a loader function to load up the "real" target, and
  * then it uses that target for all accesses.
  *
- * The easiest way to use this class is via the {@link
- # BaseProxyHandler#makeProxy()} static method.
+ * The easiest way to use this class is via the static method {@link
+ # BaseProxyHandler#makeProxy}.
  *
  * The point of this class is to help break module dependency cycles. By using
  * this class, it is possible to effectively "import" a module just before it is

--- a/local-modules/@bayou/util-core/FrozenBuffer.js
+++ b/local-modules/@bayou/util-core/FrozenBuffer.js
@@ -26,10 +26,10 @@ const HASH_BIT_LENGTH = 256;
  * **Note:** This class mixes in `CommonBase`, so that it gets the static
  * `check()` method and friends. However, because `CommonBase` uses this class,
  * we can't just mix it in here (as this class is the one that gets initialized
- * first). Instead, this happens during module initialization.
- *
+ * first). Instead, this happens during module initialization. (See `index.js`
+ * in this module.)
  */
-export class FrozenBuffer {
+export class FrozenBuffer /* extends CommonBase */ {
   /**
    * Validates that the given value is a valid hash string, such as might be
    * returned by the instance property `.hash` on this class. Throws an error if

--- a/local-modules/@bayou/util-core/Functor.js
+++ b/local-modules/@bayou/util-core/Functor.js
@@ -32,7 +32,7 @@ export class Functor /* extends CommonBase */ {
    * Constructs an instance.
    *
    * @param {string} name Functor name. This must conform to the "label"
-   *   syntax as defined by {@link TString#label()}.
+   *   syntax as defined by {@link TString#label}.
    * @param {...*} args Functor arguments.
    */
   constructor(name, ...args) {

--- a/local-modules/@bayou/util-core/Functor.js
+++ b/local-modules/@bayou/util-core/Functor.js
@@ -21,12 +21,13 @@ import { ObjectUtil } from './ObjectUtil';
  * **Note:** This class mixes in `CommonBase`, so that it gets the static
  * `check()` method and friends. However, because `CommonBase` uses this class,
  * we can't just mix it in here (as this class is the one that gets initialized
- * first). Instead, this happens during module initialization.
+ * first). Instead, this happens during module initialization. (See `index.js`
+ * in this module.)
  *
  * **Note for pedants:** This class does _not_ implement a "functor" in the
  * strict mathematical or category-theoretical sense of the word.
  */
-export class Functor {
+export class Functor /* extends CommonBase */ {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/util-core/InfoError.js
+++ b/local-modules/@bayou/util-core/InfoError.js
@@ -21,9 +21,10 @@ import { Functor } from './Functor';
  * **Note:** This class mixes in `CommonBase`, so that it gets the static
  * `check()` method and friends. However, because `CommonBase` uses this class,
  * we can't just mix it in here (as this class is the one that gets initialized
- * first). Instead, this happens during module initialization.
+ * first). Instead, this happens during module initialization. (See `index.js`
+ * in this module.)
  */
-export class InfoError extends Error {
+export class InfoError extends Error /* mixin CommonBase */ {
   /**
    * Checks if the given value is an instance of this class with the given
    * name. This is a `static` method, so that the check can be made on errors

--- a/local-modules/@bayou/util-core/InfoError.js
+++ b/local-modules/@bayou/util-core/InfoError.js
@@ -171,8 +171,8 @@ export class InfoError extends Error /* mixin CommonBase */ {
    * Chrome / Chromium and Safari.
    *
    * **TODO:** This should be removed and call sites fixed to use
-   * {@link UtilError#stackLines()}, except that method would have to be fixed
-   * to be (a) accessible here (wrong module) and (b) become explicitly aware of
+   * {@link UtilError#stackLines}, except that method would have to be fixed to
+   * be (a) accessible here (wrong module) and (b) become explicitly aware of
    * Safari's style.
    *
    * @param {string} orig The original `.stack` string.


### PR DESCRIPTION
This PR fixes a couple of "spring cleany" items I noticed while doing the other recent spring cleanings:

* There was a small handful of classes that didn't have a defined superclass. The intention for a while has been that every class has an explicit superclass that isn't `Object`, and there are three defined in `util-common` to use when nothing more specific suffices (`CommonBase`, `Singleton`, and `UtilityClass`).

* There were a bunch of places where `{@link ...}` was used to name a method and included parens. These were all leftover from before we used `{@link ...}` and instead just used backtick-quoted blocks and wrote method references in the "natural" way `someMethod()`.