### PR TITLE
Make `Context` somewhat cookie-aware.

### DIFF
--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -160,6 +160,8 @@ export class Context extends CommonBase {
         // We've seen this token ID previously in this context / session.
         if (token.sameToken(already.token)) {
           // The corresponding secrets match. All's well!
+          // **TODO:** If there are cookie requirements, they still need to be
+          // checked here.
           return already;
         } else {
           // The secrets don't match. This will happen, for example, when a

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -193,17 +193,7 @@ export class Context extends CommonBase {
     // It's not a bearer token (or this instance doesn't deal with bearer tokens
     // at all). The ID can only validly refer to an uncontrolled target.
 
-    const result = this._getOrNull(idOrToken);
-
-    if ((result === null) || (result.token !== null)) {
-      // This uses the default error message ("unknown target") even when it's
-      // due to a target existing but being controlled, so as not to reveal that
-      // the ID corresponds to an existing token (which is arguably a security
-      // leak).
-      throw this._targetError(idOrToken);
-    }
-
-    return result;
+    return this._getTargetFromId(idOrToken);
   }
 
   /**
@@ -261,6 +251,29 @@ export class Context extends CommonBase {
 
     const result = this._map.get(id);
     return (result === undefined) ? null : result;
+  }
+
+  /**
+   * Helper for {@link #getAuthorizedTarget}, which handles the non-token
+   * (uncontrolled target) case.
+   *
+   * @param {string} id Target ID.
+   * @returns {Target} The so-identified target.
+   * @throws {Error} Thrown if `id` does not correspond to a non-token
+   *   (uncontrolled) target.
+   */
+  _getTargetFromId(id) {
+    const result = this._getOrNull(id);
+
+    if ((result === null) || (result.token !== null)) {
+      // This uses the default error message ("unknown target") even when it's
+      // due to a target existing but being controlled, so as not to reveal that
+      // the ID corresponds to an existing token (as that would arguably be a
+      // security leak).
+      throw this._targetError(id);
+    }
+
+    return result;
   }
 
   /**

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -40,7 +40,7 @@ export class Context extends CommonBase {
     this._connection = BaseConnection.check(connection);
 
     /** {Map<string, Target>} The underlying map from IDs to targets. */
-    this._map = new Map();
+    this._targetMap = new Map();
 
     /**
      * {Map<object, Remote>} Map from target objects (the things wrapped by
@@ -97,7 +97,7 @@ export class Context extends CommonBase {
       throw this._targetError(id, 'Duplicate target object');
     }
 
-    this._map.set(id, target);
+    this._targetMap.set(id, target);
     this._remoteMap.set(obj, remote);
 
     return remote;
@@ -209,7 +209,7 @@ export class Context extends CommonBase {
   /**
    * Gets the target associated with the indicated ID, or `null` if the
    * so-identified target does not exist. This only checks this instance's
-   * {@link #_map}; it does _not_ try to do token authorization.
+   * {@link #_targetMap}; it does _not_ try to do token authorization.
    *
    * @param {string} id The target ID.
    * @returns {Target|null} The so-identified target, or `null` if unbound.
@@ -217,7 +217,7 @@ export class Context extends CommonBase {
   _getOrNull(id) {
     TString.check(id);
 
-    const result = this._map.get(id);
+    const result = this._targetMap.get(id);
     return (result === undefined) ? null : result;
   }
 

--- a/local-modules/@bayou/api-server/mocks/MockTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/mocks/MockTokenAuthorizer.js
@@ -1,0 +1,31 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { BearerToken } from '@bayou/api-common';
+import { BaseTokenAuthorizer } from '@bayou/api-server';
+
+/**
+ * Mock `BaseTokenAuthorizer` for testing.
+ */
+export class MockTokenAuthorizer extends BaseTokenAuthorizer {
+  get _impl_nonTokenPrefix() {
+    return 'nontoken-';
+  }
+
+  async _impl_cookieNamesForToken(value_unused) {
+    return [];
+  }
+
+  async _impl_getAuthorizedTarget(token_unused, cookies_unused) {
+    return { some: 'authority' };
+  }
+
+  _impl_isToken(tokenString_unused) {
+    return true;
+  }
+
+  _impl_tokenFromString(tokenString) {
+    return new BearerToken(tokenString, tokenString);
+  }
+}

--- a/local-modules/@bayou/api-server/mocks/index.js
+++ b/local-modules/@bayou/api-server/mocks/index.js
@@ -1,0 +1,7 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { MockTokenAuthorizer } from './MockTokenAuthorizer';
+
+export { MockTokenAuthorizer };

--- a/local-modules/@bayou/api-server/tests/test_Context.js
+++ b/local-modules/@bayou/api-server/tests/test_Context.js
@@ -5,40 +5,17 @@
 import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
-import { BearerToken, Codecs, Message, Remote } from '@bayou/api-common';
-import { BaseConnection, BaseTokenAuthorizer, Context, ContextInfo, ProxiedObject } from '@bayou/api-server';
+import { Codecs, Message, Remote } from '@bayou/api-common';
+import { BaseConnection, Context, ContextInfo, ProxiedObject } from '@bayou/api-server';
 import { Codec } from '@bayou/codec';
 import { Functor } from '@bayou/util-common';
 
-/**
- * Mock `BaseTokenAuthorizer` for testing.
- */
-class MockAuth extends BaseTokenAuthorizer {
-  get _impl_nonTokenPrefix() {
-    return 'nontoken-';
-  }
-
-  async _impl_cookieNamesForToken(value_unused) {
-    return [];
-  }
-
-  async _impl_getAuthorizedTarget(token_unused, cookies_unused) {
-    return { some: 'authority' };
-  }
-
-  _impl_isToken(tokenString_unused) {
-    return true;
-  }
-
-  _impl_tokenFromString(tokenString) {
-    return new BearerToken(tokenString, tokenString);
-  }
-}
+import { MockTokenAuthorizer } from '@bayou/api-server/mocks';
 
 describe('@bayou/api-server/Context', () => {
   describe('constructor()', () => {
     it('accepts valid arguments and produces a frozen instance', () => {
-      const info   = new ContextInfo(new Codec(), new MockAuth());
+      const info   = new ContextInfo(new Codec(), new MockTokenAuthorizer());
       const conn   = new BaseConnection(info);
       const result = new Context(info, conn);
 
@@ -48,7 +25,7 @@ describe('@bayou/api-server/Context', () => {
 
   describe('.codec', () => {
     it('is the `codec` from the `info` passed in on construction', () => {
-      const info = new ContextInfo(new Codec(), new MockAuth());
+      const info = new ContextInfo(new Codec(), new MockTokenAuthorizer());
       const conn = new BaseConnection(info);
       const ctx  = new Context(info, conn);
 
@@ -58,7 +35,7 @@ describe('@bayou/api-server/Context', () => {
 
   describe('.log', () => {
     it('is the `log` of the connection passed in on construction', () => {
-      const info = new ContextInfo(new Codec(), new MockAuth());
+      const info = new ContextInfo(new Codec(), new MockTokenAuthorizer());
       const conn = new BaseConnection(info);
       const ctx  = new Context(info, conn);
 
@@ -68,7 +45,7 @@ describe('@bayou/api-server/Context', () => {
 
   describe('.tokenAuthorizer', () => {
     it('is the `tokenAuthorizer` from the `info` passed in on construction', () => {
-      const info = new ContextInfo(new Codec(), new MockAuth());
+      const info = new ContextInfo(new Codec(), new MockTokenAuthorizer());
       const conn = new BaseConnection(info);
       const ctx  = new Context(info, conn);
 


### PR DESCRIPTION
This PR splits up the body of `Context.getAuthorizedTarget()` by extracting a couple helper methods (it was getting a bit baroque), and then adds into the class the first signs of actual cookie awareness. This PR still leaves a big ol' TODO about performing _initial_ cookie checks, but should those checks come to pass, the system is now good to go whenever follow-on checks are needed.
