### PR TITLE
Try to suss out a hard-to-track issue during connection setup

### DIFF
--- a/local-modules/@bayou/api-client/ApiClient.js
+++ b/local-modules/@bayou/api-client/ApiClient.js
@@ -47,7 +47,7 @@ export class ApiClient extends CommonBase {
 
     /**
      * {string|null} Connection ID conveyed to us by the server. Reset in
-     * `_resetConnection()`.
+     * {@link #_resetConnection}.
      */
     this._connectionId = null;
 
@@ -59,8 +59,8 @@ export class ApiClient extends CommonBase {
     this._log = log;
 
     /**
-     * {WebSocket} Actual websocket instance. Set by `open()`. Reset in
-     * `_resetConnection()`.
+     * {WebSocket} Actual websocket instance. Set by {@link #open}. Reset in
+     * {@link #_resetConnection}.
      */
     this._ws = null;
 
@@ -83,7 +83,7 @@ export class ApiClient extends CommonBase {
     /**
      * {array<string>} List of pending messages (to be sent to the far side of
      * the connection). Only used when connection is in the middle of being
-     * established. Initialized and reset in `_resetConnection()`.
+     * established. Initialized and reset in {@link #_resetConnection}.
      */
     this._pendingMessages = null;
 

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -259,8 +259,9 @@ export class Application extends CommonBase {
     // Use the `@bayou/api-server` module to handle POST requests at the API
     // endpoint, both with and without a trailing slash.
 
-    const apiPath1 = `/${Urls.API_PATH}`;  // Absolute exact path.
-    const apiPath2 = `/${Urls.API_PATH}/`; // Treated as a prefix.
+    const apiPathBase  = `/${Urls.API_PATH}`;                  // Base path.
+    const apiPathRoute = `${apiPathBase}/:rest*`;              // Express route to handle subpaths.
+    const apiPathRegex = new RegExp(`${apiPathBase}(?:/.*)?`); // Regexp to match base or subpaths.
 
     const postHandler = (req, res) => {
       try {
@@ -272,8 +273,8 @@ export class Application extends CommonBase {
       }
     };
 
-    app.post(apiPath1, postHandler);
-    app.post(`${apiPath2}:rest*`, postHandler);
+    app.post(apiPathBase,  postHandler);
+    app.post(apiPathRoute, postHandler);
 
     // Likewise, handle the same API endpoint URLs for websocket requests.
     // **Note:** The following (specifically, constructing `ws.Server` with the
@@ -284,7 +285,7 @@ export class Application extends CommonBase {
 
     const wsVerify = (info, cb = null) => {
       const url = info.req.url;
-      const ok  = (url === apiPath1) || url.startsWith(apiPath2);
+      const ok  = apiPathRegex.test(url);
 
       // **Note:** The `ws` module docs indicate that it _sometimes_ calls the
       // verifier function with a `cb` argument. If it does, and if the main

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -259,8 +259,8 @@ export class Application extends CommonBase {
     // Use the `@bayou/api-server` module to handle POST requests at the API
     // endpoint, both with and without a trailing slash.
 
-    const apiPath1 = `/${Urls.API_PATH}`;
-    const apiPath2 = `/${Urls.API_PATH}/`;
+    const apiPath1 = `/${Urls.API_PATH}`;  // Absolute exact path.
+    const apiPath2 = `/${Urls.API_PATH}/`; // Treated as a prefix.
 
     const postHandler = (req, res) => {
       try {
@@ -273,7 +273,7 @@ export class Application extends CommonBase {
     };
 
     app.post(apiPath1, postHandler);
-    app.post(apiPath2, postHandler);
+    app.post(`${apiPath2}:rest*`, postHandler);
 
     // Likewise, handle the same API endpoint URLs for websocket requests.
     // **Note:** The following (specifically, constructing `ws.Server` with the
@@ -284,7 +284,7 @@ export class Application extends CommonBase {
 
     const wsVerify = (info, cb = null) => {
       const url = info.req.url;
-      const ok  = (url === apiPath1) || (url === apiPath2);
+      const ok  = (url === apiPath1) || url.startsWith(apiPath2);
 
       // **Note:** The `ws` module docs indicate that it _sometimes_ calls the
       // verifier function with a `cb` argument. If it does, and if the main

--- a/local-modules/@bayou/codec/ItemCodec.js
+++ b/local-modules/@bayou/codec/ItemCodec.js
@@ -149,6 +149,16 @@ export class ItemCodec extends CommonBase {
 
     const tag = clazz.CODEC_TAG || clazz.name;
 
+    if ((typeof tag !== 'string') || (tag === '')) {
+      // This situation has been observed to show up. It might be a
+      // code-mangling issue, or it might be a string-security-configuration
+      // (CSP) type issue. Jury's still out, but in any case, should we find
+      // ourselves looking at a class with no name, there's nothing we can do to
+      // rectify the situation.
+      log.event.namelessClass(clazz, clazz.name, clazz.CODEC_TAG);
+      throw Errors.badUse('Cannot create codec from nameless-and-tagless class');
+    }
+
     const encode = (value, subEncode) => {
       const payload = TArray.check(value.deconstruct());
       return payload.map(subEncode);

--- a/local-modules/@bayou/doc-client/DocSession.js
+++ b/local-modules/@bayou/doc-client/DocSession.js
@@ -282,7 +282,16 @@ export class DocSession extends CommonBase {
 
     this._eventSource.emit.opening();
     this._log.event.apiAboutToOpen(url);
-    this._apiClient = new ApiClient(url, Codecs.fullCodec);
+
+    try {
+      this._apiClient = new ApiClient(url, Codecs.fullCodec);
+    } catch (e) {
+      // Log and rethrow, to help unambiguously identify when this constructor
+      // is having trouble. (Why needed? Because in some contexts we don't have
+      // a high-fidelity stack trace, but we _do_ have logs.)
+      this._log.event.troubleConstructingApiClient(e);
+      throw e;
+    }
 
     try {
       this._log.event.apiOpening();

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,6 +1,6 @@
 # Metainformation about this product.
 name = bayou
-version = 1.4.4
+version = 1.4.5
 
 #
 # Artificial Failure


### PR DESCRIPTION
This PR adds a bit of logging during connection setup and early init, in an attempt to figure out what's passing a bad string to what. I'd thought it was a URL that was somehow getting thwacked, but I am less sure of that now.

This PR bumps the product version, specifically so the new logging can be published out.

**Bonus:** Tweaked the server routes for contacting the API, so that we are in a position to play with "route hints" for load balancing.
