### PR TITLE
First cut implementation of the traffic signal.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -215,6 +215,7 @@ export class Application extends CommonBase {
     const now     = Date.now();
 
     signal.healthy(healthy);
+    signal.loadFactor(this._loadFactor.value);
     return signal.shouldAllowTrafficAt(now);
   }
 

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -415,6 +415,7 @@ export class Application extends CommonBase {
   async _handleSystemShutdown() {
     const shutdownManager = ServerEnv.theOne.shutdownManager;
 
+    this._trafficSignal.shuttingDown();
     await shutdownManager.whenShuttingDown();
 
     const allClosed = this._closeConnections();

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -423,7 +423,10 @@ export class Application extends CommonBase {
     // This `await` returns soon after the system decides it is to shut down.
     await shutdownManager.whenShuttingDown();
 
+    // Inform the traffic signal, and pump it with the call to
+    // `shouldAllowTraffic()`, so that it'll get logged.
     this._trafficSignal.shuttingDown();
+    await this.shouldAllowTraffic();
 
     const allClosed = this._closeConnections();
     shutdownManager.waitFor(allClosed);

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -215,7 +215,7 @@ export class Application extends CommonBase {
     const now     = Date.now();
 
     signal.healthy(healthy);
-    return signal.allowTrafficAt(now);
+    return signal.shouldAllowTrafficAt(now);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -415,11 +415,12 @@ export class Application extends CommonBase {
   async _handleSystemShutdown() {
     const shutdownManager = ServerEnv.theOne.shutdownManager;
 
-    this._trafficSignal.shuttingDown();
+    // This `await` returns soon after the system decides it is to shut down.
     await shutdownManager.whenShuttingDown();
 
-    const allClosed = this._closeConnections();
+    this._trafficSignal.shuttingDown();
 
+    const allClosed = this._closeConnections();
     shutdownManager.waitFor(allClosed);
   }
 

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -26,6 +26,7 @@ import { Metrics } from './Metrics';
 import { RequestLogger } from './RequestLogger';
 import { RootAccess } from './RootAccess';
 import { ServerUtil } from './ServerUtil';
+import { TrafficSignal } from './TrafficSignal';
 import { VarInfo } from './VarInfo';
 
 /**
@@ -71,6 +72,9 @@ export class Application extends CommonBase {
 
     /** {LoadFactor} Load factor calculator. */
     this._loadFactor = new LoadFactor();
+
+    /** {TrafficSignal} Traffic signal calculator. */
+    this._trafficSignal = new TrafficSignal();
 
     /**
      * {Metrics} Metrics collector / reporter. This is what's responsible for
@@ -197,6 +201,21 @@ export class Application extends CommonBase {
    */
   isListening() {
     return this._server.listening;
+  }
+
+  /**
+   * Gets the instantaneous-current traffic signal.
+   *
+   * @returns {boolean} Indication of whether (`true`) or not (`false`) traffic
+   *   should currently be allowed.
+   */
+  async shouldAllowTraffic() {
+    const signal  = this._trafficSignal;
+    const healthy = await this.isHealthy();
+    const now     = Date.now();
+
+    signal.healthy(healthy);
+    return signal.allowTrafficAt(now);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -214,7 +214,7 @@ export class Application extends CommonBase {
     const healthy = await this.isHealthy();
     const now     = Date.now();
 
-    signal.healthy(healthy);
+    signal.health(healthy);
     signal.loadFactor(this._loadFactor.value);
     return signal.shouldAllowTrafficAt(now);
   }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -487,6 +487,7 @@ export class Application extends CommonBase {
         log.metric.loadFactor(loadFactor);
         this._metrics.loadFactor(loadFactor);
 
+        // This updates the exported metric, as necessary.
         await this.shouldAllowTraffic();
       } catch (e) {
         // Ignore the error (other than logging). We don't want trouble here to

--- a/local-modules/@bayou/app-setup/Metrics.js
+++ b/local-modules/@bayou/app-setup/Metrics.js
@@ -5,7 +5,7 @@
 import { collectDefaultMetrics, register, Counter, Gauge } from 'prom-client';
 
 import { ServerEnv } from '@bayou/env-server';
-import { TInt } from '@bayou/typecheck';
+import { TBoolean, TInt } from '@bayou/typecheck';
 import { CommonBase } from '@bayou/util-common';
 
 /**
@@ -53,7 +53,13 @@ export class Metrics extends CommonBase {
     /** {Gauge} Gauge of the current load factor. */
     this._loadFactor = new Gauge({
       name: `${prefix}load_factor`,
-      help: 'Gauge of current load factor'
+      help: 'Gauge of the current load factor'
+    });
+
+    /** {Gauge} Gauge of the current traffic signal. */
+    this._trafficSignal = new Gauge({
+      name: `${prefix}traffic_signal`,
+      help: 'Gauge of the current traffic signal'
     });
 
     /**
@@ -110,6 +116,17 @@ export class Metrics extends CommonBase {
     TInt.check(loadFactor);
 
     this._loadFactor.set(loadFactor);
+  }
+
+  /**
+   * Updates the traffic signal metric.
+   *
+   * @param {boolean} trafficSignal Current traffic signal.
+   */
+  trafficSignal(trafficSignal) {
+    TBoolean.check(trafficSignal);
+
+    this._trafficSignal.set(trafficSignal ? 1 : 0);
   }
 
   /**

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -125,9 +125,7 @@ export class Monitor extends CommonBase {
     // server doesn't want new traffic; existing connections are still okay and
     // shouldn't be dropped (or similar).
     app.get('/traffic-signal', async (req_unused, res) => {
-      // **TODO:** Base this on the high-level load factor, once that
-      // calculation is available.
-      const [status, text] = await mainApplication.isHealthy()
+      const [status, text] = await mainApplication.shouldAllowTraffic()
         ? [200, '🚦 💚 Green Light! Send traffic my way! 💚 🚦\n']
         : [503, '🚦 🛑 Red Light! Please do not route to me! 🛑 🚦\n'];
 

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -183,8 +183,13 @@ export class TrafficSignal extends CommonBase {
         this._allowTraffic          = true;
         this._forceTrafficUntilMsec = this._currentTimeMsec + MINIMUM_TRAFFIC_ALLOW_TIME_MSEC;
         this._reason                = 'forced uptime';
-        return;
       }
+
+      // The signal was `false` at the start of this call, and there is nothing
+      // more to do. Either we're still holding the signal `false`, or we _just_
+      // decided that it should be `true` (and held `true` for the appropriate
+      // minimum time).
+      return;
     }
 
     // **TODO:** Depend on the load factor. Set `_allowTraffic` to `false` and

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -1,0 +1,177 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { TBoolean, TInt } from '@bayou/typecheck';
+import { CommonBase, Errors } from '@bayou/util-common';
+
+/**
+ * {Int} Minimum amount of time (in msec) that the traffic signal must be `true`
+ * for after transitioning from `false`, assuming that the server isn't either
+ * unhealthy or in the process of shutting down.
+ */
+const MINIMUM_TRAFFIC_ALLOW_TIME_MSEC = 60 * 1000; // One minute.
+
+/**
+ * Synthesizer of the high-level "traffic signal" based on various stats on what
+ * this server is up to. A little more detail:
+ *
+ * An instance of this class gets hooked up to the monitor endpoint
+ * `/traffic-signal` (see {@link Monitor}). That endpoint is meant to be used by
+ * reverse proxies that front a fleet of instances of this product, in order to
+ * determine which instances are safe to route traffic to. Under low or normal
+ * load, the traffic signal is "go;" and when an instance becomes too loaded,
+ * the signal is "stop."
+ *
+ * This class is set up so that the signal is never permanently set at "stop"
+ * based on the perceived load,  even when under very heavy load. This is meant
+ * to prevent a cross-fleet heavy load from turning into a complete outage. That
+ * is, we do not assume that the incoming heavy load indicator is a perfect
+ * metric, and we _do_ assume that it's better to continue to accept new traffic
+ * (and, approximately, risk server meltdown) than to over-prophylactically
+ * totally stop answering requests.
+ *
+ * In addition to using the high-level load factor to determine traffic flow,
+ * this instance also pays attention to the self-assessed server "health" value,
+ * _and_ whether or not the system is in the process of shutting down. With
+ * both of these, the appropriate signal _does_ turn into a permanent "stop"
+ * signal.
+ */
+export class TrafficSignal extends CommonBase {
+  /**
+   * Constructs an instance.
+   */
+  constructor() {
+    super();
+
+    /**
+     * {boolean} Current traffic flow signal; `true` indicates that traffic is
+     * allowed.
+     */
+    this._allowTraffic = true;
+
+    /**
+     * {Int} Wall time in msec since the Unix Epoch indicating the _next_ moment
+     * when traffic should be allowed, if it is not currently allowed. This
+     * value only has meaning when {@link #_allowTraffic} is `false`.
+     */
+    this._allowTrafficAtMsec = 0;
+
+    /**
+     * {Int} Wall time in msec before which {@link #_allowTraffic} is forced to
+     * be `true` (based on load factor). This value only has meaning when
+     * {@link #_allowTraffic} is `true`.
+     */
+    this._forceTrafficUntilMsec = 0;
+
+    /**
+     * {boolean} Whether (`true`) or not (`false`) the system is currently
+     * shutting down.
+     */
+    this._shuttingDown = false;
+
+    /**
+     * {boolean} Whether (`true`) or not (`false`) the system currently
+     * considers itself to be "healthy."
+     */
+    this._healthy = true;
+
+    /** {Int} Most recently reported high-level load factor. */
+    this._loadFactor = 0;
+
+    /**
+     * {Int} Wall time in msec since the Unix Epoch, as passed to the most
+     * recent call to {@link #allowTrafficAt}.
+     */
+    this._currentTimeMsec = 0;
+
+    Object.seal(this);
+  }
+
+  /**
+   * Indicates the current wall time, and gets back an indicator of whether or
+   * not to allow traffic at the moment in question.
+   *
+   * **Note:** This method is arranged the way it is (that is, to take a time),
+   * specifically so that the class does not have a built-in dependency on
+   * `Date.now()` (or similar), so that it is more easily testable / tested.
+   *
+   * @param {Int} timeMsec The current wall time, as msec since the Unix Epoch.
+   * @returns {boolean} Indication of whether (`true`) or not (`false`) traffic
+   *   should be allowed as of `timeMsec`.
+   */
+  allowTrafficAt(timeMsec) {
+    TInt.nonNegative(timeMsec);
+
+    if (timeMsec < this._currentTimeMsec) {
+      throw Errors.badUse('`timeMsec` must monotonically increase from call to call.');
+    }
+
+    this._currentTimeMsec = timeMsec;
+    this._recalc();
+
+    return this._allowTraffic;
+  }
+
+  /**
+   * Indicates to this instance the current self-assessed health of this server.
+   *
+   * @param {boolean} healthy `true` if this server considers itself "healthy"
+   *   or `false` if not.
+   */
+  health(healthy) {
+    this._healthy = TBoolean.check(healthy);
+  }
+
+  /**
+   * Indicates to this instance that this server is shutting down.
+   */
+  shuttingDown() {
+    this._shuttingDown = true;
+  }
+
+  /**
+   * Indicates to this instance the current high-level load factor.
+   *
+   * @param {Int} loadFactor The current load factor.
+   */
+  loadFactor(loadFactor) {
+    TInt.nonNegative(loadFactor);
+
+    this._loadFactor = loadFactor;
+  }
+
+  /**
+   * Recalculates the traffic signal based on currently-known stats.
+   */
+  _recalc() {
+    if (this._shuttingDown || !this._healthy) {
+      this._allowTraffic       = false;
+      this._allowTrafficAtMsec = Number.MAX_SAFE_INTEGER; // ...which is to say, "never."
+      return;
+    }
+
+    if (this._allowTraffic) {
+      if (this._currentTimeMsec < this._forceTrafficUntilMsec) {
+        // See explanation below and in the class header comment.
+        return;
+      }
+    } else {
+      if (this._currentTimeMsec >= this._allowTrafficAtMsec) {
+        // This says in effect, "When the traffic signal goes from `false` to
+        // `true`, it must be allowed to stay `true` for a minimum-specified
+        // period of time." See class header comment for the rationale for this
+        // behavior.
+        this._allowTraffic = true;
+        this._forceTrafficUntilMsec = this._currentTimeMsec + MINIMUM_TRAFFIC_ALLOW_TIME_MSEC;
+        return;
+      }
+    }
+
+    // **TODO:** Depend on the load factor. Set `_allowTraffic` to `false` and
+    // set up an appropriate `_allowTrafficAtMsec`, should the load factor turn
+    // out to be too high.
+
+    this._allowTraffic = true;
+  }
+}

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -89,6 +89,16 @@ export class TrafficSignal extends CommonBase {
   }
 
   /**
+   * Indicates to this instance the current self-assessed health of this server.
+   *
+   * @param {boolean} healthy `true` if this server considers itself "healthy"
+   *   or `false` if not.
+   */
+  health(healthy) {
+    this._healthy = TBoolean.check(healthy);
+  }
+
+  /**
    * Indicates the current wall time, and gets back an indicator of whether or
    * not to allow traffic at the moment in question.
    *
@@ -100,7 +110,7 @@ export class TrafficSignal extends CommonBase {
    * @returns {boolean} Indication of whether (`true`) or not (`false`) traffic
    *   should be allowed as of `timeMsec`.
    */
-  allowTrafficAt(timeMsec) {
+  shouldAllowTrafficAt(timeMsec) {
     TInt.nonNegative(timeMsec);
 
     if (timeMsec < this._currentTimeMsec) {
@@ -111,16 +121,6 @@ export class TrafficSignal extends CommonBase {
     this._recalc();
 
     return this._allowTraffic;
-  }
-
-  /**
-   * Indicates to this instance the current self-assessed health of this server.
-   *
-   * @param {boolean} healthy `true` if this server considers itself "healthy"
-   *   or `false` if not.
-   */
-  health(healthy) {
-    this._healthy = TBoolean.check(healthy);
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -35,7 +35,7 @@ export class DocComplex extends BaseComplexMember {
    * {@link #currentResourceConsumption}.
    */
   static get ROUGH_SIZE_HUGE() {
-    return 10000000;
+    return 25000000;
   }
 
   /**


### PR DESCRIPTION
This PR adds a non-trivial implementation under the pre-existing `/traffic-signal` monitoring endpoint, though it does leave a bit to be done in a follow-on PR. Details:

* There is a new class `TrafficSignal`, which accepts inputs representing various system activities, and responds with a go/no-go answer. The input signals are: current time, system health, system shutdown status, and load factor.
* An instance of `TrafficSignal` is set up by `Application`, which exposes a new method `shouldAllowTraffic()`. This method is used directly by `Monitor` to implement `/traffic-signal`.
* `Application` arranges for the signal to get exported via Prometheus.
* `Application` passes all the salient input signals to its `TrafficSignal` instance, and also calls it in the same stats-polling loop that also updates things like the active connections count and the load factor. (So, even in the absence of "real" use of the signal, we'll still see it reported out.)
* The main missing piece is using the load factor as an input. (That is, it's fully plumbed but just not yet used.)
