### PR TITLE
Log partially-redacted cookies.

### DIFF
--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -5,7 +5,8 @@
 import { fromPairs } from 'lodash';
 import { URL } from 'url';
 
-import { Logger, RedactUtil } from '@bayou/see-all';
+import { Logging } from '@bayou/config-server';
+import { Logger } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
@@ -196,7 +197,13 @@ export class RequestLogger extends CommonBase {
 
     const cookies = req.cookies;
     if (cookies && (Object.keys(cookies).length !== 0)) {
-      const cookieLog = RedactUtil.redactValues(cookies, 2);
+      const cookieLog = {};
+
+      for (const [name, value] of Object.entries(cookies)) {
+        const newValue = Logging.redactCookie(name, value);
+        cookieLog[name] = newValue;
+      }
+
       this._log.event[`${baseEvent}Cookies`](id, cookieLog);
     }
   }

--- a/local-modules/@bayou/app-setup/RequestLogger.js
+++ b/local-modules/@bayou/app-setup/RequestLogger.js
@@ -6,7 +6,7 @@ import { fromPairs } from 'lodash';
 import { URL } from 'url';
 
 import { Logging } from '@bayou/config-server';
-import { Logger } from '@bayou/see-all';
+import { Logger, RedactUtil } from '@bayou/see-all';
 import { TString } from '@bayou/typecheck';
 import { CommonBase, Errors, Random } from '@bayou/util-common';
 
@@ -201,7 +201,7 @@ export class RequestLogger extends CommonBase {
 
       for (const [name, value] of Object.entries(cookies)) {
         const newValue = Logging.redactCookie(name, value);
-        cookieLog[name] = newValue;
+        cookieLog[name] = (value === newValue) ? value : RedactUtil.wrapRedacted(newValue);
       }
 
       this._log.event[`${baseEvent}Cookies`](id, cookieLog);

--- a/local-modules/@bayou/config-server-default/Logging.js
+++ b/local-modules/@bayou/config-server-default/Logging.js
@@ -16,6 +16,19 @@ export class Logging extends UtilityClass {
    *
    * This implementation is a no-op, always returning its argument unchanged.
    *
+   * @param {string} name_unused The name of the cookie.
+   * @param {string} value The value of the cookie.
+   * @returns {string} `value` as given.
+   */
+  static redactCookie(name_unused, value) {
+    return value;
+  }
+
+  /**
+   * Implementation of standard configuration point.
+   *
+   * This implementation is a no-op, always returning its argument unchanged.
+   *
    * @param {Functor} payload Original event payload.
    * @returns {Functor} `payload` as given.
    */

--- a/local-modules/@bayou/config-server/Logging.js
+++ b/local-modules/@bayou/config-server/Logging.js
@@ -11,7 +11,9 @@ import { UtilityClass } from '@bayou/util-common';
 export class Logging extends UtilityClass {
   /**
    * Performs redaction on a cookie value (such as might be present in an HTTP
-   * header).
+   * header). The idea is that, in many deployment environments, cookie values
+   * will be security-sensitive and will not be appropriate to fully log; this
+   * hook provides an opportunity to filter such things when and as appropriate.
    *
    * @param {string} name The name of the cookie.
    * @param {string} value The value of the cookie.

--- a/local-modules/@bayou/config-server/Logging.js
+++ b/local-modules/@bayou/config-server/Logging.js
@@ -10,6 +10,19 @@ import { UtilityClass } from '@bayou/util-common';
  */
 export class Logging extends UtilityClass {
   /**
+   * Performs redaction on a cookie value (such as might be present in an HTTP
+   * header).
+   *
+   * @param {string} name The name of the cookie.
+   * @param {string} value The value of the cookie.
+   * @returns {string} Redacted replacement value, or `value` as given if no
+   *   redaction is necessary.
+   */
+  static redactCookie(name, value) {
+    return use.Logging.redactCookie(name, value);
+  }
+
+  /**
    * Performs redaction on an event log payload.
    *
    * @param {Functor} payload Original event payload.


### PR DESCRIPTION
This PR changes a bunch of places where cookies are used. Instead of logging only the cookie length or not logging anything about a cookie value, we log a partially-redacted form of the cookie. This is meant to make it much easier to trace a cookie value from server ingress through to the back-end-of-the-back-end.
