### PR TITLE
Hook up one more layer of cookieness.

### DIFF
--- a/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
@@ -92,8 +92,7 @@ export class BaseTokenAuthorizer extends CommonBase {
     if (cookies === null) {
       cookies = {};
     } else {
-      // **TODO:** Ensure string values.
-      TObject.plain(cookies);
+      TObject.plain(cookies, x => TString.check(x));
     }
 
     const result = await this._impl_getAuthorizedTarget(token, cookies);

--- a/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
@@ -74,14 +74,14 @@ export class BaseTokenAuthorizer extends CommonBase {
    *   exposes the so-authorized functionality, or `null` if no authority is
    *   granted.
    */
-  async targetFromToken(token) {
+  async getAuthorizedTarget(token) {
     if (typeof token === 'string') {
       token = this.tokenFromString(token);
     } else {
       BearerToken.check(token);
     }
 
-    const result = await this._impl_targetFromToken(token);
+    const result = await this._impl_getAuthorizedTarget(token);
 
     return TObject.orNull(result);
   }
@@ -132,6 +132,21 @@ export class BaseTokenAuthorizer extends CommonBase {
   }
 
   /**
+   * Subclass-specific implementation of {@link #getAuthorizedTarget}.
+   * Subclasses must override this method.
+   *
+   * @abstract
+   * @param {BearerToken} token Token to look up. Guaranteed to be a valid
+   *   {@link BearerToken} instance.
+   * @returns {object|null} If `token` grants any authority, an object which
+   *   exposes the so-authorized functionality, or `null` if no authority is
+   *   granted.
+   */
+  async _impl_getAuthorizedTarget(token) {
+    return this._mustOverride(token);
+  }
+
+  /**
    * Subclass-specific implementation of {@link #isToken}. Subclasses must
    * override this method.
    *
@@ -141,21 +156,6 @@ export class BaseTokenAuthorizer extends CommonBase {
    */
   _impl_isToken(tokenString) {
     return this._mustOverride(tokenString);
-  }
-
-  /**
-   * Subclass-specific implementation of {@link #targetFromToken}. Subclasses
-   * must override this method.
-   *
-   * @abstract
-   * @param {BearerToken} token Token to look up. Guaranteed to be a valid
-   *   {@link BearerToken} instance.
-   * @returns {object|null} If `token` grants any authority, an object which
-   *   exposes the so-authorized functionality, or `null` if no authority is
-   *   granted.
-   */
-  async _impl_targetFromToken(token) {
-    return this._mustOverride(token);
   }
 
   /**

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -136,7 +136,9 @@ export class Context extends CommonBase {
       // Determine its authorized target, and if authorized cache it in this
       // instance's target map.
 
-      const targetObject = await tokenAuth.getAuthorizedTarget(token);
+      // **TODO:** `null` below should actually be an object with all the right
+      // cookies, if any.
+      const targetObject = await tokenAuth.getAuthorizedTarget(token, null);
 
       if (targetObject === null) {
         // The `tokenAuth` told us that `token` didn't actually grant any

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -136,7 +136,7 @@ export class Context extends CommonBase {
       // Determine its authorized target, and if authorized cache it in this
       // instance's target map.
 
-      const targetObject = await tokenAuth.targetFromToken(token);
+      const targetObject = await tokenAuth.getAuthorizedTarget(token);
 
       if (targetObject === null) {
         // The `tokenAuth` told us that `token` didn't actually grant any

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -151,9 +151,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
       await test('not-an-object');
       await test(['not', 'a', 'plain', 'object']);
       await test(new Map());
-
-      // **TODO:** Check values!
-      //await test({ nonString: ['value'] });
+      await test({ nonString: ['value'] });
     });
 
     it('accepts `null` from the `_impl`', async () => {

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -31,6 +31,41 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
     });
   });
 
+  describe('cookieNamesForToken()', () => {
+    it('calls through to the `_impl` given a `BearerToken`', async () => {
+      class Authie extends BaseTokenAuthorizer {
+        async _impl_cookieNamesForToken(value) {
+          return [value.secretToken, 'florp'];
+        }
+      }
+
+      const au     = new Authie();
+      const token  = new BearerToken('x', 'xyzpdq');
+      const result = await au.cookieNamesForToken(token);
+
+      assert.deepEqual(result, [token.secretToken, 'florp']);
+    });
+
+    it('rejects a non-`BearerToken` argument', async () => {
+      class Authie extends BaseTokenAuthorizer {
+        async _impl_cookieNamesForToken(value_unused) {
+          throw new Error('unexpected');
+        }
+      }
+
+      const au = new Authie();
+
+      async function test(v) {
+        await assert.isRejected(au.cookieNamesForToken(v), /badValue/);
+      }
+
+      await test(undefined);
+      await test(null);
+      await test('florp');
+      await test([1, 2, 3]);
+    });
+  });
+
   describe('isToken()', () => {
     it('calls through to the `_impl` given a string', () => {
       class Authie extends BaseTokenAuthorizer {

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -22,6 +22,10 @@ class MockAuth extends BaseTokenAuthorizer {
     return true;
   }
 
+  async _impl_cookieNamesForToken(value_unused) {
+    return [];
+  }
+
   async _impl_targetFromToken(token_unused) {
     return { some: 'authority' };
   }

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -22,7 +22,7 @@ class MockAuth extends BaseTokenAuthorizer {
     return [];
   }
 
-  async _impl_getAuthorizedTarget(token_unused) {
+  async _impl_getAuthorizedTarget(token_unused, cookies_unused) {
     return { some: 'authority' };
   }
 

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -18,16 +18,16 @@ class MockAuth extends BaseTokenAuthorizer {
     return 'nontoken-';
   }
 
-  _impl_isToken(tokenString_unused) {
-    return true;
-  }
-
   async _impl_cookieNamesForToken(value_unused) {
     return [];
   }
 
-  async _impl_targetFromToken(token_unused) {
+  async _impl_getAuthorizedTarget(token_unused) {
     return { some: 'authority' };
+  }
+
+  _impl_isToken(tokenString_unused) {
+    return true;
   }
 
   _impl_tokenFromString(tokenString) {

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -47,21 +47,12 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
 
   /**
    * @override
-   * @param {string} tokenString The alleged token string.
-   * @returns {boolean} `true` iff `tokenString` has valid token syntax.
-   */
-  _impl_isToken(tokenString) {
-    return Auth.isToken(tokenString);
-  }
-
-  /**
-   * @override
    * @param {BearerToken} token Token to look up.
    * @returns {object|null} If `token` grants any authority, an object which
    *   exposes the so-authorized functionality, or `null` if no authority is
    *   granted.
    */
-  async _impl_targetFromToken(token) {
+  async _impl_getAuthorizedTarget(token) {
     // **TODO:** `null` below should actually be an object with all the right
     // cookies, if any.
     const authority = await Auth.getAuthority(token, null);
@@ -81,6 +72,15 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
         return null;
       }
     }
+  }
+
+  /**
+   * @override
+   * @param {string} tokenString The alleged token string.
+   * @returns {boolean} `true` iff `tokenString` has valid token syntax.
+   */
+  _impl_isToken(tokenString) {
+    return Auth.isToken(tokenString);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -48,14 +48,13 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
   /**
    * @override
    * @param {BearerToken} token Token to look up.
+   * @param {object} cookies The cookies needed in order to authorize `token`.
    * @returns {object|null} If `token` grants any authority, an object which
    *   exposes the so-authorized functionality, or `null` if no authority is
    *   granted.
    */
-  async _impl_getAuthorizedTarget(token) {
-    // **TODO:** `null` below should actually be an object with all the right
-    // cookies, if any.
-    const authority = await Auth.getAuthority(token, null);
+  async _impl_getAuthorizedTarget(token, cookies) {
+    const authority = await Auth.getAuthority(token, cookies);
 
     switch (authority.type) {
       case Auth.TYPE_root: {

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -64,7 +64,7 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
   async _impl_targetFromToken(token) {
     // **TODO:** `null` below should actually be an object with all the right
     // cookies, if any.
-    const authority = await Auth.tokenAuthority(token, null);
+    const authority = await Auth.getAuthority(token, null);
 
     switch (authority.type) {
       case Auth.TYPE_root: {

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -9,7 +9,8 @@ import { Application } from './Application';
 import { AuthorAccess } from './AuthorAccess';
 
 /**
- * Application-specific implementation of {@link BaseTokenAuthorizer}.
+ * Application-specific implementation of {@link BaseTokenAuthorizer}. Much of
+ * what this class does is hook up to the configured global {@link Auth}.
  */
 export class AppAuthorizer extends BaseTokenAuthorizer {
   /**
@@ -32,6 +33,16 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
    */
   get _impl_nonTokenPrefix() {
     return Auth.nonTokenPrefix;
+  }
+
+  /**
+   * @override
+   * @param {BearerToken} token The token in question.
+   * @returns {array<string>} The names of all the cookies which are needed to
+   *   perform validation / authorization on `token`.
+   */
+  async _impl_cookieNamesForToken(token) {
+    return Auth.cookieNamesForToken(token);
   }
 
   /**

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -79,7 +79,7 @@ export class Auth extends BaseAuth {
    *
    * This implementation succeeds for any valid author ID and always returns a
    * newly-created token. It caches every token token created, such that it can
-   * subsequently be found by {@link #tokenAuthority}.
+   * subsequently be found by {@link #getAuthority}.
    *
    * @param {string} authorId ID for the author.
    * @returns {BearerToken} Token which grants author access.
@@ -98,6 +98,27 @@ export class Auth extends BaseAuth {
   /**
    * Implementation of standard configuration point.
    *
+   * This implementation &mdash; obviously insecurely &mdash; hard-codes a
+   * particular token to have "root" authority. See {@link #THE_ROOT_TOKEN},
+   * above, for more info.
+   *
+   * @param {BearerToken} token The token in question.
+   * @param {object|null} cookies The cookies needed in order to authorize
+   *   `token`, or `null` if no cookies are needed. This value should be based
+   * @returns {object} Representation of the authority granted by `token`.
+   */
+  static async getAuthority(token, cookies) {
+    BearerToken.check(token);
+    TObject.plainOrNull(cookies);
+
+    const found = tokenMint.getInfoOrNull(token);
+
+    return (found === null) ? { type: Auth.TYPE_none } : found;
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
    * This implementation requires strings that have the general form of
    * `<type>-<id>-<secret>`, where `<type>` is four lowercase characters, and
    * the other two parts are each 16 lowercase hexadecimal digits.
@@ -108,27 +129,6 @@ export class Auth extends BaseAuth {
   static isToken(tokenString) {
     TString.check(tokenString);
     return TOKEN_REGEX.test(tokenString);
-  }
-
-  /**
-   * Implementation of standard configuration point.
-   *
-   * This implementation &mdash; obviously insecurely &mdash; hard-codes a
-   * particular token to have "root" authority. See {@link #THE_ROOT_TOKEN},
-   * above, for more info.
-   *
-   * @param {BearerToken} token The token in question.
-   * @param {object|null} cookies The cookies needed in order to authorize
-   *   `token`, or `null` if no cookies are needed. This value should be based
-   * @returns {object} Representation of the authority granted by `token`.
-   */
-  static async tokenAuthority(token, cookies) {
-    BearerToken.check(token);
-    TObject.plainOrNull(cookies);
-
-    const found = tokenMint.getInfoOrNull(token);
-
-    return (found === null) ? { type: Auth.TYPE_none } : found;
   }
 
   /**

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -66,17 +66,6 @@ export class Auth extends BaseAuth {
   }
 
   /**
-   * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
-   * token (whether or not it actually grants any access).
-   *
-   * @param {string} tokenString The alleged token.
-   * @returns {boolean} `true` iff `tokenString` is syntactically valid.
-   */
-  static isToken(tokenString) {
-    return use.Auth.isToken(tokenString);
-  }
-
-  /**
    * Gets the authority / authorization that is granted by the given
    * {@link BearerToken} and (if necessary) associated cookies. The result is a
    * plain object which binds at least `type` to the type of authority. Per
@@ -109,8 +98,19 @@ export class Auth extends BaseAuth {
    * @returns {object} Plain object with bindings as described above,
    *   representing the authority granted by `token`.
    */
-  static async tokenAuthority(token, cookies) {
-    return use.Auth.tokenAuthority(token, cookies);
+  static async getAuthority(token, cookies) {
+    return use.Auth.getAuthority(token, cookies);
+  }
+
+  /**
+   * Returns `true` iff the `tokenString` is _syntactically_ valid as a bearer
+   * token (whether or not it actually grants any access).
+   *
+   * @param {string} tokenString The alleged token.
+   * @returns {boolean} `true` iff `tokenString` is syntactically valid.
+   */
+  static isToken(tokenString) {
+    return use.Auth.isToken(tokenString);
   }
 
   /**

--- a/local-modules/@bayou/config-server/BaseAuth.js
+++ b/local-modules/@bayou/config-server/BaseAuth.js
@@ -11,12 +11,12 @@ import { UtilityClass } from '@bayou/util-common';
  * and the clients of this configuration.
  */
 export class BaseAuth extends UtilityClass {
-  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  /** {string} Constant used by {@link Auth#getAuthority} (see which). */
   static get TYPE_author() { return 'author'; }
 
-  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  /** {string} Constant used by {@link Auth#getAuthority} (see which). */
   static get TYPE_none() { return 'none'; }
 
-  /** {string} Constant used by {@link Auth#tokenAuthority} (see which). */
+  /** {string} Constant used by {@link Auth#getAuthority} (see which). */
   static get TYPE_root() { return 'root'; }
 }

--- a/local-modules/@bayou/typecheck/TArray.js
+++ b/local-modules/@bayou/typecheck/TArray.js
@@ -14,7 +14,7 @@ export class TArray extends UtilityClass {
    * @param {*} value The (alleged) array.
    * @param {function|null} [elementCheck = null] Element type checker. If
    *   passed as non-`null`, must be a function that behaves like a standard
-   *  `<type>.check()` method.
+   *   `<type>.check()` method.
    * @returns {array} `value`.
    */
   static check(value, elementCheck = null) {

--- a/local-modules/@bayou/typecheck/TObject.js
+++ b/local-modules/@bayou/typecheck/TObject.js
@@ -51,32 +51,52 @@ export class TObject extends UtilityClass {
   /**
    * Checks that a value is of type `Object` and is furthermore a plain object,
    * which is to say, not any of an array, a function, or an instance of a class
-   * other than `Object` itself.
+   * other than `Object` itself. Optionally, also check the object's values for
+   * conformance to a given checker.
    *
    * @param {*} value Value to check.
+   * @param {function|null} [valueCheck = null] Value type checker. If passed as
+   *   non-`null`, must be a function that behaves like a standard
+   *   `<type>.check()` method.
    * @returns {object} `value`.
    */
-  static plain(value) {
-    if (ObjectUtil.isPlain(value)) {
-      return value;
+  static plain(value, valueCheck = null) {
+    if (!ObjectUtil.isPlain(value)) {
+      throw Errors.badValue(value, 'plain object');
     }
 
-    throw Errors.badValue(value, 'plain object');
+    if (valueCheck !== null) {
+      TObject._checkValues(value, valueCheck);
+    }
+
+    return value;
   }
 
   /**
    * Checks that a value is a plain object (in the sense of {@link #plain}) or
-   * is `null`.
+   * is `null`. Optionally, also check a non-`null` object's values for
+   * conformance to a given checker.
    *
    * @param {*} value Value to check.
+   * @param {function|null} [valueCheck = null] Value type checker. If passed as
+   *   non-`null`, must be a function that behaves like a standard
+   *   `<type>.check()` method.
    * @returns {object} `value`.
    */
-  static plainOrNull(value) {
-    if ((value === null) || ObjectUtil.isPlain(value)) {
+  static plainOrNull(value, valueCheck = null) {
+    if (value === null) {
       return value;
     }
 
-    throw Errors.badValue(value, 'plain object|null');
+    if (!ObjectUtil.isPlain(value)) {
+      throw Errors.badValue(value, 'plain object|null');
+    }
+
+    if (valueCheck !== null) {
+      TObject._checkValues(value, valueCheck);
+    }
+
+    return value;
   }
 
   /**
@@ -111,5 +131,18 @@ export class TObject extends UtilityClass {
     }
 
     return value;
+  }
+
+  /**
+   * Helper for {@link #plain} and {@link #plainOrNull}, which does value
+   * checking.
+   *
+   * @param {*} obj Object to check.
+   * @param {function} valueCheck Value type checker.
+   */
+  static _checkValues(obj, valueCheck) {
+    for (const v of Object.values(obj)) {
+      valueCheck(v);
+    }
   }
 }

--- a/local-modules/@bayou/typecheck/tests/test_TObject.js
+++ b/local-modules/@bayou/typecheck/tests/test_TObject.js
@@ -118,7 +118,8 @@ describe('@bayou/typecheck/TObject', () => {
 
       test({});
       test({ a: 10 });
-      test({ a: 10, b: 20 });
+      test({ a: 10, b: 'x' });
+      test({ a: 10, b: 'x', c: new Map() });
     });
 
     it('rejects non-plain objects', () => {
@@ -146,10 +147,28 @@ describe('@bayou/typecheck/TObject', () => {
       test('x');
       test(37);
     });
+
+    it('checks values when passed a value checker argument', () => {
+      function checker(v) {
+        if (typeof(v) !== 'string') {
+          throw new Error('nopeNopeNope');
+        }
+
+        return v;
+      }
+
+      const good = { x: 'yes', y: 'also-yes' };
+      assert.strictEqual(plainish(good, checker), good);
+
+      for (const badOne of [123, { not: 'a-string' }, false]) {
+        const bad = { x: 'blort', oops: badOne, florp: 'like' };
+        assert.throws(() => plainish(bad, checker), /nopeNopeNope/);
+      }
+    });
   }
 
   describe('plain()', () => {
-    plainishTests(x => TObject.plain(x));
+    plainishTests((v, c) => TObject.plain(v, c));
 
     it('rejects `null`', () => {
       assert.throws(() => { TObject.plain(null); });
@@ -157,7 +176,7 @@ describe('@bayou/typecheck/TObject', () => {
   });
 
   describe('plainOrNull()', () => {
-    plainishTests(x => TObject.plainOrNull(x));
+    plainishTests((v, c) => TObject.plainOrNull(v, c));
 
     it('accepts `null`', () => {
       assert.isNull(TObject.plainOrNull(null));


### PR DESCRIPTION
This PR gets one more layer of the system able to handle the possibility that some tokens require cookies. A lot of this is just changes to `BaseTokenAuthorizer` that are very similar to what was recently done to the `Auth` configuration. I also went ahead and did a modicum of method renaming, to make things more consistent and indicative of intention.

As with earlier PRs, this one still doesn't actually do anything with cookies. There's at least one more PR in this area of the code before we could see cookies actually used.