### PR TITLE
Tolerate some bad HTTP server behavior.

### DIFF
--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -114,8 +114,20 @@ export class RequestLogger extends CommonBase {
     // what after the response is issued (because we need to know the status
     // code).
 
+    // **TODO:** We have seen the `remoteAddress` be `undefined` when fetched
+    // in the `finish` block. The code here is now a bit baroque in order to get
+    // a little visibility about what's happening. Once we know what's up, we
+    // should simplify it and remove the extra logging spew.
+    const ipAddress = req.socket.remoteAddress || '<unknown>';
+
     res.on('finish', () => {
-      aggregate.requestMade(req.socket.remoteAddress, res.statusCode);
+      const ipInFinish = req.socket.remoteAddress || '<unknown>';
+
+      if (ipAddress !== ipInFinish) {
+        this._log.event.ipMismatch(ipAddress, ipInFinish);
+      }
+
+      aggregate.requestMade(ipAddress, res.statusCode);
     });
 
     return true;

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -121,13 +121,14 @@ export class RequestLogger extends CommonBase {
     const ipAddress = req.socket.remoteAddress || '<unknown>';
 
     res.on('finish', () => {
+      const statusCode = res.statusCode || 0;
       const ipInFinish = req.socket.remoteAddress || '<unknown>';
 
       if (ipAddress !== ipInFinish) {
         this._log.event.ipMismatch(ipAddress, ipInFinish);
       }
 
-      aggregate.requestMade(ipAddress, res.statusCode);
+      aggregate.requestMade(ipAddress, statusCode);
     });
 
     return true;


### PR DESCRIPTION
This PR makes the new HTTP aggregate logging tolerant to either the IP address or the result status code being absent. Neither of these should ever be absent, but in fact we have observed the IP address coming in as `undefined`, which threw the code for a loop. This PR includes a bit of extra logging to see if this only happens if we get the IP address during `finish` handling. A follow-on PR will clean things up once we have higher-fidelity knowledge of what's going on.