### PR TITLE
Expand `Auth` to admit the possibility of cookie-auth requirements.

### DIFF
--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -51,7 +51,9 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
    *   granted.
    */
   async _impl_targetFromToken(token) {
-    const authority = await Auth.tokenAuthority(token);
+    // **TODO:** `null` below should actually be an object with all the right
+    // cookies, if any.
+    const authority = await Auth.tokenAuthority(token, null);
 
     switch (authority.type) {
       case Auth.TYPE_root: {

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -5,7 +5,7 @@
 import { BearerToken } from '@bayou/api-common';
 import { TokenMint } from '@bayou/api-server';
 import { BaseAuth } from '@bayou/config-server';
-import { TString } from '@bayou/typecheck';
+import { TObject, TString } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
 /**
@@ -118,10 +118,13 @@ export class Auth extends BaseAuth {
    * above, for more info.
    *
    * @param {BearerToken} token The token in question.
+   * @param {object|null} cookies The cookies needed in order to authorize
+   *   `token`, or `null` if no cookies are needed. This value should be based
    * @returns {object} Representation of the authority granted by `token`.
    */
-  static async tokenAuthority(token) {
+  static async tokenAuthority(token, cookies) {
     BearerToken.check(token);
+    TObject.plainOrNull(cookies);
 
     const found = tokenMint.getInfoOrNull(token);
 

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -62,6 +62,21 @@ export class Auth extends BaseAuth {
   /**
    * Implementation of standard configuration point.
    *
+   * This implementation always returns `[]`, that is, it never makes an cookies
+   * required.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {array<string>} `[]`, always.
+   */
+  static async cookieNamesForToken(token) {
+    BearerToken.check(token);
+
+    return [];
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
    * This implementation succeeds for any valid author ID and always returns a
    * newly-created token. It caches every token token created, such that it can
    * subsequently be found by {@link #tokenAuthority}.

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -78,9 +78,9 @@ export class Auth extends BaseAuth {
 
   /**
    * Gets the authority / authorization that is granted by the given
-   * {@link BearerToken}. The result is a plain object which binds at least
-   * `type` to the type of authority. Per type, the following are the other
-   * possible bindings:
+   * {@link BearerToken} and (if necessary) associated cookies. The result is a
+   * plain object which binds at least `type` to the type of authority. Per
+   * type, the following are the other possible bindings:
    *
    * * `Auth.TYPE_none` &mdash; No other bindings. The token doesn't actually
    *   grant any authority.
@@ -99,11 +99,18 @@ export class Auth extends BaseAuth {
    * **TODO:** Consider having an `expirationTime` binding.
    *
    * @param {BearerToken} token The token in question.
+   * @param {object|null} cookies The cookies needed in order to authorize
+   *   `token`, or `null` if no cookies are needed. This value should be based
+   *   on the result of an earlier call to {@link #cookieNamesForToken}.
+   *   Specifically, if that method returns something other than `[]`, then this
+   *   value should be a plain object whose keys are the indicated cookie names
+   *   and whose values are the related cookie values from the HTTP-ish request
+   *   in which `token` was presented.
    * @returns {object} Plain object with bindings as described above,
    *   representing the authority granted by `token`.
    */
-  static async tokenAuthority(token) {
-    return use.Auth.tokenAuthority(token);
+  static async tokenAuthority(token, cookies) {
+    return use.Auth.tokenAuthority(token, cookies);
   }
 
   /**

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -29,6 +29,25 @@ export class Auth extends BaseAuth {
   }
 
   /**
+   * Gets the names of any (HTTP-ish) request cookies whose contents are
+   * required in order to fully validate / authorize the given token. If the
+   * given token does not require any cookies, then this method returns `[]`
+   * (that is, an empty array).
+   *
+   * **Note:** This is defined to be an `async` method, on the expectation that
+   * in a production configuration, it might require network activity (e.g.
+   * making a request of a different service) to find out what cookie namess are
+   * associated with a given token.
+   *
+   * @param {BearerToken} token The token in question.
+   * @returns {array<string>} The names of all the cookies which are needed to
+   *   perform validation / authorization on `token`.
+   */
+  static async cookieNamesForToken(token) {
+    return use.Auth.cookieNamesForToken(token);
+  }
+
+  /**
    * Gets (makes or finds in a cache) an author token, associated with the
    * indicated author ID. This throws an error if it is not possible to make
    * such a token.

--- a/local-modules/@bayou/typecheck/TObject.js
+++ b/local-modules/@bayou/typecheck/TObject.js
@@ -65,6 +65,21 @@ export class TObject extends UtilityClass {
   }
 
   /**
+   * Checks that a value is a plain object (in the sense of {@link #plain}) or
+   * is `null`.
+   *
+   * @param {*} value Value to check.
+   * @returns {object} `value`.
+   */
+  static plainOrNull(value) {
+    if ((value === null) || ObjectUtil.isPlain(value)) {
+      return value;
+    }
+
+    throw Errors.badValue(value, 'plain object|null');
+  }
+
+  /**
    * Checks a value of type `Object`, which must be a plain object with exactly
    * the indicated set of keys as "own" properties.
    *

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -109,10 +109,11 @@ describe('@bayou/typecheck/TObject', () => {
     });
   });
 
-  describe('plain()', () => {
+  // Common tests for `plain()` and `plainOrNull()`.
+  function plainishTests(plainish) {
     it('accepts plain objects', () => {
       function test(value) {
-        assert.strictEqual(TObject.plain(value), value);
+        assert.strictEqual(plainish(value), value);
       }
 
       test({});
@@ -122,7 +123,7 @@ describe('@bayou/typecheck/TObject', () => {
 
     it('rejects non-plain objects', () => {
       function test(value) {
-        assert.throws(() => { TObject.plain(value); });
+        assert.throws(() => { plainish(value); });
       }
 
       test([]);
@@ -134,17 +135,32 @@ describe('@bayou/typecheck/TObject', () => {
       test({ [Symbol('blort')]: [1, 2, 3] });
     });
 
-    it('rejects non-objects', () => {
+    it('rejects non-objects (other than `null`)', () => {
       function test(value) {
-        assert.throws(() => { TObject.plain(value); });
+        assert.throws(() => { plainish(value); });
       }
 
-      test(null);
       test(undefined);
       test(false);
       test(true);
       test('x');
       test(37);
+    });
+  }
+
+  describe('plain()', () => {
+    plainishTests(x => TObject.plain(x));
+
+    it('rejects `null`', () => {
+      assert.throws(() => { TObject.plain(null); });
+    });
+  });
+
+  describe('plainOrNull()', () => {
+    plainishTests(x => TObject.plainOrNull(x));
+
+    it('accepts `null`', () => {
+      assert.isNull(TObject.plainOrNull(null));
     });
   });
 


### PR DESCRIPTION
This PR expands `config-server.Auth` so that it has affordances for tokens that require cookie-based auth. This PR sets up the infrastructure but doesn't actually implement any real logic around actual cookie auth.
