### PR TITLE
First cut of a load factor metric.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -145,6 +145,11 @@ export class Application extends CommonBase {
     return this._listenPort;
   }
 
+  /** {Int} The current load factor. */
+  get loadFactor() {
+    return this._loadFactor.value;
+  }
+
   /**
    * {string} The loopback (local-access) base URL. This can have a different
    * port than the default configured `listenPort` in testing scenarios. It will

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -444,6 +444,12 @@ export class Application extends CommonBase {
       try {
         this._updateConnections();
         await this._updateResourceConsumption();
+
+        // **Note:** Both of the above have to be done before pushing out a load
+        // factor update.
+        const loadFactor = this._loadFactor.value;
+        log.metric.loadFactor(loadFactor);
+        this._metrics.loadFactor(loadFactor);
       } catch (e) {
         // Ignore the error (other than logging). We don't want trouble here to
         // turn into a catastrophic failure.

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -21,6 +21,7 @@ import { CommonBase, Errors, PropertyIterable } from '@bayou/util-common';
 
 import { AppAuthorizer } from './AppAuthorizer';
 import { DebugTools } from './DebugTools';
+import { LoadFactor } from './LoadFactor';
 import { Metrics } from './Metrics';
 import { RequestLogger } from './RequestLogger';
 import { RootAccess } from './RootAccess';
@@ -67,6 +68,9 @@ export class Application extends CommonBase {
      * bearing {@link Auth#TYPE_root} authority grant access to.
      */
     this._rootAccess = this._makeRootAccess();
+
+    /** {LoadFactor} Load factor calculator. */
+    this._loadFactor = new LoadFactor();
 
     /**
      * {Metrics} Metrics collector / reporter. This is what's responsible for
@@ -472,6 +476,7 @@ export class Application extends CommonBase {
   async _updateResourceConsumption() {
     const stats = await DocServer.theOne.currentResourceConsumption();
 
+    this._loadFactor.docServerStats(stats);
     log.metric.totalResourceConsumption(stats);
   }
 }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -393,16 +393,6 @@ export class Application extends CommonBase {
   }
 
   /**
-   * Helper for {@link #_pollingUpdateLoop}, which logs resource consumption
-   * stats.
-   */
-  async _logResourceConsumption() {
-    const stats = await DocServer.theOne.currentResourceConsumption();
-
-    log.metric.totalResourceConsumption(stats);
-  }
-
-  /**
    * Makes and returns the root access object, that is, the thing that gets
    * called to answer API calls on the root token(s).
    *
@@ -449,7 +439,7 @@ export class Application extends CommonBase {
 
       try {
         this._updateConnections();
-        await this._logResourceConsumption();
+        await this._updateResourceConsumption();
       } catch (e) {
         // Ignore the error (other than logging). We don't want trouble here to
         // turn into a catastrophic failure.
@@ -473,5 +463,15 @@ export class Application extends CommonBase {
 
     log.metric.activeConnections(this.connectionCountNow);
     this._metrics.apiMetrics(this.connectionCountNow, this.connectionCountTotal);
+  }
+
+  /**
+   * Helper for {@link #_pollingUpdateLoop}, which logs resource consumption
+   * stats and uses them to update the load factor.
+   */
+  async _updateResourceConsumption() {
+    const stats = await DocServer.theOne.currentResourceConsumption();
+
+    log.metric.totalResourceConsumption(stats);
   }
 }

--- a/local-modules/@bayou/app-setup/LoadFactor.js
+++ b/local-modules/@bayou/app-setup/LoadFactor.js
@@ -1,0 +1,97 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { DocComplex } from '@bayou/doc-server';
+import { TInt, TObject } from '@bayou/typecheck';
+import { CommonBase } from '@bayou/util-common';
+
+/**
+ * {Int} The number of document sessions which should be considered to
+ * constitute a "heavy load."
+ */
+const HEAVY_SESSION_COUNT = 100;
+
+/**
+ * Synthesizer of the high-level "load factor" based on various stats on what
+ * this server is up to.
+ */
+export class LoadFactor extends CommonBase {
+  /**
+   * {Int} Value of {@link #_value} above which the system should be considered
+   * "under heavy load."
+   */
+  static get HEAVY_LOAD_VALUE() {
+    return 100;
+  }
+
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /** {Int} Current (latest calculated) load factor. */
+    this._value = 0;
+
+    /** {Int} {@link DocServer} resource consumption stat. */
+    this._roughSize = 0;
+
+    /** {Int} {@link DocServer} resource consumption stat. */
+    this._sessionCount = 0;
+
+    Object.seal(this);
+  }
+
+  /** {Int} The current (latest calculated) load factor. */
+  get value() {
+    return this._value;
+  }
+
+  /**
+   * Update this instance based on the given resource consumption stats, which
+   * are expected to be in the form reported by
+   * {@link DocServer#currentResourceConsumption}.
+   *
+   * @param {object} stats Stats, per the contract of {@link DocServer}.
+   */
+  docServerStats(stats) {
+    TObject.check(stats);
+
+    if (stats.roughSize !== undefined) {
+      this._roughSize = TInt.check(stats.roughSize);
+    }
+
+    if (stats.sessionCount !== undefined) {
+      this._sessionCount = TInt.check(stats.sessionCount);
+    }
+
+    this._recalc();
+  }
+
+  /**
+   * (Re)calculates {@link #value} based on currently-known stats.
+   *
+   * What we do is define N independent numeric stats each of which has a value
+   * beyond which it is considered "heavy load." These each scaled so that the
+   * "heavy load" value maps to {@link #HEAVY_LOAD_VALUE}, and then they're
+   * simply summed. This means that (a) all stats always contribute to the final
+   * load factor value, and (b) each stat can _independently_ cause the final
+   * load factor to be in the "heavy load" zone.
+   */
+  _recalc() {
+    // Get each of these as a fraction where `0` is "unloaded" and `1` is heavy
+    // load.
+    const roughSize    = this._roughSize    / DocComplex.ROUGH_SIZE_HUGE;
+    const sessionCount = this._sessionCount / HEAVY_SESSION_COUNT;
+
+    // Total load.
+    const total = roughSize + sessionCount;
+
+    // Total load, scaled so that heavy load is at the documented
+    // `HEAVY_LOAD_VALUE`, and rounded to an int.
+    const loadFactor = Math.round(total * LoadFactor.HEAVY_LOAD_VALUE);
+
+    this._value = loadFactor;
+  }
+}

