### PR TITLE
More songs about non-root base URLs and API endpoints.

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -22,10 +22,11 @@ const UNKNOWN_CONNECTION_ID = 'id_unknown';
 export class ApiClient extends CommonBase {
   /**
    * Constructs an instance. This instance will connect to a websocket at the
-   * same domain at the path `/api`. Once this constructor returns, it is safe
-   * to call any API methods on the instance's associated `target`. If the
-   * socket isn't yet ready for traffic, the messages will get enqueued and then
-   * replayed in order once the socket becomes ready.
+   * given URL (that is, it is expected to name the API endpoint). Once this
+   * constructor returns, it is safe to call any API methods on the instance's
+   * associated `target`. If the socket isn't yet ready for traffic, the
+   * messages will get enqueued and then replayed in order once the socket
+   * becomes ready.
    *
    * @param {string} serverUrl The server endpoint, as an `http` or `https` URL.
    * @param {Codec} codec Codec instance to use. In order to function properly,

--- a/local-modules/@bayou/app-common/Codecs.js
+++ b/local-modules/@bayou/app-common/Codecs.js
@@ -9,7 +9,7 @@ import { Codecs as otCommon_Codecs } from '@bayou/ot-common';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
- * Utilities for this module.
+ * Utilities for codec setup.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/app-common/Urls.js
+++ b/local-modules/@bayou/app-common/Urls.js
@@ -1,0 +1,51 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TString } from '@bayou/typecheck';
+import { Errors, UtilityClass } from '@bayou/util-common';
+
+/**
+ * Utilities for application-related URLs.
+ */
+export class Urls extends UtilityClass {
+  /**
+   * {string} The partial path off of a base URL which corresponds to an API
+   * endpoint. This value does _not_ start or end with a slash (`/`).
+   */
+  static get API_PATH() {
+    return 'api';
+  }
+
+  /**
+   * Gets the API endpoint given a base URL.
+   *
+   * @param {string} baseUrl The base URL for an application.
+   * @returns {string} The corresponding API endpoint URL.
+   */
+  static apiUrlFromBaseUrl(baseUrl) {
+    TString.urlAbsolute(baseUrl);
+
+    const maybeSlash = baseUrl.endsWith('/') ? '' : '/';
+
+    return `${baseUrl}${maybeSlash}${Urls.API_PATH}`;
+  }
+
+  /**
+   * Gets the base URL given corresponding to the given API endpoint URL.
+   *
+   * @param {string} apiUrl The API endpoint URL for an application.
+   * @returns {string} The corresponding base URL.
+   */
+  static baseUrlFromApiUrl(apiUrl) {
+    TString.urlAbsolute(apiUrl);
+
+    const result = apiUrl.replace(/[/]+api[/]*$/, '');
+
+    if (result === apiUrl) {
+      throw Errors.badValue(apiUrl, String, 'API URL');
+    }
+
+    return result;
+  }
+}

--- a/local-modules/@bayou/app-common/Urls.js
+++ b/local-modules/@bayou/app-common/Urls.js
@@ -24,11 +24,18 @@ export class Urls extends UtilityClass {
    * @returns {string} The corresponding API endpoint URL.
    */
   static apiUrlFromBaseUrl(baseUrl) {
+    TString.check(baseUrl);
+
+    // Accept a URL without any path, by appending a final `/` if not present.
+    // `urlAbsolute` demands that a path be present.
+    if (!baseUrl.endsWith('/')) {
+      baseUrl += '/';
+    }
+
     TString.urlAbsolute(baseUrl);
 
-    const maybeSlash = baseUrl.endsWith('/') ? '' : '/';
-
-    return `${baseUrl}${maybeSlash}${Urls.API_PATH}`;
+    // No `/` here, because we guaranteed `baseUrl` ends with one, above.
+    return `${baseUrl}${Urls.API_PATH}`;
   }
 
   /**

--- a/local-modules/@bayou/app-common/index.js
+++ b/local-modules/@bayou/app-common/index.js
@@ -3,5 +3,6 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Codecs } from './Codecs';
+import { Urls } from './Urls';
 
-export { Codecs };
+export { Codecs, Urls };

--- a/local-modules/@bayou/app-common/tests/test_Urls.js
+++ b/local-modules/@bayou/app-common/tests/test_Urls.js
@@ -27,11 +27,21 @@ describe('@bayou/app-common/Urls', () => {
 
   describe('apiUrlFromBaseUrl()', () => {
     it('appends the `API_PATH` after a slash', () => {
-      const base = 'https://foo.blort/zap';
-      const api  = `${base}/${Urls.API_PATH}`;
-      const got  = Urls.apiUrlFromBaseUrl(base);
+      function test(base) {
+        const api  = `${base}/${Urls.API_PATH}`;
+        const got  = Urls.apiUrlFromBaseUrl(base);
 
-      assert.strictEqual(got, api);
+        assert.strictEqual(got, api);
+      }
+
+      test('https://foo.blort/zap');
+      test('https://foo.blort/zap/zoop');
+      test('https://boo.eek:1234/zap');
+      test('https://boo.eek:1234/zip/zap/zop');
+
+      // Origin-only, no final slash.
+      test('https://example.com');
+      test('https://example.com:1234');
     });
 
     it('does not add an extra slash if the given `baseUrl` already ends with one', () => {
@@ -44,12 +54,14 @@ describe('@bayou/app-common/Urls', () => {
   });
 
   describe('apiUrlFromBaseUrl()', () => {
-    it('strips the `API_PATH` at the end', () => {
-      const base = 'https://milk.yummy/boop/beep';
-      const api  = `${base}/${Urls.API_PATH}`;
-      const got  = Urls.baseUrlFromApiUrl(api);
+    it('strips the `API_PATH` at the end, with or without a trailing slash', () => {
+      const base     = 'https://milk.yummy/boop/beep';
+      const api      = `${base}/${Urls.API_PATH}`;
+      const got      = Urls.baseUrlFromApiUrl(api);
+      const gotSlash = Urls.baseUrlFromApiUrl(`${api}/`);
 
       assert.strictEqual(got, base);
+      assert.strictEqual(gotSlash, base);
     });
   });
 });

--- a/local-modules/@bayou/app-common/tests/test_Urls.js
+++ b/local-modules/@bayou/app-common/tests/test_Urls.js
@@ -1,0 +1,55 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Urls } from '@bayou/app-common';
+
+describe('@bayou/app-common/Urls', () => {
+  describe('.API_PATH', () => {
+    it('is a non-empty string', () => {
+      assert.isString(Urls.API_PATH);
+      assert.isTrue(Urls.API_PATH.length > 0);
+    });
+
+    it('does not start with a slash', () => {
+      assert.notStrictEqual(Urls.API_PATH[0], '/');
+    });
+
+    it('does not end with a slash', () => {
+      const path     = Urls.API_PATH;
+      const lastChar = path[path.length - 1];
+      assert.notStrictEqual(lastChar, '/');
+    });
+  });
+
+  describe('apiUrlFromBaseUrl()', () => {
+    it('appends the `API_PATH` after a slash', () => {
+      const base = 'https://foo.blort/zap';
+      const api  = `${base}/${Urls.API_PATH}`;
+      const got  = Urls.apiUrlFromBaseUrl(base);
+
+      assert.strictEqual(got, api);
+    });
+
+    it('does not add an extra slash if the given `baseUrl` already ends with one', () => {
+      const base = 'https://foo.blort/zoop/';
+      const api  = `${base}${Urls.API_PATH}`;
+      const got  = Urls.apiUrlFromBaseUrl(base);
+
+      assert.strictEqual(got, api);
+    });
+  });
+
+  describe('apiUrlFromBaseUrl()', () => {
+    it('strips the `API_PATH` at the end', () => {
+      const base = 'https://milk.yummy/boop/beep';
+      const api  = `${base}/${Urls.API_PATH}`;
+      const got  = Urls.baseUrlFromApiUrl(api);
+
+      assert.strictEqual(got, base);
+    });
+  });
+});

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -10,7 +10,7 @@ import path from 'path';
 import ws from 'ws';
 
 import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
-import { Codecs } from '@bayou/app-common';
+import { Codecs, Urls } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
 import { Dirs, ServerEnv } from '@bayou/env-server';
@@ -246,8 +246,11 @@ export class Application extends CommonBase {
       next();
     });
 
-    // Use the `@bayou/api-server` module to handle POST requests at both `/api`
-    // and `/api/`.
+    // Use the `@bayou/api-server` module to handle POST requests at the API
+    // endpoint, both with and without a trailing slash.
+
+    const apiPath1 = `/${Urls.API_PATH}`;
+    const apiPath2 = `/${Urls.API_PATH}/`;
 
     const postHandler = (req, res) => {
       try {
@@ -259,19 +262,19 @@ export class Application extends CommonBase {
       }
     };
 
-    app.post('/api', postHandler);
-    app.post('/api/', postHandler);
+    app.post(apiPath1, postHandler);
+    app.post(apiPath2, postHandler);
 
-    // Likewise, handle `/api` and `/api/` for websocket requests. **Note:**
-    // The following (specifically, constructing `ws.Server` with the `server`
-    // option) causes the websocket server instance to handle a websocket
-    // request before Express has an opportunity to dispatch at all. This means
-    // that no Express router logic will ever be run on a connection that starts
-    // out with a websocket handshake.
+    // Likewise, handle the same API endpoint URLs for websocket requests.
+    // **Note:** The following (specifically, constructing `ws.Server` with the
+    // `server` option) causes the websocket server instance to handle a
+    // websocket request before Express has an opportunity to dispatch at all.
+    // This means that no Express router logic will ever be run on a connection
+    // that starts out with a websocket handshake.
 
     const wsVerify = (info, cb = null) => {
       const url = info.req.url;
-      const ok  = (url === '/api') || (url === '/api/');
+      const ok  = (url === apiPath1) || (url === apiPath2);
 
       // **Note:** The `ws` module docs indicate that it _sometimes_ calls the
       // verifier function with a `cb` argument. If it does, and if the main

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -140,6 +140,15 @@ export class Application extends CommonBase {
     return this._listenPort;
   }
 
+  /**
+   * {string} The loopback (local-access) base URL. This can have a different
+   * port than the default configured `listenPort` in testing scenarios. It will
+   * always match the {@link #listenPort} exposed by this instance.
+   */
+  get loopbackUrl() {
+    return `http://localhost:${this.listenPort}`;
+  }
+
   /** {Metrics} The associated metrics collector / reporter. */
   get metrics() {
     return this._metrics;

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -473,22 +473,23 @@ export class DebugTools extends CommonBase {
 
   /**
    * Makes a URL to refer to the given absolute path off of the `baseUrl` of the
-   * server.
+   * server. If the server is listening on a non-default port, this assumes that
+   * the only valid access is via the application's loopback URL.
    *
    * @param {string} urlPath Path to refer to.
    * @returns {string} Absolute URL.
    */
   _urlFromPath(urlPath) {
-    // Start with the configured `baseUrl` except with whatever port we happen
-    // to actually be listening on.
-    const url = new URL(Network.baseUrl);
-    url.port = this._application.listenPort;
+    const configuredLoopback  = Network.loopbackUrl;
+    const applicationLoopback = this._application.loopbackUrl;
+    const isTesting           = (configuredLoopback !== applicationLoopback);
 
-    // Combine the base path with the given one, ensuring that there is exactly
-    // one slash between them.
-    const basePath = url.pathname.replace(/[/]+$/, '');
-    urlPath = urlPath.replace(/^[/]+/, '');
-    url.pathname = `${basePath}/${urlPath}`;
+    const url = new URL(isTesting ? applicationLoopback : Network.baseUrl);
+
+    // Combine the base path with the given one, ensuring that there are no
+    // runs of more than one slash in a row.
+    const fullPath = `${url.pathname}/${urlPath}`.replace(/[/]+/g, '/');
+    url.pathname = fullPath;
 
     return url.href;
   }

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Urls } from '@bayou/app-common';
 import { Auth, Network, Storage } from '@bayou/config-server';
 import { SessionInfo } from '@bayou/doc-common';
 import { DocServer } from '@bayou/doc-server';
@@ -92,7 +93,7 @@ export class RootAccess extends CommonBase {
       }
     })();
 
-    const url         = `${Network.baseUrl}/api`;
+    const url         = Urls.apiUrlFromBaseUrl(Network.baseUrl);
     const authorToken = await this._getAuthorToken(authorId);
     const result      = new SessionInfo(url, authorToken, documentId);
 

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -52,8 +52,8 @@ function BAYOU_RECOVER(info) {
   })
 }
 
