### PR TITLE
Log cookies, and make sure they're parsed.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -280,8 +280,8 @@ export class Application extends CommonBase {
 
     wsServer.on('headers', (headers, req) => {
       // The `ws` handler takes control before any of the middleware gets a
-      // chance to run, so we have to "manually" do cookie parsing and logging
-      // here.
+      // chance to run, so we have to "manually" do cookie parsing and request
+      // logging here.
       if (req.headers.cookie) {
         req.cookies = cookie.parse(req.headers.cookie);
       }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import http from 'http';
@@ -278,6 +279,13 @@ export class Application extends CommonBase {
     });
 
     wsServer.on('headers', (headers, req) => {
+      // The `ws` handler takes control before any of the middleware gets a
+      // chance to run, so we have to "manually" do cookie parsing and logging
+      // here.
+      if (req.headers.cookie) {
+        req.cookies = cookie.parse(req.headers.cookie);
+      }
+
       this._requestLogger.logWebsocketRequest(req, headers);
     });
   }

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -5,7 +5,7 @@
 import { fromPairs } from 'lodash';
 import { URL } from 'url';
 
-import { Logger } from '@bayou/see-all';
+import { Logger, RedactUtil } from '@bayou/see-all';
 import { CommonBase, Random } from '@bayou/util-common';
 
 /**
@@ -124,5 +124,11 @@ export class RequestLogger extends CommonBase {
 
     this._log.event[baseEvent](id, url.pathname, details);
     this._log.event[`${baseEvent}Headers`](id, req.headers);
+
+    const cookies = req.cookies;
+    if (cookies && (Object.keys(cookies).length !== 0)) {
+      const cookieLog = RedactUtil.redactValues(cookies, 2);
+      this._log.event[`${baseEvent}Cookies`](id, cookieLog);
+    }
   }
 }

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -49,18 +49,7 @@ export class RequestLogger extends CommonBase {
   logWebsocketRequest(req, responseHeaderLines) {
     const id = Random.shortLabel('req');
 
-    // Second arg (base URL) is needed because `req.url` doesn't come with a
-    // protocol or host.
-    const url     = new URL(req.url, 'http://x.x');
-
-    const details = {
-      ip:     req.socket.remoteAddress,
-      method: req.method,
-      query:  fromPairs([...url.searchParams])
-    };
-
-    this._log.event.websocketRequest(id, url.pathname, details);
-    this._log.event.websocketRequestHeaders(id, req.headers);
+    this._logRequest(id, req, 'websocket');
 
     // Turn the response array into a status code and an object that matches the
     // form of the usual `headers` on an HTTP response object.
@@ -90,17 +79,7 @@ export class RequestLogger extends CommonBase {
   _logExpressRequest(req, res, next) {
     const id = Random.shortLabel('req');
 
-    // **Note:** This doesn't include `url` or `headers`, as those end up in the
-    // top level of the logged event because they are so handy and deserve
-    // prominent placement.
-    const details = {
-      ip:       req.ip,
-      method:   req.method,
-      query:    req.query
-    };
-
-    this._log.event.httpRequest(id, req.originalUrl, details);
-    this._log.event.httpRequestHeaders(id, req.headers);
+    this._logRequest(id, req, 'http');
 
     res.on('finish', () => {
       // Make the headers a plain object, so it gets logged in a clean
@@ -110,5 +89,40 @@ export class RequestLogger extends CommonBase {
     });
 
     next();
+  }
+
+  /**
+   * Helper for both regular and websocket loggers, which does the main request
+   * logging.
+   *
+   * @param {string} id The request ID.
+   * @param {object} req The HTTP request.
+   * @param {string} prefix The prefix for the event names.
+   */
+  _logRequest(id, req, prefix) {
+    const ip     = req.socket.remoteAddress;
+    const method = req.method;
+
+    // If this is a normal HTTP request, we'll have a good value for
+    // `originalUrl` but a possibly-altered `url` (because of routing). And for
+    // a websocket request, we'll end up with `originalUrl === undefined` and an
+    // unmodified `url`. In either case the URL value is missing both protocol
+    // and host. So, we "fluff out" the URL with valid throwaway bits, and just
+    // end up extracting the (non-throwaway) parts we want to log.
+    const url = new URL(req.originalUrl || req.url, 'http://x.x');
+
+    // Similarly, `query` will be set up with a normal HTTP request, but not
+    // for a websocket request, in which case we extract it out of `url`.
+    const query = req.query || fromPairs([...url.searchParams]);
+
+    // **Note:** This doesn't include `url` or `headers`, as those are prominent
+    // enough to deserve special treatment (separate argument and separate
+    // event, respectively).
+    const details = { ip, method, query };
+
+    const baseEvent = `${prefix}Request`;
+
+    this._log.event[baseEvent](id, url.pathname, details);
+    this._log.event[`${baseEvent}Headers`](id, req.headers);
   }
 }

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -59,7 +59,8 @@ export class RequestLogger extends CommonBase {
       query:  fromPairs([...url.searchParams])
     };
 
-    this._log.event.websocketRequest(id, url.pathname, details, req.headers);
+    this._log.event.websocketRequest(id, url.pathname, details);
+    this._log.event.websocketRequestHeaders(id, req.headers);
 
     // Turn the response array into a status code and an object that matches the
     // form of the usual `headers` on an HTTP response object.
@@ -98,7 +99,8 @@ export class RequestLogger extends CommonBase {
       query:    req.query
     };
 
-    this._log.event.httpRequest(id, req.originalUrl, details, req.headers);
+    this._log.event.httpRequest(id, req.originalUrl, details);
+    this._log.event.httpRequestHeaders(id, req.headers);
 
     res.on('finish', () => {
       // Make the headers a plain object, so it gets logged in a clean

--- a/local-modules/@bayou/deps-express/package.json
+++ b/local-modules/@bayou/deps-express/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "cookie": "^0.3.1",
     "cookie-parser": "^1.4.4",
     "express": "^4.16.0",
     "ws": "^5.2.0"


### PR DESCRIPTION
This PR reworks the HTTP request logging a bit, including especially adding logging of parsed cookies. And this logging revealed a problem, in that cookies that came with a websocket request wouldn't actually get parsed. (This happened because the websocket connection establishment code path "usurps" request handling from `express`, so basically no middleware runs, including cookie parsing.) So, this PR also fixes that by "manually" performing cookie parsing at the right spot during the websocket dance.

**Note:** What's getting logged for cookies is a redacted form that only includes the cookie names and the lengths of the strings. No actual cookie contents get logged.