--- a/local-modules/@bayou/app-setup/Metrics.js
+++ b/local-modules/@bayou/app-setup/Metrics.js
@@ -5,6 +5,7 @@
 import { collectDefaultMetrics, register, Counter, Gauge } from 'prom-client';
 
 import { ServerEnv } from '@bayou/env-server';
+import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 /**
@@ -49,6 +50,12 @@ export class Metrics extends CommonBase {
       help: 'Gauge of currently-active API connections'
     });
 
+    /** {Gauge} Gauge of the current load factor. */
+    this._loadFactor = new Gauge({
+      name: `${prefix}load_factor`,
+      help: 'Gauge of current load factor'
+    });
+
     /**
      * {Gauge} Pseudo-gauge whose labels identify the currently-running build.
      */
@@ -89,6 +96,15 @@ export class Metrics extends CommonBase {
     if (diff > 0) {
       this._connectionCountTotal.inc(diff);
     }
+  }
+
+  /**
+   * Updates the load factor metric.
+   *
+   * @param {Int} loadFactor Current load factor.
+   */
+  LoadFactor(loadFactor) {
+    TInt.check(loadFactor);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Metrics.js
+++ b/local-modules/@bayou/app-setup/Metrics.js
@@ -85,6 +85,9 @@ export class Metrics extends CommonBase {
    *   ever handled.
    */
   apiMetrics(connectionCountNow, connectionCountTotal) {
+    TInt.check(connectionCountNow);
+    TInt.check(connectionCountTotal);
+
     this._connectionCountNow.set(connectionCountNow);
 
     // There's no `set()` method on `Counter`; the best we can do is sniff the

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -96,6 +96,20 @@ export class Monitor extends CommonBase {
     });
     requestLogger.aggregate('/health');
 
+    app.get('/info', async (req_unused, res) => {
+      ServerUtil.sendJsonResponse(res, {
+        boot:    ServerEnv.theOne.bootInfo.info,
+        build:   ServerEnv.theOne.buildInfo,
+        runtime: ServerEnv.theOne.runtimeInfo
+      });
+    });
+
+    const register = mainApplication.metrics.register;
+    app.get('/metrics', async (req_unused, res) => {
+      ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
+    });
+    requestLogger.aggregate('/metrics');
+
     // This endpoint is meant to be used by a router / load balancer / reverse
     // proxy to determine whether or not it is okay to route traffic to this
     // server. If this endpoint says "no" then that _just_ means that this
@@ -111,20 +125,6 @@ export class Monitor extends CommonBase {
       ServerUtil.sendPlainTextResponse(res, text, status);
     });
     requestLogger.aggregate('/traffic-signal');
-
-    app.get('/info', async (req_unused, res) => {
-      ServerUtil.sendJsonResponse(res, {
-        boot:    ServerEnv.theOne.bootInfo.info,
-        build:   ServerEnv.theOne.buildInfo,
-        runtime: ServerEnv.theOne.runtimeInfo
-      });
-    });
-
-    const register = mainApplication.metrics.register;
-    app.get('/metrics', async (req_unused, res) => {
-      ServerUtil.sendTextResponse(res, register.metrics(), register.contentType, 200);
-    });
-    requestLogger.aggregate('/metrics');
 
     const varInfo = mainApplication.varInfo;
     app.get('/var', async (req_unused, res) => {

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -11,6 +11,7 @@ import { TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 import { Application } from './Application';
+import { LoadFactor } from './LoadFactor';
 import { RequestLogger } from './RequestLogger';
 import { ServerUtil } from './ServerUtil';
 
@@ -103,6 +104,14 @@ export class Monitor extends CommonBase {
         runtime: ServerEnv.theOne.runtimeInfo
       });
     });
+
+    app.get('/load-factor', async (req_unused, res) => {
+      const value = mainApplication.loadFactor;
+      const heavy = LoadFactor.HEAVY_LOAD_VALUE;
+
+      ServerUtil.sendJsonResponse(res, { heavy, value });
+    });
+    requestLogger.aggregate('/load-factor');
 
     const register = mainApplication.metrics.register;
     app.get('/metrics', async (req_unused, res) => {


### PR DESCRIPTION
This PR adds a high-level load factor metric, calculated heuristically, and exposes that metric three ways: Via our ad-hoc logs (tagged as a metric), via Prometheus, and via a new `/load-factor` monitor endpoint. I opted to make it an integer (not a fraction) with `100` as the inflection point that indicates "heavy load."

The heuristics underlying the calculation are almost certainly not right, and we will have to get a bit of production experience before we can tune things such that the metric becomes a useful reflection of reality.