### PR TITLE
Error tweaks.

### DIFF
--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -1286,6 +1286,7 @@ export class BaseControl extends BaseDataManager {
    * @param {Int} endExclusive Value as passed into {@link #_getChangeRange}.
    * @param {array<Int>} missingChanges All of the revision numbers of missing
    *   changes. Expected to be in order, ascending.
+   * @returns {Error} An appropriately-constructed error.
    */
   static _missingChangeError(documentId, startInclusive, endExclusive, missingChanges) {
     const rangeStr    = `for r${startInclusive}..r${endExclusive - 1}`;
@@ -1303,6 +1304,6 @@ export class BaseControl extends BaseDataManager {
       revStr = `[${first}, ... ${len - 2} more ..., ${last}]`;
     }
 
-    throw Errors.badUse(`Missing change in requested range: ${revStr}, ${rangeStr}, ${docStr}`);
+    return Errors.badUse(`Missing change in requested range: ${revStr}, ${rangeStr}, ${docStr}`);
   }
 }

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -272,10 +272,6 @@ export class BaseControl extends BaseDataManager {
    * such, even when used promptly, it should not be treated as "definitely
    * current" but more like "probably current but possibly just a lower bound."
    *
-   * **Note:** Currently, this function is practically synchronous,
-   * but has been kept `async` and takes an (unused) timeout in anticipation
-   * of a future state where it will deal with data that it has to page in.
-   *
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable
    *   range as defined by {@link Timeouts}. `null` is treated as the maximum
@@ -1134,14 +1130,14 @@ export class BaseControl extends BaseDataManager {
       throw Errors.badUse(`Too many changes requested at once: ${endExclusive - startInclusive}`);
     }
 
+    this.log.event.gettingChangeRange(startInclusive, endExclusive);
+
     const clazz           = this.constructor;
     const result          = [];
     const { file, codec } = this.fileCodec;
     const snapshot        = await file.getSnapshot(null, timeoutMsec);
     const prefix          = this.constructor.changePathPrefix;
     const data            = snapshot.getPathRange(prefix, startInclusive, endExclusive);
-
-    this.log.event.gettingChangeRange(startInclusive, endExclusive);
 
     for (let i = startInclusive; i < endExclusive; i++) {
       const path = clazz.pathForChange(i);

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,3 +1,3 @@
 # Metainformation about this product.
 name = bayou
-version = 1.4.2
+version = 1.4.3


### PR DESCRIPTION
This PR tweaks the error message produced out of `BaseControl.getChangeRange()`, in the case where it detects a missing change, to add more detail. We are still seeing this error from time to time, and this will help narrow down what's happening.

This PR also bumps the product version number, just as a "general cadence" release (not for anything more specific).