### PR TITLE
Two bits to prepare for high-level load info

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -66,11 +66,11 @@ export class AuthorAccess extends CommonBase {
 
     const authorId    = this._authorId;
     const { canEdit } = await this._checkIdsAndGetPermissions(documentId);
-    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
+    const docComplex  = await DocServer.theOne.getFileComplex(documentId);
 
     let session;
     try {
-      session = await fileComplex.findExistingSession(authorId, caretId, canEdit);
+      session = await docComplex.findExistingSession(authorId, caretId, canEdit);
     } catch (e) {
       if (Errors.is_badId(e)) {
         // Per method header doc, this isn't considered a throwable offense.
@@ -108,8 +108,8 @@ export class AuthorAccess extends CommonBase {
 
     const authorId    = this._authorId;
     const { canEdit } = await this._checkIdsAndGetPermissions(documentId);
-    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
-    const session     = await fileComplex.makeNewSession(authorId, canEdit);
+    const docComplex  = await DocServer.theOne.getFileComplex(documentId);
+    const session     = await docComplex.makeNewSession(authorId, canEdit);
     const caretId     = session.getCaretId();
 
     log.event.madeSession({ authorId, documentId, caretId, canEdit });

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -420,9 +420,9 @@ export class DebugTools extends CommonBase {
    * @returns {BodyControl} Promise for the requested document.
    */
   async _getExistingBody(req) {
-    const documentId  = req.params.documentId;
-    const fileComplex = await DocServer.theOne.getFileComplex(documentId);
-    const exists      = await fileComplex.file.exists();
+    const documentId = req.params.documentId;
+    const docComplex = await DocServer.theOne.getFileComplex(documentId);
+    const exists     = await docComplex.file.exists();
 
     if (!exists) {
       const error = new Error();
@@ -430,7 +430,7 @@ export class DebugTools extends CommonBase {
       throw error;
     }
 
-    return fileComplex.bodyControl;
+    return docComplex.bodyControl;
   }
 
   /**

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -13,7 +13,7 @@ import { CommonBase, Errors } from '@bayou/util-common';
 
 /**
  * {Int} How long to wait (in msec) in {@link #makeSessionInfo} while holding
- * a {@link FileComplex}, as a tactic to avoid overly-eager GC. See long comment
+ * a {@link DocComplex}, as a tactic to avoid overly-eager GC. See long comment
  * in that method for details.
  */
 const COMPLEX_HOLD_TIME_MSEC = 10 * 1000; // One second.

--- a/local-modules/@bayou/doc-server/BaseComplexMember.js
+++ b/local-modules/@bayou/doc-server/BaseComplexMember.js
@@ -8,8 +8,8 @@ import { CommonBase } from '@bayou/util-common';
 import { FileAccess } from './FileAccess';
 
 /**
- * Base class for things that hook up to a {@link FileComplex} and for
- * `FileComplex` itself.
+ * Base class for things that hook up to a {@link DocComplex} and for
+ * `DocComplex` itself.
  */
 export class BaseComplexMember extends CommonBase {
   /**

--- a/local-modules/@bayou/doc-server/BaseControl.js
+++ b/local-modules/@bayou/doc-server/BaseControl.js
@@ -45,7 +45,7 @@ const CHANGES_PER_STORED_SNAPSHOT = 1000;
 /**
  * Base class for document part controllers. There is one instance of each
  * concrete subclass of this class for each actively-edited document. They are
- * all managed and hooked up via {@link FileComplex}.
+ * all managed and hooked up via {@link DocComplex}.
  *
  * This class has two direct subclasses, which are both abstract,
  * {@link DurableControl} and {@link EphemeralControl}. The only difference

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -27,7 +27,7 @@ export class BaseSession extends CommonBase {
   constructor(docComplex, authorId, caretId) {
     super();
 
-    /** {DocComplex} File complex that this instance is part of. */
+    /** {DocComplex} Document complex that this instance is part of. */
     this._docComplex = DocComplex.check(docComplex);
 
     /** {string} Author ID. */

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -19,16 +19,16 @@ export class BaseSession extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {DocComplex} fileComplex File complex representing the underlying
-   *   file for this instance to use.
+   * @param {DocComplex} docComplex Document complex representing the underlying
+   *   document for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
    */
-  constructor(fileComplex, authorId, caretId) {
+  constructor(docComplex, authorId, caretId) {
     super();
 
     /** {DocComplex} File complex that this instance is part of. */
-    this._docComplex = DocComplex.check(fileComplex);
+    this._docComplex = DocComplex.check(docComplex);
 
     /** {string} Author ID. */
     this._authorId = Storage.docStore.checkAuthorIdSyntax(authorId);
@@ -40,13 +40,13 @@ export class BaseSession extends CommonBase {
     this._canEdit = TBoolean.check(this._impl_canEdit());
 
     /** {BodyControl} The underlying body content controller. */
-    this._bodyControl = fileComplex.bodyControl;
+    this._bodyControl = docComplex.bodyControl;
 
     /** {CaretControl} The underlying caret info controller. */
-    this._caretControl = fileComplex.caretControl;
+    this._caretControl = docComplex.caretControl;
 
     /** {PropertyControl} The underlying property (metadata) controller. */
-    this._propertyControl = fileComplex.propertyControl;
+    this._propertyControl = docComplex.propertyControl;
 
     /** {Logger} Logger to use to relay events coming from the client. */
     this._clientLog = this._docComplex.fileAccess.log.withAddedContext('client');

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -28,7 +28,7 @@ export class BaseSession extends CommonBase {
     super();
 
     /** {DocComplex} File complex that this instance is part of. */
-    this._fileComplex = DocComplex.check(fileComplex);
+    this._docComplex = DocComplex.check(fileComplex);
 
     /** {string} Author ID. */
     this._authorId = Storage.docStore.checkAuthorIdSyntax(authorId);
@@ -49,7 +49,7 @@ export class BaseSession extends CommonBase {
     this._propertyControl = fileComplex.propertyControl;
 
     /** {Logger} Logger to use to relay events coming from the client. */
-    this._clientLog = this._fileComplex.fileAccess.log.withAddedContext('client');
+    this._clientLog = this._docComplex.fileAccess.log.withAddedContext('client');
   }
 
   /**
@@ -151,7 +151,7 @@ export class BaseSession extends CommonBase {
    * @returns {string} The document ID.
    */
   getDocumentId() {
-    return this._fileComplex.fileAccess.documentId;
+    return this._docComplex.fileAccess.documentId;
   }
 
   /**
@@ -160,7 +160,7 @@ export class BaseSession extends CommonBase {
    * @returns {string} The file ID.
    */
   getFileId() {
-    return this._fileComplex.fileAccess.file.id;
+    return this._docComplex.fileAccess.file.id;
   }
 
   /**

--- a/local-modules/@bayou/doc-server/BaseSession.js
+++ b/local-modules/@bayou/doc-server/BaseSession.js
@@ -7,7 +7,7 @@ import { CaretId } from '@bayou/doc-common';
 import { TBoolean } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
-import { FileComplex } from './FileComplex';
+import { DocComplex } from './DocComplex';
 
 /**
  * Base class for the server-side representative of an access session for a
@@ -19,7 +19,7 @@ export class BaseSession extends CommonBase {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex representing the underlying
+   * @param {DocComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
@@ -27,8 +27,8 @@ export class BaseSession extends CommonBase {
   constructor(fileComplex, authorId, caretId) {
     super();
 
-    /** {FileComplex} File complex that this instance is part of. */
-    this._fileComplex = FileComplex.check(fileComplex);
+    /** {DocComplex} File complex that this instance is part of. */
+    this._fileComplex = DocComplex.check(fileComplex);
 
     /** {string} Author ID. */
     this._authorId = Storage.docStore.checkAuthorIdSyntax(authorId);

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -28,7 +28,7 @@ const MAKE_SESSION_TIMEOUT_MSEC = 10 * 1000; // Ten seconds.
  * how many active editors there are on that document. (This guarantee is
  * provided by `DocServer`.)
  */
-export class FileComplex extends BaseComplexMember {
+export class DocComplex extends BaseComplexMember {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/DocComplexCache.js
+++ b/local-modules/@bayou/doc-server/DocComplexCache.js
@@ -10,7 +10,7 @@ import { FileComplex } from './FileComplex';
 /**
  * Cache of active instances of {@link FileComplex}.
  */
-export class FileComplexCache extends BaseCache {
+export class DocComplexCache extends BaseCache {
   /**
    * Constructs an instance.
    *

--- a/local-modules/@bayou/doc-server/DocComplexCache.js
+++ b/local-modules/@bayou/doc-server/DocComplexCache.js
@@ -5,10 +5,10 @@
 import { Storage } from '@bayou/config-server';
 import { BaseCache } from '@bayou/weak-lru-cache';
 
-import { FileComplex } from './FileComplex';
+import { DocComplex } from './DocComplex';
 
 /**
- * Cache of active instances of {@link FileComplex}.
+ * Cache of active instances of {@link DocComplex}.
  */
 export class DocComplexCache extends BaseCache {
   /**
@@ -22,7 +22,7 @@ export class DocComplexCache extends BaseCache {
 
   /** @override */
   get _impl_cachedClass() {
-    return FileComplex;
+    return DocComplex;
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/DocComplexCache.js
+++ b/local-modules/@bayou/doc-server/DocComplexCache.js
@@ -36,8 +36,8 @@ export class DocComplexCache extends BaseCache {
   }
 
   /** @override */
-  _impl_idFromObject(fileComplex) {
-    return fileComplex.fileAccess.documentId;
+  _impl_idFromObject(docComplex) {
+    return docComplex.fileAccess.documentId;
   }
 
   /** @override */

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -7,7 +7,7 @@ import { Storage } from '@bayou/config-server';
 import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';
 
-import { FileComplex } from './FileComplex';
+import { DocComplex } from './DocComplex';
 import { DocComplexCache } from './DocComplexCache';
 
 /** {Logger} Logger for this module. */
@@ -33,7 +33,7 @@ export class DocServer extends Singleton {
     this._codec = Codecs.fullCodec;
 
     /**
-     * {DocComplexCache} Cache of {@link FileComplex} instances, mapped from
+     * {DocComplexCache} Cache of {@link DocComplex} instances, mapped from
      * document IDs.
      */
     this._complexes = new DocComplexCache(log);
@@ -42,11 +42,11 @@ export class DocServer extends Singleton {
   }
 
   /**
-   * Gets the `FileComplex` for the document with the given ID. It is okay (not
+   * Gets the `DocComplex` for the document with the given ID. It is okay (not
    * an error) if the underlying file doesn't happen to exist.
    *
    * @param {string} documentId The document ID.
-   * @returns {FileComplex} The corresponding `FileComplex`.
+   * @returns {DocComplex} The corresponding `DocComplex`.
    */
   async getFileComplex(documentId) {
     // **Note:** We don't make an `async` back-end call to check the full
@@ -66,7 +66,7 @@ export class DocServer extends Singleton {
         const fileId  = docInfo.fileId;
 
         const file   = await Storage.fileStore.getFile(fileId);
-        const result = new FileComplex(this._codec, documentId, file);
+        const result = new DocComplex(this._codec, documentId, file);
 
         result.log.event.makingComplex(...((fileId === documentId) ? [] : [fileId]));
 

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -8,7 +8,7 @@ import { Logger } from '@bayou/see-all';
 import { Singleton } from '@bayou/util-common';
 
 import { FileComplex } from './FileComplex';
-import { FileComplexCache } from './FileComplexCache';
+import { DocComplexCache } from './DocComplexCache';
 
 /** {Logger} Logger for this module. */
 const log = new Logger('doc-server');
@@ -33,10 +33,10 @@ export class DocServer extends Singleton {
     this._codec = Codecs.fullCodec;
 
     /**
-     * {FileComplexCache} Cache of {@link FileComplex} instances, mapped from
+     * {DocComplexCache} Cache of {@link FileComplex} instances, mapped from
      * document IDs.
      */
-    this._complexes = new FileComplexCache(log);
+    this._complexes = new DocComplexCache(log);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -17,7 +17,7 @@ export class EditSession extends ViewSession {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex representing the underlying
+   * @param {DocComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.

--- a/local-modules/@bayou/doc-server/EditSession.js
+++ b/local-modules/@bayou/doc-server/EditSession.js
@@ -17,13 +17,13 @@ export class EditSession extends ViewSession {
   /**
    * Constructs an instance.
    *
-   * @param {DocComplex} fileComplex File complex representing the underlying
-   *   file for this instance to use.
+   * @param {DocComplex} docComplex Document complex representing the underlying
+   *   document for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
    */
-  constructor(fileComplex, authorId, caretId) {
-    super(fileComplex, authorId, caretId);
+  constructor(docComplex, authorId, caretId) {
+    super(docComplex, authorId, caretId);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/FileAccess.js
+++ b/local-modules/@bayou/doc-server/FileAccess.js
@@ -16,7 +16,7 @@ const log = new Logger('doc');
  * {@link Logger} instance for use with a file complex. This class mainly exists
  * exists so as to make it easier to test {@link BaseControl} and its subclasses
  * in isolation, since otherwise they would all have mutual dependencies via
- * {@link FileComplex}.
+ * {@link DocComplex}.
  */
 export class FileAccess extends CommonBase {
   /**

--- a/local-modules/@bayou/doc-server/ViewSession.js
+++ b/local-modules/@bayou/doc-server/ViewSession.js
@@ -21,13 +21,13 @@ export class ViewSession extends BaseSession {
   /**
    * Constructs an instance.
    *
-   * @param {DocComplex} fileComplex File complex representing the underlying
-   *   file for this instance to use.
+   * @param {DocComplex} docComplex Document complex representing the underlying
+   *   document for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.
    */
-  constructor(fileComplex, authorId, caretId) {
-    super(fileComplex, authorId, caretId);
+  constructor(docComplex, authorId, caretId) {
+    super(docComplex, authorId, caretId);
 
     Object.freeze(this);
   }

--- a/local-modules/@bayou/doc-server/ViewSession.js
+++ b/local-modules/@bayou/doc-server/ViewSession.js
@@ -21,7 +21,7 @@ export class ViewSession extends BaseSession {
   /**
    * Constructs an instance.
    *
-   * @param {FileComplex} fileComplex File complex representing the underlying
+   * @param {DocComplex} fileComplex File complex representing the underlying
    *   file for this instance to use.
    * @param {string} authorId The author this instance acts on behalf of.
    * @param {string} caretId Caret ID for this instance.

--- a/local-modules/@bayou/doc-server/index.js
+++ b/local-modules/@bayou/doc-server/index.js
@@ -8,12 +8,12 @@ import { BaseDataManager } from './BaseDataManager';
 import { BodyControl } from './BodyControl';
 import { BodyDeltaHtml } from './BodyDeltaHtml';
 import { CaretControl } from './CaretControl';
+import { DocComplex } from './DocComplex';
 import { DocServer } from './DocServer';
 import { EditSession } from './EditSession';
 import { DurableControl } from './DurableControl';
 import { EphemeralControl } from './EphemeralControl';
 import { FileAccess } from './FileAccess';
-import { FileComplex } from './FileComplex';
 import { PropertyControl } from './PropertyControl';
 import { SchemaHandler } from './SchemaHandler';
 import { ValidationStatus } from './ValidationStatus';
@@ -25,12 +25,12 @@ export {
   BodyControl,
   BodyDeltaHtml,
   CaretControl,
+  DocComplex,
   DocServer,
   EditSession,
   DurableControl,
   EphemeralControl,
   FileAccess,
-  FileComplex,
   PropertyControl,
   SchemaHandler,
   ValidationStatus

--- a/local-modules/@bayou/weak-lru-cache/BaseCache.js
+++ b/local-modules/@bayou/weak-lru-cache/BaseCache.js
@@ -64,6 +64,17 @@ export class BaseCache extends CommonBase {
   }
 
   /**
+   * {Int} An upper bound on the size (count of cached items) of this instance.
+   *
+   * **Note:** This value can be _larger_ than the actual number of items in the
+   * cache, because it is possible that there are entries in the cache whose
+   * cached values have been GC'ed.
+   */
+  get size() {
+    return this._weakCache.size;
+  }
+
+  /**
    * Adds the given instance to the cache, both as a weak reference and strongly
    * at the head of the LRU cache (that is, as the _most_ recently referenced
    * object). It is an error to add an instance with an ID that is already

--- a/product-info.txt
+++ b/product-info.txt
@@ -9,7 +9,8 @@ version = 1.4.3
 # failures, e.g. for testing and for deployment/rollback drills.
 #
 
-# The proportion of servers which should experience the failure. Recommendation:
+# The proportion of servers which should experience the failure. Uncomment this
+# (and set to the desired level) to enable artificial failure. Recommendation:
 # If actually deploying into production, it is probably not a good idea to set
 # this higher than 50.
 


### PR DESCRIPTION
This PR has two changes, both small steps in service of eventually exposing a high-level "load" metric, that is, how utilized a server is.

* Add a `.size` property to `weak-lru-cache.BaseCache`.
* In `doc-server`, rename `FileComplex` to `DocComplex`, along with related name changes.

I did the latter, exactly because I managed to confuse myself with the misleading (former) name while poking around the code for the effort in question.
