### PR TITLE
File cache refactoring, and related stats exposition.

### DIFF
--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -528,9 +528,9 @@ export class Application extends CommonBase {
    * stats and uses them to update the load factor.
    */
   async _updateResourceConsumption() {
-    const stats = await DocServer.theOne.currentResourceConsumption();
+    const docServerStats = await DocServer.theOne.currentResourceConsumption();
 
-    this._loadFactor.docServerStats(stats);
-    log.metric.totalResourceConsumption(stats);
+    this._loadFactor.resourceConsumption(docServerStats);
+    log.metric.totalResourceConsumption(docServerStats);
   }
 }

--- a/local-modules/@bayou/app-setup/Application.js
+++ b/local-modules/@bayou/app-setup/Application.js
@@ -12,7 +12,7 @@ import ws from 'ws';
 import { ContextInfo, PostConnection, WsConnection } from '@bayou/api-server';
 import { Codecs, Urls } from '@bayou/app-common';
 import { ClientBundle } from '@bayou/client-bundle';
-import { Deployment, Network } from '@bayou/config-server';
+import { Deployment, Network, Storage } from '@bayou/config-server';
 import { DocServer } from '@bayou/doc-server';
 import { Dirs, ServerEnv } from '@bayou/env-server';
 import { Delay } from '@bayou/promise-util';
@@ -529,8 +529,16 @@ export class Application extends CommonBase {
    */
   async _updateResourceConsumption() {
     const docServerStats = await DocServer.theOne.currentResourceConsumption();
+    const fileStoreStats = await Storage.fileStore.currentResourceConsumption();
 
-    this._loadFactor.resourceConsumption(docServerStats);
-    log.metric.totalResourceConsumption(docServerStats);
+    this._loadFactor.resourceConsumption(docServerStats, fileStoreStats);
+
+    const allStats = {
+      docServer: docServerStats,
+      fileStore: fileStoreStats,
+      roughSize: docServerStats.roughSize + fileStoreStats.roughSize
+    };
+
+    log.metric.totalResourceConsumption(allStats);
   }
 }

--- a/local-modules/@bayou/app-setup/LoadFactor.js
+++ b/local-modules/@bayou/app-setup/LoadFactor.js
@@ -13,10 +13,10 @@ import { CommonBase } from '@bayou/util-common';
 const HEAVY_CONNECTION_COUNT = 400;
 
 /**
- * {Int} The number of active documents which should be considered to constitute
- * a "heavy load."
+ * {Int} The number of active files or documents ("major items") which should be
+ * considered to constitute a "heavy load."
  */
-const HEAVY_DOCUMENT_COUNT = 4000;
+const HEAVY_MAJOR_ITEM_COUNT = 4000;
 
 /**
  * {Int} The number of document sessions which should be considered to
@@ -154,12 +154,17 @@ export class LoadFactor extends CommonBase {
     // Get each of these as a fraction where `0` is "unloaded" and `1` is heavy
     // load.
     const connectionCount = this._connectionCount / HEAVY_CONNECTION_COUNT;
-    const documentCount   = this._documentCount   / HEAVY_DOCUMENT_COUNT;
     const roughSize       = this._roughSize       / HEAVY_ROUGH_SIZE;
     const sessionCount    = this._sessionCount    / HEAVY_SESSION_COUNT;
 
+    // Because the document and file counts really ought to pretty much track
+    // each other (that is, be very nearly the same value almost all the time),
+    // just take a max of the two and treat it as a single stat.
+    const majorItemCount =
+      Math.max(this._documentCount, this._fileCount) / HEAVY_MAJOR_ITEM_COUNT;
+
     // Total load.
-    const total = connectionCount + documentCount + roughSize + sessionCount;
+    const total = connectionCount + majorItemCount + roughSize + sessionCount;
 
     // Total load, scaled so that heavy load is at the documented
     // `HEAVY_LOAD_VALUE`, and rounded to an int. `ceil()` so that a tiny but

--- a/local-modules/@bayou/app-setup/LoadFactor.js
+++ b/local-modules/@bayou/app-setup/LoadFactor.js
@@ -91,21 +91,22 @@ export class LoadFactor extends CommonBase {
    * are expected to be in the form reported by
    * {@link DocServer#currentResourceConsumption}.
    *
-   * @param {object} stats Stats, per the contract of {@link DocServer}.
+   * @param {object} docServerStats Stats, per the contract of {@link
+   *   DocServer}.
    */
