### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -28,17 +28,19 @@ export class ApiClient extends CommonBase {
    * messages will get enqueued and then replayed in order once the socket
    * becomes ready.
    *
-   * @param {string} serverUrl The server endpoint, as an `http` or `https` URL.
+   * @param {string} apiUrl The server endpoint, as an `http` or `https` URL.
+   *   This endpoint is expected to respond using the API protocol as defined
+   *   in this and the other `api-*` modules.
    * @param {Codec} codec Codec instance to use. In order to function properly,
    *   its registry must include all of the encodable classes defined in
    *   `@bayou/api-common` classes. See
    *   {@link @bayou/api-common.Codecs.registerCodecs}.
    */
-  constructor(serverUrl, codec) {
+  constructor(apiUrl, codec) {
     super();
 
     /** {string} The server endpoint, as an `http` or `https` URL. */
-    this._serverUrl = TString.urlAbsolute(serverUrl);
+    this._serverUrl = TString.urlAbsolute(apiUrl);
 
     /** {Codec} Codec instance to use. */
     this._codec = Codec.check(codec);
@@ -99,7 +101,7 @@ export class ApiClient extends CommonBase {
     // Initialize the active connection fields (described above).
     this._resetConnection();
 
-    this._log.event.constructed(serverUrl);
+    this._log.event.constructed(apiUrl);
 
     Object.seal(this);
   }

--- a/local-modules/@bayou/api-common/Codecs.js
+++ b/local-modules/@bayou/api-common/Codecs.js
@@ -11,7 +11,7 @@ import { Response } from './Response';
 import { Remote } from './Remote';
 
 /**
- * Utilities for this module.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/app-common/Codecs.js
+++ b/local-modules/@bayou/app-common/Codecs.js
@@ -9,7 +9,7 @@ import { Codecs as otCommon_Codecs } from '@bayou/ot-common';
 import { UtilityClass } from '@bayou/util-common';
 
 /**
- * Utilities for codec setup.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/assets-client/.eslintrc
+++ b/local-modules/@bayou/assets-client/.eslintrc
@@ -1,0 +1,16 @@
+{
+  "overrides": [
+    {
+      "files": ["files/**/*.js"],
+      "parserOptions": {
+        "sourceType": "script",
+        "ecmaVersion": "2017"
+      },
+      "globals": {
+        "document": "readonly",
+        "window": "readonly",
+        "XMLHttpRequest": "readonly"
+      }
+    }
+  ]
+}

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -7,31 +7,34 @@
 // and most likely because the developer restarted their local server). Beyond
 // that, it _also_ kicks off loading of the regular bootstrap code.
 
-// Disable Eslint, because this file is delivered as-is and has to be fairly
-// conservative.
-/* eslint-disable */
+// Inform ESLint about the special globals used by this file.
+/* global DEBUG_AUTHOR_ID DEBUG_DOCUMENT_ID */
 
 /**
  * This global function is what ultimately gets called to attempt recovery. In
  * this case, we rely on the `/access/*` debugging endpoints to generate new
  * access info. If that's successful, we report it back up through the layers.
+ *
+ * @param {object} info Information about how to connect to the session.
+ * @returns {Promise<object>} Replacement session info, to use when next
+ *   attempting to connect.
  */
