### PR TITLE
Calculate and log overall resource consumption.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -13,6 +13,7 @@ import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
 import { Codecs, Urls } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
 import { Deployment, Network } from '@bayou/config-server';
+import { DocServer } from '@bayou/doc-server';
 import { Dirs, ServerEnv } from '@bayou/env-server';
 import { Delay } from '@bayou/promise-util';
 import { Logger } from '@bayou/see-all';
@@ -392,6 +393,16 @@ export class Application extends CommonBase {
   }
 
   /**
+   * Helper for {@link #_pollingUpdateLoop}, which logs resource consumption
+   * stats.
+   */
+  async _logResourceConsumption() {
+    const stats = await DocServer.theOne.currentResourceConsumption();
+
+    log.metric.totalResourceConsumption(stats);
+  }
+
+  /**
    * Makes and returns the root access object, that is, the thing that gets
    * called to answer API calls on the root token(s).
    *
@@ -438,6 +449,7 @@ export class Application extends CommonBase {
 
       try {
         this._updateConnections();
+        await this._logResourceConsumption();
       } catch (e) {
         // Ignore the error (other than logging). We don't want trouble here to
         // turn into a catastrophic failure.

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -173,7 +173,7 @@ export class AuthorAccess extends CommonBase {
       const documentId = docComplex.fileAccess.documentId;
       const stats      = await docComplex.currentResourceConsumption();
 
-      log.event.documentResourceUsage(documentId, stats);
+      log.event.documentResourceConsumption(documentId, stats);
     } catch (e) {
       // We don't want a failure here to escape and either derail a more useful
       // operation or (worse) turn into an uncaught rejection and hald the

--- a/local-modules/@bayou/app-setup/AuthorAccess.js
+++ b/local-modules/@bayou/app-setup/AuthorAccess.js
@@ -177,8 +177,8 @@ export class AuthorAccess extends CommonBase {
     } catch (e) {
       // We don't want a failure here to escape and either derail a more useful
       // operation or (worse) turn into an uncaught rejection and hald the
-      // system.
-      log.event.failedToDetermineResourceConsumption(e);
+      // system. That is, this method is run on a best-effort basis.
+      log.event.errorDuringResourceConsumptionCalculation(e);
     }
   }
 }

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -106,7 +106,16 @@ export class DocComplex extends BaseComplexMember {
       + (bodyRevNum * 25)
       + (bodySnapshot.roughSize * 4);
 
-    return { roughSize, sessionCount };
+    // Because we don't (yet) do file GC, the number of file changes is the same
+    // as `revNum + 1`, but that (hopefully) won't be true forever. **TODO:**
+    // Revisit this when file GC happens.
+    const fileChangeCount = fileRevNum + 1;
+
+    // No similar caveat (to the one above) required here, because body changes
+    // aren't designed to be GCed.
+    const bodyChangeCount = bodyRevNum + 1;
+
+    return { bodyChangeCount, fileChangeCount, roughSize, sessionCount };
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -96,21 +96,21 @@ export class DocServer extends Singleton {
    * @returns {object} Ad-hoc plain object with resource consumption stats.
    */
   async currentResourceConsumption(timeoutMsec = null) {
-    let totalDocuments   = 0;
-    let totalBodyChanges = 0;
-    let totalFileChanges = 0;
-    let totalRoughSize   = 0;
-    let totalSessions    = 0;
+    let bodyChangeCount = 0;
+    let documentCount   = 0;
+    let fileChangeCount = 0;
+    let roughSize       = 0;
+    let sessionCount    = 0;
 
     // Helper for the loop below: Process a `DocComplex`.
     async function processDocComplex(complex) {
       const stats = await complex.currentResourceConsumption(timeoutMsec);
 
-      totalDocuments++;
-      totalBodyChanges += stats.bodyChangeCount;
-      totalFileChanges += stats.fileChangeCount;
-      totalRoughSize   += stats.roughSize;
-      totalSessions    += stats.sessionCount;
+      documentCount++;
+      bodyChangeCount += stats.bodyChangeCount;
+      fileChangeCount += stats.fileChangeCount;
+      roughSize       += stats.roughSize;
+      sessionCount    += stats.sessionCount;
     }
 
     for (const value of this._complexes.values()) {
@@ -128,11 +128,11 @@ export class DocServer extends Singleton {
     }
 
     return {
-      totalDocuments,
-      totalBodyChanges,
-      totalFileChanges,
-      totalRoughSize,
-      totalSessions
+      bodyChangeCount,
+      documentCount,
+      fileChangeCount,
+      roughSize,
+      sessionCount
     };
   }
 }

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -123,7 +123,7 @@ export class DocServer extends Singleton {
       } catch (e) {
         // Ignore the exception (other than logging): Resource consumption
         // calculation is best-effort only.
-        log.event.errorDuringResourceConsumption(e);
+        log.event.errorDuringResourceConsumptionCalculation(e);
       }
     }
 


### PR DESCRIPTION
This PR represents another chunk of work on the way to having a server be able to report its high-level load factor. Specifically, as of this PR, the server now calculates and reports its overall resource usage stats on an occasional basis (in the same loop that reports active connection counts), currently set to report once per minute. Right now logging is just in the form of an ad-hoc metric. A future PR will add a Prometheus-ish metric report as well, and an even later PR will use the same underlying info to (finally) start offering the `/load` monitoring endpoint.
