### PR TITLE
Use the load factor to drive the traffic signal in a duty-cycle fashion.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -176,6 +176,11 @@ export class Application extends CommonBase {
     return this._rootAccess;
   }
 
+  /** {string} The current traffic signal "reason." */
+  get trafficSignalReason() {
+    return this._trafficSignal.reason;
+  }
+
   /** {VarInfo} The "variable info" handler. */
   get varInfo() {
     return this._varInfo;

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -125,11 +125,16 @@ export class Monitor extends CommonBase {
     // server doesn't want new traffic; existing connections are still okay and
     // shouldn't be dropped (or similar).
     app.get('/traffic-signal', async (req_unused, res) => {
-      const [status, text] = await mainApplication.shouldAllowTraffic()
-        ? [200, '🚦 💚 Green Light! Send traffic my way! 💚 🚦\n']
-        : [503, '🚦 🛑 Red Light! Please do not route to me! 🛑 🚦\n'];
+      const allow  = await mainApplication.shouldAllowTraffic();
+      const reason = mainApplication.trafficSignalReason;
 
-      ServerUtil.sendPlainTextResponse(res, text, status);
+      const [status, emoji, text] = allow
+        ? [200, '💚', 'Green Light! Send traffic my way!']
+        : [503, '🛑', 'Red Light! Please do not route to me!'];
+
+      const fullText = `🚦 ${emoji} ${text} ${emoji} 🚦\n\n(${reason})\n`;
+
+      ServerUtil.sendPlainTextResponse(res, fullText, status);
     });
     requestLogger.aggregate('/traffic-signal');
 

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -228,7 +228,7 @@ export class TrafficSignal extends CommonBase {
       return;
     }
 
-    if (this._loadFactor <= MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) {
+    if (this._loadFactor < MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) {
       // Not enough load to have to cycle off. That is, it's all good!
       this._allowTraffic = true;
       this._reason       = 'normal flow';

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -23,7 +23,7 @@ const NEVER_TIME_MSEC = Number.MAX_SAFE_INTEGER;
 const MINIMUM_TRAFFIC_ALLOW_TIME_MSEC = 60 * 1000; // One minute.
 
 /** {Int} Load factor above which duty-cycling begins. */
-const MIN_LOAD_FACTOR_FOR_DUTY_CYCLE = 75;
+const MIN_LOAD_FACTOR_FOR_DUTY_CYCLE = 80;
 
 /**
  * {Int} Load factor at-or-above which duty-cycling should have the maximum

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -272,8 +272,8 @@ export class TrafficSignal extends CommonBase {
     const FRAC_RANGE        = MAX_DUTY_CYCLE_OFF_TIME_FRAC - MIN_DUTY_CYCLE_OFF_TIME_FRAC;
     const offFrac = (scaledLoad * FRAC_RANGE) + MIN_DUTY_CYCLE_OFF_TIME_FRAC;
 
-    // That the off-fraction (F) and the minimum on-time (T), and solve for N
-    // (actual amount of time in msec to be off), as follows. The first line
+    // Take the off-fraction (F) and the minimum on-time (T), and solve for the
+    // actual amount of time in msec to be off (N), as follows. The first line
     // in the derivation states fairly directly, "The ratio of off-time to
     // total time is F."
     //

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -258,7 +258,7 @@ export class TrafficSignal extends CommonBase {
     // value for duty cycling and `1` is the max.
     const LOAD_FACTOR_RANGE = MAX_LOAD_FACTOR_FOR_DUTY_CYCLE - MIN_LOAD_FACTOR_FOR_DUTY_CYCLE;
     const scaledLoad =
-      Math.min(1, (this._loadFactor - MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) / LOAD_FACTOR_RANGE);
+      Math.min(1, (loadFactor - MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) / LOAD_FACTOR_RANGE);
 
     // Take the scaled load factor, and multiply it out, and adjust it, so that
     // it is in the desired range of "off" cycle fractions. E.g. if `offFrac` is

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -97,7 +97,7 @@ export class TrafficSignal extends CommonBase {
 
     /**
      * {string} Brief "reason" for the current traffic situation. Used when
-     * logging.
+     * logging and also exposed as {@link #reason}.
      */
     this._reason = 'initial state';
 
@@ -123,6 +123,11 @@ export class TrafficSignal extends CommonBase {
     this._currentTimeMsec = 0;
 
     Object.seal(this);
+  }
+
+  /** {string} The glib "reason" for the current traffic signal. */
+  get reason() {
+    return this._reason;
   }
 
   /**
@@ -213,7 +218,7 @@ export class TrafficSignal extends CommonBase {
         // behavior.
         this._allowTraffic          = true;
         this._forceTrafficUntilMsec = this._currentTimeMsec + MINIMUM_TRAFFIC_ALLOW_TIME_MSEC;
-        this._reason                = 'forced uptime';
+        this._reason                = `forced uptime until ${this._forceTrafficUntilMsec}`;
       }
 
       // The signal was `false` at the start of this call, and there is nothing
@@ -237,7 +242,7 @@ export class TrafficSignal extends CommonBase {
 
     this._allowTraffic       = false;
     this._allowTrafficAtMsec = this._currentTimeMsec + offTimeMsec;
-    this._reason             = 'avoiding load';
+    this._reason             = `avoiding load until ${this._allowTrafficAtMsec}`;
   }
 
   /**

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -22,6 +22,27 @@ const NEVER_TIME_MSEC = Number.MAX_SAFE_INTEGER;
  */
 const MINIMUM_TRAFFIC_ALLOW_TIME_MSEC = 60 * 1000; // One minute.
 
+/** {Int} Load factor above which duty-cycling begins. */
+const MIN_LOAD_FACTOR_FOR_DUTY_CYCLE = 75;
+
+/**
+ * {Int} Load factor at-or-above which duty-cycling should have the maximum
+ * allowed "off" time.
+ */
+const MAX_LOAD_FACTOR_FOR_DUTY_CYCLE = 150;
+
+/**
+ * {number} Fraction of time to prevent traffic, when doing minimal (but
+ * active) duty cycling.
+ */
+const MIN_DUTY_CYCLE_OFF_TIME_FRAC = 0.1; // 10% of the time.
+
+/**
+ * {number} Fraction of time to prevent traffic, when doing maximal duty
+ * cycling.
+ */
+const MAX_DUTY_CYCLE_OFF_TIME_FRAC = 0.5; // 50% of the time.
+
 /**
  * Synthesizer of the high-level "traffic signal" based on various stats on what
  * this server is up to. A little more detail:
@@ -202,11 +223,65 @@ export class TrafficSignal extends CommonBase {
       return;
     }
 
-    // **TODO:** Depend on the load factor. Set `_allowTraffic` to `false` and
-    // set up an appropriate `_allowTrafficAtMsec`, should the load factor turn
-    // out to be too high.
+    if (this._loadFactor <= MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) {
+      // Not enough load to have to cycle off. That is, it's all good!
+      this._allowTraffic = true;
+      this._reason       = 'normal flow';
+      return;
+    }
 
-    this._allowTraffic = true;
-    this._reason       = 'normal flow';
+    // The load factor is high enough to start duty-cycling, and we are
+    // currently allowing traffic, but we are now going to stop (for a while).
+
+    const offTimeMsec = TrafficSignal._offTimeMsecFromLoadFactor(this._loadFactor);
+
+    this._allowTraffic       = false;
+    this._allowTrafficAtMsec = this._currentTimeMsec + offTimeMsec;
+    this._reason             = 'avoiding load';
+  }
+
+  /**
+   * Given a load factor at or above the minimum value required for
+   * duty-cycling, returns the amount of time that should be spent in the "off"
+   * state.
+   *
+   * @param {Int} loadFactor The load factor.
+   * @returns {Int} The amount of time (in msec) which the traffic signal should
+   *   be "off" before going back on again.
+   */
+  static _offTimeMsecFromLoadFactor(loadFactor) {
+    if (loadFactor < MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) {
+      return 0;
+    }
+
+    // Scale the load factor to a range of `[0..1]`, where `0` is the minimum
+    // value for duty cycling and `1` is the max.
+    const LOAD_FACTOR_RANGE = MAX_LOAD_FACTOR_FOR_DUTY_CYCLE - MIN_LOAD_FACTOR_FOR_DUTY_CYCLE;
+    const scaledLoad =
+      Math.min(1, (this._loadFactor - MIN_LOAD_FACTOR_FOR_DUTY_CYCLE) / LOAD_FACTOR_RANGE);
+
+    // Take the scaled load factor, and multiply it out, and adjust it, so that
+    // it is in the desired range of "off" cycle fractions. E.g. if `offFrac` is
+    // `0.25` then the duty cycle should be such that the off-time is 0.25 of
+    // the minimum on-time.
+    const FRAC_RANGE        = MAX_DUTY_CYCLE_OFF_TIME_FRAC - MIN_DUTY_CYCLE_OFF_TIME_FRAC;
+    const offFrac = (scaledLoad * FRAC_RANGE) + MIN_DUTY_CYCLE_OFF_TIME_FRAC;
+
+    // That the off-fraction (F) and the minimum on-time (T), and solve for N
+    // (actual amount of time in msec to be off), as follows. The first line
+    // in the derivation states fairly directly, "The ratio of off-time to
+    // total time is F."
+    //
+    //   (N / (N + T)) = F
+    //   N             = F * (N + T)
+    //   N             = F*N + F*T
+    //   N - F*N       = F * T
+    //   1*N - F*N     = F * T
+    //   (1 - F) * N   = F * T
+    //   N             = (F * T) / (1 - F)
+    const ON_MSEC     = MINIMUM_TRAFFIC_ALLOW_TIME_MSEC;
+    const offTimeMsec = Math.round((offFrac * ON_MSEC) / (1 - offFrac));
+
+    return offTimeMsec;
   }
 }

--- a/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
@@ -1,0 +1,43 @@
+// Copyright 2016-2019 the Bayou Authors (Dan Bornstein et alia).
+// Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+// Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import { TrafficSignal } from '../TrafficSignal';
+
+describe('@bayou/app-setup/TrafficSignal', () => {
+  // **Note:** This file builds in assumptions about the values of the various
+  // constants. If we find ourselves tweaking the constants a lot, we might want
+  // to make the test more parametric.
+  describe('_offTimeMsecFromLoadFactor()', () => {
+    it('returns `0` for "non-loady" low values', () => {
+      for (let lf = 0; lf < 75; lf++) {
+        const got = TrafficSignal._offTimeMsecFromLoadFactor(lf);
+
+        assert.strictEqual(got, 0, `load factor ${lf}`);
+      }
+    });
+
+    it('returns the minimum off-time when at the low-end of the duty-cycle range', () => {
+      const got = TrafficSignal._offTimeMsecFromLoadFactor(75);
+
+      assert.strictEqual(got, 6667);
+    });
+
+    it('returns the maximum off-time when at the high-end of the duty-cycle range', () => {
+      const got = TrafficSignal._offTimeMsecFromLoadFactor(150);
+
+      assert.strictEqual(got, 60000);
+    });
+
+    it('returns the maximum off-time when the load factor is higher than the max end of the range', () => {
+      for (let lf = 151; lf < 10000; lf = Math.floor(lf * 5 / 3)) {
+        const got = TrafficSignal._offTimeMsecFromLoadFactor(lf);
+
+        assert.strictEqual(got, 60000, `load factor ${lf}`);
+      }
+    });
+  });
+});

--- a/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
@@ -21,9 +21,15 @@ describe('@bayou/app-setup/TrafficSignal', () => {
     });
 
     it('returns the minimum off-time when at the low-end of the duty-cycle range', () => {
-      const got = TrafficSignal._offTimeMsecFromLoadFactor(75);
+      const got = TrafficSignal._offTimeMsecFromLoadFactor(80);
 
       assert.strictEqual(got, 6667);
+    });
+
+    it('returns the middle off-time when at the middle of the duty-cycle range', () => {
+      const got = TrafficSignal._offTimeMsecFromLoadFactor(115);
+
+      assert.strictEqual(got, 25714);
     });
 
     it('returns the maximum off-time when at the high-end of the duty-cycle range', () => {

--- a/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/tests/test_TrafficSignal.js
@@ -8,7 +8,7 @@ import { describe, it } from 'mocha';
 import { TrafficSignal } from '../TrafficSignal';
 
 describe('@bayou/app-setup/TrafficSignal', () => {
-  // **Note:** This file builds in assumptions about the values of the various
+  // **Note:** This test builds in assumptions about the values of the various
   // constants. If we find ourselves tweaking the constants a lot, we might want
   // to make the test more parametric.
   describe('_offTimeMsecFromLoadFactor()', () => {

--- a/product-info.txt
+++ b/product-info.txt
@@ -1,6 +1,6 @@
 # Metainformation about this product.
 name = bayou
-version = 1.4.6
+version = 1.4.7
 
 #
 # Artificial Failure


### PR DESCRIPTION
This PR gets `TrafficSignal` to start paying attention to the load factor it is given, and implements a duty-cycle mechanism which "pulses" the signal off and on, once the load factor hits or exceeds a specified value, with the off-time increasing as the load factor increases.

In addition, I ended up getting `TrafficSignal`'s `reason` code (why it's in its current state) plumbed out and exposed on the `/traffic-signal` endpoint, so e.g. in steady low-load state we now will see the reason as a parenthetical below the high-order bit:

```
🚦 💚 Green Light! Send traffic my way! 💚 🚦

(normal flow)
```
