### PR TITLE
Organize the monitor server, in advance of a proliferation of commands.

### DIFF
--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -90,7 +90,7 @@ export class Monitor extends CommonBase {
 
     // **TODO:** Consider disabling (or fully removing) this when there are no
     // known memory leaks (or similar) being investigated.
-    app.get('/heapdump', async (req_unused, res) => {
+    app.get('/dump-heap', async (req_unused, res) => {
       const dumpFile = path.join(Dirs.theOne.VAR_DIR, 'node.heapsnapshot');
       heapdump.writeSnapshot(dumpFile, (error, filename) => {
         if (error) {

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -52,7 +52,7 @@ export class Monitor extends CommonBase {
     /** {RequestLogger} HTTP request / response logger. */
     this._requestLogger = new RequestLogger(log);
 
-    this._addRoutes();
+    this._addAllRoutes();
   }
 
   /**
@@ -71,9 +71,9 @@ export class Monitor extends CommonBase {
   }
 
   /**
-   * Sets up the webserver routes.
+   * Sets up all of the webserver routes.
    */
-  _addRoutes() {
+  _addAllRoutes() {
     const app             = this._app;
     const requestLogger   = this._requestLogger;
     const mainApplication = this._mainApplication;

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -71,22 +71,45 @@ export class Monitor extends CommonBase {
   }
 
   /**
-   * Sets up all of the webserver routes.
+   * Sets up all of the webserver routes, including middleware that handles
+   * (aspects of) all routes.
    */
   _addAllRoutes() {
+    this._addMiddleware();
+    this._addCommandRoutes();
+    this._addInfoRoutes();
+  }
+
+  /**
+   * Sets up all of the command routes, that is, routes which cause active
+   * action of some sort, as opposed to the "info" routes which merely return
+   * information.
+   */
+  _addCommandRoutes() {
+    const app             = this._app;
+
+    // **TODO:** Consider disabling (or fully removing) this when there are no
+    // known memory leaks (or similar) being investigated.
+    app.get('/heapdump', async (req_unused, res) => {
+      const dumpFile = path.join(Dirs.theOne.VAR_DIR, 'node.heapsnapshot');
+      heapdump.writeSnapshot(dumpFile, (error, filename) => {
+        if (error) {
+          const msg = `Trouble with dump:\n${error.toString()}\n`;
+          ServerUtil.sendPlainTextResponse(res, msg, 200);
+        } else {
+          ServerUtil.sendFileResponse(res, filename, 'application/octet-stream');
+        }
+      });
+    });
+  }
+
+  /**
+   * Sets up all of the info-only routes.
+   */
+  _addInfoRoutes() {
     const app             = this._app;
     const requestLogger   = this._requestLogger;
     const mainApplication = this._mainApplication;
-
-    // Logging.
-    app.use(this._requestLogger.expressMiddleware);
-
-    // Thwack the `X-Powered-By` header that Express provides by default,
-    // replacing it with something that identifies this product.
-    app.use((req_unused, res, next) => {
-      res.setHeader('X-Powered-By', ServerEnv.theOne.buildInfo.buildId);
-      next();
-    });
 
     // This endpoint is meant to be used by a system health monitor to determine
     // whether or not the server thinks it is operating properly.
@@ -159,6 +182,23 @@ export class Monitor extends CommonBase {
       const info = await varInfo.get();
 
       ServerUtil.sendJsonResponse(res, info);
+    });
+  }
+
+  /**
+   * Sets up the middleware that gets invoked for all routes.
+   */
+  _addMiddleware() {
+    const app = this._app;
+
+    // Logging.
+    app.use(this._requestLogger.expressMiddleware);
+
+    // Thwack the `X-Powered-By` header that Express provides by default,
+    // replacing it with something that identifies this product.
+    app.use((req_unused, res, next) => {
+      res.setHeader('X-Powered-By', ServerEnv.theOne.buildInfo.buildId);
+      next();
     });
   }
 }

--- a/local-modules/@bayou/app-setup/Monitor.js
+++ b/local-modules/@bayou/app-setup/Monitor.js
@@ -90,7 +90,7 @@ export class Monitor extends CommonBase {
 
     // **TODO:** Consider disabling (or fully removing) this when there are no
     // known memory leaks (or similar) being investigated.
-    app.get('/dump-heap', async (req_unused, res) => {
+    app.get('/cmd/dump-heap', async (req_unused, res) => {
       const dumpFile = path.join(Dirs.theOne.VAR_DIR, 'node.heapsnapshot');
       heapdump.writeSnapshot(dumpFile, (error, filename) => {
         if (error) {

--- a/local-modules/@bayou/app-setup/TrafficSignal.js
+++ b/local-modules/@bayou/app-setup/TrafficSignal.js
@@ -274,16 +274,16 @@ export class TrafficSignal extends CommonBase {
 
     // Take the off-fraction (F) and the minimum on-time (T), and solve for the
     // actual amount of time in msec to be off (N), as follows. The first line
-    // in the derivation states fairly directly, "The ratio of off-time to
-    // total time is F."
+    // in the derivation states fairly directly, "The ratio of off-time to total
+    // time is F."
     //
-    //   (N / (N + T)) = F
-    //   N             = F * (N + T)
-    //   N             = F*N + F*T
-    //   N - F*N       = F * T
-    //   1*N - F*N     = F * T
-    //   (1 - F) * N   = F * T
-    //   N             = (F * T) / (1 - F)
+    //   N / (N + T) = F
+    //   N           = F * (N + T)
+    //   N           = F*N + F*T
+    //   N - F*N     = F * T
+    //   1*N - F*N   = F * T
+    //   (1 - F) * N = F * T
+    //   N           = (F * T) / (1 - F)
     const ON_MSEC     = MINIMUM_TRAFFIC_ALLOW_TIME_MSEC;
     const offTimeMsec = Math.round((offFrac * ON_MSEC) / (1 - offFrac));
 

--- a/scripts/slurp-heap
+++ b/scripts/slurp-heap
@@ -169,7 +169,7 @@ else
 fi
 
 echo ''
-curl -o "${outFile}" "${baseUrl}/heapdump"
+curl -o "${outFile}" "${baseUrl}/cmd/dump-heap"
 
 echo ''
 echo 'Done!'


### PR DESCRIPTION
The main point of this PR is to introduce a `/cmd` directory on the monitor server, to hold those "monitor" URIs which in fact take an active action, as opposed to most of the monitor endpoints which are more purely information-providing.

In addition, I took the opportunity to rename `heapdump` to the more command-like `dump-heap`, which pre-harmonizes it with the upcoming other new commands.