### PR TITLE
Provide `Context` access to its connection.

### DIFF
--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -49,9 +49,6 @@ export class BaseConnection extends CommonBase {
      */
     this._log = log.withAddedContext(this._connectionId);
 
-    /** {Context} The binding context to provide access to. */
-    this._context = ContextInfo.check(contextInfo).makeContext(this._log);
-
     /** {ApiLog} The API logger to use. */
     this._apiLog = new ApiLog(this._log, Logging.shouldRedact());
 
@@ -63,6 +60,9 @@ export class BaseConnection extends CommonBase {
      * closed.
      */
     this._closedCondition = new Condition();
+
+    /** {Context} The binding context to provide access to. */
+    this._context = ContextInfo.check(contextInfo).makeContext(this);
 
     // Add a `meta` binding to the initial set of targets, which is specific to
     // this instance/connection.

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -115,19 +115,6 @@ export class BaseConnection extends CommonBase {
   }
 
   /**
-   * Encodes a message suitable for sending to the other side of this
-   * connection.
-   *
-   * @param {Message} message Message to encode.
-   * @returns {string} Encoded form of `message`.
-   */
-  encodeMessage(message) {
-    Message.check(message);
-
-    return this._context.encodeJson(message);
-  }
-
-  /**
    * Gets the value for the indicated HTTP-ish cookie. This returns `null` if
    * there is no such cookie, including if this kind of connection doesn't
    * actually have cookies at all.

--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -10,7 +10,7 @@ import { TBoolean, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
 import { ApiLog } from './ApiLog';
-import { ContextInfo } from './ContextInfo';
+import { Context } from './Context';
 import { MetaHandler } from './MetaHandler';
 import { ProxiedObject } from './ProxiedObject';
 import { Target } from './Target';
@@ -62,7 +62,7 @@ export class BaseConnection extends CommonBase {
     this._closedCondition = new Condition();
 
     /** {Context} The binding context to provide access to. */
-    this._context = ContextInfo.check(contextInfo).makeContext(this);
+    this._context = new Context(contextInfo, this);
 
     // Add a `meta` binding to the initial set of targets, which is specific to
     // this instance/connection.

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -227,7 +227,7 @@ export class Context extends CommonBase {
     const target   = new Target(targetId, obj);
     const remote   = this.addTarget(target);
 
-    this._log.event.newRemote(targetId, obj);
+    this.log.event.newRemote(targetId, obj);
 
     return remote;
   }

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -103,6 +103,28 @@ export class Context extends CommonBase {
   }
 
   /**
+   * Decodes an object from JSON representation, using this instance's
+   * associated {@link Codec}.
+   *
+   * @param {string} encoded Encoded value.
+   * @returns {*} Decoded value.
+   */
+  decodeJson(encoded) {
+    return this.codec.decodeJson(encoded);
+  }
+
+  /**
+   * Encodes an object into JSON representation, using this instance's
+   * associated {@link Codec}.
+   *
+   * @param {*} value Value to encode.
+   * @returns {string} JSON-encoded form.
+   */
+  encodeJson(value) {
+    return this.codec.encodeJson(value);
+  }
+
+  /**
    * Gets an authorized target. This will find targets that were previously
    * added via {@link #addTarget} as well as those authorized by virtue of this
    * method being passed a valid authority-bearing token (in string form).

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -3,30 +3,29 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Message, Remote } from '@bayou/api-common';
-import { BaseLogger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
+import { BaseConnection } from './BaseConnection';
 import { ContextInfo } from './ContextInfo';
 import { ProxiedObject } from './ProxiedObject';
 import { Target } from './Target';
 
 /**
- * Binding context for an API server or session therein. Instances of this class
- * are used to map from IDs to `Target` instances, including targets which are
- * ephemerally bound to the session as well as ones that are authorized via
- * bearer tokens. In addition, this class is used to hold the knowledge of which
- * {@link Codec} to use for a session.
+ * Binding context for an API server or session therein, with linkage back to
+ * a {@link BaseConnection}. Instances of this class are used to map from IDs to
+ * `Target` instances, including targets which are ephemerally bound to the
+ * session as well as ones that are authorized via bearer tokens.
  */
 export class Context extends CommonBase {
   /**
-   * Constructs an instance which is initially empty.
+   * Constructs an instance which is initially empty (has no bound targets).
    *
    * @param {ContextInfo} info The typically-fixed parameters used to construct
    *   instances.
-   * @param {BaseLogger} log Logger to use for this instance.
+   * @param {BaseConnection} connection The connection to be associated with.
    */
-  constructor(info, log) {
+  constructor(info, connection) {
     super();
 
     /**
@@ -35,8 +34,8 @@ export class Context extends CommonBase {
      */
     this._info = ContextInfo.check(info);
 
-    /** {BaseLogger} Logger for this instance. */
-    this._log = BaseLogger.check(log);
+    /** {BaseConnection} The connection this instance is associated with. */
+    this._connection = BaseConnection.check(connection);
 
     /** {Map<string, Target>} The underlying map from IDs to targets. */
     this._map = new Map();
@@ -58,7 +57,7 @@ export class Context extends CommonBase {
 
   /** {Logger} The logger used by this instance. */
   get log() {
-    return this._log;
+    return this._connection.log;
   }
 
   /** {BaseTokenAuthorizer|null} The token authorizer to use. */

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -24,6 +24,8 @@ export class Context extends CommonBase {
    * @param {ContextInfo} info The typically-fixed parameters used to construct
    *   instances.
    * @param {BaseConnection} connection The connection to be associated with.
+   *   This is used for a couple of things, including accessing (HTTP-ish)
+   *   headers / cookies, as well as logging.
    */
   constructor(info, connection) {
     super();

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Remote } from '@bayou/api-common';
+import { Message, Remote } from '@bayou/api-common';
 import { BaseLogger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
@@ -122,6 +122,19 @@ export class Context extends CommonBase {
    */
   encodeJson(value) {
     return this.codec.encodeJson(value);
+  }
+
+  /**
+   * Encodes a {@link Message} suitable for sending to the other side of the
+   * connection that this instance is used for.
+   *
+   * @param {Message} message Message to encode.
+   * @returns {string} JSON-encoded form of `message`.
+   */
+  encodeMessage(message) {
+    Message.check(message);
+
+    return this.encodeJson(message);
   }
 
   /**

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -47,17 +47,4 @@ export class ContextInfo extends CommonBase {
   get tokenAuthorizer() {
     return this._tokenAuthorizer;
   }
-
-  /**
-   * Makes a new instance of {@link Context} hooked up to the given
-   * {@link BaseConnection}, and with this instance as its `info`.
-   *
-   * @param {BaseConnection} connection The connection to be associated with.
-   * @returns {Context} An appropriately-constructed instance.
-   */
-  makeContext(connection) {
-    BaseConnection.check(connection);
-
-    return new Context(this, connection);
-  }
 }

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -5,6 +5,7 @@
 import { Codec } from '@bayou/codec';
 import { CommonBase } from '@bayou/util-common';
 
+import { BaseConnection } from './BaseConnection';
 import { BaseTokenAuthorizer } from './BaseTokenAuthorizer';
 import { Context } from './Context';
 
@@ -48,13 +49,16 @@ export class ContextInfo extends CommonBase {
   }
 
   /**
-   * Makes a new instance of {@link Context}, with this instance as the `info`
-   * and with the given logger.
+   * Makes a new instance of {@link Context} hooked up to the given
+   * {@link BaseConnection}, and with this instance as its `info`.
    *
-   * @param {BaseLogger} log The logger to use.
+   * @param {BaseConnection} connection The connection to be associated with.
    * @returns {Context} An appropriately-constructed instance.
    */
-  makeContext(log) {
-    return new Context(this, log);
+  makeContext(connection) {
+    BaseConnection.check(connection);
+
+    // **TODO:** `Context` should take a connection and not a logger.
+    return new Context(this, connection.log);
   }
 }

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -58,7 +58,6 @@ export class ContextInfo extends CommonBase {
   makeContext(connection) {
     BaseConnection.check(connection);
 
-    // **TODO:** `Context` should take a connection and not a logger.
-    return new Context(this, connection.log);
+    return new Context(this, connection);
   }
 }

--- a/local-modules/@bayou/api-server/ContextInfo.js
+++ b/local-modules/@bayou/api-server/ContextInfo.js
@@ -5,9 +5,7 @@
 import { Codec } from '@bayou/codec';
 import { CommonBase } from '@bayou/util-common';
 
-import { BaseConnection } from './BaseConnection';
 import { BaseTokenAuthorizer } from './BaseTokenAuthorizer';
-import { Context } from './Context';
 
 /**
  * All the info needed to construct instances of {@link Context}, except for

--- a/local-modules/@bayou/api-server/WsConnection.js
+++ b/local-modules/@bayou/api-server/WsConnection.js
@@ -78,7 +78,7 @@ export class WsConnection extends HttpConnection {
       // Send a message to the client telling them what's up. If they're nice,
       // they'll handle it promptly instead of, say, continuing to try to send
       // messages.
-      this._ws.send(this.encodeMessage(new Message(0, 'meta', new Functor('close'))));
+      this._ws.send(this.context.encodeMessage(new Message(0, 'meta', new Functor('close'))));
     } catch (e) {
       // Ignore exceptions. It's probably that the websocket is already closed
       // (common case when we end up here from the client proactively closing),

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -6,9 +6,8 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { BearerToken, Codecs, Message, Remote } from '@bayou/api-common';
-import { BaseTokenAuthorizer, Context, ContextInfo, ProxiedObject } from '@bayou/api-server';
+import { BaseConnection, BaseTokenAuthorizer, Context, ContextInfo, ProxiedObject } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
-import { Logger } from '@bayou/see-all';
 import { Functor } from '@bayou/util-common';
 
 /**
@@ -40,7 +39,8 @@ describe('@bayou/api-server/Context', () => {
   describe('constructor()', () => {
     it('accepts valid arguments and produces a frozen instance', () => {
       const info   = new ContextInfo(new Codec(), new MockAuth());
-      const result = new Context(info, new Logger('some-tag'));
+      const conn   = new BaseConnection(info);
+      const result = new Context(info, conn);
 
       assert.isFrozen(result);
     });
@@ -49,26 +49,28 @@ describe('@bayou/api-server/Context', () => {
   describe('.codec', () => {
     it('is the `codec` from the `info` passed in on construction', () => {
       const info = new ContextInfo(new Codec(), new MockAuth());
-      const ctx  = new Context(info, new Logger('some-tag'));
+      const conn = new BaseConnection(info);
+      const ctx  = new Context(info, conn);
 
       assert.strictEqual(ctx.codec, info.codec);
     });
   });
 
   describe('.log', () => {
-    it('is the `log` passed in on construction', () => {
+    it('is the `log` of the connection passed in on construction', () => {
       const info = new ContextInfo(new Codec(), new MockAuth());
-      const log  = new Logger('yowzers');
-      const ctx  = new Context(info, log);
+      const conn = new BaseConnection(info);
+      const ctx  = new Context(info, conn);
 
-      assert.strictEqual(ctx.log, log);
+      assert.strictEqual(ctx.log, conn.log);
     });
   });
 
   describe('.tokenAuthorizer', () => {
     it('is the `tokenAuthorizer` from the `info` passed in on construction', () => {
       const info = new ContextInfo(new Codec(), new MockAuth());
-      const ctx  = new Context(info, new Logger('some-tag'));
+      const conn = new BaseConnection(info);
+      const ctx  = new Context(info, conn);
 
       assert.strictEqual(ctx.tokenAuthorizer, info.tokenAuthorizer);
     });
@@ -87,7 +89,8 @@ describe('@bayou/api-server/Context', () => {
 
       const codec   = new TestCodec();
       const info    = new ContextInfo(codec);
-      const ctx     = new Context(info, new Logger('some-tag'));
+      const conn    = new BaseConnection(info);
+      const ctx     = new Context(info, conn);
       const value   = ['what', 'is', 'the', 'meaning', 'of', 42];
       const encoded = codec.encodeJson(value);
       const got     = ctx.decodeJson(encoded);
@@ -110,7 +113,8 @@ describe('@bayou/api-server/Context', () => {
 
       const codec   = new TestCodec();
       const info    = new ContextInfo(codec);
-      const ctx     = new Context(info, new Logger('some-tag'));
+      const conn    = new BaseConnection(info);
+      const ctx     = new Context(info, conn);
       const value   = { hello: 'there', what: 'is happening?' };
       const encoded = codec.encodeJson(value);
       const got     = ctx.encodeJson(value);
@@ -135,7 +139,8 @@ describe('@bayou/api-server/Context', () => {
       Codecs.registerCodecs(codec.registry);
 
       const info    = new ContextInfo(codec);
-      const ctx     = new Context(info, new Logger('some-tag'));
+      const conn    = new BaseConnection(info);
+      const ctx     = new Context(info, conn);
       const value   = new Message(1, 'florp', new Functor('xyz', 'pdq'));
       const encoded = codec.encodeJson(value);
       const got     = ctx.encodeMessage(value);
@@ -149,7 +154,8 @@ describe('@bayou/api-server/Context', () => {
       Codecs.registerCodecs(codec.registry);
 
       const info = new ContextInfo(codec);
-      const ctx  = new Context(info, new Logger('some-tag'));
+      const conn = new BaseConnection(info);
+      const ctx  = new Context(info, conn);
 
       function test(v) {
         assert.throws(() => ctx.encodeMessage(v), /badValue/);
@@ -166,7 +172,8 @@ describe('@bayou/api-server/Context', () => {
   describe('getRemoteFor()', () => {
     it('returns a `Remote` given a `ProxiedObject`', () => {
       const info   = new ContextInfo(new Codec());
-      const ctx    = new Context(info, new Logger('some-tag'));
+      const conn   = new BaseConnection(info);
+      const ctx    = new Context(info, conn);
       const obj    = { some: 'object' };
       const po     = new ProxiedObject(obj);
       const result = ctx.getRemoteFor(po);
@@ -176,7 +183,8 @@ describe('@bayou/api-server/Context', () => {
 
     it('returns a `Remote` whose `id` maps back to the underlying object', async () => {
       const info   = new ContextInfo(new Codec());
-      const ctx    = new Context(info, new Logger('some-tag'));
+      const conn   = new BaseConnection(info);
+      const ctx    = new Context(info, conn);
       const obj    = { some: 'object' };
       const po     = new ProxiedObject(obj);
       const result = ctx.getRemoteFor(po);
@@ -190,7 +198,8 @@ describe('@bayou/api-server/Context', () => {
 
     it('returns the same `Remote` when given the same `ProxiedObject`', () => {
       const info    = new ContextInfo(new Codec());
-      const ctx     = new Context(info, new Logger('some-tag'));
+      const conn    = new BaseConnection(info);
+      const ctx     = new Context(info, conn);
       const obj     = { some: 'object' };
       const po      = new ProxiedObject(obj);
       const result1 = ctx.getRemoteFor(po);
@@ -201,7 +210,8 @@ describe('@bayou/api-server/Context', () => {
 
     it('returns the same `Remote` when given two `ProxiedObject`s for the same underlying object', () => {
       const info    = new ContextInfo(new Codec());
-      const ctx     = new Context(info, new Logger('some-tag'));
+      const conn    = new BaseConnection(info);
+      const ctx     = new Context(info, conn);
       const obj     = { some: 'object' };
       const result1 = ctx.getRemoteFor(new ProxiedObject(obj));
       const result2 = ctx.getRemoteFor(new ProxiedObject(obj));

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -73,7 +73,53 @@ describe('@bayou/api-server/Context', () => {
     });
   });
 
-  describe('getRemoteFor', () => {
+  describe('decodeJson()', () => {
+    it('calls through to the codec', () => {
+      let gotJson = null;
+
+      class TestCodec extends Codec {
+        decodeJson(encoded) {
+          gotJson = encoded;
+          return super.decodeJson(encoded);
+        }
+      }
+
+      const codec   = new TestCodec();
+      const info    = new ContextInfo(codec);
+      const ctx     = new Context(info, new Logger('some-tag'));
+      const value   = ['what', 'is', 'the', 'meaning', 'of', 42];
+      const encoded = codec.encodeJson(value);
+      const got     = ctx.decodeJson(encoded);
+
+      assert.strictEqual(gotJson, encoded);
+      assert.deepEqual(got, value);
+    });
+  });
+
+  describe('encodeJson()', () => {
+    it('calls through to the codec', () => {
+      let gotValue = null;
+
+      class TestCodec extends Codec {
+        encodeJson(value) {
+          gotValue = value;
+          return super.encodeJson(value);
+        }
+      }
+
+      const codec   = new TestCodec();
+      const info    = new ContextInfo(codec);
+      const ctx     = new Context(info, new Logger('some-tag'));
+      const value   = { hello: 'there', what: 'is happening?' };
+      const encoded = codec.encodeJson(value);
+      const got     = ctx.encodeJson(value);
+
+      assert.strictEqual(gotValue, value);
+      assert.strictEqual(got, encoded);
+    });
+  });
+
+  describe('getRemoteFor()', () => {
     it('returns a `Remote` given a `ProxiedObject`', () => {
       const info   = new ContextInfo(new Codec());
       const ctx    = new Context(info, new Logger('some-tag'));

--- a/local-modules/@bayou/api-server/tests/test_ContextInfo.js
+++ b/local-modules/@bayou/api-server/tests/test_ContextInfo.js
@@ -55,18 +55,4 @@ describe('@bayou/api-server/ContextInfo', () => {
       assert.isNull(ci.tokenAuthorizer);
     });
   });
-
-  describe('makeContext()', () => {
-    it('makes an instance of `Context` with this instance as the `info` attached to the given connection', () => {
-      const ci     = new ContextInfo(new Codec(), new BaseTokenAuthorizer());
-      const conn   = new BaseConnection(ci);
-      const result = ci.makeContext(conn);
-
-      assert.instanceOf(result, Context);
-      assert.strictEqual(result.codec, ci.codec);
-      assert.strictEqual(result.tokenAuthorizer, ci.tokenAuthorizer);
-
-      assert.strictEqual(result.log, conn.log);
-    });
-  });
 });

--- a/local-modules/@bayou/api-server/tests/test_ContextInfo.js
+++ b/local-modules/@bayou/api-server/tests/test_ContextInfo.js
@@ -5,9 +5,8 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BaseTokenAuthorizer, Context, ContextInfo } from '@bayou/api-server';
+import { BaseConnection, BaseTokenAuthorizer, Context, ContextInfo } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
-import { Logger } from '@bayou/see-all';
 
 describe('@bayou/api-server/ContextInfo', () => {
   describe('constructor()', () => {
@@ -58,16 +57,16 @@ describe('@bayou/api-server/ContextInfo', () => {
   });
 
   describe('makeContext()', () => {
-    it('makes an instance of `Context` with this instance as the `info` and with the given logger', () => {
+    it('makes an instance of `Context` with this instance as the `info` attached to the given connection', () => {
       const ci     = new ContextInfo(new Codec(), new BaseTokenAuthorizer());
-      const log    = new Logger('florp');
-      const result = ci.makeContext(log);
+      const conn   = new BaseConnection(ci);
+      const result = ci.makeContext(conn);
 
       assert.instanceOf(result, Context);
       assert.strictEqual(result.codec, ci.codec);
       assert.strictEqual(result.tokenAuthorizer, ci.tokenAuthorizer);
 
-      assert.strictEqual(result.log, log);
+      assert.strictEqual(result.log, conn.log);
     });
   });
 });

--- a/local-modules/@bayou/api-server/tests/test_ContextInfo.js
+++ b/local-modules/@bayou/api-server/tests/test_ContextInfo.js
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BaseConnection, BaseTokenAuthorizer, Context, ContextInfo } from '@bayou/api-server';
+import { BaseTokenAuthorizer, ContextInfo } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
 
 describe('@bayou/api-server/ContextInfo', () => {


### PR DESCRIPTION
This PR makes it so that `Context` has direct access to the `BaseConnection` instance which spawned it. This is done so that the former is in a position to make use of the cookies from the latter.
