### PR TITLE
Tokenny tweak.

### DIFF
--- a/local-modules/@bayou/api-server/BaseConnection.js
+++ b/local-modules/@bayou/api-server/BaseConnection.js
@@ -338,7 +338,7 @@ export class BaseConnection extends CommonBase {
       const auth     = this._context.tokenAuthorizer;
       const targetId = msg.targetId;
 
-      if (auth.isToken(targetId)) {
+      if (auth.isTokenString(targetId)) {
         // The `targetId` is a token string. Replace the string with an actual
         // `BearerToken` instance.
         return msg.withTargetId(auth.tokenFromString(targetId));

--- a/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
@@ -13,8 +13,8 @@ import { CommonBase, Errors } from '@bayou/util-common';
 export class BaseTokenAuthorizer extends CommonBase {
   /**
    * {string} Prefix which when prepended to an arbitrary ID string is
-   * guaranteed to result in string for which {@link #isTokenString} is `false`. This
-   * is used by {@link Context} when generating non-token IDs.
+   * guaranteed to result in string for which {@link #isTokenString} is `false`.
+   * This is used by {@link Context} when generating non-token IDs.
    */
   get nonTokenPrefix() {
     return TString.check(this._impl_nonTokenPrefix);

--- a/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/BaseTokenAuthorizer.js
@@ -13,7 +13,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
 export class BaseTokenAuthorizer extends CommonBase {
   /**
    * {string} Prefix which when prepended to an arbitrary ID string is
-   * guaranteed to result in string for which {@link #isToken} is `false`. This
+   * guaranteed to result in string for which {@link #isTokenString} is `false`. This
    * is used by {@link Context} when generating non-token IDs.
    */
   get nonTokenPrefix() {
@@ -50,7 +50,7 @@ export class BaseTokenAuthorizer extends CommonBase {
    * @param {string} tokenString The alleged token string.
    * @returns {boolean} `true` iff `tokenString` has valid token syntax.
    */
-  isToken(tokenString) {
+  isTokenString(tokenString) {
     TString.check(tokenString);
 
     return TBoolean.check(this._impl_isToken(tokenString));
@@ -106,11 +106,11 @@ export class BaseTokenAuthorizer extends CommonBase {
    * any authority / authorization.
    *
    * @param {string} tokenString The token string. It is only valid to pass a
-   *   value for which {@link #isToken} returns `true`.
+   *   value for which {@link #isTokenString} returns `true`.
    * @returns {BearerToken} An appropriately-constructed instance.
    */
   tokenFromString(tokenString) {
-    if (!this.isToken(tokenString)) {
+    if (!this.isTokenString(tokenString)) {
       // Redact the token string in the error to avoid leaking
       // security-sensitive information.
       throw Errors.badValue(BearerToken.redactString(tokenString), 'bearer token');
@@ -164,7 +164,7 @@ export class BaseTokenAuthorizer extends CommonBase {
   }
 
   /**
-   * Subclass-specific implementation of {@link #isToken}. Subclasses must
+   * Subclass-specific implementation of {@link #isTokenString}. Subclasses must
    * override this method.
    *
    * @abstract
@@ -181,7 +181,7 @@ export class BaseTokenAuthorizer extends CommonBase {
    *
    * @abstract
    * @param {string} tokenString The alleged token string. It is guaranteed that
-   *   this is a string for which {@link #isToken} returned `true`.
+   *   this is a string for which {@link #isTokenString} returned `true`.
    * @returns {BearerToken} An appropriately-constructed instance.
    */
   _impl_tokenFromString(tokenString) {

--- a/local-modules/@bayou/api-server/Context.js
+++ b/local-modules/@bayou/api-server/Context.js
@@ -159,7 +159,7 @@ export class Context extends CommonBase {
   async getAuthorizedTarget(idOrToken) {
     const tokenAuth = this.tokenAuthorizer;
 
-    if ((tokenAuth !== null) && tokenAuth.isToken(idOrToken)) {
+    if ((tokenAuth !== null) && tokenAuth.isTokenString(idOrToken)) {
       // `idOrToken` is syntactically a bearer token according to our associated
       // token authorizer.
       return this._getTargetFromToken(idOrToken);
@@ -440,7 +440,7 @@ export class Context extends CommonBase {
    */
   _targetError(idOrToken, msg = 'Unknown target') {
     const tokenAuth = this.tokenAuthorizer;
-    const idToReport = ((tokenAuth !== null) && tokenAuth.isToken(idOrToken))
+    const idToReport = ((tokenAuth !== null) && tokenAuth.isTokenString(idOrToken))
       ? tokenAuth.tokenFromString(idOrToken).safeString
       : idOrToken;
 

--- a/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
+++ b/local-modules/@bayou/api-server/tests/test_BaseTokenAuthorizer.js
@@ -181,7 +181,7 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
     });
   });
 
-  describe('isToken()', () => {
+  describe('isTokenString()', () => {
     it('calls through to the `_impl` given a string', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_isToken(value) {
@@ -191,8 +191,8 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
 
       const au = new Authie();
 
-      assert.isTrue(au.isToken('token-yes'));
-      assert.isFalse(au.isToken('not-a-token'));
+      assert.isTrue(au.isTokenString('token-yes'));
+      assert.isFalse(au.isTokenString('not-a-token'));
     });
 
     it('rejects a non-string without calling through to the `_impl`', () => {
@@ -204,9 +204,9 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
 
       const au = new Authie();
 
-      assert.throws(() => au.isToken(null), /badValue/);
-      assert.throws(() => au.isToken(123), /badValue/);
-      assert.throws(() => au.isToken(['x']), /badValue/);
+      assert.throws(() => au.isTokenString(null), /badValue/);
+      assert.throws(() => au.isTokenString(123), /badValue/);
+      assert.throws(() => au.isTokenString(['x']), /badValue/);
     });
 
     it('rejects a bad subclass implementation', () => {
@@ -216,12 +216,12 @@ describe('@bayou/api-server/BaseTokenAuthorizer', () => {
         }
       }
 
-      assert.throws(() => new Authie().isToken('x'), /badValue/);
+      assert.throws(() => new Authie().isTokenString('x'), /badValue/);
     });
   });
 
   describe('tokenFromString()', () => {
-    it('validates via `isToken()` given a string, and calls through to the `_impl`', () => {
+    it('validates via `isTokenString()` given a string, and calls through to the `_impl`', () => {
       class Authie extends BaseTokenAuthorizer {
         _impl_isToken(value) {
           return value.startsWith('token-');

--- a/local-modules/@bayou/app-setup/AppAuthorizer.js
+++ b/local-modules/@bayou/app-setup/AppAuthorizer.js
@@ -79,7 +79,7 @@ export class AppAuthorizer extends BaseTokenAuthorizer {
    * @returns {boolean} `true` iff `tokenString` has valid token syntax.
    */
   _impl_isToken(tokenString) {
-    return Auth.isToken(tokenString);
+    return Auth.isTokenString(tokenString);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -206,7 +206,7 @@ export class DebugTools extends CommonBase {
    */
   _check_token(req_unused, value) {
     try {
-      if (Auth.isToken(value)) {
+      if (Auth.isTokenString(value)) {
         return;
       }
       Storage.docStore.checkAuthorIdSyntax(value);

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -126,7 +126,7 @@ export class Auth extends BaseAuth {
    * @param {string} tokenString The alleged token.
    * @returns {boolean} `true` iff `tokenString` is valid token syntax.
    */
-  static isToken(tokenString) {
+  static isTokenString(tokenString) {
     TString.check(tokenString);
     return TOKEN_REGEX.test(tokenString);
   }
@@ -135,7 +135,7 @@ export class Auth extends BaseAuth {
    * Implementation of standard configuration point.
    *
    * @param {string} tokenString The token. It is only valid to pass a value for
-   *   which {@link #isToken} returns `true`.
+   *   which {@link #isTokenString} returns `true`.
    * @returns {BearerToken} An appropriately-constructed instance.
    */
   static tokenFromString(tokenString) {

--- a/local-modules/@bayou/config-server-default/Auth.js
+++ b/local-modules/@bayou/config-server-default/Auth.js
@@ -38,7 +38,7 @@ const tokenMint = new TokenMint('autr');
 tokenMint.registerToken(THE_ROOT_TOKEN, Object.freeze({ type: BaseAuth.TYPE_root }));
 
 /**
- * Utility functionality regarding the network configuration of a server.
+ * Authorization-related functionality.
  */
 export class Auth extends BaseAuth {
   /**

--- a/local-modules/@bayou/config-server-default/tests/test_Auth.js
+++ b/local-modules/@bayou/config-server-default/tests/test_Auth.js
@@ -72,10 +72,10 @@ describe('@bayou/config-server-default/Auth', () => {
       assert.isFalse(t1.sameToken(t2));
     });
 
-    it('returns a token whose full string conforms to `isToken()`', async () => {
+    it('returns a token whose full string conforms to `isTokenString()`', async () => {
       const t = await Auth.getAuthorToken('some-author');
 
-      assert.isTrue(Auth.isToken(t.secretToken));
+      assert.isTrue(Auth.isTokenString(t.secretToken));
     });
 
     it('returns a token which elicits a correct response from `getAuthority()`', async () => {
@@ -151,28 +151,28 @@ describe('@bayou/config-server-default/Auth', () => {
     });
   });
 
-  describe('isToken()', () => {
+  describe('isTokenString()', () => {
     it('accepts token syntax', () => {
-      assert.isTrue(Auth.isToken(ROOT_TOKEN));
+      assert.isTrue(Auth.isTokenString(ROOT_TOKEN));
 
       for (const t of EXAMPLE_TOKENS) {
-        assert.isTrue(Auth.isToken(t), t);
+        assert.isTrue(Auth.isTokenString(t), t);
       }
     });
 
     it('rejects non-token syntax', () => {
-      assert.isFalse(Auth.isToken('00000000-11234def0'));
-      assert.isFalse(Auth.isToken('-0000000-11234def'));
-      assert.isFalse(Auth.isToken('z-0000000-1123cdef'));
-      assert.isFalse(Auth.isToken('zz-0000000-1123cdef'));
-      assert.isFalse(Auth.isToken('zzz-0000000-1123cdef'));
-      assert.isFalse(Auth.isToken('zzzz-0000000-1123cdef'));
-      assert.isFalse(Auth.isToken('root-0000000-112bcdef-'));
-      assert.isFalse(Auth.isToken('root-0000000-11234def-1'));
-      assert.isFalse(Auth.isToken('root-z0000000-112bcdef'));
-      assert.isFalse(Auth.isToken('root-00000000-11abcdef1'));
-      assert.isFalse(Auth.isToken('root-000000001123cdef'));
-      assert.isFalse(Auth.isToken('root-1-2'));
+      assert.isFalse(Auth.isTokenString('00000000-11234def0'));
+      assert.isFalse(Auth.isTokenString('-0000000-11234def'));
+      assert.isFalse(Auth.isTokenString('z-0000000-1123cdef'));
+      assert.isFalse(Auth.isTokenString('zz-0000000-1123cdef'));
+      assert.isFalse(Auth.isTokenString('zzz-0000000-1123cdef'));
+      assert.isFalse(Auth.isTokenString('zzzz-0000000-1123cdef'));
+      assert.isFalse(Auth.isTokenString('root-0000000-112bcdef-'));
+      assert.isFalse(Auth.isTokenString('root-0000000-11234def-1'));
+      assert.isFalse(Auth.isTokenString('root-z0000000-112bcdef'));
+      assert.isFalse(Auth.isTokenString('root-00000000-11abcdef1'));
+      assert.isFalse(Auth.isTokenString('root-000000001123cdef'));
+      assert.isFalse(Auth.isTokenString('root-1-2'));
     });
   });
 

--- a/local-modules/@bayou/config-server/Auth.js
+++ b/local-modules/@bayou/config-server/Auth.js
@@ -12,7 +12,7 @@ import { BaseAuth } from './BaseAuth';
 export class Auth extends BaseAuth {
   /**
    * {string} Prefix which when prepended to an arbitrary ID string is
-   * guaranteed to result in string for which {@link #isToken} is `false`.
+   * guaranteed to result in string for which {@link #isTokenString} is `false`.
    */
   static get nonTokenPrefix() {
     return use.Auth.nonTokenPrefix;
@@ -109,8 +109,8 @@ export class Auth extends BaseAuth {
    * @param {string} tokenString The alleged token.
    * @returns {boolean} `true` iff `tokenString` is syntactically valid.
    */
-  static isToken(tokenString) {
-    return use.Auth.isToken(tokenString);
+  static isTokenString(tokenString) {
+    return use.Auth.isTokenString(tokenString);
   }
 
   /**
@@ -119,7 +119,7 @@ export class Auth extends BaseAuth {
    * any authority / authorization.
    *
    * @param {string} tokenString The token. It is only valid to pass a value for
-   *   which {@link #isToken} returns `true`.
+   *   which {@link #isTokenString} returns `true`.
    * @returns {BearerToken} An appropriately-constructed instance.
    */
   static tokenFromString(tokenString) {
@@ -131,7 +131,7 @@ export class Auth extends BaseAuth {
    * for the purposes of lookup, logging, etc.
    *
    * @param {string} tokenString The token. It is only valid to pass a value for
-   *   which {@link #isToken} returns `true`.
+   *   which {@link #isTokenString} returns `true`.
    * @returns {string} The ID portion.
    */
   static tokenId(tokenString) {


### PR DESCRIPTION
This PR just renames `isToken()` to `isTokenString()`, to make things just a little less ambiguous / confusing.