### PR TITLE
First cut of "just logging" version of artificial failure.

### DIFF
--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -96,7 +96,7 @@ export class Monitor extends CommonBase {
 
     app.get('/info', async (req_unused, res) => {
       ServerUtil.sendJsonResponse(res, {
-        boot:    ServerEnv.theOne.bootInfo,
+        boot:    ServerEnv.theOne.bootInfo.info,
         build:   ServerEnv.theOne.buildInfo,
         runtime: ServerEnv.theOne.runtimeInfo
       });

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -142,7 +142,7 @@ export class ArtificialFailureInfo extends CommonBase {
    * @param {string} s The string to hash.
    * @returns {Int} The hashed value.
    */
-  _stringPercentHash(s) {
+  static _stringPercentHash(s) {
     TString.check(s);
 
     const hash = crypto.createHash('sha256');

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -131,7 +131,7 @@ export class ArtificialFailureInfo extends CommonBase {
     }
 
     // Hash the server ID and convert it into a value in the range 0..99.
-    const serverNum = ArtificialFailureInfo.stringPercentHash(Deployment.serverId());
+    const serverNum = ArtificialFailureInfo._percentFromString(Deployment.serverId());
 
     return serverNum < percent;
   }
@@ -142,7 +142,7 @@ export class ArtificialFailureInfo extends CommonBase {
    * @param {string} s The string to hash.
    * @returns {Int} The hashed value.
    */
-  static _stringPercentHash(s) {
+  static _percentFromString(s) {
     TString.check(s);
 
     const hash = crypto.createHash('sha256');

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -137,26 +137,6 @@ export class ArtificialFailureInfo extends CommonBase {
   }
 
   /**
-   * Gets an integer value in the range `[0..99]` as the hash of a given string.
-   *
-   * @param {string} s The string to hash.
-   * @returns {Int} The hashed value.
-   */
-  static _percentFromString(s) {
-    TString.check(s);
-
-    const hash = crypto.createHash('sha256');
-
-    hash.update(s);
-
-    const digest = hash.digest();
-    const value  = digest.readUInt32LE(); // Grab first 32 bits as the base hash.
-    const frac   = value / 0x100000000;
-
-    return Math.floor(frac * 100);
-  }
-
-  /**
    * Parses the failure info out of a boot info object.
    *
    * @param {BootInfo} buildInfo The boot info.
@@ -179,5 +159,25 @@ export class ArtificialFailureInfo extends CommonBase {
     }
 
     return [percentNum, typeConst];
+  }
+
+  /**
+   * Gets an integer value in the range `[0..99]` as the hash of a given string.
+   *
+   * @param {string} s The string to hash.
+   * @returns {Int} The hashed value.
+   */
+  static _percentFromString(s) {
+    TString.check(s);
+
+    const hash = crypto.createHash('sha256');
+
+    hash.update(s);
+
+    const digest = hash.digest();
+    const value  = digest.readUInt32LE(); // Grab first 32 bits as the base hash.
+    const frac   = value / 0x100000000;
+
+    return Math.floor(frac * 100);
   }
 }

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -105,26 +105,28 @@ export class ArtificialFailureInfo extends CommonBase {
   }
 
   /**
-   * Indicates whether this server should actually be failing with the indicated
-   * type of failure. This will be `true` _if and only if_ all of:
+   * Indicates whether this server should actually be failing at all, or failing
+   * specifically with the indicated type of failure. This will be `true` _if
+   * and only if_ all of:
    *
    * * {@link #allowFailure} was called.
-   * * {@link #failType} is the one passed here.
+   * * {@link #failType} is the one passed here or is `null`.
    * * This server's hash causes it to be in the failing cohort per the
    *   {@link #failPercent}.
    *
-   * @param {string} failType Type of failure in question. Must be one of the
-   *   `TYPE_*` constants defined by this class.
+   * @param {string|null} [failType = null] Type of failure in question, or
+   *   `null` to just ask if this server should be faily in general. If
+   *   non-`null`, must be one of the `TYPE_*` constants defined by this class.
    * @returns {boolean} `true` if this server should be failing in the indicated
    *   manner, or `false` if not.
    */
-  shouldFail(failType) {
-    TString.check(failType);
+  shouldFail(failType = null) {
+    TString.orNull(failType);
 
-    // This will be `0` if `allowFailure()` wasn't called.
-    const percent = this.failPercent;
+    const percent     = this.failPercent; // This will be `0` if `allowFailure()` wasn't called.
+    const typeMatches = (failType === null) || (failType === this.failType);
 
-    if ((percent === 0) || (failType !== this.failType)) {
+    if ((percent === 0) || !typeMatches) {
       return false;
     }
 

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -152,7 +152,7 @@ export class ArtificialFailureInfo extends CommonBase {
     const typeConst  = ArtificialFailureInfo[`TYPE_${camelType}`];
 
     if (   isNaN(percentNum) || (percentNum < 0) || (percentNum > 100)
-        || (typeConst !== artificialFailureType)) {
+        || (typeConst !== camelType)) {
       // Fail-safe: If the build info properties aren't set up right, treat it
       // as a no-failure situation.
       return [0, ArtificialFailureInfo.TYPE_none];

--- a/local-modules/@bayou/env-server/ArtificialFailureInfo.js
+++ b/local-modules/@bayou/env-server/ArtificialFailureInfo.js
@@ -131,7 +131,7 @@ export class ArtificialFailureInfo extends CommonBase {
     }
 
     // Hash the server ID and convert it into a value in the range 0..99.
-    const serverNum = ArtificialFailureInfo.stringPercentHash(Deployment.serverId);
+    const serverNum = ArtificialFailureInfo.stringPercentHash(Deployment.serverId());
 
     return serverNum < percent;
   }

--- a/local-modules/@bayou/env-server/BootInfo.js
+++ b/local-modules/@bayou/env-server/BootInfo.js
@@ -90,6 +90,21 @@ export class BootInfo extends CommonBase {
   }
 
   /**
+   * Logs a boot metric, specifically for the purpose of an artificial failure
+   * scenario.
+   *
+   * @param {Int} errorCount How many errors to indicate in the logged record.
+   */
+  logArtificialFailure(errorCount) {
+    const payload = this._bootMetricPayload();
+
+    payload.bootCount          += errorCount;
+    payload.errorShutdownCount += errorCount;
+
+    log.metric.boot(payload);
+  }
+
+  /**
    * Records an error which caused server shutdown, for inclusion in the
    * instance of this class upon the _next_ server start.
    *
@@ -126,11 +141,21 @@ export class BootInfo extends CommonBase {
   }
 
   /**
+   * Gets the payload to use for the `boot` metric.
+   *
+   * @returns {object} The boot metric payload.
+   */
+  _bootMetricPayload() {
+    const { bootCount, buildId, cleanShutdownCount, errorShutdownCount } = this._info;
+
+    return { bootCount, buildId, cleanShutdownCount, errorShutdownCount };
+  }
+
+  /**
    * Logs the `boot` metric.
    */
   _logBoot() {
-    const { bootCount, buildId, cleanShutdownCount, errorShutdownCount } = this._info;
-    log.metric.boot({ buildId, bootCount, cleanShutdownCount, errorShutdownCount });
+    log.metric.boot(this._bootMetricPayload());
   }
 
   /**

--- a/local-modules/@bayou/env-server/ServerEnv.js
+++ b/local-modules/@bayou/env-server/ServerEnv.js
@@ -64,14 +64,11 @@ export class ServerEnv extends Singleton {
   }
 
   /**
-   * {object} Ad-hoc object with generally-useful info about the booting of this
-   * server, intended for logging / debugging.
-   *
-   * **Note:** This isn't all-caps `*_INFO` because it's not necessarily
-   * expected to be a constant value.
+   * {BootInfo} Info about the booting of this server, intended for logging /
+   * debugging.
    */
   get bootInfo() {
-    return this._bootInfo.info;
+    return this._bootInfo;
   }
 
   /**

--- a/local-modules/@bayou/env-server/index.js
+++ b/local-modules/@bayou/env-server/index.js
@@ -3,7 +3,8 @@
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
 import { ArtificialFailureInfo } from './ArtificialFailureInfo';
+import { BootInfo } from './BootInfo';
 import { Dirs } from './Dirs';
 import { ServerEnv } from './ServerEnv';
 
-export { ArtificialFailureInfo, Dirs, ServerEnv };
+export { ArtificialFailureInfo, BootInfo, Dirs, ServerEnv };

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -16,6 +16,7 @@ import { HumanSink, FileSink } from '@bayou/see-all-server';
 import { ClientTests, ServerTests } from '@bayou/testing-server';
 import { CommonBase } from '@bayou/util-common';
 
+import { ArtificialFailure } from './ArtificialFailure';
 import { Options } from './Options';
 
 /** {Logger} Logger for this file. */
@@ -281,6 +282,10 @@ export class Action extends CommonBase {
         }
       }
     }
+
+    // If configured for artificial failure _and_ the top-level handler for same
+    // knows how to do it, this will kick off the failure in question.
+    ArtificialFailure.startFailingIfAppropriate();
 
     return result;
   }

--- a/local-modules/@bayou/top-server/Action.js
+++ b/local-modules/@bayou/top-server/Action.js
@@ -262,7 +262,7 @@ export class Action extends CommonBase {
 
     log.event.buildInfo(ServerEnv.theOne.buildInfo);
     log.event.runtimeInfo(ServerEnv.theOne.runtimeInfo);
-    log.event.bootInfo(ServerEnv.theOne.bootInfo);
+    log.event.bootInfo(ServerEnv.theOne.bootInfo.info);
 
     /** {Application} The main app server. */
     const theApp = new Application(devRoutes);

--- a/local-modules/@bayou/top-server/ArtificialFailure.js
+++ b/local-modules/@bayou/top-server/ArtificialFailure.js
@@ -2,7 +2,7 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
-import { ArtificialFailureInfo, ServerEnv } from '@bayou/env-server';
+import { ServerEnv } from '@bayou/env-server';
 import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
 import { UtilityClass } from '@bayou/util-common';
@@ -25,7 +25,7 @@ export class ArtificialFailure extends UtilityClass {
    * action, no error); this is done so that it's possible to call this method
    * unconditionally during system startup.
    */
-  static startFailingAsAppropriate() {
+  static startFailingIfAppropriate() {
     const failInfo = ServerEnv.theOne.artificialFailureInfo;
 
     if (failInfo.shouldFail()) {

--- a/local-modules/@bayou/top-server/ArtificialFailure.js
+++ b/local-modules/@bayou/top-server/ArtificialFailure.js
@@ -42,13 +42,18 @@ export class ArtificialFailure extends UtilityClass {
    * Start behaving badly per the `justLogging` failure mode.
    */
   static fail_justLogging() {
+    const bootInfo = ServerEnv.theOne.bootInfo;
+
     (async () => {
       let count = 0;
 
       for (;;) {
+        // One spate of logging every ten seconds.
+        await Delay.resolve(10 * 1000);
+
         count++;
         log.event.artificialFailure(count);
-        await Delay.resolve(1000);
+        bootInfo.logArtificialFailure(count);
       }
     })();
   }

--- a/local-modules/@bayou/top-server/ArtificialFailure.js
+++ b/local-modules/@bayou/top-server/ArtificialFailure.js
@@ -1,0 +1,55 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { ArtificialFailureInfo, ServerEnv } from '@bayou/env-server';
+import { Delay } from '@bayou/promise-util';
+import { Logger } from '@bayou/see-all';
+import { UtilityClass } from '@bayou/util-common';
+
+/** {Logger} Logger for this file. */
+const log = new Logger('art-fail');
+
+/**
+ * Utility class with the top-level implementations of some of the possible
+ * artificial failures.
+ *
+ * **Note:** As of this writing, this file has _all_ the artificial failure
+ * implementations, but in the long run that will probably stop being true.
+ */
+export class ArtificialFailure extends UtilityClass {
+  /**
+   * Start behaving badly per the configiured failure mode, if any. If either
+   * (a) no failure is to happen on this server, or (b) this class doesn't
+   * handle the failure mode in question, then this method is a no-op (no
+   * action, no error); this is done so that it's possible to call this method
+   * unconditionally during system startup.
+   */
+  static startFailingAsAppropriate() {
+    const failInfo = ServerEnv.theOne.artificialFailureInfo;
+
+    if (failInfo.shouldFail()) {
+      const failType   = failInfo.failType;
+      const failMethod = ArtificialFailure[`fail_${failType}`];
+      if (failMethod !== undefined) {
+        log.event.topLevelArtificialFailure(failType);
+        failMethod.call(ArtificialFailure);
+      }
+    }
+  }
+
+  /**
+   * Start behaving badly per the `justLogging` failure mode.
+   */
+  static fail_justLogging() {
+    (async () => {
+      let count = 0;
+
+      for (;;) {
+        count++;
+        log.event.artificialFailure(count);
+        await Delay.resolve(1000);
+      }
+    })();
+  }
+}


### PR DESCRIPTION
This PR fixes a few problems with the artificial failure infrastructure, and builds the first actual failure scenario. Specifically, when the `just_logging` failure is enabled, a server will log a `boot` metric as if it were in an early crash loop.

To be clear, this PR _does not_ configure the system to actually produce any artificial failures.
