### PR TITLE
A little more WIP on "load factor" reporting

### DIFF
--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -66,7 +66,7 @@ export class AuthorAccess extends CommonBase {
 
     const authorId    = this._authorId;
     const { canEdit } = await this._checkIdsAndGetPermissions(documentId);
-    const docComplex  = await DocServer.theOne.getFileComplex(documentId);
+    const docComplex  = await DocServer.theOne.getDocComplex(documentId);
 
     let session;
     try {
@@ -108,7 +108,7 @@ export class AuthorAccess extends CommonBase {
 
     const authorId    = this._authorId;
     const { canEdit } = await this._checkIdsAndGetPermissions(documentId);
-    const docComplex  = await DocServer.theOne.getFileComplex(documentId);
+    const docComplex  = await DocServer.theOne.getDocComplex(documentId);
     const session     = await docComplex.makeNewSession(authorId, canEdit);
     const caretId     = session.getCaretId();
 

--- a/local-modules/@bayou/app-setup/DebugTools.js
+++ b/local-modules/@bayou/app-setup/DebugTools.js
@@ -421,7 +421,7 @@ export class DebugTools extends CommonBase {
    */
   async _getExistingBody(req) {
     const documentId = req.params.documentId;
-    const docComplex = await DocServer.theOne.getFileComplex(documentId);
+    const docComplex = await DocServer.theOne.getDocComplex(documentId);
     const exists     = await docComplex.file.exists();
 
     if (!exists) {

--- a/local-modules/@bayou/app-setup/RootAccess.js
+++ b/local-modules/@bayou/app-setup/RootAccess.js
@@ -72,7 +72,7 @@ export class RootAccess extends CommonBase {
     // might as well warm it up. But also, this ensures that the complex is in
     // at least a semblance of a valid state before we return the info to the
     // caller.
-    const complex = await DocServer.theOne.getFileComplex(documentId);
+    const complex = await DocServer.theOne.getDocComplex(documentId);
 
     // This is a little bit of a hack: Immediately after the above call to get
     // the file complex returns, the complex _would_ be GC-able because there

--- a/local-modules/@bayou/doc-common/BodyOp.js
+++ b/local-modules/@bayou/doc-common/BodyOp.js
@@ -297,7 +297,7 @@ export class BodyOp extends BaseOp {
    */
   get _impl_roughSize() {
     const props = this.props;
-    let   total = 10;
+    let   total = props.opName.length + 10;
 
     if (props.text !== undefined) {
       total += props.text.length;

--- a/local-modules/@bayou/doc-common/BodyOp.js
+++ b/local-modules/@bayou/doc-common/BodyOp.js
@@ -293,6 +293,33 @@ export class BodyOp extends BaseOp {
   }
 
   /**
+   * {Int} Subclass-specific implementation of {@link #roughSize}.
+   */
+  get _impl_roughSize() {
+    const props = this.props;
+    let   total = 10;
+
+    if (props.text !== undefined) {
+      total += props.text.length;
+    }
+
+    if (props.value !== undefined) {
+      // **TODO:** This is an arbitrary value, so we can't do anything too
+      // specific with it, but maybe we should do better than just adding an
+      // arbitrary constant.
+      total += 50;
+    }
+
+    if (props.attributes !== undefined) {
+      // **TODO:** Similar to `.value`, we might want to do more than just add
+      // a constant per attribute binding.
+      total += Object.keys(props.attributes) * 20;
+    }
+
+    return total;
+  }
+
+  /**
    * Converts an `attributes` argument value into an array (of zero or one
    * element), suitable for passing to the payload constructor call, including
    * deep freezing a non-`null` value (if not already deep-frozen). Throws an

--- a/local-modules/@bayou/doc-common/BodyOp.js
+++ b/local-modules/@bayou/doc-common/BodyOp.js
@@ -299,21 +299,22 @@ export class BodyOp extends BaseOp {
     const props = this.props;
     let   total = props.opName.length + 10;
 
-    if (props.text !== undefined) {
+    if (typeof props.text === 'string') {
       total += props.text.length;
     }
 
     if (props.value !== undefined) {
-      // **TODO:** This is an arbitrary value, so we can't do anything too
-      // specific with it, but maybe we should do better than just adding an
-      // arbitrary constant.
+      // **TODO:** `props.value` is a value of arbitrary type, so we can't do
+      // anything too specific with it, but maybe we should do better than just
+      // adding an arbitrary constant.
       total += 50;
     }
 
-    if (props.attributes !== undefined) {
+    const attribs = props.attributes;
+    if ((attribs !== null) && (typeof attribs === 'object')) {
       // **TODO:** Similar to `.value`, we might want to do more than just add
       // a constant per attribute binding.
-      total += Object.keys(props.attributes) * 20;
+      total += Object.keys(attribs).length * 20;
     }
 
     return total;

--- a/local-modules/@bayou/doc-common/CaretOp.js
+++ b/local-modules/@bayou/doc-common/CaretOp.js
@@ -100,6 +100,14 @@ export class CaretOp extends BaseOp {
   }
 
   /**
+   * {Int} Subclass-specific implementation of {@link #roughSize}.
+   */
+  get _impl_roughSize() {
+    // **TODO:** Consider higher-fidelity implementation.
+    return 1;
+  }
+
+  /**
    * Subclass-specific implementation of {@link #isValidPayload}.
    *
    * @param {Functor} payload_unused The would-be payload for an instance.

--- a/local-modules/@bayou/doc-common/PropertyOp.js
+++ b/local-modules/@bayou/doc-common/PropertyOp.js
@@ -75,6 +75,14 @@ export class PropertyOp extends BaseOp {
   }
 
   /**
+   * {Int} Subclass-specific implementation of {@link #roughSize}.
+   */
+  get _impl_roughSize() {
+    // **TODO:** Consider higher-fidelity implementation.
+    return 1;
+  }
+
+  /**
    * Subclass-specific implementation of {@link #isValidPayload}.
    *
    * @param {Functor} payload_unused The would-be payload for an instance.

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -30,6 +30,15 @@ const MAKE_SESSION_TIMEOUT_MSEC = 10 * 1000; // Ten seconds.
  */
 export class DocComplex extends BaseComplexMember {
   /**
+   * {Int} Benchmark size which can be considered representative of a "huge
+   * document," if reported as the value for `roughSize` from
+   * {@link #currentResourceConsumption}.
+   */
+  static get ROUGH_SIZE_HUGE() {
+    return 1000000;
+  }
+
+  /**
    * Constructs an instance.
    *
    * @param {Codec} codec Codec instance to use.

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -35,7 +35,7 @@ export class DocComplex extends BaseComplexMember {
    * {@link #currentResourceConsumption}.
    */
   static get ROUGH_SIZE_HUGE() {
-    return 1000000;
+    return 10000000;
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -48,7 +48,7 @@ export class DocServer extends Singleton {
    * @param {string} documentId The document ID.
    * @returns {DocComplex} The corresponding `DocComplex`.
    */
-  async getFileComplex(documentId) {
+  async getDocComplex(documentId) {
     // **Note:** We don't make an `async` back-end call to check the full
     // validity of `documentId` here, because that would be a waste if it turns
     // out we've already cached a valid result. Once we determine that we need

--- a/local-modules/@bayou/file-store-ot/FileOp.js
+++ b/local-modules/@bayou/file-store-ot/FileOp.js
@@ -210,6 +210,28 @@ export class FileOp extends BaseOp {
   }
 
   /**
+   * {Int} Subclass-specific implementation of {@link #roughSize}.
+   */
+  get _impl_roughSize() {
+    const props = this.props;
+    let   total = props.opName.length + 10;
+
+    if (props.path !== undefined) {
+      total += props.path.length;
+    }
+
+    if (props.hash !== undefined) {
+      total += props.hash.length;
+    }
+
+    if (props.blob !== undefined) {
+      total += props.blob.length;
+    }
+
+    return total;
+  }
+
+  /**
    * Implementation as required by the superclass.
    *
    * @override

--- a/local-modules/@bayou/ot-common/BaseChange.js
+++ b/local-modules/@bayou/ot-common/BaseChange.js
@@ -137,6 +137,19 @@ export class BaseChange extends CommonBase {
   }
 
   /**
+   * {Int} The "rough size" of this instance, in terms of storage requirements
+   * in working memory or stable storage, as positive integer of an ill-defined
+   * unit. This is _not_ a guaranteed size (such as of bytes); it is merely
+   * meant for apples-to-apples comparisons amongst instances of the same class.
+   *
+   * More specifically, on this class, the rough size is the same as the rough
+   * size of the {@link BaseDelta} it contains.
+   */
+  get roughSize() {
+    return this.contents.roughSize;
+  }
+
+  /**
    * {Timestamp|null} The time of the change, or `null` if the change has no
    * specific associated moment in time.
    */

--- a/local-modules/@bayou/ot-common/BaseDelta.js
+++ b/local-modules/@bayou/ot-common/BaseDelta.js
@@ -111,6 +111,26 @@ export class BaseDelta extends CommonBase {
   }
 
   /**
+   * {Int} The "rough size" of this instance, in terms of storage requirements
+   * in working memory or stable storage, as positive integer of an ill-defined
+   * unit. This is _not_ a guaranteed size (such as of bytes); it is merely
+   * meant for apples-to-apples comparisons amongst instances of the same class.
+   *
+   * More specifically, on this class, the rough size is the sum of the rough
+   * sizes of all ops, plus an arbitrary small constant factor per op.
+   */
+  get roughSize() {
+    const ops   = this._ops;
+    let   total = ops.length * 8;
+
+    for (const op of ops) {
+      total += op.roughSize;
+    }
+
+    return total;
+  }
+
+  /**
    * Composes another instance on top of this one, to produce a new instance.
    * This operation works equally whether or not `this` is a document delta.
    * If `other` is an empty delta, this method still typically returns a new

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -121,11 +121,11 @@ export class BaseOp extends CommonBase {
   }
 
   /**
-   * {Int} The "rough size" of the op, in terms of storage requirements in
-   * working memory or stable storage. This is _not_ a guaranteed size, nor does
-   * it have a defined unit. It is merely meant for apples-to-apples comparisons
-   * (and mostly for doing so in the aggregate). This value is always a positive
-   * integer.
+   * {Int} The "rough size" of this instance, in terms of storage requirements
+   * in working memory or stable storage, as positive integer of an ill-defined
+   * unit. This is _not_ a guaranteed size (such as of bytes); it is merely
+   * meant for apples-to-apples comparisons amongst instances of the same class
+   * (and mostly for doing so in the aggregate).
    */
   get roughSize() {
     return TInt.min(this._impl_roughSize, 1);

--- a/local-modules/@bayou/ot-common/BaseOp.js
+++ b/local-modules/@bayou/ot-common/BaseOp.js
@@ -4,7 +4,7 @@
 
 import { inspect } from 'util';
 
-import { TBoolean, TString } from '@bayou/typecheck';
+import { TBoolean, TInt, TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Functor } from '@bayou/util-common';
 
 /**
@@ -121,6 +121,17 @@ export class BaseOp extends CommonBase {
   }
 
   /**
+   * {Int} The "rough size" of the op, in terms of storage requirements in
+   * working memory or stable storage. This is _not_ a guaranteed size, nor does
+   * it have a defined unit. It is merely meant for apples-to-apples comparisons
+   * (and mostly for doing so in the aggregate). This value is always a positive
+   * integer.
+   */
+  get roughSize() {
+    return TInt.min(this._impl_roughSize, 1);
+  }
+
+  /**
    * Gets reconstruction arguments for this instance.
    *
    * @returns {array<*>} Reconstruction arguments.
@@ -149,6 +160,16 @@ export class BaseOp extends CommonBase {
 
     return (this.constructor === other.constructor)
       && this._payload.equals(other._payload);
+  }
+
+  /**
+   * {Int} Main implementation of {@link #roughSize}. Subclasses must fill this
+   * in.
+   *
+   * @abstract
+   */
+  get _impl_roughSize() {
+    return this._mustOverride();
   }
 
   /**

--- a/local-modules/@bayou/ot-common/BaseSnapshot.js
+++ b/local-modules/@bayou/ot-common/BaseSnapshot.js
@@ -102,6 +102,19 @@ export class BaseSnapshot extends CommonBase {
   }
 
   /**
+   * {Int} The "rough size" of this instance, in terms of storage requirements
+   * in working memory or stable storage, as positive integer of an ill-defined
+   * unit. This is _not_ a guaranteed size (such as of bytes); it is merely
+   * meant for apples-to-apples comparisons amongst instances of the same class.
+   *
+   * More specifically, on this class, the rough size is the same as the rough
+   * size of the {@link BaseDelta} it contains.
+   */
+  get roughSize() {
+    return this.contents.roughSize;
+  }
+
+  /**
    * Composes a change on top of this instance, to produce a new instance. If
    * the given `change` has an empty `delta` and has a `revNum` which is the
    * same as this instance, then this method returns `this`. Otherwise, this

--- a/local-modules/@bayou/ot-common/mocks/MockOp.js
+++ b/local-modules/@bayou/ot-common/mocks/MockOp.js
@@ -26,6 +26,10 @@ export class MockOp extends BaseOp {
     return this.payload.args[0];
   }
 
+  get _impl_roughSize() {
+    return this.payload.name.length + 1000;
+  }
+
   static _impl_isValidPayload() {
     return true;
   }

--- a/local-modules/@bayou/ot-common/tests/test_BaseOp.js
+++ b/local-modules/@bayou/ot-common/tests/test_BaseOp.js
@@ -96,6 +96,33 @@ describe('@bayou/ot-common/BaseOp', () => {
     });
   });
 
+  describe('.roughSize', () => {
+    it('calls through to the `impl`', () => {
+      const op = new MockOp('snap');
+
+      assert.strictEqual(op.roughSize, 1004); // name + 1000 per `MockOp` definition.
+    });
+
+    it('rejects a bogus subclass `impl`', () => {
+      function test(v) {
+        class BadOp extends MockOp {
+          _impl_roughSize() {
+            return v;
+          }
+        }
+
+        const op = new BadOp('x');
+        assert.throws(() => op.roughSize, /badValue/);
+      }
+
+      test(0);
+      test(-1);
+      test(123.123);
+      test(null);
+      test('x');
+    });
+  });
+
   describe('deconstruct()', () => {
     it('returns an array data value', () => {
       const op     = new MockOp('x', ['florp', 'like'], { timeline: 'sideways' });


### PR DESCRIPTION
This PR is another chunk of work on being able to have a server able to report its current "load factor." In this one, the main accomplishment is that every `DocComplex` can now report its current resource consumption, including a very-handwavy "rough size" of the document it manages. The resource consumption is reported via the logs upon document activation, but is not hooked up in any other way yet.
