### PR TITLE
Remove `pollingDelayMsec`.

### DIFF
--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.4.0
+version = 1.4.1


### PR DESCRIPTION
The FE recently stopped using the `BodyClient` constructor argument `pollingDelayMsec`. This PR removes the argument, and thereby simplifies the system just a wee bit.
