### PR TITLE
Module audit and fix.

### DIFF
--- a/local-modules/@bayou/deps-testing-server/package.json
+++ b/local-modules/@bayou/deps-testing-server/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "puppeteer": "^0.11.0"
+    "puppeteer": "^1.15.0"
   }
 }

--- a/local-modules/@bayou/testing-server/package.json
+++ b/local-modules/@bayou/testing-server/package.json
@@ -4,6 +4,7 @@
     "@bayou/deps-testing-common": "local",
     "@bayou/deps-testing-server": "local",
     "@bayou/env-server": "local",
+    "@bayou/promise-util": "local",
     "@bayou/testing-common": "local",
     "@bayou/util-common": "local"
   }

--- a/scripts/audit
+++ b/scripts/audit
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+# Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+# Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+#
+# Does `npm audit` over each built subproject of the project.
+#
+
+# Set `progName` to the program name, `progDir` to its directory, and `baseDir`
+# to `progDir`'s directory. Follows symlinks.
+function init-prog {
+    local newp p="$0"
+
+    while newp="$(readlink "$p")"; do
+        [[ ${newp} =~ ^/ ]] && p="${newp}" || p="$(dirname "$p")/${newp}"
+    done
+
+    progName="${p##*/}"
+    progDir="$(cd "$(dirname "$p")"; /bin/pwd -P)"
+    baseDir="$(cd "${progDir}/.."; /bin/pwd -P)"
+}
+init-prog
+
+
+#
+# Argument parsing
+#
+
+# Error during argument processing?
+argError=0
+
+# Need help?
+showHelp=0
+
+# Option for the output directory, if any.
+outDirOpt=()
+
+# Option for the extra modules source directory, if any.
+extraModulesOpt=()
+
+# Extra modules source directory, if any.
+extraModulesDir=''
+
+while true; do
+    case $1 in
+        -h|--help)
+            showHelp=1
+            break
+            ;;
+        --out=?*)
+            outDirOpt=("$1")
+            ;;
+        --) # End of all options
+            shift
+            break
+            ;;
+        -?*)
+            echo "Unknown option: $1" 1>&2
+            argError=1
+            break
+            ;;
+        *)  # Default case: No more options, break out of the loop.
+            break
+    esac
+
+    shift
+done
+
+if (( ${showHelp} || ${argError} )); then
+    echo 'Usage:'
+    echo ''
+    echo "${progName} [<opt> ...]"
+    echo '  Run `npm audit` over each of the built subprojects. This does not do'
+    echo '  any building first.'
+    echo ''
+    echo '  --out=<dir>'
+    echo '    Where to find built output.'
+    echo ''
+    echo "${progName} [--help | -h]"
+    echo '  Display this message.'
+    exit ${argError}
+fi
+
+
+#
+# Main script
+#
+
+outDir="$("${progDir}/lib/out-dir-setup" "${outDirOpt[@]}")"
+if (( $? != 0 )); then
+    exit 1
+fi
+
+projects=($(
+    cd "${outDir}"
+    find . -mindepth 1 -maxdepth 2 -name package.json | awk -F/ '{ print $2 }' | sort
+))
+
+auditFile="${outDir}/audit-report.txt"
+rm -f "${auditFile}"
+touch "${auditFile}" || exit 1
+
+problems=0
+for p in "${projects[@]}"; do
+    echo "Auditing ${p}..."
+
+    (
+        echo "---------- ${p} ----------"
+        echo ''
+    ) >> "${auditFile}"
+
+    cd "${outDir}/${p}"
+
+    # `--offline` so as to not try to refetch dependencies.
+    npm install --offline --package-lock-only || exit 1
+
+    npm audit >>"${auditFile}" 2>&1
+    if (( $? != 0 )); then
+        (( problems++ ))
+    fi
+
+    rm -f package-lock.json
+
+    echo '' >> "${auditFile}"
+    echo ''
+done
+
+(
+    echo '---------- ---------- ----------'
+    echo ''
+
+    if (( $problems == 0 )); then
+        echo 'All good! Yay!'
+    else
+        echo "Alas: ${problems} project(s) with audit problems."
+        exit 1
+    fi
+) >> "${auditFile}"
+
+if (( $problems == 0 )); then
+    echo 'All good! Yay!'
+else
+    echo "Alas: ${problems} project(s) with audit problems."
+    exit 1
+fi

--- a/scripts/build
+++ b/scripts/build
@@ -63,6 +63,9 @@ while true; do
         --clean)
             outOpts+=("$1")
             ;;
+        --client)
+            buildProjects+=(client)
+            ;;
         --compiler)
             buildProjects+=(compiler)
             ;;
@@ -86,6 +89,9 @@ while true; do
             ;;
         --product-info=?*)
             productInfoPath="${1#*=}"
+            ;;
+        --server)
+            buildProjects+=(server)
             ;;
         --) # End of all options
             shift
@@ -116,6 +122,8 @@ if (( ${showHelp} || ${argError} )); then
     echo '  this performs a full build.'
     echo ''
     echo 'Target options:'
+    echo '  --client'
+    echo '    Build the client (code that runs in a browser).'
     echo '  --compiler'
     echo '    Build the compiler (transpiler).'
     echo '  --copy-sources'
@@ -124,6 +132,8 @@ if (( ${showHelp} || ${argError} )); then
     echo '    this by itself.'
     echo '  --linter'
     echo '    Build the linter.'
+    echo '  --server'
+    echo '    Build the server (main server application).'
     echo ''
     echo 'Other options:'
     echo '  --clean'


### PR DESCRIPTION
I noticed during a recent build that the lightweight security report that npm spits out during a build had started to indicate a new vulnerability. This prompted me to make this PR, wherein:

* Added a new `audit` script, which runs `npm audit` over each of the built subprojects.
* Fixed the now-elucidated security issue.

The actual security issue turned out to be in Puppeteer, which is only used during testing, so it wasn't a real problem for us. Nonetheless, it served as a great prompt to go ahead and build out the audit facility, so that _when_ we run into a more meaningful vulnerability, we won't get caught quite so off-guard.