-  docServerStats(stats) {
-    TObject.check(stats);
+  resourceConsumption(docServerStats) {
+    TObject.check(docServerStats);
 
-    if (stats.documentCount !== undefined) {
-      this._documentCount = TInt.nonNegative(stats.documentCount);
+    if (docServerStats.documentCount !== undefined) {
+      this._documentCount = TInt.nonNegative(docServerStats.documentCount);
     }
 
-    if (stats.roughSize !== undefined) {
-      this._roughSize = TInt.nonNegative(stats.roughSize);
+    if (docServerStats.roughSize !== undefined) {
+      this._roughSize = TInt.nonNegative(docServerStats.roughSize);
     }
 
-    if (stats.sessionCount !== undefined) {
-      this._sessionCount = TInt.nonNegative(stats.sessionCount);
+    if (docServerStats.sessionCount !== undefined) {
+      this._sessionCount = TInt.nonNegative(docServerStats.sessionCount);
     }
 
     this._recalc();

--- a/local-modules/@bayou/app-setup/LoadFactor.js
+++ b/local-modules/@bayou/app-setup/LoadFactor.js
@@ -59,7 +59,12 @@ export class LoadFactor extends CommonBase {
     /** {Int} {@link DocServer} resource consumption stat. */
     this._documentCount = 0;
 
-    /** {Int} {@link DocServer} resource consumption stat. */
+    /** {Int} {@link BaseFile} resource consumption stat. */
+    this._fileCount = 0;
+
+    /**
+     * {Int} {@link DocServer} and {@link BaseFile} resource consumption stat.
+     */
     this._roughSize = 0;
 
     /** {Int} {@link DocServer} resource consumption stat. */
@@ -87,26 +92,41 @@ export class LoadFactor extends CommonBase {
   }
 
   /**
-   * Updates this instance based on the given resource consumption stats, which
-   * are expected to be in the form reported by
-   * {@link DocServer#currentResourceConsumption}.
+   * Updates this instance based on the given resource consumption stats.
    *
    * @param {object} docServerStats Stats, per the contract of {@link
-   *   DocServer}.
+   *   DocServer#currentResourceConsumption}.
+   * @param {object} fileStoreStats Stats, per the contract of {@link
+   *   BaseFileStore#currentResourceConsumption}.
    */
-  resourceConsumption(docServerStats) {
+  resourceConsumption(docServerStats, fileStoreStats) {
     TObject.check(docServerStats);
+    TObject.check(fileStoreStats);
+
+    let roughSize = 0;
 
     if (docServerStats.documentCount !== undefined) {
       this._documentCount = TInt.nonNegative(docServerStats.documentCount);
     }
 
     if (docServerStats.roughSize !== undefined) {
-      this._roughSize = TInt.nonNegative(docServerStats.roughSize);
+      roughSize = TInt.nonNegative(docServerStats.roughSize);
     }
 
     if (docServerStats.sessionCount !== undefined) {
       this._sessionCount = TInt.nonNegative(docServerStats.sessionCount);
+    }
+
+    if (fileStoreStats.fileCount !== undefined) {
+      this._fileCount = TInt.nonNegative(fileStoreStats.fileCount);
+    }
+
+    if (fileStoreStats.roughSize !== undefined) {
+      roughSize += TInt.nonNegative(fileStoreStats.roughSize);
+    }
+
+    if (roughSize !== 0) {
+      this._roughSize = roughSize;
     }
 
     this._recalc();

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -79,7 +79,8 @@ export class DocComplex extends BaseComplexMember {
   /**
    * Gets stats about the resource consumption managed by this instance, in the
    * form of an ad-hoc plain object. This information is used as part of the
-   * high-level "load factor" metric calculation.
+   * high-level "load factor" metric calculation, as well as logged and exposed
+   * on the monitoring port.
    *
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable

--- a/local-modules/@bayou/doc-server/DocComplex.js
+++ b/local-modules/@bayou/doc-server/DocComplex.js
@@ -91,32 +91,21 @@ export class DocComplex extends BaseComplexMember {
   async currentResourceConsumption(timeoutMsec = null) {
     const sessionCount = this._sessions.size;
 
-    const [fileRevNum, fileSnapshot, bodyRevNum, bodySnapshot] = await Promise.all([
-      this.file.currentRevNum(timeoutMsec),
-      this.file.getSnapshot(null, timeoutMsec),
+    const [bodyRevNum, bodySnapshot] = await Promise.all([
       this.bodyControl.currentRevNum(timeoutMsec),
       this.bodyControl.getSnapshot(null, timeoutMsec)
     ]);
 
     // The following is a very ad-hoc heuristic to get a sense of the
-    // "largeness" of a file. See docs for any of the `.roughSize` properties
-    // for a little more color.
+    // "largeness" of a document. See docs for any of the `.roughSize`
+    // properties for a little more color.
     const roughSize =
-        (fileRevNum * 15)
-      + (fileSnapshot.roughSize * 2)
       + (bodyRevNum * 25)
       + (bodySnapshot.roughSize * 4);
 
-    // Because we don't (yet) do file GC, the number of file changes is the same
-    // as `revNum + 1`, but that (hopefully) won't be true forever. **TODO:**
-    // Revisit this when file GC happens.
-    const fileChangeCount = fileRevNum + 1;
-
-    // No similar caveat (to the one above) required here, because body changes
-    // aren't designed to be GCed.
     const bodyChangeCount = bodyRevNum + 1;
 
-    return { bodyChangeCount, fileChangeCount, roughSize, sessionCount };
+    return { bodyChangeCount, roughSize, sessionCount };
   }
 
   /**

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -99,7 +99,6 @@ export class DocServer extends Singleton {
   async currentResourceConsumption(timeoutMsec = null) {
     let bodyChangeCount = 0;
     let documentCount   = 0;
-    let fileChangeCount = 0;
     let roughSize       = 0;
     let sessionCount    = 0;
 
@@ -109,7 +108,6 @@ export class DocServer extends Singleton {
 
       documentCount++;
       bodyChangeCount += stats.bodyChangeCount;
-      fileChangeCount += stats.fileChangeCount;
       roughSize       += stats.roughSize;
       sessionCount    += stats.sessionCount;
     }
@@ -131,7 +129,6 @@ export class DocServer extends Singleton {
     return {
       bodyChangeCount,
       documentCount,
-      fileChangeCount,
       roughSize,
       sessionCount
     };

--- a/local-modules/@bayou/doc-server/DocServer.js
+++ b/local-modules/@bayou/doc-server/DocServer.js
@@ -87,7 +87,8 @@ export class DocServer extends Singleton {
   /**
    * Gets stats about the resource consumption managed by this instance, in the
    * form of an ad-hoc plain object. This information is used as part of the
-   * high-level "load factor" metric calculation.
+   * high-level "load factor" metric calculation, as well as logged and
+   * exposed on the monitoring port.
    *
    * @param {Int|null} [timeoutMsec = null] Maximum amount of time to allow in
    *   this call, in msec. This value will be silently clamped to the allowable

--- a/local-modules/@bayou/file-store-local/LocalFileStore.js
+++ b/local-modules/@bayou/file-store-local/LocalFileStore.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { Codec } from '@bayou/codec';
 import { Dirs } from '@bayou/env-server';
-import { BaseFileStore, FileCache } from '@bayou/file-store';
+import { BaseFileStore } from '@bayou/file-store';
 import { Codecs } from '@bayou/file-store-ot';
 import { DefaultIdSyntax } from '@bayou/doc-id-default';
 import { Logger } from '@bayou/see-all';
@@ -26,14 +26,11 @@ export class LocalFileStore extends BaseFileStore {
    * Constructs an instance. This is not meant to be used publicly.
    */
   constructor() {
-    super();
+    super(log);
 
     /** {Codec} Codec to use when reading and writing file OT objects. */
     this._codec = new Codec();
     Codecs.registerCodecs(this._codec.registry);
-
-    /** {FileCache} Cache of {@link LocalFile} instances. */
-    this._cache = new FileCache(log);
 
     /** {string} The directory for file storage. */
     this._dir = path.resolve(Dirs.theOne.VAR_DIR, 'files');
@@ -56,16 +53,7 @@ export class LocalFileStore extends BaseFileStore {
   async _impl_getFile(fileId) {
     await this._ensureFileStorageDirectory();
 
-    const already = this._cache.getOrNull(fileId);
-
-    if (already) {
-      return already;
-    }
-
-    const result = new LocalFile(fileId, this._filePath(fileId), this._codec);
-
-    this._cache.add(result);
-    return result;
+    return new LocalFile(fileId, this._filePath(fileId), this._codec);
   }
 
   /**

--- a/local-modules/@bayou/file-store/BaseFileStore.js
+++ b/local-modules/@bayou/file-store/BaseFileStore.js
@@ -2,18 +2,40 @@
 // Licensed AS IS and WITHOUT WARRANTY under the Apache License,
 // Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
 
+import { BaseLogger } from '@bayou/see-all';
 import { TBoolean, TObject, TString } from '@bayou/typecheck';
 import { CommonBase, Errors } from '@bayou/util-common';
 
 import { BaseFile } from './BaseFile';
+import { FileCache } from './FileCache';
 
 /**
  * Base class for file storage access. This is, essentially, the filesystem
  * interface when dealing with the high-level "files" of this system. Subclasses
  * must override several methods defined by this class, as indicated in the
  * documentation. Methods to override are all named with the prefix `_impl_`.
+ *
+ * Notably, this class provides an instance cache, such that subclasses
+ * shouldn't ever end up getting asked to create a file object for one that's
+ * already around due to a previous request for same.
+ *
  */
 export class BaseFileStore extends CommonBase {
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseLogger} log Logger to use.
+   */
+  constructor(log) {
+    super();
+
+    /** {BaseLogger} Logger to use. */
+    this._log = BaseLogger.check(log);
+
+    /** {FileCache} Cache of {@link BaseFile} instances. */
+    this._cache = new FileCache(this._log);
+  }
+
   /**
    * Checks a file ID for full validity, beyond simply checking the syntax of
    * the ID. Returns the given ID if all is well, or throws an error if the ID
@@ -63,7 +85,11 @@ export class BaseFileStore extends CommonBase {
   async getFile(fileId) {
     this.checkFileIdSyntax(fileId);
     await this.checkFileId(fileId);
-    return BaseFile.check(await this._impl_getFile(fileId));
+
+    return this._cache.resolveOrAdd(fileId, async () => {
+      const result = await this._impl_getFile(fileId);
+      return BaseFile.check(result);
+    });
   }
 
   /**
@@ -138,7 +164,8 @@ export class BaseFileStore extends CommonBase {
 
   /**
    * Main implementation of {@link #isFileId}. Only ever called with a string
-   * argument.
+   * argument with valid syntax, and furthermore for a file which is not already
+   * in the instance's cache of same.
    *
    * @abstract
    * @param {string} fileId The alleged file ID.

--- a/local-modules/@bayou/file-store/FileCache.js
+++ b/local-modules/@bayou/file-store/FileCache.js
@@ -31,9 +31,7 @@ export class FileCache extends BaseCache {
 
   /** @override */
   get _impl_maxRejectionAge() {
-    // Valid value so that the constructor won't complain, but note that this
-    // class isn't used asynchronously, so the actual value shouldn't matter.
-    return 1000;
+    return 10 * 1000; // Ten seconds.
   }
 
   /** @override */


### PR DESCRIPTION
This PR factors the file-level cache out of the two `BaseFileStore` subclasses and into `BaseFileStore` itself, so that said cache could be straightforwardly queried in order to generate stats therefrom. These stats get reported out as part of the `totalResourceConsumption` metric (logged, not Prometheus), as well as used as part of the load factor calculation (instead of getting _some_ of the info from the doc server stats, which have been suitably modified to avoid what would have been a newly-introduced redundancy).

The original, and main, point of all this is to get a solid logging of active files, in that is going to help us understand memory usage.

Though probably not a real problem in practice, this PR also fixes a bug in file cache implementation which could conceivably caused an occasional extra file instance to be created that covered an already-existing (or really in-the-process-of-being-initialized) instance.