-function BAYOU_RECOVER(info) {
-  var documentId = DEBUG_DOCUMENT_ID;
-  var authorId   = DEBUG_AUTHOR_ID;
+window.BAYOU_RECOVER = function BAYOU_RECOVER(info) {
+  const documentId = DEBUG_DOCUMENT_ID;
+  const authorId   = DEBUG_AUTHOR_ID;
 
   // Get the base URL from the server URL by dropping the final `/api`. This is
   // brittle, in that it bakes in knowledge of the API endpoint.
-  var baseUrl = info.serverUrl.replace(/[/]api$/, '');
-  var url     = `${baseUrl}/debug/access/${documentId}/${authorId}`;
+  const baseUrl = info.serverUrl.replace(/[/]api$/, '');
+  const url     = `${baseUrl}/debug/access/${documentId}/${authorId}`;
 
   return new Promise((resolve) => {
-    var req = new XMLHttpRequest();
+    const req = new XMLHttpRequest();
     req.open('GET', url);
     req.send();
     req.addEventListener('abort', reloadPage);
     req.addEventListener('error', reloadPage);
-    req.addEventListener('load', gotKey);
+    req.addEventListener('load', gotInfo);
 
     // If there's any trouble, we just ask the window to reload. This will
     // almost certainly work but is definitely a last-resort hail-mary kind of
@@ -42,21 +45,21 @@ function BAYOU_RECOVER(info) {
 
     // On successful request completion, check to see if we actually got good
     // data. If so, report it back. If not, fall back to `reloadPage()`.
-    function gotKey() {
+    function gotInfo() {
       if (req.status === 200) {
         resolve(req.response);
       } else {
         reloadPage();
       }
     }
-  })
-}
+  });
+};
 
 // Once the rest of the page is loaded, find the DOM node for the editor, and
 // arrange for the main boot script to load and run.
 window.addEventListener('load', () => {
   // This is the node that is IDed specifically in `DebugTools._handle_edit`.
-  var editorNode = document.querySelector('#debugEditor');
+  const editorNode = document.querySelector('#debugEditor');
   if (!editorNode) {
     // Indicates a bug either here or in `DebugTools`. **Note:** This code is
     // run too early to be able to use `@bayou/util-common`'s error facilities.
@@ -71,10 +74,10 @@ window.addEventListener('load', () => {
   // Get the base URL from the window's URL by dropping `/debug` and everything
   // after (e.g. `/debug/edit/...`). This is brittle, in that it bakes in a bit
   // of specific knowledge about the endpoint path.
-  var windowUrl = window.location.href;
-  var baseUrl   = windowUrl.replace(/[/]debug[/].*$/, '');
+  const windowUrl = window.location.href;
+  const baseUrl   = windowUrl.replace(/[/]debug[/].*$/, '');
 
-  var elem = document.createElement('script');
+  const elem = document.createElement('script');
   elem.src = `${baseUrl}/boot-from-info.js`;
   document.head.appendChild(elem);
-})
+});

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -7,21 +7,19 @@
 // and most likely because the developer restarted their local server). Beyond
 // that, it _also_ kicks off loading of the regular bootstrap code.
 
-// Inform ESLint about the special globals used by this file.
-/* global DEBUG_AUTHOR_ID DEBUG_DOCUMENT_ID */
-
 /**
  * This global function is what ultimately gets called to attempt recovery. In
  * this case, we rely on the `/access/*` debugging endpoints to generate new
  * access info. If that's successful, we report it back up through the layers.
  *
- * @param {object} info Information about how to connect to the session.
- * @returns {Promise<object>} Replacement session info, to use when next
- *   attempting to connect.
+ * @param {SessionInfo} info Information about how to connect to the session.
+ * @returns {Promise<object>} Promise for replacement session info, in the form
+ *   of a codec-encoded `SessionInfo` object, to use when next attempting to
+ *   connect.
  */
 window.BAYOU_RECOVER = function BAYOU_RECOVER(info) {
-  const documentId = DEBUG_DOCUMENT_ID;
-  const authorId   = DEBUG_AUTHOR_ID;
+  const documentId = window.DEBUG_DOCUMENT_ID;
+  const authorId   = window.DEBUG_AUTHOR_ID;
 
   // Get the base URL from the server URL by dropping the final `/api`. This is
   // brittle, in that it bakes in knowledge of the API endpoint.

--- a/local-modules/@bayou/assets-client/files/boot-for-debug.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-debug.js
@@ -23,7 +23,7 @@ window.BAYOU_RECOVER = function BAYOU_RECOVER(info) {
 
   // Get the base URL from the server URL by dropping the final `/api`. This is
   // brittle, in that it bakes in knowledge of the API endpoint.
-  const baseUrl = info.serverUrl.replace(/[/]api$/, '');
+  const baseUrl = info.apiUrl.replace(/[/]api$/, '');
   const url     = `${baseUrl}/debug/access/${documentId}/${authorId}`;
 
   return new Promise((resolve) => {

--- a/local-modules/@bayou/assets-client/files/boot-for-test.js
+++ b/local-modules/@bayou/assets-client/files/boot-for-test.js
@@ -5,10 +5,6 @@
 // This file is included by the `/client-test` debugging endpoint and is used
 // to actually kick off the tests.
 
-// Disable Eslint, because this file is delivered as-is and has to be fairly
-// conservative.
-/* eslint-disable */
-
 // We wrap everything in an immediately-executed function so as to avoid
 // polluting the global namespace.
 (function () {
@@ -20,10 +16,10 @@
   // Get the base URL from the window's URL by dropping `/debug` and everything
   // after (e.g. `/debug/test`). This is brittle, in that it bakes in a bit of
   // specific knowledge about the endpoint path.
-  var windowUrl = window.location.href;
-  var baseUrl   = windowUrl.replace(/[/]debug[/].*$/, '');
+  const windowUrl = window.location.href;
+  const baseUrl   = windowUrl.replace(/[/]debug[/].*$/, '');
 
-  var elem = document.createElement('script');
+  const elem = document.createElement('script');
   elem.src = `${baseUrl}/static/js/test.bundle.js`;
   document.head.appendChild(elem);
 }());

--- a/local-modules/@bayou/assets-client/files/boot-from-info.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-info.js
@@ -32,17 +32,17 @@
   // {@link @bayou/doc-common/SessionInfo}, the encoded form in particular, if
   // you want to understand what's going on.
   const info = JSON.parse(window.BAYOU_INFO);
-  let   serverUrl;
+  let   apiUrl;
 
   if (info.SessionInfo) {
-    serverUrl = info.SessionInfo[0];
+    apiUrl = info.SessionInfo[0];
   } else {
     throw new Error('Unrecognized format for `BAYOU_INFO`.');
   }
 
   // Get the base URL from the server URL by dropping the final `/api`. This is
   // brittle, in that it bakes in knowledge of the API endpoint.
-  const baseUrl = serverUrl.replace(/[/]api$/, '');
+  const baseUrl = apiUrl.replace(/[/]api$/, '');
 
   // Add the main JavaScript bundle to the page. Once loaded, this continues
   // the boot process. You can find its main entrypoint in

--- a/local-modules/@bayou/assets-client/files/boot-from-info.js
+++ b/local-modules/@bayou/assets-client/files/boot-from-info.js
@@ -16,10 +16,6 @@
 // See {@link @bayou/top-client/TopControl} for more details about these
 // parameters.
 
-// Disable Eslint, because this file is delivered as-is and has to be fairly
-// conservative.
-/* eslint-disable */
-
 // We wrap everything in an immediately-executed function so as to avoid
 // polluting the global namespace.
 (function () {
@@ -35,8 +31,8 @@
   // parsing needed to get the URL and then head on our merry way. See
   // {@link @bayou/doc-common/SessionInfo}, the encoded form in particular, if
   // you want to understand what's going on.
-  var info = JSON.parse(window.BAYOU_INFO);
-  var serverUrl;
+  const info = JSON.parse(window.BAYOU_INFO);
+  let   serverUrl;
 
   if (info.SessionInfo) {
     serverUrl = info.SessionInfo[0];
@@ -46,12 +42,12 @@
 
   // Get the base URL from the server URL by dropping the final `/api`. This is
   // brittle, in that it bakes in knowledge of the API endpoint.
-  var baseUrl = serverUrl.replace(/[/]api$/, '');
+  const baseUrl = serverUrl.replace(/[/]api$/, '');
 
   // Add the main JavaScript bundle to the page. Once loaded, this continues
   // the boot process. You can find its main entrypoint in
   // {@link @bayou/main-client} listed as the `main` in that module's manifest.
-  var elem = document.createElement('script');
+  const elem = document.createElement('script');
   elem.src = `${baseUrl}/static/js/main.bundle.js`;
   document.head.appendChild(elem);
 }());

--- a/local-modules/@bayou/config-client/Editor.js
+++ b/local-modules/@bayou/config-client/Editor.js
@@ -35,12 +35,14 @@ export class Editor extends UtilityClass {
    *
    * @param {object} window Window which will ultimately contain one or more
    *   editors.
-   * @param {string} serverUrl URL at which to contact the server.
+   * @param {string} apiUrl URL at which to contact the server. This endpoint is
+   *   expected to respond using the API protocol as defined in the `api-*`
+   *   modules.
    * @returns {Promise|undefined} A promise whose resolution indicates the end
    *   of hook activity, or `undefined` if there is nothing to wait for.
    */
-  static aboutToRun(window, serverUrl) {
-    return use.Editor.aboutToRun(window, serverUrl);
+  static aboutToRun(window, apiUrl) {
+    return use.Editor.aboutToRun(window, apiUrl);
   }
 
   /**

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -278,7 +278,7 @@ export class DocSession extends CommonBase {
       return this._apiClient;
     }
 
-    const url = this._sessionInfo.serverUrl;
+    const url = this._sessionInfo.apiUrl;
 
     this._eventSource.emit.opening();
     this._log.event.apiAboutToOpen(url);

--- a/local-modules/@bayou/doc-common/Codecs.js
+++ b/local-modules/@bayou/doc-common/Codecs.js
@@ -22,7 +22,7 @@ import { PropertySnapshot } from './PropertySnapshot';
 import { SessionInfo } from './SessionInfo';
 
 /**
- * Utilities for this module.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -86,7 +86,10 @@ export class SessionInfo extends CommonBase {
   /**
    * {string} URL of the server to connect to in order to use the session.
    * **TODO:** Remove this property, once we are sure there are no more deployed
-   * references to it.
+   * references to it. More specifically, this can only be removed after a
+   * version bump and module republish. (That is, as of this writing, the next
+   * module republish needs to have this property, but the one after _that_ does
+   * not.)
    *
    * @deprecated Replaced by {@link #apiUrl}.
    */

--- a/local-modules/@bayou/doc-common/SessionInfo.js
+++ b/local-modules/@bayou/doc-common/SessionInfo.js
@@ -15,8 +15,9 @@ export class SessionInfo extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {string} serverUrl URL of the server to connect to in order to use
-   *   the session.
+   * @param {string} apiUrl URL of the server to connect to in order to use
+   *   the session. This endpoint is expected to respond using the API protocol
+   *   as defined in the `api-*` modules.
    * @param {string|BearerToken} authorToken Token which identifies the author
    *   (user) under whose authority the session is to be run.
    * @param {string} documentId ID of the document to be edited in the session.
@@ -24,7 +25,7 @@ export class SessionInfo extends CommonBase {
    *   with the session. If `null`, a new caret will ultimately be created for
    *   the session.
    */
-  constructor(serverUrl, authorToken, documentId, caretId = null) {
+  constructor(apiUrl, authorToken, documentId, caretId = null) {
     super();
 
     // **TODO:** Consider performing more validation of the arguments. If
@@ -32,7 +33,7 @@ export class SessionInfo extends CommonBase {
     // but arguably it's better to know sooner.
 
     /** {string} URL of the server to connect to in order to use the session. */
-    this._serverUrl = TString.urlAbsolute(serverUrl);
+    this._apiUrl = TString.urlAbsolute(apiUrl);
 
     /**
      * {string} Token which identifies the author (user) under whose authority
@@ -50,6 +51,15 @@ export class SessionInfo extends CommonBase {
     this._caretId = TString.orNull(caretId);
 
     Object.freeze(this);
+  }
+
+  /**
+   * {string} URL of the server to connect to in order to use the session. This
+   * endpoint is expected to respond using the API protocol as defined in the
+   * `api-*` modules.
+   */
+  get apiUrl() {
+    return this._apiUrl;
   }
 
   /**
@@ -74,11 +84,14 @@ export class SessionInfo extends CommonBase {
   }
 
   /**
-   * {string} Origin-only URL of the server to connect to in order to use the
-   * session.
+   * {string} URL of the server to connect to in order to use the session.
+   * **TODO:** Remove this property, once we are sure there are no more deployed
+   * references to it.
+   *
+   * @deprecated Replaced by {@link #apiUrl}.
    */
   get serverUrl() {
-    return this._serverUrl;
+    return this._apiUrl;
   }
 
   /**
@@ -94,7 +107,7 @@ export class SessionInfo extends CommonBase {
       : BearerToken.redactString(token);
 
     const result = {
-      serverUrl:   this._serverUrl,
+      apiUrl:      this._apiUrl,
       authorToken: redactedToken,
       documentId:  this._documentId
     };
@@ -128,7 +141,7 @@ export class SessionInfo extends CommonBase {
     const authorToken = (origToken instanceof BearerToken) ? origToken.secretToken : origToken;
     const maybeCaret  = (this._caretId === null) ? [] : [this._caretId];
 
-    return [this._serverUrl, authorToken, this._documentId, ...maybeCaret];
+    return [this._apiUrl, authorToken, this._documentId, ...maybeCaret];
   }
 
   /**
@@ -139,7 +152,7 @@ export class SessionInfo extends CommonBase {
    * @returns {SessionInfo} An appropriately-constructed instance.
    */
   withAuthorToken(authorToken) {
-    return new SessionInfo(this._serverUrl, authorToken, this._documentId, this._caretId);
+    return new SessionInfo(this._apiUrl, authorToken, this._documentId, this._caretId);
   }
 
   /**
@@ -152,7 +165,7 @@ export class SessionInfo extends CommonBase {
    */
   withCaretId(caretId) {
     TString.check(caretId);
-    return new SessionInfo(this._serverUrl, this._authorToken, this._documentId, caretId);
+    return new SessionInfo(this._apiUrl, this._authorToken, this._documentId, caretId);
   }
 
   /**
@@ -161,6 +174,6 @@ export class SessionInfo extends CommonBase {
    * @returns {SessionInfo} An appropriately-constructed instance.
    */
   withoutCaretId() {
-    return new SessionInfo(this._serverUrl, this._authorToken, this._documentId);
+    return new SessionInfo(this._apiUrl, this._authorToken, this._documentId);
   }
 }

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -187,11 +187,11 @@ describe('@bayou/doc-common/SessionInfo', () => {
 
       function test(token) {
         const result1 = orig1.withAuthorToken(token);
-        const expect1 = new SessionInfo(orig1.serverUrl, token, orig1.documentId, orig1.caretId);
+        const expect1 = new SessionInfo(orig1.apiUrl, token, orig1.documentId, orig1.caretId);
         assert.deepEqual(result1, expect1);
 
         const result2 = orig2.withAuthorToken(token);
-        const expect2 = new SessionInfo(orig2.serverUrl, token, orig2.documentId, orig2.caretId);
+        const expect2 = new SessionInfo(orig2.apiUrl, token, orig2.documentId, orig2.caretId);
         assert.deepEqual(result2, expect2);
       }
 
@@ -205,11 +205,11 @@ describe('@bayou/doc-common/SessionInfo', () => {
 
       function test(token) {
         const result1 = orig1.withAuthorToken(token);
-        const expect1 = new SessionInfo(orig1.serverUrl, token, orig1.documentId, orig1.caretId);
+        const expect1 = new SessionInfo(orig1.apiUrl, token, orig1.documentId, orig1.caretId);
         assert.deepEqual(result1, expect1);
 
         const result2 = orig2.withAuthorToken(token);
-        const expect2 = new SessionInfo(orig2.serverUrl, token, orig2.documentId, orig2.caretId);
+        const expect2 = new SessionInfo(orig2.apiUrl, token, orig2.documentId, orig2.caretId);
         assert.deepEqual(result2, expect2);
       }
 
@@ -238,11 +238,11 @@ describe('@bayou/doc-common/SessionInfo', () => {
 
       function test(c) {
         const result1 = orig1.withCaretId(c);
-        const expect1 = new SessionInfo(orig1.serverUrl, orig1.authorToken, orig1.documentId, c);
+        const expect1 = new SessionInfo(orig1.apiUrl, orig1.authorToken, orig1.documentId, c);
         assert.deepEqual(result1, expect1);
 
         const result2 = orig2.withCaretId(c);
-        const expect2 = new SessionInfo(orig2.serverUrl, orig2.authorToken, orig2.documentId, c);
+        const expect2 = new SessionInfo(orig2.apiUrl, orig2.authorToken, orig2.documentId, c);
         assert.deepEqual(result2, expect2);
       }
 
@@ -268,7 +268,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
     it('returns a new instance with `caretId === null`', () => {
       function test(orig) {
         const result = orig.withoutCaretId();
-        const expect = new SessionInfo(orig.serverUrl, orig.authorToken, orig.documentId);
+        const expect = new SessionInfo(orig.apiUrl, orig.authorToken, orig.documentId);
 
         assert.isNull(result.caretId);
         assert.deepEqual(result, expect);

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -61,6 +61,14 @@ describe('@bayou/doc-common/SessionInfo', () => {
     });
   });
 
+  describe('.apiUrl', () => {
+    it('is the constructed value', () => {
+      const url    = 'https://milk.com:1234/florp';
+      const result = new SessionInfo(url, 'token', 'x');
+      assert.strictEqual(result.apiUrl, url);
+    });
+  });
+
   describe('.authorToken', () => {
     it('is the constructed value if constructed from a string', () => {
       const token  = 'florp';
@@ -84,7 +92,7 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.serverUrl', () => {
-    it('is the constructed value', () => {
+    it('is the constructed `apiUrl` value', () => {
       const url    = 'https://milk.com:1234/florp';
       const result = new SessionInfo(url, 'token', 'x');
       assert.strictEqual(result.serverUrl, url);

--- a/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
+++ b/local-modules/@bayou/doc-common/tests/test_SessionInfo.js
@@ -105,11 +105,11 @@ describe('@bayou/doc-common/SessionInfo', () => {
   });
 
   describe('.logInfo', () => {
-    it('reflects the constructed `serverUrl`', () => {
+    it('reflects the constructed `apiUrl`', () => {
       const si   = new SessionInfo(SERVER_URL, 'token', 'doc');
       const info = si.logInfo;
 
-      assert.strictEqual(info.serverUrl, si.serverUrl);
+      assert.strictEqual(info.apiUrl, si.apiUrl);
     });
 
     it('reflects the constructed `documentId`', () => {

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -86,11 +86,11 @@ export class EditorComplex extends CommonBase {
     (async () => {
       log.event.starting();
 
-      const serverUrl = info.serverUrl;
+      const apiUrl = info.serverUrl;
 
       // Do all of the DOM setup for the instance.
       const [headerNode_unused, titleNode, bodyNode, authorOverlayNode] =
-        await this._domSetup(topNode, serverUrl);
+        await this._domSetup(topNode, apiUrl);
 
       // Construct the `QuillProm` instances.
       const [titleQuill, bodyQuill] = this._quillSetup(titleNode, bodyNode);
@@ -223,12 +223,12 @@ export class EditorComplex extends CommonBase {
    * ready to have Quill and the author overlay attached to it.
    *
    * @param {Element} topNode The top DOM node for the complex.
-   * @param {string} serverUrl URL used to contact the server.
+   * @param {string} apiUrl URL used to contact the server.
    * @returns {array<Element>} Array of `[headerNode, titleNode, bodyNode,
    *   authorOverlayNode]`, for immediate consumption by the constructor.
    */
-  async _domSetup(topNode, serverUrl) {
-    const baseUrl = Urls.baseUrlFromApiUrl(serverUrl);
+  async _domSetup(topNode, apiUrl) {
+    const baseUrl = Urls.baseUrlFromApiUrl(apiUrl);
 
     // Validate the top node, and give it the right CSS style.
     if (topNode.nodeName !== 'DIV') {

--- a/local-modules/@bayou/doc-ui/EditorComplex.js
+++ b/local-modules/@bayou/doc-ui/EditorComplex.js
@@ -86,7 +86,7 @@ export class EditorComplex extends CommonBase {
     (async () => {
       log.event.starting();
 
-      const apiUrl = info.serverUrl;
+      const apiUrl = info.apiUrl;
 
       // Do all of the DOM setup for the instance.
       const [headerNode_unused, titleNode, bodyNode, authorOverlayNode] =

--- a/local-modules/@bayou/file-store-ot/Codecs.js
+++ b/local-modules/@bayou/file-store-ot/Codecs.js
@@ -11,7 +11,7 @@ import { FileOp } from './FileOp';
 import { FileSnapshot } from './FileSnapshot';
 
 /**
- * Utilities for this module.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/ot-common/Codecs.js
+++ b/local-modules/@bayou/ot-common/Codecs.js
@@ -8,7 +8,7 @@ import { UtilityClass } from '@bayou/util-common';
 import { Timestamp } from './Timestamp';
 
 /**
- * Utilities for this module.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/ot-common/mocks/Codecs.js
+++ b/local-modules/@bayou/ot-common/mocks/Codecs.js
@@ -11,7 +11,7 @@ import { MockOp } from './MockOp';
 import { MockSnapshot } from './MockSnapshot';
 
 /**
- * Utilities for this module.
+ * Codec setup for this module.
  */
 export class Codecs extends UtilityClass {
   /**

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -77,8 +77,8 @@ export class TopControl extends CommonBase {
   async start() {
     // Let the outer app do its setup.
 
-    const serverUrl = this._sessionInfo.serverUrl;
-    await Editor.aboutToRun(this._window, serverUrl);
+    const apiUrl = this._sessionInfo.serverUrl;
+    await Editor.aboutToRun(this._window, apiUrl);
 
     // Arrange for the rest of initialization to happen once the initial page
     // contents are ready (from the browser's perspective).

--- a/local-modules/@bayou/top-client/TopControl.js
+++ b/local-modules/@bayou/top-client/TopControl.js
@@ -77,7 +77,7 @@ export class TopControl extends CommonBase {
   async start() {
     // Let the outer app do its setup.
 
-    const apiUrl = this._sessionInfo.serverUrl;
+    const apiUrl = this._sessionInfo.apiUrl;
     await Editor.aboutToRun(this._window, apiUrl);
 
     // Arrange for the rest of initialization to happen once the initial page

--- a/scripts/api-call
+++ b/scripts/api-call
@@ -29,7 +29,7 @@ init-prog
 argError=0
 
 # URL to contact.
-serverUrl='http://localhost:8080/api'
+apiUrl='http://localhost:8080/api'
 
 # Need help?
 showHelp=0
@@ -41,7 +41,7 @@ while true; do
             break
             ;;
         --url=?*)
-            serverUrl="${1#*=}"
+            apiUrl="${1#*=}"
             ;;
         --) # End of all options.
             shift
@@ -110,7 +110,7 @@ response="$(curl \
     --silent \
     --header 'Content-Type: application/json; charset=utf-8' \
     --data-raw "${payload}" \
-    "${serverUrl}"
+    "${apiUrl}"
 )"
 
 if [[ $? != 0 ]]; then


### PR DESCRIPTION
This PR consists of a few unrelated bits of cleanup, which amount to tech-debt paydown on a few minor issues I noticed while working on cookie auth. Specifically:

* Got the local-dev and test-setup `.js` files covered by `eslint`, and modernized them a bit.
* Fixed the class doc comments on all the `Codecs` classes, which had been renamed in an earlier PR (which left the doc comments in an inaccurate / misleading state).
* Renamed almost all mentions of the term (variable / property) `serverUrl` to be the more specific and elucidative term `apiUrl`. I left one use of it (as described in a code comment / TODO near the definition).