### PR TITLE
Do aggregate logging for the `/heath` and `/metrics` monitor endpoints.

### DIFF
--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -72,6 +72,7 @@ export class Monitor extends CommonBase {
    */
   _addRoutes() {
     const app             = this._app;
+    const requestLogger   = this._requestLogger;
     const mainApplication = this._mainApplication;
 
     // Logging.
@@ -91,6 +92,7 @@ export class Monitor extends CommonBase {
 
       ServerUtil.sendPlainTextResponse(res, text, status);
     });
+    requestLogger.aggregate('/health');
 
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
@@ -104,6 +106,7 @@ export class Monitor extends CommonBase {
     app.get('/metrics', async (req_unused, res) => {
       ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
     });
+    requestLogger.aggregate('/metrics');
 
     const varInfo = mainApplication.varInfo;
     app.get('/var', async (req_unused, res) => {

--- a/local-modules/@bayou/app-setup/RequestAggregateData.js
+++ b/local-modules/@bayou/app-setup/RequestAggregateData.js
@@ -17,7 +17,7 @@ const MAX_UNIQUE_IPS_PER_LOG = 20;
  * {Int} Aggregation interval, in msec. The system will only log an event for
  * any given aggregated path this often.
  */
-const AGGREGATION_INTERVAL_MSEC = 10000; //60 * 1000; // Once per minute.
+const AGGREGATION_INTERVAL_MSEC = 60 * 1000; // Once per minute.
 
 /**
  * Mutable holder for aggregated log data for requests to a particular path.

--- a/local-modules/@bayou/app-setup/RequestAggregateData.js
+++ b/local-modules/@bayou/app-setup/RequestAggregateData.js
@@ -1,0 +1,25 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { Logger } from '@bayou/see-all';
+import { CommonBase } from '@bayou/util-common';
+
+/**
+ * Mutable holder for aggregated log data for requests to a particular path.
+ */
+export class RequestAggregateData extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {Logger} log Logger to use.
+   */
+  constructor(log) {
+    super();
+
+    /** {Logger} Logger to use. */
+    this._log = Logger.check(log);
+  }
+
+  // **TODO:** Fill this in!
+}

--- a/local-modules/@bayou/app-setup/RequestAggregateData.js
+++ b/local-modules/@bayou/app-setup/RequestAggregateData.js
@@ -3,7 +3,14 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { Logger } from '@bayou/see-all';
+import { TInt, TString } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
+
+/**
+ * {Int} Maximum number of unique IP addresses to ever include in a logged item.
+ * (More than that will just get reported as a number.)
+ */
+const MAX_UNIQUE_IPS_PER_LOG = 20;
 
 /**
  * Mutable holder for aggregated log data for requests to a particular path.
@@ -19,7 +26,83 @@ export class RequestAggregateData extends CommonBase {
 
     /** {Logger} Logger to use. */
     this._log = Logger.check(log);
+
+    /**
+     * {Map<string, object>} Map from source IP addresses to an ad-hoc object
+     * which maps status codes to counts of requests.
+     */
+    this._ipMap = new Map();
+
+    Object.freeze(this);
   }
 
-  // **TODO:** Fill this in!
+  /**
+   * Indicates that a request was made to this path.
+   *
+   * @param {string} sourceIp Source IP address of the request.
+   * @param {Int} status Result status code.
+   */
+  requestMade(sourceIp, status) {
+    TString.nonEmpty(sourceIp);
+    TInt.nonNegative(status);
+
+    const statusCounts = this._getStatusArray(sourceIp);
+    statusCounts[status]++;
+  }
+
+  /**
+   * Writes out all the aggregated information held by this instance, and resets
+   * the instance for further aggregation.
+   */
+  logAndReset() {
+    let   totalRequests = 0;
+    const statusCounts  = {};
+    const allIps        = new Set();
+
+    for (const [ip, counts] of this._ipMap) {
+      allIps.add(ip);
+      for (const [status, count] of Object.entries(counts)) {
+        totalRequests += count;
+        statusCounts[status] += count;
+      }
+    }
+
+    const ips = RequestAggregateData._ipsForLogging(allIps);
+    this._log.event.httpAggregate({ totalRequests, statusCounts, ips });
+
+    this._ipMap.clear();
+  }
+
+  /**
+   * Gets the sparse array from status code to count, for the given source IP
+   * address. This creates and binds the array into {@link #_ipMap} if it isn't
+   * already bound.
+   *
+   * @param {string} sourceIp Source IP address.
+   * @returns {array} Corresponding array.
+   */
+  _getStatusArray(sourceIp) {
+    const already = this._ipMap.get(sourceIp);
+
+    if (already !== undefined) {
+      return already;
+    }
+
+    const result = {};
+
+    this._ipMap.set(sourceIp, result);
+    return result;
+  }
+
+  /**
+   * Gets the logging form for the given set of IP addresses.
+   *
+   * @param {Set} ips Set of IP addresses.
+   * @returns {*} Logging form for same.
+   */
+  static _ipsForLogging(ips) {
+    return (ips.size <= MAX_UNIQUE_IPS_PER_LOG)
+      ? [...ips]
+      : `${ips.size} unique addresses`;
+  }
 }

--- a/local-modules/@bayou/app-setup/RequestAggregateData.js
+++ b/local-modules/@bayou/app-setup/RequestAggregateData.js
@@ -17,7 +17,7 @@ const MAX_UNIQUE_IPS_PER_LOG = 20;
  * {Int} Aggregation interval, in msec. The system will only log an event for
  * any given aggregated path this often.
  */
-const AGGREGATION_INTERVAL_MSEC = 60 * 1000; // Once per minute.
+const AGGREGATION_INTERVAL_MSEC = 10000; //60 * 1000; // Once per minute.
 
 /**
  * Mutable holder for aggregated log data for requests to a particular path.
@@ -61,7 +61,7 @@ export class RequestAggregateData extends CommonBase {
     TInt.nonNegative(status);
 
     const statusCounts = this._getStatusArray(sourceIp);
-    statusCounts[status]++;
+    statusCounts[status] = (statusCounts[status] || 0) + 1;
 
     if (!this._timerRunning) {
       // There's no aggregation timer already running. Set it up, so that we
@@ -109,7 +109,7 @@ export class RequestAggregateData extends CommonBase {
       allIps.add(ip);
       for (const [status, count] of Object.entries(counts)) {
         totalRequests += count;
-        statusCounts[status] += count;
+        statusCounts[status] = (statusCounts[status] || 0) + count;
       }
     }
 

--- a/local-modules/@bayou/app-setup/RequestAggregateData.js
+++ b/local-modules/@bayou/app-setup/RequestAggregateData.js
@@ -19,10 +19,14 @@ export class RequestAggregateData extends CommonBase {
   /**
    * Constructs an instance.
    *
+   * @param {string} path Path which this instance is all about.
    * @param {Logger} log Logger to use.
    */
-  constructor(log) {
+  constructor(path, log) {
     super();
+
+    /** {String} path Path which this instance is all about. */
+    this._path = TString.nonEmpty(path);
 
     /** {Logger} Logger to use. */
     this._log = Logger.check(log);
@@ -68,7 +72,7 @@ export class RequestAggregateData extends CommonBase {
     }
 
     const ips = RequestAggregateData._ipsForLogging(allIps);
-    this._log.event.httpAggregate({ totalRequests, statusCounts, ips });
+    this._log.event.httpAggregate(this._path, { totalRequests, statusCounts, ips });
 
     this._ipMap.clear();
   }

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -6,7 +6,10 @@ import { fromPairs } from 'lodash';
 import { URL } from 'url';
 
 import { Logger, RedactUtil } from '@bayou/see-all';
-import { CommonBase, Random } from '@bayou/util-common';
+import { TString } from '@bayou/typecheck';
+import { CommonBase, Errors, Random } from '@bayou/util-common';
+
+import { RequestAggregateData } from './RequestAggregateData';
 
 /**
  * HTTP request logging functions. This includes logging to an HTTP `access.log`
@@ -27,6 +30,13 @@ export class RequestLogger extends CommonBase {
     /** {Logger} Logger to use. */
     this._log = Logger.check(log);
 
+    /**
+     * {Map<string, RequestAggregateData>} Map from request paths the
+     * corresponding aggregate data for the path. Keys are bound by
+     * {@link #aggregate}.
+     */
+    this._pathAggregateMap = new Map();
+
     Object.freeze(this);
   }
 
@@ -36,6 +46,22 @@ export class RequestLogger extends CommonBase {
    */
   get expressMiddleware() {
     return this._logExpressRequest.bind(this);
+  }
+
+  /**
+   * Adds a path to the set which are reported only in aggregate (instead of
+   * per request).
+   *
+   * @param {string} path Path to aggregate.
+   */
+  aggregate(path) {
+    TString.nonEmpty(path);
+
+    if (this._pathAggregateMap.has(path)) {
+      throw Errors.badUse(`Already aggregated: ${path}`);
+    }
+
+    this._pathAggregateMap.set(path, new RequestAggregateData(this._log));
   }
 
   /**

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -61,7 +61,7 @@ export class RequestLogger extends CommonBase {
       throw Errors.badUse(`Already aggregated: ${path}`);
     }
 
-    this._pathAggregateMap.set(path, new RequestAggregateData(this._log));
+    this._pathAggregateMap.set(path, new RequestAggregateData(path, this._log));
   }
 
   /**


### PR DESCRIPTION
Historically speaking, we issue logs for every HTTP request and response, including specifically the monitor server / endpoints. And in practice, we see a _lot_ of ops-driven activity on the `/health` and `/metrics` endpoints. This activity is enough to (a) obscure the "real" action of the servers, and (b) chew up noticeable CPU time and disk space to log (and to compress and rotate the logs).

Arguably, we should expect a lot fewer calls to these endpoints, but nonetheless we ought to tolerate the status quo and, to the extent possible, not make a bad situation worse. This PR aims to do (or _not_ do) just that. Specifically, for the aforementioned two endpoints, we now aggregate data about the requests and only log an event for them once every N seconds (where N == 60 right now, but we could tweak that).
