### PR TITLE
Check cookies when told.

### DIFF
--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -327,7 +327,7 @@ export class Context extends CommonBase {
     // target, check cookies if necessary, and if everything looks good, cache
     // the target and associated data for lighterweight subsequent use.
 
-    const cookieNames = tokenAuth.cookieNamesForToken(token);
+    const cookieNames = await tokenAuth.cookieNamesForToken(token);
     const cookies     = {};
 
     // **TODO:** Remove this log spew once we're satisfied that cookie-ish

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -2,8 +2,8 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { Message, Remote } from '@bayou/api-common';
-import { TString } from '@bayou/typecheck';
+import { BearerToken, Message, Remote } from '@bayou/api-common';
+import { TObject, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
 import { BaseConnection } from './BaseConnection';
@@ -214,6 +214,21 @@ export class Context extends CommonBase {
   }
 
   /**
+   * Helper for {@link #_getTargetFromToken}, which caches the cookies that were
+   * recently used to validate the given token.
+   *
+   * @param {BearerToken} token The token in question.
+   * @param {object} cookies The cookies that were required (`{}` if no cookies
+   *   were required).
+   */
+  _cacheCookies(token, cookies) {
+    BearerToken.check(token);
+    TObject.plain(cookies);
+
+    this._cookieMap.set(token, cookies);
+  }
+
+  /**
    * Helper for {@link #_getTargetFromToken}, which confirms that the
    * connection's current cookies are a match for the cookies that were used
    * when the given token was originally authorized. This method is a no-op if
@@ -236,10 +251,11 @@ export class Context extends CommonBase {
   _cachedCookiesMatch(token) {
     const cookies = this._cookieMap.get(token);
 
-    if (!cookies) {
-      // No cookies were previously required. So, there's no need for further
-      // checking.
-      return true;
+    if (cookies === undefined) {
+      // No record of the token. This is indicative of a bug, but rather than
+      // just let it slide -- which could cascade into a security issue -- throw
+      // an error.
+      throw Errors.badUse(`Expected but did not find cookie record for token \`${token.safeString}\`.`);
     }
 
     for (const [name, origCookie] of Object.entries(cookies)) {
@@ -344,6 +360,8 @@ export class Context extends CommonBase {
     const target = new Target(token, targetObject);
 
     this.addTarget(target);
+    this._cacheCookies(token, cookies);
+
     return target;
   }
 


### PR DESCRIPTION
This PR fills in the last bits of stuff on the "front end of the back end" to perform cookie-based token authentication. Specifically, when the configured token authority indicates that cookies are required, `api-server.Context` checks its connection for the indicated cookies, passes them back to the token authority, and, if the token is indeed authorized, it then caches the now-known-good cookies so as to avoid having to re-re-…-check things on the back end.