-// Once the rest of the page is loaded, find the `#editor` node and arrange for
-// the main boot script to load and run.
+// Once the rest of the page is loaded, find the DOM node for the editor, and
+// arrange for the main boot script to load and run.
 window.addEventListener('load', () => {
   // This is the node that is IDed specifically in `DebugTools._handle_edit`.
   var editorNode = document.querySelector('#debugEditor');
@@ -67,7 +67,14 @@ window.addEventListener('load', () => {
   window.BAYOU_NODE = editorNode;
 
   // Add the standard bootstrap code to the page.
+
+  // Get the base URL from the window's URL by dropping `/debug` and everything
+  // after (e.g. `/debug/edit/...`). This is brittle, in that it bakes in a bit
+  // of specific knowledge about the endpoint path.
+  var windowUrl = window.location.href;
+  var baseUrl   = windowUrl.replace(/[/]debug[/].*$/, '');
+
   var elem = document.createElement('script');
-  elem.src = '/boot-from-info.js';
+  elem.src = `${baseUrl}/boot-from-info.js`;
   document.head.appendChild(elem);
 })

--- a/local-modules/@bayou/assets-client/files/index.html
+++ b/local-modules/@bayou/assets-client/files/index.html
@@ -8,10 +8,10 @@ Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 <html lang="en-US">
 
 <script>
-window.onload = () => {
+window.addEventListener('load', = () => {
   var newPath = `${window.location.pathname}/debug/edit/some-id`;
   window.location.pathname = newPath.replace(/[/]+/g, '/');
-};
+});
 </script>
 
 <head>

--- a/local-modules/@bayou/assets-client/files/index.html
+++ b/local-modules/@bayou/assets-client/files/index.html
@@ -8,10 +8,10 @@ Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 <html lang="en-US">
 
 <script>
-function redirect() {
+window.onload = () => {
   var newPath = `${window.location.pathname}/debug/edit/some-id`;
   window.location.pathname = newPath.replace(/[/]+/g, '/');
-}
+};
 </script>
 
 <head>

--- a/local-modules/@bayou/assets-client/files/index.html
+++ b/local-modules/@bayou/assets-client/files/index.html
@@ -7,8 +7,15 @@ Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 <html lang="en-US">
 
+<script>
+function redirect() {
+  var newPath = `${window.location.pathname}/debug/edit/some-id`;
+  window.location.pathname = newPath.replace(/[/]+/g, '/');
+}
+</script>
+
 <head>
-  <meta http-equiv="refresh" content="0; url=./debug/edit/some-id">
+  <title>Redirecting&hellip;</title>
 </head>
 
 <body>

--- a/local-modules/@bayou/assets-client/files/index.html
+++ b/local-modules/@bayou/assets-client/files/index.html
@@ -8,7 +8,7 @@ Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 <html lang="en-US">
 
 <head>
-  <meta http-equiv="refresh" content="0; url=/debug/edit/some-id">
+  <meta http-equiv="refresh" content="0; url=./debug/edit/some-id">
 </head>
 
 <body>

--- a/local-modules/@bayou/assets-client/files/index.html
+++ b/local-modules/@bayou/assets-client/files/index.html
@@ -8,7 +8,7 @@ Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 <html lang="en-US">
 
 <script>
-window.addEventListener('load', = () => {
+window.addEventListener('load', () => {
   var newPath = `${window.location.pathname}/debug/edit/some-id`;
   window.location.pathname = newPath.replace(/[/]+/g, '/');
 });

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -2,6 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { Urls } from '@bayou/app-common';
 import { Editor } from '@bayou/config-client';
 import { BodyClient, DocSession } from '@bayou/doc-client';
 import { SessionInfo } from '@bayou/doc-common';
@@ -227,7 +228,7 @@ export class EditorComplex extends CommonBase {
    *   authorOverlayNode]`, for immediate consumption by the constructor.
    */
   async _domSetup(topNode, serverUrl) {
-    const baseUrl = new URL(serverUrl).origin;
+    const baseUrl = Urls.baseUrlFromApiUrl(serverUrl);
 
     // Validate the top node, and give it the right CSS style.
     if (topNode.nodeName !== 'DIV') {

--- a/local-modules/@bayou/file-store-ot/FileSnapshot.js
+++ b/local-modules/@bayou/file-store-ot/FileSnapshot.js
@@ -6,7 +6,7 @@ import { BaseSnapshot } from '@bayou/ot-common';
 import { TInt } from '@bayou/typecheck';
 import { Errors } from '@bayou/util-common';
 
-import fileStoreOt_Errors from './Errors';
+import { Errors as fileStoreOt_Errors } from './Errors';
 import { FileChange } from './FileChange';
 import { FileDelta } from './FileDelta';
 import { FileOp } from './FileOp';


### PR DESCRIPTION
This PR is a compendium of fixes and tweaks, which in aggregate address all the current known issues with cases where the base URL for a server doesn't have a simple root path of `/`. Highlights:

* New class `api-common.Urls` to hold all the logic for converting between base URLs and API endpoints. Use it to avoid writing `/api` (or similar) all over the place.
* Change how all the static `.js` files (for local-dev and unit testing) figure out the server base URL (including a bunch of cases where they were still assuming it was always `/`.
* Make places that inserted DOM links (e.g. notably CSS) stop assuming a `/` base URL path.