### PR TITLE
New monitor endpoint `/traffic-signal`.

### DIFF
--- a/product-info.txt
+++ b/product-info.txt
@@ -1,6 +1,6 @@
 # Metainformation about this product.
 name = bayou
-version = 1.4.3
+version = 1.4.4
 
 #
 # Artificial Failure


### PR DESCRIPTION
This modest-size PR adds a new monitor endpoint, `/traffic-signal`, which is meant to be used by reverse proxies (and the like) to make a determination about whether or not to send traffic to a server. For now, this is implemented the same as `/health`, but once we have a high-level load factor in place, we can change the implementation to be based on that instead.

**Bonus:** Bumped the product version, as a "general cadence" release.
